### PR TITLE
fix: remove duplicate hooks field from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,6 +24,5 @@
     "best-practices"
   ],
   "commands": "./commands",
-  "skills": "./skills",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills"
 }


### PR DESCRIPTION
## What this fixes

Removes the `hooks` field from `.claude-plugin/plugin.json` to eliminate the duplicate hooks warning.

**Note:** This issue only occurs when installing via the plugin marketplace. Manual file copy installation is not affected.

## Why it's needed

Claude Code automatically loads `hooks/hooks.json` from the plugin directory. Explicitly specifying it in `plugin.json` causes a duplicate hooks error:

> Failed to load hooks from .../hooks/hooks.json: Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file .../hooks/hooks.json. The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only reference additional hook files.
> → Check hooks.json file syntax and structure

## How I tested it

1. Installed the plugin via `/plugin marketplace add affaan-m/everything-claude-code`
2. Confirmed the error appeared in `/plugin` output
3. Removed the `hooks` field from `plugin.json`
4. Restarted Claude Code session
5. Confirmed the error no longer appears and hooks still load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration by removing hooks configuration from the plugin manifest.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->