### PR TITLE
fix: remove version field to enable automatic plugin updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "everything-claude-code",
-  "version": "1.0.0",
   "description": "Complete collection of battle-tested Claude Code configs from an Anthropic hackathon winner - agents, skills, hooks, commands, and rules evolved over 10+ months of intensive daily use",
   "author": {
     "name": "Affaan Mustafa",


### PR DESCRIPTION
This PR removes the static `version` field from `plugin.json` to enable automatic plugin updates via `/plugin update`.

## Changes

- Remove `version: "1.0.0"` from `.claude-plugin/plugin.json`

## Why

Claude Code uses different version detection strategies:
- **Without version field** → Uses git commit SHA → Auto-updates work
- **With version field** → Uses static version string → Auto-updates broken

This change aligns with the pattern used by all official Anthropic plugins.

Fixes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->