### PR TITLE
feat: add dual-mode personal config (programming + writing)

### DIFF
--- a/agents/content-writer.md
+++ b/agents/content-writer.md
@@ -1,0 +1,72 @@
+---
+name: content-writer
+description: Bilingual content creation specialist for multi-platform publishing. Use when writing articles, posts, or threads for WeChat, Zhihu, Xiaohongshu, or Twitter/X. Handles original writing, cross-platform adaptation, and format compliance.
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+model: opus
+---
+
+You are a bilingual (Chinese/English) content creation specialist. You write original content and adapt existing content across platforms.
+
+## Your Role
+
+- Write original articles, posts, and threads in Chinese or English
+- Adapt content across platforms (WeChat, Zhihu, Xiaohongshu, Twitter/X)
+- Ensure platform-specific format compliance
+- Maintain consistent voice while adjusting for platform culture
+
+## Writing Process
+
+### 1. Topic Analysis
+
+- Understand the subject and target audience
+- Identify the core thesis (one idea per piece)
+- Determine which platform(s) to target
+- Research existing content if needed
+
+### 2. Outline Creation
+
+- Create a structured outline before writing
+- Present the outline to the user for confirmation
+- WAIT for user approval before proceeding to full draft
+
+### 3. Draft Writing
+
+- Write the full draft following platform specifications
+- Reference the `content-creation` skill for format requirements
+- Use the appropriate language for the target platform
+- Output content as inline text (not to files) unless user requests saving
+
+### 4. Platform Adaptation
+
+When adapting existing content to another platform:
+- Re-read the source material completely
+- Rewrite (not translate) for the target platform's culture
+- Adjust length, structure, and tone per platform specs
+- For Chinese-to-English: rewrite for Western audience context
+- For English-to-Chinese: rewrite with Chinese reader context
+
+## Platform Quick Reference
+
+| Platform | Language | Length | Tone |
+|----------|----------|--------|------|
+| WeChat (公众号) | Chinese | 1500-4000 chars | Professional, accessible |
+| Zhihu (知乎) | Chinese | 2000-6000 chars | Analytical, evidence-based |
+| Xiaohongshu (小红书) | Chinese | 300-1000 chars | Casual, relatable |
+| Twitter/X | English | 280/tweet, 5-15 thread | Concise, punchy |
+
+## Output Rules
+
+- Default output is inline text in the conversation
+- Only write to files when the user explicitly requests saving
+- When saving, use the project's `content/` directory or user-specified path
+- Always present the outline first and wait for confirmation before writing the full piece
+
+## Quality Checklist
+
+Before presenting content:
+- [ ] Follows platform format specifications
+- [ ] One clear core idea throughout
+- [ ] Claims supported by evidence or examples
+- [ ] Appropriate length for the platform
+- [ ] Correct language (Chinese or English)
+- [ ] Actionable takeaways for the reader

