### PR TITLE
feat(hooks): auto-detect formatter in post-edit hook (Biome/Prettier)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -108,7 +108,7 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/post-edit-format.js\""
           }
         ],
-        "description": "Auto-format JS/TS files with Prettier after edits"
+        "description": "Auto-format JS/TS files after edits (auto-detects Biome or Prettier)"
       },
       {
         "matcher": "Edit",


### PR DESCRIPTION
## Description

The `post-edit-format` hook was hardcoded to use Prettier. Projects using
Biome had their code silently reformatted with Prettier defaults (e.g.
single quotes → double quotes), causing unexpected diffs.

This change makes the hook auto-detect the project's formatter by walking
up the directory tree from the edited file and checking for config files:

- `biome.json` / `biome.jsonc` → Biome
- `.prettierrc` / `prettier.config.*` → Prettier
- Neither found → skip formatting silently

## Type of Change
- [x] `feat:` New feature

## Checklist
- [x] Tests pass locally (`node tests/run-all.js`)
- [x] Validation scripts pass
- [x] Follows conventional commits format
- [x] Updated relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-format hooks now support both Biome and Prettier, automatically detecting and applying whichever formatter your project is configured to use when formatting JavaScript and TypeScript files after edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->