### PR TITLE
docs(opencode): clarify OpenCode-specific usage

### DIFF
--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -36,6 +36,7 @@ After installation, the `ecc-install` CLI becomes available:
 
 ```bash
 npx ecc-install typescript
+```
 
 ### Option 2: Direct Use
 


### PR DESCRIPTION
## Description
Clarifies that .opencode/README.md is specific to OpenCode usage and not the npm-based installation path.

Adds a short notice at the top of the file to prevent confusion between:
	•	npm installation (npm install opencode-ecc)
	•	OpenCode plugin-based usage

This helps reduce onboarding friction and aligns documentation expectations.
## Type of Change
	•	fix: Bug fix
	•	feat: New feature
	•	refactor: Code refactoring
	•	docs: Documentation
	•	test: Tests
	•	chore: Maintenance/tooling
	•	ci: CI/CD changes

## Checklist
	•	Tests pass locally (node tests/run-all.js)
	•	Validation scripts pass
	•	Follows conventional commits format
	•	Updated relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation guide with an Installation Overview presenting two setup methods: npm package and direct repository clone.
  * Added detailed, step-by-step instructions and concrete command examples for both approaches, plus usage/configuration snippets and an expanded Features/usage section for running the tool directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->