### PR TITLE
fix: preserve directory structure in installation to prevent file overwrites

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# install.sh — Install claude rules while preserving directory structure.
+#
+# Usage:
+#   ./install.sh <language> [<language> ...]
+#
+# Examples:
+#   ./install.sh typescript
+#   ./install.sh typescript python golang
+#
+# This script copies rules into ~/.claude/rules/ keeping the common/ and
+# language-specific subdirectories intact so that:
+#   1. Files with the same name in common/ and <language>/ don't overwrite
+#      each other.
+#   2. Relative references (e.g. ../common/coding-style.md) remain valid.
+
+set -euo pipefail
+
+RULES_DIR="$(cd "$(dirname "$0")/rules" && pwd)"
+DEST_DIR="${CLAUDE_RULES_DIR:-$HOME/.claude/rules}"
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <language> [<language> ...]"
+    echo ""
+    echo "Available languages:"
+    for dir in "$RULES_DIR"/*/; do
+        name="$(basename "$dir")"
+        [[ "$name" == "common" ]] && continue
+        echo "  - $name"
+    done
+    exit 1
+fi
+
+# Always install common rules
+echo "Installing common rules -> $DEST_DIR/common/"
+mkdir -p "$DEST_DIR/common"
+cp -r "$RULES_DIR/common/." "$DEST_DIR/common/"
+
+# Install each requested language
+for lang in "$@"; do
+    lang_dir="$RULES_DIR/$lang"
+    if [[ ! -d "$lang_dir" ]]; then
+        echo "Warning: rules/$lang/ does not exist, skipping." >&2
+        continue
+    fi
+    echo "Installing $lang rules -> $DEST_DIR/$lang/"
+    mkdir -p "$DEST_DIR/$lang"
+    cp -r "$lang_dir/." "$DEST_DIR/$lang/"
+done
+
+echo "Done. Rules installed to $DEST_DIR/"

--- a/rules/README.md
+++ b/rules/README.md
@@ -25,17 +25,36 @@ rules/
 
 ## Installation
 
+### Option 1: Install Script (Recommended)
+
+```bash
+# Install common + one or more language-specific rule sets
+./install.sh typescript
+./install.sh python
+./install.sh golang
+
+# Install multiple languages at once
+./install.sh typescript python
+```
+
+### Option 2: Manual Installation
+
+> **Important:** Copy entire directories — do NOT flatten with `/*`.
+> Common and language-specific directories contain files with the same names.
+> Flattening them into one directory causes language-specific files to overwrite
+> common rules, and breaks the relative `../common/` references used by
+> language-specific files.
+
 ```bash
 # Install common rules (required for all projects)
-cp -r rules/common/* ~/.claude/rules/
+cp -r rules/common ~/.claude/rules/common
 
 # Install language-specific rules based on your project's tech stack
-cp -r rules/typescript/* ~/.claude/rules/
-cp -r rules/python/* ~/.claude/rules/
-cp -r rules/golang/* ~/.claude/rules/
+cp -r rules/typescript ~/.claude/rules/typescript
+cp -r rules/python ~/.claude/rules/python
+cp -r rules/golang ~/.claude/rules/golang
 
 # Attention ! ! ! Configure according to your actual project requirements; the configuration here is for reference only.
-
 ```
 
 ## Rules vs Skills


### PR DESCRIPTION
## Problem

Fixes #164.

The current installation instructions use `cp -r rules/common/* ~/.claude/rules/` followed by `cp -r rules/typescript/* ~/.claude/rules/`, which flattens all files into a single directory. Since `common/` and language-specific directories contain files with the same names (`coding-style.md`, `hooks.md`, `patterns.md`, `security.md`, `testing.md`), the later copy overwrites the common rules entirely.

Additionally, language-specific files contain relative references like `../common/coding-style.md` which break when everything is flattened into one directory.

## Solution

1. **Updated `rules/README.md`** — Installation instructions now copy entire subdirectories (`cp -r rules/common ~/.claude/rules/common`) instead of flattening their contents, preserving the directory structure and keeping relative references intact.

2. **Added `install.sh`** — A convenience script that automatically installs common rules alongside any requested language-specific rules:
   ```bash
   ./install.sh typescript
   ./install.sh typescript python golang
   ```

## Changes

- `rules/README.md` — Rewrote installation section with correct commands and added an explicit warning about not flattening directories.
- `install.sh` — New install script that handles directory creation and always includes common rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation script enabling automated deployment of rules across multiple language configurations.

* **Documentation**
  * Installation guide enhanced with recommended automated installation script and manual setup option for flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->