### PR TITLE
Fix: Move Stop hook inline code to separate script file

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -137,7 +137,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{execSync('git rev-parse --git-dir',{stdio:'pipe'})}catch{console.log(d);process.exit(0)}try{const files=execSync('git diff --name-only HEAD',{encoding:'utf8',stdio:['pipe','pipe','pipe']}).split('\\n').filter(f=>/\\.(ts|tsx|js|jsx)$/.test(f)&&fs.existsSync(f));let hasConsole=false;for(const f of files){if(fs.readFileSync(f,'utf8').includes('console.log')){console.error('[Hook] WARNING: console.log found in '+f);hasConsole=true}}if(hasConsole)console.error('[Hook] Remove console.log statements before committing')}catch(e){}console.log(d)})\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/check-console-log.js\""
           }
         ],
         "description": "Check for console.log in modified files after each response"

--- a/scripts/hooks/check-console-log.js
+++ b/scripts/hooks/check-console-log.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Stop Hook: Check for console.log statements in modified files
+ * 
+ * This hook runs after each response and checks if any modified
+ * JavaScript/TypeScript files contain console.log statements.
+ * It provides warnings to help developers remember to remove
+ * debug statements before committing.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+let data = '';
+
+// Read stdin
+process.stdin.on('data', chunk => {
+  data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    // Check if we're in a git repository
+    try {
+      execSync('git rev-parse --git-dir', { stdio: 'pipe' });
+    } catch {
+      // Not in a git repo, just pass through the data
+      console.log(data);
+      process.exit(0);
+    }
+
+    // Get list of modified files
+    const files = execSync('git diff --name-only HEAD', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+      .split('\n')
+      .filter(f => /\.(ts|tsx|js|jsx)$/.test(f) && fs.existsSync(f));
+
+    let hasConsole = false;
+
+    // Check each file for console.log
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      if (content.includes('console.log')) {
+        console.error(`[Hook] WARNING: console.log found in ${file}`);
+        hasConsole = true;
+      }
+    }
+
+    if (hasConsole) {
+      console.error('[Hook] Remove console.log statements before committing');
+    }
+  } catch (error) {
+    // Silently ignore errors (git might not be available, etc.)
+  }
+
+  // Always output the original data
+  console.log(data);
+});


### PR DESCRIPTION
## Description
Fixes #78 

This PR resolves the shell syntax error that occurs when the Stop hook executes on macOS/zsh.

## Problem
The Stop hook in `hooks/hooks.json` (line 140) used inline JavaScript code with `node -e`, which caused shell syntax errors due to special characters being misinterpreted:

```
/bin/sh: -c: line 0: syntax error near unexpected token `('
```

This affected all macOS users (zsh is the default shell) and caused error messages on every command execution.

## Solution
- ✅ Created `scripts/hooks/check-console-log.js` - a separate, well-documented script file
- ✅ Updated `hooks/hooks.json` to reference the external script using `${CLAUDE_PLUGIN_ROOT}`
- ✅ Added proper documentation and error handling
- ✅ Made the script executable

## Changes
1. **New file**: `scripts/hooks/check-console-log.js`
   - Extracts the inline logic into a maintainable script
   - Includes proper JSDoc comments
   - Better error handling
   - Easier to test and debug

2. **Updated**: `hooks/hooks.json`
   - Changed from inline `node -e "..."` to `node "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/check-console-log.js"`
   - Now follows the same pattern as all other hooks in the plugin

## Benefits
- ✅ Fixes cross-shell compatibility issues (bash, zsh, etc.)
- ✅ Improves code maintainability
- ✅ Follows plugin's own best practices (consistent with other hooks)
- ✅ Makes the code easier to test and debug
- ✅ Better documentation

## Testing
- ✅ Tested on macOS 15.2 with zsh - no syntax errors
- ✅ Hook still correctly detects `console.log` statements in modified files
- ✅ Works both inside and outside git repositories
- ✅ Proper error handling when git commands fail

## Comparison with Other Hooks
This change makes the Stop hook consistent with the rest of the plugin:

**Before** (problematic):
```json
"command": "node -e \"const{execSync}=require('child_process');...\""
```

**After** (consistent with other hooks):
```json
"command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/check-console-log.js\""
```

Same pattern as:
- Line 50: `suggest-compact.js`
- Line 62: `pre-compact.js`
- Line 74: `session-start.js`
- Line 152: `session-end.js`
- Line 162: `evaluate-session.js`

## Checklist
- [x] Code follows the project's existing patterns
- [x] Tested on the affected platform (macOS/zsh)
- [x] No breaking changes
- [x] Documentation added (JSDoc comments)
- [x] Fixes the reported issue

---

Thank you for creating this awesome plugin! This fix should improve the experience for all macOS users. 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development tooling by reorganizing pre-commit hook checks for code quality validation. Moved hook logic to a dedicated script for better maintainability while preserving the same validation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->