### PR TITLE
fix: correct TIMESTAMP environment variable syntax in observe.sh

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -103,7 +103,8 @@ PARSED_OK=$(echo "$PARSED" | python3 -c "import json,sys; print(json.load(sys.st
 if [ "$PARSED_OK" != "True" ]; then
   # Fallback: log raw input for debugging
   timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  TIMESTAMP="$timestamp" echo "$INPUT_JSON" | python3 -c "
+  export TIMESTAMP="$timestamp"
+  echo "$INPUT_JSON" | python3 -c "
 import json, sys, os
 raw = sys.stdin.read()[:2000]
 print(json.dumps({'timestamp': os.environ['TIMESTAMP'], 'event': 'parse_error', 'raw': raw}))
@@ -124,7 +125,8 @@ fi
 # Build and write observation
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-TIMESTAMP="$timestamp" echo "$PARSED" | python3 -c "
+export TIMESTAMP="$timestamp"
+echo "$PARSED" | python3 -c "
 import json, sys, os
 
 parsed = json.load(sys.stdin)


### PR DESCRIPTION
## Summary

- Fixed bash syntax error in `observe.sh` where `TIMESTAMP` environment variable was incorrectly set for piped commands
- Changed from `TIMESTAMP="$timestamp" echo ... | python3 -c "..."` to `export TIMESTAMP="$timestamp"` followed by separate `echo` command
- This ensures the environment variable is available to the python subprocess through `os.environ['TIMESTAMP']`

## Problem

The original syntax:
```bash
TIMESTAMP="$timestamp" echo "$INPUT_JSON" | python3 -c "..."
```

Does not work because:
1. The environment variable syntax `VAR=val command` only sets the variable for that specific command
2. The pipe (`|`) creates a subshell that doesn't inherit the variable
3. Python's `os.environ['TIMESTAMP']` throws `KeyError: 'TIMESTAMP'`

## Solution

```bash
export TIMESTAMP="$timestamp"
echo "$INPUT_JSON" | python3 -c "..."
```

Using `export` makes the variable available to all child processes, including the python subprocess.

## Test plan

- [ ] Verify bash script syntax: `bash -n observe.sh`
- [ ] Test with sample JSON input to confirm TIMESTAMP is accessible in Python
- [ ] Confirm observations are correctly written to observations.jsonl

Fixes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp handling in continuous learning observation logging to ensure timestamps are properly exported and accessible across subprocess environments.

* **Improvements**
  * Enhanced observation payloads to capture more comprehensive event details including tools, sessions, and conditional input/output information for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->