### PR TITLE
chore: update Sonnet model references from 4.5 to 4.6

### DIFF
--- a/.cursor/rules/common-performance.md
+++ b/.cursor/rules/common-performance.md
@@ -12,7 +12,7 @@ alwaysApply: true
 - Pair programming and code generation
 - Worker agents in multi-agent systems
 
-**Sonnet 4.5** (Best coding model):
+**Sonnet 4.6** (Best coding model):
 - Main development work
 - Orchestrating multi-agent workflows
 - Complex coding tasks

--- a/examples/statusline.json
+++ b/examples/statusline.json
@@ -13,7 +13,7 @@
       "C": "Cyan - username, todos",
       "T": "Gray - model name"
     },
-    "output_example": "affoon:~/projects/myapp main* ctx:73% sonnet-4.5 14:30 todos:3",
+    "output_example": "affoon:~/projects/myapp main* ctx:73% sonnet-4.6 14:30 todos:3",
     "usage": "Copy the statusLine object to your ~/.claude/settings.json"
   }
 }

--- a/rules/common/performance.md
+++ b/rules/common/performance.md
@@ -7,7 +7,7 @@
 - Pair programming and code generation
 - Worker agents in multi-agent systems
 
-**Sonnet 4.5** (Best coding model):
+**Sonnet 4.6** (Best coding model):
 - Main development work
 - Orchestrating multi-agent workflows
 - Complex coding tasks

--- a/skills/cost-aware-llm-pipeline/SKILL.md
+++ b/skills/cost-aware-llm-pipeline/SKILL.md
@@ -21,7 +21,7 @@ Patterns for controlling LLM API costs while maintaining quality. Combines model
 Automatically select cheaper models for simple tasks, reserving expensive models for complex ones.
 
 ```python
-MODEL_SONNET = "claude-sonnet-4-5-20250929"
+MODEL_SONNET = "claude-sonnet-4-6"
 MODEL_HAIKU = "claude-haiku-4-5-20251001"
 
 _SONNET_TEXT_THRESHOLD = 10_000  # chars
@@ -155,7 +155,7 @@ def process(text: str, config: Config, tracker: CostTracker) -> tuple[Result, Co
 | Model | Input ($/1M tokens) | Output ($/1M tokens) | Relative Cost |
 |-------|---------------------|----------------------|---------------|
 | Haiku 4.5 | $0.80 | $4.00 | 1x |
-| Sonnet 4.5 | $3.00 | $15.00 | ~4x |
+| Sonnet 4.6 | $3.00 | $15.00 | ~4x |
 | Opus 4.5 | $15.00 | $75.00 | ~19x |
 
 ## Best Practices


### PR DESCRIPTION
## Summary
- Update `MODEL_SONNET` constant from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6` in cost-aware-llm-pipeline skill
- Update Sonnet version references in pricing table, performance rules, and statusline example

## Changed files
- `skills/cost-aware-llm-pipeline/SKILL.md` — model constant + pricing table
- `rules/common/performance.md` — model selection strategy
- `.claude/rules/common/performance.md` — model selection strategy (mirror)
- `examples/statusline.json` — output example

## Test plan
- [ ] Verify no remaining stale Sonnet 4.5 references in updated files
- [ ] Confirm existing tests still pass (`node tests/run-all.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation and examples to reference Sonnet 4.6 instead of Sonnet 4.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->