### PR TITLE
fix: correct requirePermission HOF pattern

### DIFF
--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -397,7 +397,8 @@ export function hasPermission(user: User, permission: Permission): boolean {
 export function requirePermission(permission: Permission) {
   return (handler: (request: Request, user: User) => Promise<Response>) => {
     return async (request: Request) => {
-      const user = await requireAuth(request)
+      const payload = await requireAuth(request)
+      const user: User = { id: payload.userId, role: payload.role }
 
       if (!hasPermission(user, permission)) {
         throw new ApiError(403, 'Insufficient permissions')


### PR DESCRIPTION
Fixes #54                                                                                                         
The \`requirePermission\` implementation was returning a function that expected a \`Request\`, but the usage example passed a handler function - causing a type mismatch. 

Updated to properly wrap the handler and pass the authenticated user to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Permission handling flow simplified: authenticated user is now provided directly to request handlers, streamlining authorization checks and response generation.

---

*Note: This is an internal refactor with no direct changes to end-user functionality.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->