### PR TITLE
docs(example): add privacy rule to user-CLAUDE template

### DIFF
--- a/examples/user-CLAUDE.md
+++ b/examples/user-CLAUDE.md
@@ -64,6 +64,9 @@ Located in `~/.claude/agents/`:
 - Many small files over few large files
 - 200-400 lines typical, 800 max per file
 
+### Privacy
+- Always redact logs; never paste secrets (API keys/tokens/passwords/JWTs).
+
 ### Git
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`
 - Always test locally before committing


### PR DESCRIPTION
## Summary

- Add privacy guideline to `examples/user-CLAUDE.md`
- Reminds users to redact logs and avoid pasting secrets (API keys/tokens/passwords/JWTs)

## Related Issue

Closes #38

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added privacy guidelines covering secure handling of sensitive information such as API keys, tokens, passwords, and authentication credentials in logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->