### PR TITLE
docs: clarify hook override limitation (issue #226)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -50,8 +50,9 @@ User request → Claude picks a tool → PreToolUse hook runs → Tool executes 
 
 ### Disabling a Hook
 
-Remove or comment out the hook entry in `hooks.json`. If installed as a plugin, override in your `~/.claude/settings.json`:
+Remove or comment out the hook entry in `hooks.json`. 
 
+> **Note:** Hook override via `~/.claude/settings.json` is **not currently supported** due to how Claude Code merges configuration files. The documented override mechanism (adding an entry with empty `hooks: []` array) does not work because configurations are merged rather than replaced. This is a limitation in Claude Code's core configuration system. See [Issue #226](https://github.com/affaan-m/everything-claude-code/issues/226) for details.
 ```json
 {
   "hooks": {


### PR DESCRIPTION
Update hooks/README.md to clarify that hook override via ~/.claude/settings.json is not currently supported.

The documented override mechanism (adding an entry with empty hooks: [] array) does not work because Claude Code merges configurations rather than replacing them. This is a limitation in Claude Code's core configuration system.

Adds a prominent note explaining this limitation and referencing issue #226.

Related: #226

## Description
<!-- Brief description of changes -->

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Checklist
- [ ] Tests pass locally (`node tests/run-all.js`)
- [ ] Validation scripts pass
- [ ] Follows conventional commits format
- [ ] Updated relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hooks README to clarify that hook override functionality via configuration files is not currently supported. A note was added explaining this limitation with reference to the related issue. The disabling hook guidance was revised accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->