### PR TITLE
fix: correct markdown code block syntax in go-test.md

### DIFF
--- a/commands/go-test.md
+++ b/commands/go-test.md
@@ -35,7 +35,7 @@ REPEAT  → Next test case
 
 ## Example Session
 
-````md
+````
 User: /go-test I need a function to validate email addresses
 
 Agent:


### PR DESCRIPTION
## Description
  Fix nested code block rendering in go-test.md.

  Problem

  When displaying content that contains code blocks within a Markdown code block, the outer wrapper must use more backticks (4+) than the inner ones. Previously using only 3 backticks for the    
  outer block caused the parser to terminate at the first inner ```, resulting in broken formatting.

  Solution

  - Changed outer code block delimiter from ```text to ```` (4 backticks)
  - This ensures proper rendering of nested code block examples

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Checklist
- [ ] Tests pass locally (`node tests/run-all.js`)
- [ ] Validation scripts pass
- [ ] Follows conventional commits format
- [ ] Updated relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated markdown fenced code blocks in the Example Session and TDD Complete! sections for consistent formatting; no functional changes to code, APIs, or public declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->