--- a/commands/adapt.md
+++ b/commands/adapt.md
@@ -1,0 +1,92 @@
+---
+description: Adapt existing content for a different platform. Rewrite articles/posts/threads across WeChat, Zhihu, Xiaohongshu, and Twitter/X with proper format and cultural adaptation.
+---
+
+# Adapt Command
+
+This command invokes the **content-writer** agent to adapt existing content for a different platform.
+
+## What This Command Does
+
+1. **Read Source Content** - Analyze the original piece
+2. **Plan Adaptation** - Determine what changes are needed for the target platform
+3. **Rewrite Content** - Produce a platform-native version (not a direct translation)
+4. **Output Result** - Present the adapted content inline
+
+## Supported Parameters
+
+- `--from` - Source platform: `wechat`, `zhihu`, `xiaohongshu`, `twitter` (auto-detected if content is provided)
+- `--to` - Target platform (required): `wechat`, `zhihu`, `xiaohongshu`, `twitter`
+
+## When to Use
+
+Use `/adapt` when:
+- You have existing content and want to publish on another platform
+- Converting a Chinese article to an English Twitter thread
+- Condensing a long-form piece into a short Xiaohongshu note
+- Expanding a Twitter thread into a full Zhihu analysis
+
+## Adaptation Matrix
+
+| From | To | What Changes |
+|------|----|--------------|
+| Zhihu | WeChat | Restructure for narrative flow, add visual breaks, soften academic tone |
+| Zhihu | Xiaohongshu | Extract 3-5 tips, rewrite casually, shorten to 300-1000 chars |
+| Zhihu/WeChat | Twitter | Rewrite in English, extract key insights, format as thread |
+| Twitter | Zhihu | Expand into full Chinese analysis, add sources and depth |
+| WeChat | Xiaohongshu | Extract core takeaways, casual rewrite, add formatting |
+| Xiaohongshu | WeChat | Expand with depth, add analysis, professional tone |
+
+## How It Works
+
+The content-writer agent will:
+
+1. **Read the source content** you provide (paste inline or reference a file)
+2. **Identify key ideas** and structure from the original
+3. **Rewrite for the target platform** following its format specs
+4. **Adjust language** if crossing Chinese/English boundary
+5. **Output the adapted version** inline
+
+## Example Usage
+
+```
+User: /adapt --to xiaohongshu
+[pastes a 3000-char Zhihu article about productivity tools]
+
+Agent (content-writer):
+# Adapted for Xiaohongshu (小红书)
+
+5个让我效率翻倍的工具
+
+1/5 Notion - 知识管理神器
+把所有笔记、项目、文档放在一个地方
+再也不用在10个app之间切换了
+
+2/5 Arc Browser - 浏览器革命
+...
+
+[300-800 chars, casual tone, structured as numbered tips]
+
+#效率工具 #生产力 #工具推荐 #自我提升 #职场干货
+```
+
+## Important Notes
+
+- Adaptation is rewriting, NOT translation
+- Each platform has its own culture and reader expectations
+- The core idea stays the same; the presentation changes completely
+- Provide the source content by pasting it or referencing a file path
+
+## Integration with Other Commands
+
+- Use `/write` first to create original content
+- Use `/adapt` to distribute across platforms
+- Recommended flow: Write deep (Zhihu) -> Adapt to WeChat -> Adapt to Xiaohongshu -> Adapt to Twitter
+
+## Related Agents
+
+This command invokes the `content-writer` agent located at:
+`~/.claude/agents/content-writer.md`
+
+And references the `content-creation` skill at:
+`~/.claude/skills/content-creation/`

--- a/commands/write.md
+++ b/commands/write.md
@@ -1,0 +1,85 @@
+---
+description: Start a content writing workflow. Generate outlines, write articles/posts/threads for WeChat, Zhihu, Xiaohongshu, or Twitter/X. WAIT for outline approval before writing full content.
+---
+
+# Write Command
+
+This command invokes the **content-writer** agent to create original content for social media platforms.
+
+## What This Command Does
+
+1. **Confirm Topic** - Clarify the subject, angle, and target platform
+2. **Generate Outline** - Create a structured outline for approval
+3. **Wait for Confirmation** - MUST receive user approval before writing
+4. **Write Full Content** - Produce the complete piece following platform specs
+
+## Supported Parameters
+
+- `--platform` - Target platform: `wechat`, `zhihu`, `xiaohongshu`, `twitter` (default: `wechat`)
+- `--type` - Content type: `article`, `answer`, `note`, `thread` (auto-detected from platform)
+- `--lang` - Language override: `zh`, `en` (default: platform native language)
+
+## When to Use
+
+Use `/write` when:
+- Creating a new article or post from scratch
+- Writing about a specific topic for a target platform
+- Starting the content creation workflow
+
+## How It Works
+
+The content-writer agent will:
+
+1. **Analyze the topic** and confirm the angle with you
+2. **Create an outline** with section headers and key points
+3. **Present the outline** and WAIT for your explicit confirmation
+4. **Write the full piece** following the target platform's format specs
+5. **Output as inline text** in the conversation (not to a file)
+
+## Example Usage
+
+```
+User: /write --platform zhihu How AI is changing software development
+
+Agent (content-writer):
+# Outline: AI is Changing Software Development
+
+Platform: Zhihu (知乎)
+Estimated length: 3000-4000 chars
+
+## Proposed Outline
+
+1. Opening: The current state of AI-assisted coding
+2. Three key shifts:
+   - From writing code to reviewing AI-generated code
+   - From debugging to prompt engineering
+   - From solo coding to human-AI pair programming
+3. Real examples from my experience
+4. What this means for junior developers
+5. Conclusion: Adapt or stagnate
+
+WAITING FOR CONFIRMATION: Proceed with this outline? (yes/modify)
+```
+
+## Important Notes
+
+**CRITICAL**: The agent will NOT write the full piece until you explicitly approve the outline.
+
+If you want changes, respond with:
+- "modify: [your changes]"
+- "add a section about [topic]"
+- "shorter, focus on [aspect]"
+
+## Integration with Other Commands
+
+After writing:
+- Use `/adapt` to repurpose content for other platforms
+- Content is output inline; ask to save if you need a file
+
+## Related Agents
+
+This command invokes the `content-writer` agent located at:
+`~/.claude/agents/content-writer.md`
+
+And references the `content-creation` skill at:
+`~/.claude/skills/content-creation/`

