### PR TITLE
fix: use ${CLAUDE_PLUGIN_ROOT} for hook script paths

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/strategic-compact/suggest-compact.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strategic-compact/suggest-compact.sh"
           }
         ],
         "description": "Suggest manual compaction at logical intervals"
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/memory-persistence/pre-compact.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-persistence/pre-compact.sh"
           }
         ],
         "description": "Save state before context compaction"
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/memory-persistence/session-start.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-persistence/session-start.sh"
           }
         ],
         "description": "Load previous context on new session"
@@ -135,7 +135,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/memory-persistence/session-end.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-persistence/session-end.sh"
           }
         ],
         "description": "Persist session state on end"
@@ -145,7 +145,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./skills/continuous-learning/evaluate-session.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning/evaluate-session.sh"
           }
         ],
         "description": "Evaluate session for extractable patterns"


### PR DESCRIPTION
Hooks run in the project directory, not the plugin directory. Using relative paths like ./hooks/... fails when the plugin is installed anywhere other than the project root. Using ${CLAUDE_PLUGIN_ROOT} ensures scripts are found regardless of installation location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal hook command paths to use environment parameterization for improved configuration flexibility and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->