### PR TITLE
fix: expand doc whitelist for memory files and project paths

### DIFF
--- a/scripts/hooks/doc-file-warning.js
+++ b/scripts/hooks/doc-file-warning.js
@@ -13,9 +13,9 @@ process.stdin.on('end', () => {
 
     if (
       /\.(md|txt)$/.test(filePath) &&
-      !/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL)\.md$/i.test(filePath) &&
-      !/\.claude[/\\]plans[/\\]/.test(filePath) &&
-      !/(^|[/\\])(docs|skills|\.history)[/\\]/.test(filePath)
+      !/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL|MEMORY)\.md$/i.test(filePath) &&
+      !/\.claude[/\\](plans|projects)[/\\]/.test(filePath) &&
+      !/(^|[/\\])(docs|skills|\.history|memory)[/\\]/.test(filePath)
     ) {
       console.error('[Hook] WARNING: Non-standard documentation file detected');
       console.error('[Hook] File: ' + filePath);


### PR DESCRIPTION
## Problem

The `PreToolUse` Write hook in `scripts/hooks/doc-file-warning.js` was blocking legitimate Claude Code files:

- `MEMORY.md` — used by auto-memory
- `.claude/projects/` — project-specific memory paths
- `memory/` subdirectories — memory directories

When blocked, Claude falls back to writing via Bash (`cat > file`), which defeats the purpose of the hook and creates a worse UX.

## Solution

Expanded the whitelist regex to include these paths:

```javascript
!/(README|CLAUDE|AGENTS|CONTRIBUTING|CHANGELOG|LICENSE|SKILL|MEMORY)\.md$/i.test(filePath) &&
!/\.claude[\/\\](plans|projects)[\/\\]/.test(filePath) &&
!/(^|[\/\\])(docs|skills|\.history|memory)[\/\\]/.test(filePath)
```

## Changes

- Added `MEMORY` to filename whitelist
- Added `projects` to `.claude/` path whitelist
- Added `memory` to directory whitelist

Fixes #305

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the doc-file whitelist in the PreToolUse write hook to stop blocking legitimate memory files and project paths, preventing bash fallbacks and improving the write flow.

- **Bug Fixes**
  - Whitelisted MEMORY.md
  - Whitelisted .claude/projects/ paths
  - Whitelisted memory/ subdirectories

<sup>Written for commit 9e70b28c78c0c46aa149703e133f343c0c25cec1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced unnecessary documentation warnings during builds by excluding memory-related and project-oriented documentation locations and select docs from warning checks, resulting in fewer spurious alerts for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->