### PR TITLE
feat(agents): slim e2e-runner agent, extract patterns to e2e-testing skill

### DIFF
--- a/agents/e2e-runner.md
+++ b/agents/e2e-runner.md
@@ -11,68 +11,48 @@ You are an expert end-to-end testing specialist. Your mission is to ensure criti
 
 ## Primary Tool: Vercel Agent Browser
 
-**Prefer Agent Browser over raw Playwright** - It's optimized for AI agents with semantic selectors and better handling of dynamic content.
+**Prefer Agent Browser over raw Playwright** — it's optimized for AI agents with semantic selectors and better handling of dynamic content.
 
 ### Why Agent Browser?
-- **Semantic selectors** - Find elements by meaning, not brittle CSS/XPath
-- **AI-optimized** - Designed for LLM-driven browser automation
-- **Auto-waiting** - Intelligent waits for dynamic content
-- **Built on Playwright** - Full Playwright compatibility as fallback
+- **Semantic selectors** — find elements by meaning, not brittle CSS/XPath
+- **AI-optimized** — designed for LLM-driven browser automation
+- **Auto-waiting** — intelligent waits for dynamic content
+- **Built on Playwright** — full Playwright compatibility as fallback
 
 ### Agent Browser Setup
 ```bash
-# Install agent-browser globally
 npm install -g agent-browser
-
-# Install Chromium (required)
-agent-browser install
+agent-browser install  # Install Chromium
 ```
 
-### Agent Browser CLI Usage (Primary)
-
-Agent Browser uses a snapshot + refs system optimized for AI agents:
+### Agent Browser CLI Usage
 
 ```bash
-# Open a page and get a snapshot with interactive elements
+# Open page and get snapshot with interactive elements
 agent-browser open https://example.com
 agent-browser snapshot -i  # Returns elements with refs like [ref=e1]
 
-# Interact using element references from snapshot
-agent-browser click @e1                      # Click element by ref
-agent-browser fill @e2 "user@example.com"   # Fill input by ref
-agent-browser fill @e3 "password123"        # Fill password field
-agent-browser click @e4                      # Click submit button
-
-# Wait for conditions
-agent-browser wait visible @e5               # Wait for element
-agent-browser wait navigation                # Wait for page load
-
-# Take screenshots
+# Interact using element references
+agent-browser click @e1
+agent-browser fill @e2 "user@example.com"
+agent-browser wait visible @e5
+agent-browser wait navigation
 agent-browser screenshot after-login.png
-
-# Get text content
 agent-browser get text @e1
 ```
 
 ### Agent Browser in Scripts
 
-For programmatic control, use the CLI via shell commands:
-
 ```typescript
 import { execSync } from 'child_process'
 
-// Execute agent-browser commands
 const snapshot = execSync('agent-browser snapshot -i --json').toString()
 const elements = JSON.parse(snapshot)
-
-// Find element ref and interact
 execSync('agent-browser click @e1')
 execSync('agent-browser fill @e2 "test@example.com"')
 ```
 
 ### Programmatic API (Advanced)
-
-For direct browser control (screencasts, low-level events):
 
 ```typescript
 import { BrowserManager } from 'agent-browser'
@@ -81,16 +61,12 @@ const browser = new BrowserManager()
 await browser.launch({ headless: true })
 await browser.navigate('https://example.com')
 
-// Low-level event injection
 await browser.injectMouseEvent({ type: 'mousePressed', x: 100, y: 200, button: 'left' })
 await browser.injectKeyboardEvent({ type: 'keyDown', key: 'Enter', code: 'Enter' })
-
-// Screencast for AI vision
-await browser.startScreencast()  // Stream viewport frames
+await browser.startScreencast()
 ```
 
-### Agent Browser with Claude Code
-If you have the `agent-browser` skill installed, use `/agent-browser` for interactive browser automation tasks.
+If the `agent-browser` skill is installed, use `/agent-browser` for interactive browser automation.
 
 ---
 
@@ -98,700 +74,71 @@ If you have the `agent-browser` skill installed, use `/agent-browser` for intera
 
 When Agent Browser isn't available or for complex test suites, fall back to Playwright.
 
+### Key Commands
+```bash
+npx playwright test                          # Run all E2E tests
+npx playwright test tests/feature.spec.ts    # Run specific file
+npx playwright test --headed                 # See browser
+npx playwright test --debug                  # Debug with inspector
+npx playwright codegen http://localhost:3000 # Generate test code
+npx playwright test --trace on               # Run with trace
+npx playwright show-report                   # Show HTML report
+npx playwright test --update-snapshots       # Update snapshots
+npx playwright test --project=chromium       # Specific browser
+```
+
 ## Core Responsibilities
 
