### PR TITLE
fix(hooks): cross-platform path normalization for .claude/plans/ detection (fixes #275)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\\.md$/i.test(p)&&!/\\.claude[\\/\\\\]plans[\\/\\\\]/.test(p)&&!/(^|[\\/\\\\])(docs|skills)[\\/\\\\]/.test(p)){console.error('[Hook] WARNING: Non-standard documentation file detected');console.error('[Hook] File: '+p);console.error('[Hook] Consider consolidating into README.md or docs/ directory')}}catch{}console.log(d)})\""
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d);const p=(i.tool_input?.file_path||'').replace(/\\\\/g,'/');if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\\.md$/i.test(p)&&!/\\.claude\\/plans\\//.test(p)&&!/(^|\\/)(docs|skills)\\//.test(p)){console.error('[Hook] WARNING: Non-standard documentation file detected');console.error('[Hook] File: '+p);console.error('[Hook] Consider consolidating into README.md or docs/ directory')}}catch{}console.log(d)})\""
           }
         ],
         "description": "Doc file warning: warn about non-standard documentation files (exit code 0; warns only)"


### PR DESCRIPTION
## Description

Fixes the Windows path compatibility issue in the `PreToolUse:Write` hook where `.claude/plans/` files were incorrectly blocked on Windows.

### Root Cause

The original regex `\.claude\/plans\/` only matches forward slashes. On Windows, paths use backslashes (e.g., `C:\Users\.claude\plans\file.md`), so the exclusion regex never matched and the hook blocked legitimate plan files.

### Solution

Replaced the character class `[\/\\]` regex approach (which caused invalid regex errors) with **path normalization**: before matching, all backslashes in the file path are replaced with forward slashes. This ensures cross-platform compatibility on both Windows and Unix-like systems.

```js
// Normalize path separators for cross-platform compatibility
const normalizedPath = filePath.replace(/\\/g, '/');
if (normalizedPath.includes('.claude/plans/')) { ... }
```

### Files Changed

- `hooks/hooks.json` — Updated `PreToolUse:Write` hook script to normalize path separators

## Type of Change

- [x] `fix:` Bug fix

## Testing

- [x] Existing CI tests pass
- [x] Fix validated against the `validate-hooks.js` test (was failing before)

## Notes

- Resolves #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling and documentation detection logic for enhanced cross-platform consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->