### PR TITLE
feat(commands): add skill-stocktake command

### DIFF
--- a/commands/skill-stocktake.md
+++ b/commands/skill-stocktake.md
@@ -102,14 +102,19 @@ Output the scores table:
 | Condition | Recommended Action |
 |-----------|-------------------|
 | origin: `ECC` | **Keep** if Freshness ≥ 3 or N/A; **Update** if Freshness ≤ 2 — do not modify other content |
-| origin: `auto-extracted` AND duplicates content in MEMORY.md | **Delete** — remove immediately |
+| origin: `auto-extracted` AND duplicates content in MEMORY.md | **Delete** — confirm with user, then remove |
+| Non-redundancy ≤ 2 | **Retire/Merge** — near-duplicate; delete or merge into existing skill |
+| Freshness = N/A AND 5-dim Total ≥ 17 AND usage present | **Keep** — maintain as-is |
+| Freshness = N/A AND 5-dim Total ≥ 17 AND zero usage | **Watch** — monitor until next audit |
+| Freshness = N/A AND 5-dim Total 13–16 | **Improve** — address lowest-scoring dimensions |
+| Freshness = N/A AND 5-dim Total < 13 | **Retire/Merge** — delete or merge into existing skill |
 | Total ≥ 20 AND Freshness ≥ 3 AND usage present | **Keep** — maintain as-is |
 | Total ≥ 20 AND Freshness ≥ 3 AND zero usage | **Watch** — monitor until next audit |
 | Freshness ≤ 2 | **Update** — refresh outdated content (takes priority over Improve/Retire) |
 | Total 15–19 | **Improve** — address lowest-scoring dimensions |
-| Total < 15 OR Non-redundancy ≤ 2 | **Retire/Merge** — delete or merge into existing skill |
+| Total < 15 | **Retire/Merge** — delete or merge into existing skill |
 
-> **Freshness = N/A handling:** When a skill has no technical elements (Freshness = N/A), display `N/A` in the Fresh column and calculate Total from the remaining 5 dimensions only (max 25). Skip the Freshness ≤ 2 and Freshness ≥ 3 conditions. Use adjusted thresholds: Keep ≥ 17 (with usage) / Watch ≥ 17 (zero usage), Improve 13–16, Retire/Merge < 13.
+> **Freshness = N/A:** When a skill has no technical elements, display `N/A` in the Fresh column and calculate Total from the remaining 5 dimensions only (max 25). The N/A-specific rows above use this 5-dimension total.
 
 ## Phase 4: Consolidation
 


### PR DESCRIPTION
> **Re-submission of #260** (closed due to broken fork relationship)

## Summary

- Adds `/skill-stocktake` command for auditing all installed skills with 6-dimension quality scoring
- Combines inventory, usage stats, quality evaluation, and consolidation decisions in one pass
- Supports ECC-sourced, auto-extracted, and original skills with appropriate triage rules

## Key design decisions

- **Freshness ≥ 3 guard on Keep/Watch**: prevents high-score stale skills from being held at Keep without Update
- **Freshness = N/A handling**: display `N/A`, calculate Total from 5 dimensions only (max 25), use proportionally adjusted thresholds (Keep ≥ 17, Improve 13–16, Retire/Merge < 13)
- **External-repo origin**: `origin: {org/repo}` receives full scoring like `origin: original`

## Test plan

- [ ] Walk through all 13 edge cases in the decision table
- [ ] High-total stale skill (Total 22, Fresh 1) → Update via Freshness ≤ 2 row
- [ ] N/A skill with 5-dim total 18 → Keep (adjusted threshold ≥ 17)
- [ ] N/A skill with 5-dim total 12 → Retire/Merge (adjusted threshold < 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Comprehensive Skill Audit workflow added: four-phase process covering inventory (global/project scopes), optional usage stats, a six-dimension quality rubric (Specificity, Actionability, Scope Fit, Non-redundancy, Coverage, Freshness), scoring and threshold-based decision rules (including special origin handling and Freshness=N/A), consolidation actions (retire/merge/improve/update), output artifacts (inventory and scores/decisions tables), and verification/sanity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->