### PR TITLE
docs: fix README reference to non-existent opencode-ecc npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,13 +657,13 @@ opencode
 
 **Option 2: Install as npm package**
 ```bash
-npm install opencode-ecc
+⚠️ Note: opencode-ecc is referenced here but is not published on npm and cannot be installed.
 ```
 
 Then add to your `opencode.json`:
 ```json
 {
-  "plugin": ["opencode-ecc"]
+  // "plugin": ["opencode-ecc"]
 }
 ```
 


### PR DESCRIPTION
## Summary
Fixes incorrect README instructions that referenced a non-existent `opencode-ecc` npm package, which caused installation failures.

## Type
- [x] Documentation

## Testing
Verified by attempting `npm install opencode-ecc` and confirming the package does not exist on npm.

## Checklist
- [x] Follows format guidelines
- [x] No sensitive information included
- [x] Clear and minimal documentation fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation instructions to inform users that the OpenCode plugin is not available on npm and cannot be installed via the package manager.
  * Modified the example configuration to reflect the current plugin status by updating the opencode.json snippet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->