### PR TITLE
fix: whitelist .claude/plans/ in doc file creation hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING)\\.md$/.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(2)}}catch{}console.log(d)})\""
+            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING)\\.md$/.test(p)&&!/\\.claude\\/plans\\//.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(2)}}catch{}console.log(d)})\""
           }
         ],
         "description": "Block creation of random .md files - keeps docs consolidated"


### PR DESCRIPTION
## Summary

- The `PreToolUse:Write` hook that blocks unnecessary `.md` file creation also incorrectly blocks Claude Code's **plan mode** from writing plan files to `.claude/plans/*.md`
- This causes `[Hook] BLOCKED: Unnecessary documentation file creation` errors every time a plan is created or updated via plan mode
- Added `.claude/plans/` path to the whitelist regex so plan files are no longer blocked

## Reproduction

1. Install the plugin
2. Enter plan mode (`/plan` or `EnterPlanMode`)
3. Claude tries to write a plan file to `.claude/plans/<name>.md`
4. Hook blocks it with: `[Hook] BLOCKED: Unnecessary documentation file creation`

## Fix

Added `&&!/\\.claude\\/plans\\//.test(p)` to the condition in the doc file creation hook, alongside the existing whitelist for `README.md`, `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md`.

## Test plan

- [ ] Verify plan mode can create/update `.claude/plans/*.md` files without being blocked
- [ ] Verify random `.md` file creation is still blocked as expected
- [ ] Verify whitelisted files (README.md, CLAUDE.md, etc.) are still allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation file handling to properly allow plan files in designated directories while maintaining existing restrictions on other documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->