### PR TITLE
fix: Add origin metadata to distributed skills for traceability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ skills/
 ---
 name: your-skill-name
 description: Brief description shown in skill list
+origin: ECC
 ---
 
 # Your Skill Title

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: api-design
 description: REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.
+origin: ECC
 ---
 
 # API Design Patterns

--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: backend-patterns
 description: Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes.
+origin: ECC
 ---
 
 # Backend Development Patterns

--- a/skills/clickhouse-io/SKILL.md
+++ b/skills/clickhouse-io/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: clickhouse-io
 description: ClickHouse database patterns, query optimization, analytics, and data engineering best practices for high-performance analytical workloads.
+origin: ECC
 ---
 
 # ClickHouse Analytics Patterns

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: coding-standards
 description: Universal coding standards, best practices, and patterns for TypeScript, JavaScript, React, and Node.js development.
+origin: ECC
 ---
 
 # Coding Standards & Best Practices

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: configure-ecc
 description: Interactive installer for Everything Claude Code — guides users through selecting and installing skills and rules to user-level or project-level directories, verifies paths, and optionally optimizes installed files.
+origin: ECC
 ---
 
 # Configure Everything Claude Code (ECC)

--- a/skills/content-hash-cache-pattern/SKILL.md
+++ b/skills/content-hash-cache-pattern/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: content-hash-cache-pattern
 description: Cache expensive file processing results using SHA-256 content hashes — path-independent, auto-invalidating, with service layer separation.
+origin: ECC
 ---
 
 # Content-Hash File Cache Pattern

--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: continuous-learning-v2
 description: Instinct-based learning system that observes sessions via hooks, creates atomic instincts with confidence scoring, and evolves them into skills/commands/agents.
+origin: ECC
 version: 2.0.0
 ---
 

--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: continuous-learning
 description: Automatically extract reusable patterns from Claude Code sessions and save them as learned skills for future use.
+origin: ECC
 ---
 
 # Continuous Learning Skill

--- a/skills/cost-aware-llm-pipeline/SKILL.md
+++ b/skills/cost-aware-llm-pipeline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cost-aware-llm-pipeline
 description: Cost optimization patterns for LLM API usage — model routing by task complexity, budget tracking, retry logic, and prompt caching.
+origin: ECC
 ---
 
 # Cost-Aware LLM Pipeline

--- a/skills/cpp-coding-standards/SKILL.md
+++ b/skills/cpp-coding-standards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cpp-coding-standards
 description: C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.
+origin: ECC
 ---
 
 # C++ Coding Standards (C++ Core Guidelines)

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cpp-testing
 description: Use only when writing/updating/fixing C++ tests, configuring GoogleTest/CTest, diagnosing failing or flaky tests, or adding coverage/sanitizers.
+origin: ECC
 ---
 
 # C++ Testing (Agent Skill)

--- a/skills/database-migrations/SKILL.md
+++ b/skills/database-migrations/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: database-migrations
 description: Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Django, TypeORM, golang-migrate).
+origin: ECC
 ---
 
 # Database Migration Patterns

--- a/skills/deployment-patterns/SKILL.md
+++ b/skills/deployment-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deployment-patterns
 description: Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications.
+origin: ECC
 ---
 
 # Deployment Patterns

--- a/skills/django-patterns/SKILL.md
+++ b/skills/django-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: django-patterns
 description: Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps.
+origin: ECC
 ---
 
 # Django Development Patterns

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: django-security
 description: Django security best practices, authentication, authorization, CSRF protection, SQL injection prevention, XSS prevention, and secure deployment configurations.
+origin: ECC
 ---
 
 # Django Security Best Practices

--- a/skills/django-tdd/SKILL.md
+++ b/skills/django-tdd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: django-tdd
 description: Django testing strategies with pytest-django, TDD methodology, factory_boy, mocking, coverage, and testing Django REST Framework APIs.