--- a/contexts/writing.md
+++ b/contexts/writing.md
@@ -1,0 +1,27 @@
+# Writing Context
+
+Mode: Content creation
+Focus: Multi-platform writing and adaptation
+
+## Behavior
+- Chinese by default unless targeting English platforms
+- Outline first, wait for confirmation, then write full content
+- Follow platform-specific format specs from content-creation skill
+- Output content inline, not to files, unless asked to save
+- One core idea per piece
+
+## Priorities
+1. Value and clarity
+2. Platform-native style
+3. Actionable takeaways
+
+## Tools to favor
+- Read for reviewing source material
+- Edit for revising drafts
+- Grep, Glob for finding reference content
+
+## Workflow
+1. Clarify topic and platform
+2. Present outline for approval
+3. Write full draft
+4. Adapt to other platforms if requested

--- a/examples/jessie-CLAUDE.md
+++ b/examples/jessie-CLAUDE.md
@@ -1,0 +1,146 @@
+# Jessie's CLAUDE.md
+
+Personal configuration for dual-mode workflow: programming and writing.
+
+---
+
+## Work Modes
+
+### Programming Mode (default)
+Full-stack development with Next.js, TypeScript, Supabase, and Vercel.
+
+### Writing Mode
+Multi-platform content creation for WeChat, Zhihu, Xiaohongshu, and Twitter/X.
+
+Switch context with `/context writing` or `/context dev`.
+
+---
+
+## Programming Rules
+
+### Code Organization
+- Many small files over few large files
+- 200-400 lines typical, 800 max per file
+- Organize by feature/domain, not by type
+- High cohesion, low coupling
+
+### Code Style
+- Immutability always - never mutate objects or arrays
+- No console.log in production code
+- Input validation with Zod
+- Proper error handling with try/catch
+- No emojis in code or comments
+
+### Testing
+- TDD: Write tests first, always
+- 80% minimum coverage
+- 100% for auth, payments, and core business logic
+- Unit + integration + E2E for critical flows
+
+### Security
+- No hardcoded secrets
+- Environment variables for sensitive data
+- Validate all user inputs
+- Parameterized queries only
+
+---
+
+## Writing Rules
+
+### Language
+- Chinese by default for WeChat, Zhihu, Xiaohongshu
+- English for Twitter/X
+- Cross-language adaptation is rewriting, not translation
+
+### Process
+- Outline first, wait for confirmation, then write
+- Follow platform format specs (see content-creation skill)
+- Output content inline unless asked to save to file
+
+### Quality
+- One core idea per piece
+- Evidence-based claims
+- Actionable takeaways for the reader
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js (App Router) |
+| Language | TypeScript (strict mode) |
+| Database | Supabase (PostgreSQL) |
+| Auth | Supabase Auth |
+| Hosting | Vercel |
+| Styling | Tailwind CSS |
+
+### File Structure
+
+```
+src/
+|-- app/              # Next.js app router
+|-- components/       # Reusable UI components
+|-- hooks/            # Custom React hooks
+|-- lib/              # Utility libraries
+|-- types/            # TypeScript definitions
+```
+
+---
+
+## Available Commands
+
+### Programming
+| Command | Purpose |
+|---------|---------|
+| `/plan` | Create implementation plan before coding |
+| `/tdd` | Test-driven development workflow |
+| `/code-review` | Review code for quality and security |
+| `/build-fix` | Resolve build errors |
+| `/learn` | Extract patterns from session |
+| `/evolve` | Improve agent configurations |
+| `/verify` | Run verification checks |
+| `/checkpoint` | Save progress checkpoint |
+
+### Writing
+| Command | Purpose |
+|---------|---------|
+| `/write` | Start content writing workflow |
+| `/adapt` | Adapt content for another platform |
+
+---
+
+## Available Agents
+
+| Agent | Purpose |
+|-------|---------|
+| planner | Feature implementation planning |
+| architect | System design and architecture |
+| code-reviewer | Code review for quality and security |
+| build-error-resolver | Build error resolution |
+| tdd-guide | Test-driven development |
+| content-writer | Multi-platform content creation |
+
+---
+
+## Personal Preferences
+
+### Privacy
+- Never paste secrets, API keys, tokens, passwords, or JWTs
+- Redact logs before sharing
+- Review output before sharing externally
+
+### Communication
+- Reply in Chinese unless the context is English
+- Be concise; skip unnecessary explanations
+- When in doubt, ask before acting
+
+### Git
+- Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`
+- Small, focused commits
+- Never commit to main directly
+- Test locally before committing
+
+---
+
+**Philosophy**: Plan before code, test before implementation, outline before writing. Use the right agent for the job.

--- a/examples/jessie-mcp-servers.json
+++ b/examples/jessie-mcp-servers.json
@@ -1,0 +1,38 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT_HERE"
+      },
+      "description": "GitHub operations - PRs, issues, repos"
+    },
+    "supabase": {
+      "command": "npx",
+      "args": ["-y", "@supabase/mcp-server-supabase@latest", "--project-ref=YOUR_PROJECT_REF"],
+      "description": "Supabase database operations"
+    },
+    "vercel": {
+      "type": "http",
+      "url": "https://mcp.vercel.com",
+      "description": "Vercel deployments and projects"
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@context7/mcp-server"],
+      "description": "Live documentation lookup"
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "description": "Persistent memory across sessions"
+    }
+  },
+  "_comments": {
+    "usage": "Copy to your ~/.claude.json mcpServers section",
+    "env_vars": "Replace YOUR_*_HERE placeholders with actual values",
+    "philosophy": "Minimal set: code collaboration (github), database (supabase), deployment (vercel), docs (context7), memory (memory)",
+    "context_warning": "5 MCPs keeps context window usage low"
+  }
+}

--- a/skills/content-creation/SKILL.md
+++ b/skills/content-creation/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: content-creation
+description: Multi-platform content creation knowledge base for Chinese and English social media. Use when writing articles, posts, or threads for WeChat Official Account, Zhihu, Xiaohongshu, or Twitter/X. Provides format specs, style guides, and cross-platform adaptation strategies.
+---
+
+# Content Creation Skill
+
+Platform-specific writing guidelines for multi-platform content distribution.
+
+## Platform Specifications
+
+### 1. WeChat Official Account (公众号)
+
+**Format:**
+- Length: 1500-4000 characters
+- Format: Rich text (HTML-rendered)
+- Language: Chinese
+
+**Structure:**
+```
+Title (compelling, 15-30 chars)
+Lead paragraph (hook the reader in 2-3 sentences)
+Body sections (3-5 sections with subheadings)
+Conclusion (summary + call to action)
+```
+
+**Style Guidelines:**
+- Professional yet accessible tone
+- Deep analysis with real-world examples
+- Use section dividers for visual clarity
+- Include data and references where relevant
+- Avoid clickbait; provide genuine value
+- End with a question or call-to-action to drive engagement
+
+**Best Practices:**
+- Front-load key insights in the first paragraph
+- Use short paragraphs (2-3 sentences max)
+- Bold key phrases for scannability
+- One core idea per article
+
+---
+
+### 2. Zhihu (知乎)
+
+**Format:**
+- Length: 2000-6000 characters
+- Format: Markdown
+- Language: Chinese
+
+**Structure:**
+```
+Opening statement (direct answer or thesis)
+Background / Context
+Analysis (structured arguments with evidence)
+Examples / Case studies
+Counter-arguments or nuances
+Conclusion with key takeaways
+```
+
+**Style Guidelines:**
+- Analytical and evidence-based
+- First-person perspective welcome
+- Reference specific sources and data
+- Acknowledge complexity and nuance
+- Use numbered lists for structured arguments
+- Code blocks for technical content
+
+**Best Practices:**
+- Answer the question directly in the first paragraph
+- Use `> quote blocks` for key definitions
+- Structure long answers with clear `##` headings
+- Include personal experience when relevant
+- Be rigorous but avoid jargon overload
+
+---
+
+### 3. Xiaohongshu (小红书)
+
+**Format:**
+- Length: 300-1000 characters
+- Format: Short note with visual emphasis
+- Language: Chinese (casual)
+
+**Structure:**
+```
+Hook title (with relevant keywords)
+Key point 1
+Key point 2
+Key point 3
+Summary / Takeaway
+Tags
+```
+
+**Style Guidelines:**
+- Conversational and relatable tone
+- Use line breaks generously for readability
+- Strategic use of relevant punctuation and formatting
+- Personal experience and storytelling
+- Practical, actionable tips
+- Keep sentences short and punchy
+
+**Best Practices:**
+- Lead with the most valuable tip
+- Use numbered lists (1/2/3) for structure
+- End with relevant hashtags (5-10)
+- Focus on one specific topic per note
+- Write as if talking to a friend
+
+---
+
+### 4. Twitter/X
+
+**Format:**
+- Length: 280 characters per tweet
+- Format: Thread (5-15 tweets)
+- Language: English
+
+**Thread Structure:**
+```
+Tweet 1: Hook + promise (what reader will learn)
+Tweet 2-N: One key point per tweet
+Final tweet: Summary + CTA (follow/retweet/reply)
+```
+
+**Style Guidelines:**
+- Concise and punchy
+- Use line breaks within tweets for readability
+- One idea per tweet
+- End threads with a clear call-to-action
+- Use "1/" numbering for thread tweets
+
+**Best Practices:**
+- First tweet must hook within 50 characters
+- Add context before making claims
+- Use concrete examples over abstract statements
+- Quote-tweet relevant sources when citing
+- Space out threads; avoid tweet storms
+
+---
+
+## Cross-Platform Distribution Strategy
+
+### Content Cascade Model
+
+Write content in order of depth, then adapt downward:
+
+```
+Zhihu (deepest analysis, 2000-6000 chars)
+  -> WeChat (polished article, 1500-4000 chars)
+    -> Xiaohongshu (key takeaways, 300-1000 chars)
+    -> Twitter (English thread, 5-15 tweets)
+```
+
+### Adaptation Rules
+
+| From | To | Strategy |
+|------|----|----------|
+| Zhihu | WeChat | Restructure for narrative flow, add visual breaks, trim academic tone |
+| Zhihu | Xiaohongshu | Extract 3-5 actionable tips, rewrite casually, add formatting |
+| Zhihu/WeChat | Twitter | Translate to English, extract key insights, one per tweet |
+| Twitter | Zhihu | Expand thread into full analysis with sources |
+
+### Language Handling
+
+- Chinese platforms (WeChat, Zhihu, Xiaohongshu): Write natively in Chinese
+- English platforms (Twitter/X): Write natively in English
+- Cross-language adaptation is NOT direct translation; rewrite for the target audience
+
+---
+
+## Content Quality Principles
+
+1. **Value First**: Every piece must teach, inform, or inspire
+2. **One Core Idea**: Each content piece centers on a single thesis
+3. **Evidence-Based**: Support claims with data, examples, or experience
+4. **Platform-Native**: Write for each platform's culture, not just format
+5. **Authentic Voice**: Maintain a consistent personal perspective
+6. **Actionable**: Readers should know what to do after reading


