### PR TITLE
docs: add note about rules limitation in plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ Or add directly to your `~/.claude/settings.json`:
 
 This gives you instant access to all commands, agents, skills, and hooks.
 
+> **Note:** The Claude Code plugin system does not support distributing `rules` via plugins ([upstream limitation](https://code.claude.com/docs/en/plugins-reference)). You need to install rules manually:
+>
+> ```bash
+> # Clone the repo first
+> git clone https://github.com/affaan-m/everything-claude-code.git
+>
+> # Option A: User-level rules (applies to all projects)
+> cp -r everything-claude-code/rules/* ~/.claude/rules/
+>
+> # Option B: Project-level rules (applies to current project only)
+> mkdir -p .claude/rules
+> cp -r everything-claude-code/rules/* .claude/rules/
+> ```
+
 ---
 
 ### Option 2: Manual Installation


### PR DESCRIPTION
## Summary

- Added a note to the "Option 1: Install as Plugin" section explaining that the Claude Code plugin system does not support distributing `rules` via plugins
- Provided clear manual installation steps for rules (both user-level and project-level options)
- Links to the official plugin reference documentation

## Related Issue

Closes #88

## Test plan

- [x] README renders correctly with the new blockquote and code block
- [x] Links to plugin reference documentation are valid

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification explaining that rules cannot be distributed via plugins
  * Added step-by-step installation instructions for setting up rules at both user-level and project-level
  * Provided guidance on cloning and copying rule files to the appropriate directories

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->