-1. **Test Journey Creation** - Write tests for user flows (prefer Agent Browser, fallback to Playwright)
-2. **Test Maintenance** - Keep tests up to date with UI changes
-3. **Flaky Test Management** - Identify and quarantine unstable tests
-4. **Artifact Management** - Capture screenshots, videos, traces
-5. **CI/CD Integration** - Ensure tests run reliably in pipelines
-6. **Test Reporting** - Generate HTML reports and JUnit XML
-
-## Playwright Testing Framework (Fallback)
-
-### Tools
-- **@playwright/test** - Core testing framework
-- **Playwright Inspector** - Debug tests interactively
-- **Playwright Trace Viewer** - Analyze test execution
-- **Playwright Codegen** - Generate test code from browser actions
-
-### Test Commands
-```bash
-# Run all E2E tests
-npx playwright test
-
-# Run specific test file
-npx playwright test tests/markets.spec.ts
-
-# Run tests in headed mode (see browser)
-npx playwright test --headed
-
-# Debug test with inspector
-npx playwright test --debug
-
-# Generate test code from actions
-npx playwright codegen http://localhost:3000
-
-# Run tests with trace
-npx playwright test --trace on
-
-# Show HTML report
-npx playwright show-report
-
-# Update snapshots
-npx playwright test --update-snapshots
-
-# Run tests in specific browser
-npx playwright test --project=chromium
-npx playwright test --project=firefox
-npx playwright test --project=webkit
-```
-
-## E2E Testing Workflow
-
-### 1. Test Planning Phase
-```
-a) Identify critical user journeys
-   - Authentication flows (login, logout, registration)
-   - Core features (market creation, trading, searching)
-   - Payment flows (deposits, withdrawals)
-   - Data integrity (CRUD operations)
-
-b) Define test scenarios
-   - Happy path (everything works)
-   - Edge cases (empty states, limits)
-   - Error cases (network failures, validation)
-
-c) Prioritize by risk
-   - HIGH: Financial transactions, authentication
-   - MEDIUM: Search, filtering, navigation
-   - LOW: UI polish, animations, styling
-```
-
-### 2. Test Creation Phase
-```
-For each user journey:
-
-1. Write test in Playwright
-   - Use Page Object Model (POM) pattern
-   - Add meaningful test descriptions
-   - Include assertions at key steps
-   - Add screenshots at critical points
-
-2. Make tests resilient
-   - Use proper locators (data-testid preferred)
-   - Add waits for dynamic content
-   - Handle race conditions
-   - Implement retry logic
-
-3. Add artifact capture
-   - Screenshot on failure
-   - Video recording
-   - Trace for debugging
-   - Network logs if needed
-```
-
-### 3. Test Execution Phase
-```
-a) Run tests locally
-   - Verify all tests pass
-   - Check for flakiness (run 3-5 times)
-   - Review generated artifacts
-
-b) Quarantine flaky tests
-   - Mark unstable tests as @flaky
-   - Create issue to fix
-   - Remove from CI temporarily
-
-c) Run in CI/CD
-   - Execute on pull requests
-   - Upload artifacts to CI
-   - Report results in PR comments
-```
-
-## Playwright Test Structure
-
-### Test File Organization
-```
-tests/
-├── e2e/                       # End-to-end user journeys
-│   ├── auth/                  # Authentication flows
-│   │   ├── login.spec.ts
-│   │   ├── logout.spec.ts
-│   │   └── register.spec.ts
-│   ├── markets/               # Market features
-│   │   ├── browse.spec.ts
-│   │   ├── search.spec.ts
-│   │   ├── create.spec.ts
-│   │   └── trade.spec.ts
-│   ├── wallet/                # Wallet operations
-│   │   ├── connect.spec.ts
-│   │   └── transactions.spec.ts
-│   └── api/                   # API endpoint tests
-│       ├── markets-api.spec.ts
-│       └── search-api.spec.ts
-├── fixtures/                  # Test data and helpers
-│   ├── auth.ts                # Auth fixtures
-│   ├── markets.ts             # Market test data
-│   └── wallets.ts             # Wallet fixtures
-└── playwright.config.ts       # Playwright configuration
-```
-
-### Page Object Model Pattern
-
-```typescript
-// pages/MarketsPage.ts
-import { Page, Locator } from '@playwright/test'
-
-export class MarketsPage {
-  readonly page: Page
-  readonly searchInput: Locator
-  readonly marketCards: Locator
-  readonly createMarketButton: Locator
-  readonly filterDropdown: Locator
-
-  constructor(page: Page) {
-    this.page = page
-    this.searchInput = page.locator('[data-testid="search-input"]')
-    this.marketCards = page.locator('[data-testid="market-card"]')
-    this.createMarketButton = page.locator('[data-testid="create-market-btn"]')
-    this.filterDropdown = page.locator('[data-testid="filter-dropdown"]')
-  }
-
-  async goto() {
-    await this.page.goto('/markets')
-    await this.page.waitForLoadState('networkidle')
-  }
-
-  async searchMarkets(query: string) {
-    await this.searchInput.fill(query)
-    await this.page.waitForResponse(resp => resp.url().includes('/api/markets/search'))
-    await this.page.waitForLoadState('networkidle')
-  }
-
-  async getMarketCount() {
-    return await this.marketCards.count()
-  }
-
-  async clickMarket(index: number) {
-    await this.marketCards.nth(index).click()
-  }
-
-  async filterByStatus(status: string) {
-    await this.filterDropdown.selectOption(status)
-    await this.page.waitForLoadState('networkidle')
-  }
-}
-```
-
-### Example Test with Best Practices
-
-```typescript
-// tests/e2e/markets/search.spec.ts
-import { test, expect } from '@playwright/test'
-import { MarketsPage } from '../../pages/MarketsPage'
-
-test.describe('Market Search', () => {
-  let marketsPage: MarketsPage
-
-  test.beforeEach(async ({ page }) => {
-    marketsPage = new MarketsPage(page)
-    await marketsPage.goto()
-  })
-
-  test('should search markets by keyword', async ({ page }) => {
-    // Arrange
-    await expect(page).toHaveTitle(/Markets/)
-
-    // Act
-    await marketsPage.searchMarkets('trump')
-
-    // Assert
-    const marketCount = await marketsPage.getMarketCount()
-    expect(marketCount).toBeGreaterThan(0)
-
-    // Verify first result contains search term
-    const firstMarket = marketsPage.marketCards.first()
-    await expect(firstMarket).toContainText(/trump/i)
-
-    // Take screenshot for verification
-    await page.screenshot({ path: 'artifacts/search-results.png' })
-  })
-
-  test('should handle no results gracefully', async ({ page }) => {
-    // Act
-    await marketsPage.searchMarkets('xyznonexistentmarket123')
-
-    // Assert
-    await expect(page.locator('[data-testid="no-results"]')).toBeVisible()
-    const marketCount = await marketsPage.getMarketCount()
-    expect(marketCount).toBe(0)
-  })
-
-  test('should clear search results', async ({ page }) => {
-    // Arrange - perform search first
-    await marketsPage.searchMarkets('trump')
-    await expect(marketsPage.marketCards.first()).toBeVisible()
-
-    // Act - clear search
-    await marketsPage.searchInput.clear()
-    await page.waitForLoadState('networkidle')
-
-    // Assert - all markets shown again
-    const marketCount = await marketsPage.getMarketCount()
-    expect(marketCount).toBeGreaterThan(10) // Should show all markets
-  })
-})
-```
-
-## Example Project-Specific Test Scenarios
-
-### Critical User Journeys for Example Project
-
-**1. Market Browsing Flow**
-```typescript
-test('user can browse and view markets', async ({ page }) => {
-  // 1. Navigate to markets page
-  await page.goto('/markets')
-  await expect(page.locator('h1')).toContainText('Markets')
-
-  // 2. Verify markets are loaded
-  const marketCards = page.locator('[data-testid="market-card"]')
-  await expect(marketCards.first()).toBeVisible()
-
-  // 3. Click on a market
-  await marketCards.first().click()
-
-  // 4. Verify market details page
-  await expect(page).toHaveURL(/\/markets\/[a-z0-9-]+/)
-  await expect(page.locator('[data-testid="market-name"]')).toBeVisible()
-
-  // 5. Verify chart loads
-  await expect(page.locator('[data-testid="price-chart"]')).toBeVisible()
-})
-```
-
-**2. Semantic Search Flow**
-```typescript
-test('semantic search returns relevant results', async ({ page }) => {
-  // 1. Navigate to markets
-  await page.goto('/markets')
-
-  // 2. Enter search query
-  const searchInput = page.locator('[data-testid="search-input"]')
-  await searchInput.fill('election')
-
-  // 3. Wait for API call
-  await page.waitForResponse(resp =>
-    resp.url().includes('/api/markets/search') && resp.status() === 200
-  )
-
-  // 4. Verify results contain relevant markets
-  const results = page.locator('[data-testid="market-card"]')
-  await expect(results).not.toHaveCount(0)
-
-  // 5. Verify semantic relevance (not just substring match)
-  const firstResult = results.first()
-  const text = await firstResult.textContent()
-  expect(text?.toLowerCase()).toMatch(/election|trump|biden|president|vote/)
-})
-```
-
-**3. Wallet Connection Flow**
-```typescript
-test('user can connect wallet', async ({ page, context }) => {
-  // Setup: Mock Privy wallet extension
-  await context.addInitScript(() => {
-    // @ts-ignore
-    window.ethereum = {
-      isMetaMask: true,
-      request: async ({ method }) => {
-        if (method === 'eth_requestAccounts') {
-          return ['0x1234567890123456789012345678901234567890']
-        }
-        if (method === 'eth_chainId') {
-          return '0x1'
-        }
-      }
-    }
-  })
-
-  // 1. Navigate to site
-  await page.goto('/')
-
-  // 2. Click connect wallet
-  await page.locator('[data-testid="connect-wallet"]').click()
-
-  // 3. Verify wallet modal appears
-  await expect(page.locator('[data-testid="wallet-modal"]')).toBeVisible()
-
-  // 4. Select wallet provider
-  await page.locator('[data-testid="wallet-provider-metamask"]').click()
-
-  // 5. Verify connection successful
-  await expect(page.locator('[data-testid="wallet-address"]')).toBeVisible()
-  await expect(page.locator('[data-testid="wallet-address"]')).toContainText('0x1234')
-})
-```
-
-**4. Market Creation Flow (Authenticated)**
-```typescript
-test('authenticated user can create market', async ({ page }) => {
-  // Prerequisites: User must be authenticated
-  await page.goto('/creator-dashboard')
-
-  // Verify auth (or skip test if not authenticated)
-  const isAuthenticated = await page.locator('[data-testid="user-menu"]').isVisible()
-  test.skip(!isAuthenticated, 'User not authenticated')
-
-  // 1. Click create market button
-  await page.locator('[data-testid="create-market"]').click()
-
-  // 2. Fill market form
-  await page.locator('[data-testid="market-name"]').fill('Test Market')
-  await page.locator('[data-testid="market-description"]').fill('This is a test market')
-  await page.locator('[data-testid="market-end-date"]').fill('2025-12-31')
-
-  // 3. Submit form
-  await page.locator('[data-testid="submit-market"]').click()
-
-  // 4. Verify success
-  await expect(page.locator('[data-testid="success-message"]')).toBeVisible()
-
-  // 5. Verify redirect to new market
-  await expect(page).toHaveURL(/\/markets\/test-market/)
-})
-```
-
-**5. Trading Flow (Critical - Real Money)**
-```typescript
-test('user can place trade with sufficient balance', async ({ page }) => {
-  // WARNING: This test involves real money - use testnet/staging only!
-  test.skip(process.env.NODE_ENV === 'production', 'Skip on production')
-
-  // 1. Navigate to market
-  await page.goto('/markets/test-market')
-
-  // 2. Connect wallet (with test funds)
-  await page.locator('[data-testid="connect-wallet"]').click()
-  // ... wallet connection flow
-
-  // 3. Select position (Yes/No)
-  await page.locator('[data-testid="position-yes"]').click()
-
-  // 4. Enter trade amount
-  await page.locator('[data-testid="trade-amount"]').fill('1.0')
-
-  // 5. Verify trade preview
-  const preview = page.locator('[data-testid="trade-preview"]')
-  await expect(preview).toContainText('1.0 SOL')
-  await expect(preview).toContainText('Est. shares:')
-
-  // 6. Confirm trade
-  await page.locator('[data-testid="confirm-trade"]').click()
-
-  // 7. Wait for blockchain transaction
-  await page.waitForResponse(resp =>
-    resp.url().includes('/api/trade') && resp.status() === 200,
-    { timeout: 30000 } // Blockchain can be slow
-  )
-
-  // 8. Verify success
-  await expect(page.locator('[data-testid="trade-success"]')).toBeVisible()
-
-  // 9. Verify balance updated
-  const balance = page.locator('[data-testid="wallet-balance"]')
-  await expect(balance).not.toContainText('--')
-})
-```
-
-## Playwright Configuration
-
-```typescript
-// playwright.config.ts
-import { defineConfig, devices } from '@playwright/test'
-
-export default defineConfig({
-  testDir: './tests/e2e',
-  fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: [
-    ['html', { outputFolder: 'playwright-report' }],
-    ['junit', { outputFile: 'playwright-results.xml' }],
-    ['json', { outputFile: 'playwright-results.json' }]
-  ],
-  use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
-    actionTimeout: 10000,
-    navigationTimeout: 30000,
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-    {
-      name: 'mobile-chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-  ],
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
-})
-```
-
-## Flaky Test Management
-
-### Identifying Flaky Tests
-```bash
-# Run test multiple times to check stability
-npx playwright test tests/markets/search.spec.ts --repeat-each=10
-
-# Run specific test with retries
-npx playwright test tests/markets/search.spec.ts --retries=3
-```
-
-### Quarantine Pattern
-```typescript
-// Mark flaky test for quarantine
-test('flaky: market search with complex query', async ({ page }) => {
-  test.fixme(true, 'Test is flaky - Issue #123')
-
-  // Test code here...
-})
-
-// Or use conditional skip
-test('market search with complex query', async ({ page }) => {
-  test.skip(process.env.CI, 'Test is flaky in CI - Issue #123')
-
-  // Test code here...
-})
-```
-
-### Common Flakiness Causes & Fixes
-
-**1. Race Conditions**
-```typescript
-// ❌ FLAKY: Don't assume element is ready
-await page.click('[data-testid="button"]')
-
-// ✅ STABLE: Wait for element to be ready
-await page.locator('[data-testid="button"]').click() // Built-in auto-wait
-```
-
-**2. Network Timing**
-```typescript
-// ❌ FLAKY: Arbitrary timeout
-await page.waitForTimeout(5000)
-
-// ✅ STABLE: Wait for specific condition
-await page.waitForResponse(resp => resp.url().includes('/api/markets'))
-```
-
-**3. Animation Timing**
-```typescript
-// ❌ FLAKY: Click during animation
-await page.click('[data-testid="menu-item"]')
-
-// ✅ STABLE: Wait for animation to complete
-await page.locator('[data-testid="menu-item"]').waitFor({ state: 'visible' })
-await page.waitForLoadState('networkidle')
-await page.click('[data-testid="menu-item"]')
-```
-
-## Artifact Management
-
-### Screenshot Strategy
-```typescript
-// Take screenshot at key points
-await page.screenshot({ path: 'artifacts/after-login.png' })
-
-// Full page screenshot
-await page.screenshot({ path: 'artifacts/full-page.png', fullPage: true })
-
-// Element screenshot
-await page.locator('[data-testid="chart"]').screenshot({
-  path: 'artifacts/chart.png'
-})
-```
-
-### Trace Collection
-```typescript
-// Start trace
-await browser.startTracing(page, {
-  path: 'artifacts/trace.json',
-  screenshots: true,
-  snapshots: true,
-})
-
-// ... test actions ...
-
-// Stop trace
-await browser.stopTracing()
-```
-
-### Video Recording
-```typescript
-// Configured in playwright.config.ts
-use: {
-  video: 'retain-on-failure', // Only save video if test fails
-  videosPath: 'artifacts/videos/'
-}
-```
-
-## CI/CD Integration
-
-### GitHub Actions Workflow
-```yaml
-# .github/workflows/e2e.yml
-name: E2E Tests
-
-on: [push, pull_request]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
-      - name: Run E2E tests
-        run: npx playwright test
-        env:
-          BASE_URL: https://staging.pmx.trade
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: playwright-results
-          path: playwright-results.xml
-```
-
-## Test Report Format
-
-```markdown
-# E2E Test Report
-
-**Date:** YYYY-MM-DD HH:MM
-**Duration:** Xm Ys
-**Status:** ✅ PASSING / ❌ FAILING
-
-## Summary
-
-- **Total Tests:** X
-- **Passed:** Y (Z%)
-- **Failed:** A
-- **Flaky:** B
-- **Skipped:** C
-
-## Test Results by Suite
-
-### Markets - Browse & Search
-- ✅ user can browse markets (2.3s)
-- ✅ semantic search returns relevant results (1.8s)
-- ✅ search handles no results (1.2s)
-- ❌ search with special characters (0.9s)
-
-### Wallet - Connection
-- ✅ user can connect MetaMask (3.1s)
-- ⚠️  user can connect Phantom (2.8s) - FLAKY
-- ✅ user can disconnect wallet (1.5s)
-
-### Trading - Core Flows
-- ✅ user can place buy order (5.2s)
-- ❌ user can place sell order (4.8s)
-- ✅ insufficient balance shows error (1.9s)
-
-## Failed Tests
-
-### 1. search with special characters
-**File:** `tests/e2e/markets/search.spec.ts:45`
-**Error:** Expected element to be visible, but was not found
-**Screenshot:** artifacts/search-special-chars-failed.png
-**Trace:** artifacts/trace-123.zip
-
-**Steps to Reproduce:**
-1. Navigate to /markets
-2. Enter search query with special chars: "trump & biden"
-3. Verify results
-
-**Recommended Fix:** Escape special characters in search query
+1. **Test Journey Creation** — write tests for user flows (prefer Agent Browser, fallback Playwright)
+2. **Test Maintenance** — keep tests up to date with UI changes
+3. **Flaky Test Management** — identify, quarantine, and fix unstable tests
+4. **Artifact Management** — capture screenshots, videos, traces on failure
+5. **CI/CD Integration** — ensure tests run reliably in pipelines
+6. **Test Reporting** — generate HTML reports and JUnit XML
+
+## Workflow
+
+### 1. Plan
+- Identify critical user journeys (auth, core features, payments, CRUD)
+- Define scenarios: happy path, edge cases, error cases
+- Prioritize by risk: HIGH (financial, auth), MEDIUM (search, nav), LOW (UI polish)
+
+### 2. Create
+- Use Page Object Model pattern (centralizes selectors)
+- Prefer `data-testid` selectors — resilient to styling changes
+- Wait for conditions, not time (`waitForResponse` over `waitForTimeout`)
+- Structure tests as Arrange-Act-Assert
+- Add screenshots at critical points
+
+### 3. Execute & Validate
+- Run locally first, check for flakiness (`--repeat-each=5`)
+- Quarantine flaky tests with `test.fixme()` and create issues
+- Guard production-unsafe tests with `test.skip(process.env.NODE_ENV === 'production')`
+- Upload artifacts to CI (screenshots, video, traces)
+
+## Key Principles
+
+- **One assertion per concern** — easier to diagnose failures
+- **No arbitrary waits** — wait for network, elements, or navigation instead
+- **Capture artifacts on failure** — configure `screenshot: 'only-on-failure'`, `video: 'retain-on-failure'`
+- **Parallel by default** — use `fullyParallel: true`, single worker in CI
+- **Retries in CI only** — `retries: process.env.CI ? 2 : 0`
+
+## Success Criteria
+
+After an E2E run:
+- All critical journeys passing (100%)
+- Overall pass rate > 95%
+- Flaky rate < 5%
+- No failed tests blocking deployment
+- Artifacts uploaded and accessible
+- Test duration < 10 minutes
+- HTML report generated
+
+## Reference
+
+For detailed Playwright patterns, Page Object Model examples, configuration templates, CI/CD workflows, and test report formats, see skill: `e2e-testing`.
 
 ---
 
-### 2. user can place sell order
-**File:** `tests/e2e/trading/sell.spec.ts:28`
-**Error:** Timeout waiting for API response /api/trade
-**Video:** artifacts/videos/sell-order-failed.webm
-
-**Possible Causes:**
-- Blockchain network slow
-- Insufficient gas
-- Transaction reverted
-
-**Recommended Fix:** Increase timeout or check blockchain logs
-
-## Artifacts
-
-- HTML Report: playwright-report/index.html
-- Screenshots: artifacts/*.png (12 files)
-- Videos: artifacts/videos/*.webm (2 files)
-- Traces: artifacts/*.zip (2 files)
-- JUnit XML: playwright-results.xml
-
-## Next Steps
-
-- [ ] Fix 2 failing tests
-- [ ] Investigate 1 flaky test
-- [ ] Review and merge if all green
-```
-
-## Success Metrics
-
-After E2E test run:
-- ✅ All critical journeys passing (100%)
-- ✅ Pass rate > 95% overall
-- ✅ Flaky rate < 5%
-- ✅ No failed tests blocking deployment
-- ✅ Artifacts uploaded and accessible
-- ✅ Test duration < 10 minutes
-- ✅ HTML report generated
-
----
-
-**Remember**: E2E tests are your last line of defense before production. They catch integration issues that unit tests miss. Invest time in making them stable, fast, and comprehensive. For Example Project, focus especially on financial flows - one bug could cost users real money.
+**E2E tests are your last line of defense before production. They catch integration issues that unit tests miss. Invest in making them stable, fast, and comprehensive.**

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: e2e-testing
+description: E2E testing patterns with Playwright — Page Object Model, test structure, flaky test management, configuration, CI/CD integration, and artifact handling.
+---
+
+# E2E Testing Patterns
+
+Practical patterns for building reliable end-to-end tests with Playwright. Covers test structure, Page Object Model, flaky test handling, configuration, CI/CD integration, and artifact management.
+
+## Test File Organization
+
+```
+tests/
+├── e2e/                       # End-to-end user journeys
+│   ├── auth/                  # Authentication flows
+│   │   ├── login.spec.ts
+│   │   ├── logout.spec.ts
+│   │   └── register.spec.ts
+│   ├── features/              # Core feature flows
+│   │   ├── browse.spec.ts
+│   │   ├── search.spec.ts
+│   │   └── create.spec.ts
+│   └── api/                   # API endpoint tests
+│       └── api.spec.ts
+├── fixtures/                  # Test data and helpers
+│   ├── auth.ts
+│   └── data.ts
+└── playwright.config.ts
+```
+
+## Page Object Model Pattern
+
+```typescript
+// pages/MarketsPage.ts
+import { Page, Locator } from '@playwright/test'
+
+export class MarketsPage {
+  readonly page: Page
+  readonly searchInput: Locator
+  readonly marketCards: Locator
+  readonly createMarketButton: Locator
+  readonly filterDropdown: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.searchInput = page.locator('[data-testid="search-input"]')
+    this.marketCards = page.locator('[data-testid="market-card"]')
+    this.createMarketButton = page.locator('[data-testid="create-market-btn"]')
+    this.filterDropdown = page.locator('[data-testid="filter-dropdown"]')
+  }
+
+  async goto() {
+    await this.page.goto('/markets')
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  async searchMarkets(query: string) {
+    await this.searchInput.fill(query)
+    await this.page.waitForResponse(resp => resp.url().includes('/api/search'))
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  async getMarketCount() {
+    return await this.marketCards.count()
+  }
+
+  async clickMarket(index: number) {
+    await this.marketCards.nth(index).click()
+  }
+
+  async filterByStatus(status: string) {
+    await this.filterDropdown.selectOption(status)
+    await this.page.waitForLoadState('networkidle')
+  }
+}
+```
+
+## Example Test with Best Practices
+
+```typescript
+import { test, expect } from '@playwright/test'
+import { MarketsPage } from '../../pages/MarketsPage'
+
+test.describe('Market Search', () => {
+  let marketsPage: MarketsPage
+
+  test.beforeEach(async ({ page }) => {
+    marketsPage = new MarketsPage(page)
+    await marketsPage.goto()
+  })
+
+  test('should search by keyword', async ({ page }) => {
+    // Arrange
+    await expect(page).toHaveTitle(/Markets/)
+
+    // Act
+    await marketsPage.searchMarkets('election')
+
+    // Assert
+    const count = await marketsPage.getMarketCount()
+    expect(count).toBeGreaterThan(0)
+    await expect(marketsPage.marketCards.first()).toContainText(/election/i)
+    await page.screenshot({ path: 'artifacts/search-results.png' })
+  })
+
+  test('should handle no results gracefully', async ({ page }) => {
+    await marketsPage.searchMarkets('xyznonexistent123')
+    await expect(page.locator('[data-testid="no-results"]')).toBeVisible()
+    expect(await marketsPage.getMarketCount()).toBe(0)
+  })
+})
+```
+
+## Common Test Scenarios
+
+### Browse & Navigate
+
+```typescript
+test('user can browse and view details', async ({ page }) => {
+  await page.goto('/markets')
+  const cards = page.locator('[data-testid="market-card"]')
+  await expect(cards.first()).toBeVisible()
+
+  await cards.first().click()
+  await expect(page).toHaveURL(/\/markets\/[a-z0-9-]+/)
+  await expect(page.locator('[data-testid="detail-name"]')).toBeVisible()
+})
+```
+
+### Wallet Connection (with mock)
+
+```typescript
+test('user can connect wallet', async ({ page, context }) => {
+  await context.addInitScript(() => {
+    window.ethereum = {
+      isMetaMask: true,
+      request: async ({ method }) => {
+        if (method === 'eth_requestAccounts') return ['0x1234...']
+        if (method === 'eth_chainId') return '0x1'
+      }
+    }
+  })
+
+  await page.goto('/')
+  await page.locator('[data-testid="connect-wallet"]').click()
+  await expect(page.locator('[data-testid="wallet-modal"]')).toBeVisible()
+  await page.locator('[data-testid="wallet-provider-metamask"]').click()
+  await expect(page.locator('[data-testid="wallet-address"]')).toContainText('0x1234')
+})
+```
+
+### Authenticated Actions
+
+```typescript
+test('authenticated user can create resource', async ({ page }) => {
+  await page.goto('/dashboard')
+  const isAuthenticated = await page.locator('[data-testid="user-menu"]').isVisible()
+  test.skip(!isAuthenticated, 'User not authenticated')
+
+  await page.locator('[data-testid="create-btn"]').click()
+  await page.locator('[data-testid="name-input"]').fill('Test Item')
+  await page.locator('[data-testid="submit"]').click()
+  await expect(page.locator('[data-testid="success-message"]')).toBeVisible()
+})
+```
+
+### Financial/Critical Flows
+
+```typescript
+test('user can place trade', async ({ page }) => {
+  test.skip(process.env.NODE_ENV === 'production', 'Skip on production')
+
+  await page.goto('/markets/test-market')
+  await page.locator('[data-testid="position-yes"]').click()
+  await page.locator('[data-testid="trade-amount"]').fill('1.0')
+
+  const preview = page.locator('[data-testid="trade-preview"]')
+  await expect(preview).toContainText('1.0')
+
+  await page.locator('[data-testid="confirm-trade"]').click()
+  await page.waitForResponse(
+    resp => resp.url().includes('/api/trade') && resp.status() === 200,
+    { timeout: 30000 }
+  )
+  await expect(page.locator('[data-testid="trade-success"]')).toBeVisible()
+})
+```
+
+## Flaky Test Patterns
+
+### Common Causes & Fixes
+
+**Race conditions:**
+```typescript
+// BAD: Don't assume element is ready
+await page.click('[data-testid="button"]')
+
+// GOOD: Use locator with built-in auto-wait
+await page.locator('[data-testid="button"]').click()
+```
+
+**Network timing:**
+```typescript
+// BAD: Arbitrary timeout
+await page.waitForTimeout(5000)
+
+// GOOD: Wait for specific condition
+await page.waitForResponse(resp => resp.url().includes('/api/data'))
+```
+
+**Animation timing:**
+```typescript
+// BAD: Click during animation
+await page.click('[data-testid="menu-item"]')
+
+// GOOD: Wait for stability
+await page.locator('[data-testid="menu-item"]').waitFor({ state: 'visible' })
+await page.waitForLoadState('networkidle')
+await page.locator('[data-testid="menu-item"]').click()
+```
+
+### Quarantine Pattern
+
+```typescript
+test('flaky: complex query search', async ({ page }) => {
+  test.fixme(true, 'Flaky - Issue #123')
+  // ...
+})
+
+test('conditional skip in CI', async ({ page }) => {
+  test.skip(process.env.CI, 'Flaky in CI - Issue #456')
+  // ...
+})
+```
+
+## Playwright Configuration
+
+```typescript
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['junit', { outputFile: 'playwright-results.xml' }],
+  ],
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10000,
+    navigationTimeout: 30000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+})
+```
+
+## Artifact Management
+
+```typescript
+// Screenshots
+await page.screenshot({ path: 'artifacts/after-login.png' })
+await page.screenshot({ path: 'artifacts/full-page.png', fullPage: true })
+await page.locator('[data-testid="chart"]').screenshot({ path: 'artifacts/chart.png' })
+
+// Trace collection
+await browser.startTracing(page, { path: 'artifacts/trace.json', screenshots: true, snapshots: true })
+// ... test actions ...
+await browser.stopTracing()
+```
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npx playwright test
+        env:
+          BASE_URL: ${{ vars.STAGING_URL }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+## Test Report Format
+
+```markdown
+# E2E Test Report
+
+**Date:** YYYY-MM-DD | **Duration:** Xm Ys | **Status:** PASSING / FAILING
+
+## Summary
+- Total: X | Passed: Y | Failed: A | Flaky: B | Skipped: C
+
+## Failed Tests
+### test-name
+- **File:** `tests/e2e/feature.spec.ts:45`
+- **Error:** Expected element to be visible
+- **Screenshot:** artifacts/failed.png
+
+## Artifacts
+- HTML Report: playwright-report/index.html
+- Screenshots: artifacts/*.png
+- Traces: artifacts/*.zip
+```
+
+## Best Practices
+
+- **Prefer `data-testid` selectors** — resilient to styling and text changes
+- **Use Page Object Model** — centralizes selectors, reduces duplication
+- **Wait for conditions, not time** — `waitForResponse` over `waitForTimeout`
+- **Arrange-Act-Assert** — clear test structure
+- **One assertion per concern** — easier to diagnose failures
+- **Skip production-unsafe tests** — guard financial flows with env checks
+- **Capture artifacts on failure** — screenshots, video, traces for debugging
+- **Run flaky detection** — `--repeat-each=10` before merging new tests
+
+## When to Use
+
+- Writing or maintaining Playwright E2E test suites
+- Setting up E2E infrastructure (config, CI/CD, reporting)
+- Debugging flaky tests or improving test reliability
+- Implementing Page Object Model for a new feature area


### PR DESCRIPTION
## Description
**What changed:**

**agents/e2e-runner.md:** 797 → 144 lines (-82%). Kept: Agent Browser docs (core identity), Playwright commands, workflow, principles, success criteria. Removed: all code examples, POM pattern, test scenarios, config, CI/CD YAML, report template.
**skills/e2e-testing/SKILL.md (new):** 356 lines. Contains all extracted patterns — POM, test examples, flaky test fixes, Playwright config, CI/CD workflow, artifact management, report template, best practices.

**What's preserved:**

Every code pattern from the original agent is in the skill
Agent still has all its behavioral instructions (workflow, principles, criteria)
The ## Reference section at the bottom links to skill: e2e-testing

**Approach:**

This approach aims to be a first attempt to solve this issue ([#174](https://github.com/affaan-m/everything-claude-code/issues/174)) on an initial agent. The plan is then to proceed in the same way on the next ones.
Requires a validated first iteration.

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [x] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Checklist
- [ ] Tests pass locally (`node tests/run-all.js`)
- [ ] Validation scripts pass
- [x] Follows conventional commits format
- [x] Updated relevant documentation
