### PR TITLE
fix(hooks): exclude .history/ directory from doc file warning

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\\.md$/i.test(p)&&!/\\.claude[\\/\\\\]plans[\\/\\\\]/.test(p)&&!/(^|[\\/\\\\])(docs|skills)[\\/\\\\]/.test(p)){console.error('[Hook] WARNING: Non-standard documentation file detected');console.error('[Hook] File: '+p);console.error('[Hook] Consider consolidating into README.md or docs/ directory')}}catch{}console.log(d)})\""
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\\.md$/i.test(p)&&!/\\.claude[\\/\\\\]plans[\\/\\\\]/.test(p)&&!/(^|[\\/\\\\])(docs|skills|\\.history)[\\/\\\\]/.test(p)){console.error('[Hook] WARNING: Non-standard documentation file detected');console.error('[Hook] File: '+p);console.error('[Hook] Consider consolidating into README.md or docs/ directory')}}catch{}console.log(d)})\""
           }
         ],
         "description": "Doc file warning: warn about non-standard documentation files (exit code 0; warns only)"


### PR DESCRIPTION
## Summary

- Add `.history/` directory to the exclusion pattern in the doc file warning hook
- The `.history/` directory is used for storing AI-generated planning and handoff documents (as defined in `commands/orchestrate.md`), but is not currently excluded, causing unnecessary warnings
- Change the regex from `(docs|skills)` to `(docs|skills|\.history)`

## Motivation

The Handoff Document workflow defined in `commands/orchestrate.md` stores AI-generated plans, designs, and handoff documents in the `.history/` directory. However, the doc file warning hook in `hooks.json` does not recognize this directory, triggering the following warning every time a `.md` or `.txt` file is written under `.history/`:

```
[Hook] WARNING: Non-standard documentation file detected
[Hook] File: .history/handoff-2025-01-15.md
[Hook] Consider consolidating into README.md or docs/ directory
```

These unnecessary warnings consume context tokens and degrade user experience.

## Changes

**`hooks/hooks.json`** (1 line change):
- Add `\.history` to the exclusion regex pattern
- JSON escaping: `\\.history` → JS string `\.history` → regex literal dot match

## Test plan

E2E tested by extracting the actual hook command from `hooks.json`, piping simulated tool input via `node -e`, and verifying stderr output:

### 1. JSON syntax check
- [x] `node -e "JSON.parse(require('fs').readFileSync('hooks/hooks.json','utf8'))"` succeeds

### 2. E2E hook command tests (10 patterns)

Excluded paths (no warning):
- [x] `.history/plan.md` → no warning
- [x] `project/.history/design.md` → no warning
- [x] `docs/guide.md` → no warning
- [x] `skills/coding/SKILL.md` → no warning
- [x] `README.md` → no warning
- [x] `.claude/plans/abc.md` → no warning

Non-excluded paths (warning triggered):
- [x] `NOTES.md` → warning
- [x] `history/notes.md` → warning (no leading dot = not `.history/`)
- [x] `src/history/data.md` → warning
- [x] `TODO.txt` → warning

### 3. Test suite (`node tests/run-all.js`)
- [x] 990/992 passed — 2 failures are pre-existing known issues unrelated to this change (verified by running the suite before and after the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)