+origin: ECC
 ---
 
 # Django Testing with TDD

--- a/skills/django-verification/SKILL.md
+++ b/skills/django-verification/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: django-verification
 description: "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR."
+origin: ECC
 ---
 
 # Django Verification Loop

--- a/skills/docker-patterns/SKILL.md
+++ b/skills/docker-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docker-patterns
 description: Docker and Docker Compose patterns for local development, container security, networking, volume strategies, and multi-service orchestration.
+origin: ECC
 ---
 
 # Docker Patterns

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: e2e-testing
 description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.
+origin: ECC
 ---
 
 # E2E Testing Patterns

--- a/skills/eval-harness/SKILL.md
+++ b/skills/eval-harness/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: eval-harness
 description: Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles
+origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/frontend-patterns/SKILL.md
+++ b/skills/frontend-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-patterns
 description: Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices.
+origin: ECC
 ---
 
 # Frontend Development Patterns

--- a/skills/golang-patterns/SKILL.md
+++ b/skills/golang-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: golang-patterns
 description: Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.
+origin: ECC
 ---
 
 # Go Development Patterns

--- a/skills/golang-testing/SKILL.md
+++ b/skills/golang-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: golang-testing
 description: Go testing patterns including table-driven tests, subtests, benchmarks, fuzzing, and test coverage. Follows TDD methodology with idiomatic Go practices.
+origin: ECC
 ---
 
 # Go Testing Patterns

--- a/skills/iterative-retrieval/SKILL.md
+++ b/skills/iterative-retrieval/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: iterative-retrieval
 description: Pattern for progressively refining context retrieval to solve the subagent context problem
+origin: ECC
 ---
 
 # Iterative Retrieval Pattern

--- a/skills/java-coding-standards/SKILL.md
+++ b/skills/java-coding-standards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: java-coding-standards
 description: "Java coding standards for Spring Boot services: naming, immutability, Optional usage, streams, exceptions, generics, and project layout."
+origin: ECC
 ---
 
 # Java Coding Standards

--- a/skills/jpa-patterns/SKILL.md
+++ b/skills/jpa-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: jpa-patterns
 description: JPA/Hibernate patterns for entity design, relationships, query optimization, transactions, auditing, indexing, pagination, and pooling in Spring Boot.
+origin: ECC
 ---
 
 # JPA/Hibernate Patterns

--- a/skills/nutrient-document-processing/SKILL.md
+++ b/skills/nutrient-document-processing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nutrient-document-processing
 description: Process, convert, OCR, extract, redact, sign, and fill documents using the Nutrient DWS API. Works with PDFs, DOCX, XLSX, PPTX, HTML, and images.
+origin: ECC
 ---
 
 # Nutrient Document Processing

--- a/skills/postgres-patterns/SKILL.md
+++ b/skills/postgres-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: postgres-patterns
 description: PostgreSQL database patterns for query optimization, schema design, indexing, and security. Based on Supabase best practices.
+origin: ECC
 ---
 
 # PostgreSQL Patterns

--- a/skills/project-guidelines-example/SKILL.md
+++ b/skills/project-guidelines-example/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: project-guidelines-example
 description: "Example project-specific skill template based on a real production application."
+origin: ECC
 ---
 
 # Project Guidelines Skill (Example)

--- a/skills/python-patterns/SKILL.md
+++ b/skills/python-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: python-patterns
 description: Pythonic idioms, PEP 8 standards, type hints, and best practices for building robust, efficient, and maintainable Python applications.
+origin: ECC
 ---
 
 # Python Development Patterns

--- a/skills/python-testing/SKILL.md
+++ b/skills/python-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: python-testing
 description: Python testing strategies using pytest, TDD methodology, fixtures, mocking, parametrization, and coverage requirements.
+origin: ECC
 ---
 
 # Python Testing Patterns

