### PR TITLE
feat(agents): add chief-of-staff communication triage agent

### DIFF
--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -96,9 +96,9 @@ For each action_required message:
 2. **Relationships** — Append interaction to sender's section in `relationships.md`
 3. **Todo** — Update upcoming events table, mark completed items
 4. **Pending responses** — Set follow-up deadlines, remove resolved items
-5. **Git commit & push** — Version-control all knowledge file changes
-6. **Archive** — Remove processed message from inbox
-7. **Triage files** — Update LINE/Messenger draft status
+5. **Archive** — Remove processed message from inbox
+6. **Triage files** — Update LINE/Messenger draft status
+7. **Git commit & push** — Version-control all knowledge file changes
 
 This checklist is enforced by a `PostToolUse` hook that blocks completion until all steps are done. The hook intercepts `gmail send` / `conversations_add_message` and injects the checklist as a system reminder.
 


### PR DESCRIPTION
## Summary

- Adds `agents/chief-of-staff.md` — a personal communication agent that triages email, Slack, LINE, and Messenger through a 4-tier classification system (skip → info_only → meeting_info → action_required)
- Generates draft replies matching user tone via SOUL.md, enforces post-send follow-through (calendar/todo/relationships) via PostToolUse hooks
- First non-development agent in the collection — extends everything-claude-code into personal productivity

## Type

- [x] New Agent

## Testing

1. Copy `agents/chief-of-staff.md` to your workspace
2. Set up a Gmail CLI tool ([gog](https://github.com/pterm/gog) or similar)
3. Run `claude /mail` to triage unread email
4. Verify: skip-tier messages get archived, action-required messages get draft replies

Full setup with hooks, rules, autonomous execution, and all 5 channels: [ai-chief-of-staff](https://github.com/tomochang/ai-chief-of-staff)

## Checklist

- [x] Follows agent template (YAML frontmatter with name, description, tools, model)
- [x] Includes clear role definition and workflow steps
- [x] Self-contained but links to full repo for complete setup
- [x] Tested in production daily since January 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive chief-of-staff guide describing a personal multi-channel triage system (email, Slack, LINE, Messenger, calendar). Covers a 4-tier classification and priority rules, parallel fetch/classify workflow, per-tier actions, context- and relationship-aware draft replies, briefing output template, enforced post-send checklist, example modes/invocations, setup/deployment guidance, and core design principles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->