### PR TITLE
fix: add agents declaration to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -23,5 +23,6 @@
     "best-practices"
   ],
   "commands": "./commands",
-  "skills": "./skills"
+  "skills": "./skills",
+  "agents": "./agents"
 }


### PR DESCRIPTION
## Summary

- Add `"agents": "./agents"` to plugin.json manifest to make the 9 agent files discoverable by Claude Code

## Problem

The plugin's `agents/` directory contains 9 agent markdown files with proper frontmatter, but they don't appear in Claude Code's `/agents` command because the manifest was missing the agents field declaration.

Fixes #66

## Test plan

- [ ] Install the plugin
- [ ] Run `/agents` command in Claude Code
- [ ] Verify all 9 agents appear in the list:
  - architect
  - build-error-resolver
  - code-reviewer
  - doc-updater
  - e2e-runner
  - planner
  - refactor-cleaner
  - security-reviewer
  - tdd-guide

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration to support agents functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->