### PR TITLE
fix(continuous-learning-v2): observer background process crashes immediately

### DIFF
--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -157,7 +157,10 @@ case "${1:-start}" in
 
       cleanup() {
         [ -n "$SLEEP_PID" ] && kill "$SLEEP_PID" 2>/dev/null
-        rm -f "$PID_FILE"
+        # Only remove PID file if it still belongs to this process
+        if [ -f "$PID_FILE" ] && [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ]; then
+          rm -f "$PID_FILE"
+        fi
         exit 0
       }
       trap cleanup TERM INT


### PR DESCRIPTION
## Summary

The observer background process (`start-observer.sh`) crashes immediately after starting due to three independent bugs. This PR fixes all three and also fixes the Haiku prompt so that generated instinct files match the format expected by `instinct-cli.py`.

### Bug 1: Nested session detection
When launched from a Claude Code session, the child process inherits the `CLAUDECODE` env var, causing `claude` CLI to refuse with *"cannot be launched inside another Claude Code session"*.

**Fix:** `unset CLAUDECODE` in the background process.

### Bug 2: `set -e` kills the loop
The parent script's `set -e` is inherited by the subshell. When `claude` exits non-zero (e.g. max turns reached), the entire observer loop dies silently.

**Fix:** `set +e` in the background process.

### Bug 3: Subshell dies when parent exits
`( ... ) & disown` loses IO handles when the parent shell exits, killing the background process within seconds.

**Fix:** Use `nohup /bin/bash -c '...'` for full detachment, and `sleep & wait` pattern to allow SIGUSR1 to interrupt sleep without killing the process.

### Bonus: Inline instinct format in prompt
The previous prompt told Haiku to follow *"the format in the observer agent spec"*, but Haiku has no way to read `observer.md`. This resulted in free-form Markdown files that `instinct-cli.py` could not parse (missing YAML frontmatter / `id` field). The prompt now includes the exact format inline.

## Test plan

- [x] `start-observer.sh start` → process stays alive after 10+ seconds
- [x] `start-observer.sh status` → correctly reports running PID
- [x] `start-observer.sh stop` → cleanly stops the process
- [x] Observer survives parent shell exit
- [x] Observer survives `claude` CLI failures (non-zero exit)
- [x] Generated instinct files have correct YAML frontmatter format
- [x] `instinct-cli.py status` correctly parses generated files

## Related

- #295 (Windows observer hang — different root cause but same area)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes observer background process crashes and makes the service robust and signal-safe. Instinct generation now uses a strict YAML format and archives processed observations to prevent duplicates and reprocessing.

- **Bug Fixes**
  - Start via nohup with env-passed vars; interruptible sleep/wait; verify PID is alive on start.
  - Unset CLAUDECODE and disable set -e so claude failures don’t kill the loop.
  - Stronger process management: track/kill SLEEP_PID, USR1 handler clears pending sleep, USR1_FIRED prevents double runs, unified cleanup.
  - Guard PID file cleanup to avoid restart races; only remove if it belongs to the current process.

- **New Features**
  - Prompt inlines the exact instinct spec: mandatory YAML frontmatter (id/trigger/confidence/domain/source), allowed domains, confidence guidance, project/global scope, no code snippets, and update existing instead of duplicating.
  - Archive processed observations to observations.archive/ after analysis.

<sup>Written for commit e5fd15fdfe315cf6825ea8e0b1757c60009582d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Observer now runs as a fully detached background service with stronger startup validation, clearer success/failure messages, and refined timing/error handling.
  * More responsive, interruptible scheduling that avoids duplicate runs when manually triggered.

* **New Features**
  * Signal-triggered on-demand analysis that runs immediately without disrupting schedule.
  * Automatic archival of processed observations with timestamped filenames.
  * Stricter, expanded structured output for analysis results including required fields and an evidence block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->