### PR TITLE
fix: prevent command injection in Prettier hook (Found when analyzing code)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -105,7 +105,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){try{execSync('npx prettier --write \"'+p+'\"',{stdio:['pipe','pipe','pipe']})}catch(e){}}console.log(d)})\""
+            "command": "node -e \"const{execFileSync}=require('child_process');const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){try{execFileSync('npx',['prettier','--write',p],{stdio:['pipe','pipe','pipe']})}catch(e){}}console.log(d)})\""
           }
         ],
         "description": "Auto-format JS/TS files with Prettier after edits"


### PR DESCRIPTION
This fixes a potential command injection vulnerability. The old code concatenated the file path directly into a shell command string, meaning a malicious file path with shell metacharacters could execute arbitrary commands. The new code uses execFileSync with an array of arguments, which bypasses the shell and treats the path as a literal string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Prettier auto-format hook execution mechanism for better stability and reliability while maintaining the same functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->