### PR TITLE
fix(session-end): always update session summary content

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -171,9 +171,10 @@ async function main() {
     if (summary) {
       const existing = readFile(sessionFile);
       if (existing) {
-        // Use a flexible regex that tolerates CRLF, extra whitespace, and minor template variations
+        // Use a flexible regex that matches both "## Session Summary" and "## Current State"
+        // Match to end-of-string to avoid duplicate ### Stats sections
         const updatedContent = existing.replace(
-          /## Session Summary[\s\S]*?(?=### Stats|$)/,
+          /## (?:Session Summary|Current State)[\s\S]*?$/ ,
           buildSummarySection(summary).trim() + '\n'
         );
         writeFile(sessionFile, updatedContent);


### PR DESCRIPTION
```markdown
## Problem
Previously, `session-end.js` would only write content to session files on first creation. Subsequent sessions would only update the timestamp, causing stale content (e.g., old tasks, resolved issues) to persist indefinitely.

## Root Cause
The original code had a check that only replaced content if the file contained the blank template marker `[Session context goes here]`. This meant:
- First session → creates file with content ✅
- Subsequent sessions → only updates timestamp, keeps old content ❌

## Solution
Remove the blank-template-only check and always update the Session Summary section with fresh content from the current session transcript.

## Changes
- Remove the `[Session context goes here]` check
- Replace entire `## Session Summary` section on every session end
- Keep timestamp update separate from content update

## Related
- Fixes #187 (addresses the stale content issue)
- Complements commit 87d19f9 which fixed blank template writing
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always replace the session summary on session end, matching both "## Session Summary" and "## Current State" and replacing to the end of the file to avoid duplicate "### Stats". Keeps summaries fresh across sessions and addresses #187.

<sup>Written for commit ad3bd32a82d91f937e3fb89f89ed6e96f9a3a905. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable session summary updates: the system now recognizes both "Session Summary" and "Current State" headers, replaces the entire existing summary section to prevent duplicates, and updates the file whenever a summary is present—resulting in cleaner, consistent session files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->