### PR TITLE
refactor(hooks): simplify post-edit-format with npxBin constant

### DIFF
--- a/scripts/hooks/post-edit-format.js
+++ b/scripts/hooks/post-edit-format.js
@@ -37,8 +37,8 @@ process.stdin.on('end', () => {
     if (filePath && JS_TS_EXT.test(filePath)) {
       const cwd = process.cwd();
 
-      // Walk up from cwd (max 4 levels) for monorepo support
-      const dirs = Array.from({ length: 5 }).reduce((acc) => {
+      // Walk up from cwd checking up to 4 ancestor levels for monorepo support
+      const dirs = Array.from({ length: 4 }).reduce((acc) => {
         const parent = path.dirname(acc.at(-1));
         return parent === acc.at(-1) ? acc : [...acc, parent];
       }, [cwd]);


### PR DESCRIPTION
## Summary
- Simplified `post-edit-format.js` by removing over-engineered `findProjectRoot()`, `detectFormatter()`, `getFormatterCommand()` functions
- Uses `process.cwd()` for Biome config detection instead of walking the directory tree
- Uses a simple `npxBin` constant instead of complex formatter command builder
- Removed `RUNNERS` map and `CLAUDE_PACKAGE_MANAGER` support (over-engineering)
- Removed related tests (Round 96) from `hooks.test.js`

Introduced by #252.

## Test plan
- [x] Biome path: tested with `hiddenmoney-admin-v2.5` project (biome.json present) — formats correctly
- [x] Prettier path: tested with project without biome.json — formats correctly
- [x] All tests pass (`node tests/run-all.js` — 995/996, 1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable formatting with a 15s enforced timeout and non-blocking error handling to avoid workflow stalls.
  * Improved JavaScript/TypeScript detection for accurate formatting.
  * Cross-platform formatter invocation for consistent behavior across environments.
  * Smarter formatter selection that prefers project-specific tooling when available, otherwise falls back to the standard formatter.
  * Monorepo-aware directory scanning for consistent results in nested repositories.
  * Safer input/output handling by parsing tool input and preserving original data in output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->