### PR TITLE
docs: update example dates from 2025 to 2026

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -138,7 +138,7 @@ Use Redis Stack with vector search capability.
 Accepted
 
 ## Date
-2025-01-15
+2026-01-15
 ```
 
 ## System Design Checklist

--- a/agents/e2e-runner.md
+++ b/agents/e2e-runner.md
@@ -361,7 +361,7 @@ test('authenticated user can create market', async ({ page }) => {
   // 2. Fill market form
   await page.locator('[data-testid="market-name"]').fill('Test Market')
   await page.locator('[data-testid="market-description"]').fill('This is a test market')
-  await page.locator('[data-testid="market-end-date"]').fill('2025-12-31')
+  await page.locator('[data-testid="market-end-date"]').fill('2026-12-31')
 
   // 3. Submit form
   await page.locator('[data-testid="submit-market"]').click()

--- a/skills/clickhouse-io/SKILL.md
+++ b/skills/clickhouse-io/SKILL.md
@@ -89,7 +89,7 @@ ORDER BY hour DESC;
 -- ✅ GOOD: Use indexed columns first
 SELECT *
 FROM markets_analytics
-WHERE date >= '2025-01-01'
+WHERE date >= '2026-01-01'
   AND market_id = 'market-123'
   AND volume > 1000
 ORDER BY date DESC
@@ -100,7 +100,7 @@ SELECT *
 FROM markets_analytics
 WHERE volume > 1000
   AND market_name LIKE '%election%'
-  AND date >= '2025-01-01';
+  AND date >= '2026-01-01';
 ```
 
 ### Aggregations

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -215,7 +215,7 @@ test('user can create a new market', async ({ page }) => {
   // Fill market creation form
   await page.fill('input[name="name"]', 'Test Market')
   await page.fill('textarea[name="description"]', 'Test description')
-  await page.fill('input[name="endDate"]', '2025-12-31')
+  await page.fill('input[name="endDate"]', '2026-12-31')
 
   // Submit form
   await page.click('button[type="submit"]')


### PR DESCRIPTION
## Summary
Updates example/sample dates in documentation from 2025 to 2026 for relevance.

## Files Changed
- agents/architect.md (ADR example date)
- agents/e2e-runner.md (Playwright test date)
- skills/clickhouse-io/SKILL.md (SQL query examples)
- skills/tdd-workflow/SKILL.md (E2E test date)

## Notes
- Preserved README.md hackathon date (Sep 2025) as historical reference
- Preserved model version strings (actual API identifiers)

## Test Plan
- Verified no functional code affected
- Dates appear only in documentation examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated date references in architectural and skill documentation files.

* **Tests**
  * Updated test data dates in end-to-end and test workflow scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->