### PR TITLE
Add mandatory frontmatter to eval-harness SKILL.md

### DIFF
--- a/skills/eval-harness/SKILL.md
+++ b/skills/eval-harness/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: eval-harness
+description: A formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles. Use this skill when defining capability evals (testing new functionality), running regression evals (ensuring changes don't break existing behavior), tracking pass@k metrics for reliability measurement, or implementing systematic eval workflows before, during, and after implementation phases.
+---
+
 # Eval Harness Skill
 
 A formal evaluation framework for Claude Code sessions, implementing eval-driven development (EDD) principles.


### PR DESCRIPTION
Got a warning about this when adding this skill via https://github.com/frmlabz/omnidev so just wanted to quickly fix it. 

From [claude docs](https://code.claude.com/docs/en/skills)

> Every skill needs a SKILL.md file with two parts: YAML frontmatter (between --- markers) that tells Claude when to use the skill, and markdown content with instructions Claude follows when the skill is invoked. The name field becomes the /slash-command, and the description helps Claude decide when to load it automatically.

So the `frontmatter` part is mandatory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved skill documentation with added metadata, including skill identification and comprehensive description for better organization and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->