### PR TITLE
fix: preserve content after frontmatter in parse_instinct_file()

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -50,13 +50,8 @@ def parse_instinct_file(content: str) -> list[dict]:
     for line in content.split('\n'):
         if line.strip() == '---':
             if in_frontmatter:
-                # End of frontmatter
+                # End of frontmatter - content comes next, don't append yet
                 in_frontmatter = False
-                if current:
-                    current['content'] = '\n'.join(content_lines).strip()
-                    instincts.append(current)
-                    current = {}
-                    content_lines = []
             else:
                 # Start of frontmatter
                 in_frontmatter = True

--- a/skills/continuous-learning-v2/scripts/test_parse_instinct.py
+++ b/skills/continuous-learning-v2/scripts/test_parse_instinct.py
@@ -1,0 +1,82 @@
+"""Tests for parse_instinct_file() — verifies content after frontmatter is preserved."""
+
+import importlib.util
+import os
+
+# Load instinct-cli.py (hyphenated filename requires importlib)
+_spec = importlib.util.spec_from_file_location(
+    "instinct_cli",
+    os.path.join(os.path.dirname(__file__), "instinct-cli.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+parse_instinct_file = _mod.parse_instinct_file
+
+
+MULTI_SECTION = """\
+---
+id: instinct-a
+trigger: "when coding"
+confidence: 0.9
+domain: general
+---
+
+## Action
+Do thing A.
+
+## Examples
+- Example A1
+
+---
+id: instinct-b
+trigger: "when testing"
+confidence: 0.7
+domain: testing
+---
+
+## Action
+Do thing B.
+"""
+
+
+def test_multiple_instincts_preserve_content():
+    result = parse_instinct_file(MULTI_SECTION)
+    assert len(result) == 2
+    assert "Do thing A." in result[0]["content"]
+    assert "Example A1" in result[0]["content"]
+    assert "Do thing B." in result[1]["content"]
+
+
+def test_single_instinct_preserves_content():
+    content = """\
+---
+id: solo
+trigger: "when reviewing"
+confidence: 0.8
+domain: review
+---
+
+## Action
+Check for security issues.
+
+## Evidence
+Prevents vulnerabilities.
+"""
+    result = parse_instinct_file(content)
+    assert len(result) == 1
+    assert "Check for security issues." in result[0]["content"]
+    assert "Prevents vulnerabilities." in result[0]["content"]
+
+
+def test_empty_content_no_error():
+    content = """\
+---
+id: empty
+trigger: "placeholder"
+confidence: 0.5
+domain: general
+---
+"""
+    result = parse_instinct_file(content)
+    assert len(result) == 1
+    assert result[0]["content"] == ""


### PR DESCRIPTION
## Summary

- `parse_instinct_file()` appended the instinct and reset state when frontmatter ended (`---`), **before** content lines could be collected — causing silent data loss of Action, Evidence, Examples sections during import.
- Fix: only set `in_frontmatter = False` at frontmatter close; defer append to next frontmatter start or EOF, where the logic already exists.
- Added pytest test covering multi-section instincts, single instinct, and empty content edge case.

Fixes #148

## Reproduction

```python
from parse_instinct_file import ...

content = """
---
id: test-1
trigger: "when coding"
confidence: 0.9
---

## Action
Always write tests first.

## Evidence
TDD improves quality.
"""

# Before fix: [{'id': 'test-1', 'content': ''}]
# After fix:  [{'id': 'test-1', 'content': '## Action\nAlways write tests first.\n\n## Evidence\nTDD improves quality.'}]
```

## Test plan

- [x] `pytest skills/continuous-learning-v2/scripts/test_parse_instinct.py -v` — 3 passed
- [x] Manual verification with multi-instinct file — all content preserved
- [x] Empty content edge case — no error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontmatter parsing to correctly handle instinct boundary processing and content finalization

* **Tests**
  * Added comprehensive unit tests for instinct parsing covering multiple instincts, single instinct, and empty content scenarios to ensure parsing reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->