### PR TITLE
fix(skills): add missing name frontmatter for search-first

### DIFF
--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: search-first
 description: Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.
 ---
 


### PR DESCRIPTION
## Summary
- add missing `name: search-first` frontmatter to `skills/search-first/SKILL.md`
- align skill metadata with the expected frontmatter shape used by other skills

## Description
Adds the missing `name` field in the `search-first` skill frontmatter.

## Type
- [x] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Testing
- `node scripts/ci/validate-skills.js`
- `npm test`

## Checklist
- [x] Tests pass locally (`node tests/run-all.js`)
- [x] Validation scripts pass
- [x] Follows conventional commits format
- [x] Updated relevant documentation
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->