### PR TITLE
fix: remove version fields from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,13 @@
     "email": "affaan@example.com"
   },
   "metadata": {
-    "description": "Battle-tested Claude Code configurations from an Anthropic hackathon winner",
-    "version": "1.0.0"
+    "description": "Battle-tested Claude Code configurations from an Anthropic hackathon winner"
   },
   "plugins": [
     {
       "name": "everything-claude-code",
       "source": "./",
       "description": "Complete collection of agents, skills, hooks, commands, and rules evolved over 10+ months of intensive daily use",
-      "version": "1.0.0",
       "author": {
         "name": "Affaan Mustafa"
       },


### PR DESCRIPTION
This PR removes the remaining version fields from `marketplace.json` to enable automatic plugin updates.

## Changes

- Remove `metadata.version`
- Remove `plugins[0].version`

## Context

PR #34 removed the version field from `plugin.json`, but `marketplace.json` still contained version fields. These version fields are used by Claude Code for:
1. Cache directory naming (e.g., `1.0.0/`)
2. Update detection

As long as version fields exist, `/plugin update` will not detect new commits.

## Official Plugin Pattern

Official plugins do not have version fields in `marketplace.json`, which enables git SHA-based version detection and automatic updates.

Fixes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed version fields from marketplace configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->