--- a/skills/regex-vs-llm-structured-text/SKILL.md
+++ b/skills/regex-vs-llm-structured-text/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: regex-vs-llm-structured-text
 description: Decision framework for choosing between regex and LLM when parsing structured text — start with regex, add LLM only for low-confidence edge cases.
+origin: ECC
 ---
 
 # Regex vs LLM for Structured Text Parsing

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: search-first
 description: Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.
+origin: ECC
 ---
 
 # /search-first — Research Before You Code

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-review
 description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
+origin: ECC
 ---
 
 # Security Review Skill

--- a/skills/security-scan/SKILL.md
+++ b/skills/security-scan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-scan
 description: Scan your Claude Code configuration (.claude/ directory) for security vulnerabilities, misconfigurations, and injection risks using AgentShield. Checks CLAUDE.md, settings.json, MCP servers, hooks, and agent definitions.
+origin: ECC
 ---
 
 # Security Scan Skill

--- a/skills/skill-stocktake/SKILL.md
+++ b/skills/skill-stocktake/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation."
+origin: ECC
 ---
 
 # skill-stocktake

--- a/skills/springboot-patterns/SKILL.md
+++ b/skills/springboot-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: springboot-patterns
 description: Spring Boot architecture patterns, REST API design, layered services, data access, caching, async processing, and logging. Use for Java Spring Boot backend work.
+origin: ECC
 ---
 
 # Spring Boot Development Patterns

--- a/skills/springboot-security/SKILL.md
+++ b/skills/springboot-security/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: springboot-security
 description: Spring Security best practices for authn/authz, validation, CSRF, secrets, headers, rate limiting, and dependency security in Java Spring Boot services.
+origin: ECC
 ---
 
 # Spring Boot Security Review

--- a/skills/springboot-tdd/SKILL.md
+++ b/skills/springboot-tdd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: springboot-tdd
 description: Test-driven development for Spring Boot using JUnit 5, Mockito, MockMvc, Testcontainers, and JaCoCo. Use when adding features, fixing bugs, or refactoring.
+origin: ECC
 ---
 
 # Spring Boot TDD Workflow

--- a/skills/springboot-verification/SKILL.md
+++ b/skills/springboot-verification/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: springboot-verification
 description: "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR."
+origin: ECC
 ---
 
 # Spring Boot Verification Loop

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: strategic-compact
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction.
+origin: ECC
 ---
 
 # Strategic Compact Skill

--- a/skills/swift-actor-persistence/SKILL.md
+++ b/skills/swift-actor-persistence/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: swift-actor-persistence
 description: Thread-safe data persistence in Swift using actors — in-memory cache with file-backed storage, eliminating data races by design.
+origin: ECC
 ---
 
 # Swift Actors for Thread-Safe Persistence

--- a/skills/swift-protocol-di-testing/SKILL.md
+++ b/skills/swift-protocol-di-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: swift-protocol-di-testing
 description: Protocol-based dependency injection for testable Swift code — mock file system, network, and external APIs using focused protocols and Swift Testing.
+origin: ECC
 ---
 
 # Swift Protocol-Based Dependency Injection for Testing

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tdd-workflow
 description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
+origin: ECC
 ---
 
 # Test-Driven Development Workflow

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verification-loop
 description: "A comprehensive verification system for Claude Code sessions."
+origin: ECC
 ---
 
 # Verification Loop Skill


### PR DESCRIPTION
## Summary

Adds origin metadata to all distributed skills for improved traceability. Each skill now includes an `origin: ECC` field in its frontmatter, making it easy to identify where the skill came from and enabling better tracking when skills are shared or copied between projects.

## Issue

Fixes #246

## Changes

- Added `origin: ECC` metadata to frontmatter in all 45 skill files
- Updated CONTRIBUTING.md skill template to document the required `origin` field

## Testing

- Verified frontmatter syntax is valid YAML in all modified files
- Confirmed all 46 files contain the new origin field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation metadata across skill guides to include origin attribution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->