### PR DESCRIPTION
## Summary

- Add content creation modules for multi-platform publishing (WeChat, Zhihu, Xiaohongshu, Twitter/X) alongside existing dev workflow
- New skill (`content-creation`), agent (`content-writer`), commands (`/write`, `/adapt`), and writing context
- Personal `jessie-CLAUDE.md` with dual-mode setup and minimal 5-server MCP config

## New Files (7)

| File | Purpose |
|------|---------|
| `skills/content-creation/SKILL.md` | Platform format specs, style guides, cross-platform distribution strategy |
| `agents/content-writer.md` | Bilingual (CN/EN) content creation agent (opus model) |
| `commands/write.md` | `/write` command — start content writing workflow |
| `commands/adapt.md` | `/adapt` command — cross-platform content adaptation |
| `contexts/writing.md` | Writing mode context definition |
| `examples/jessie-mcp-servers.json` | Minimal MCP config (github, supabase, vercel, context7, memory) |
| `examples/jessie-CLAUDE.md` | Personal CLAUDE.md with programming + writing dual-mode |

## Test plan

- [x] All frontmatter follows repo YAML `---` conventions
- [x] All agent/command references in `jessie-CLAUDE.md` point to existing files
- [x] MCP JSON validates correctly
- [ ] Verify `/write` and `/adapt` commands invoke content-writer agent correctly
- [ ] Test cross-platform adaptation workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added write command for creating platform-specific content across WeChat, Zhihu, Xiaohongshu, and Twitter/X.
  * Added adapt command for repurposing content across multiple platforms.
  * Supports bilingual content creation (Chinese/English) with outline approval workflow.

* **Documentation**
  * Added comprehensive content creation guidelines and quality checklists.
  * Added example configuration files for workflow setup and platform integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->