### PR TITLE
docs: add upstream tracking flag to CONTRIBUTING push example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ cp -r skills/my-skill ~/.claude/skills/  # for skills
 # Then test with Claude Code
 
 # 5. Submit PR
-git add . && git commit -m "feat: add my-skill" && git push
+git add . && git commit -m "feat: add my-skill" && git push -u origin feat/my-contribution
 ```
 
 ---


### PR DESCRIPTION
Updates the Quick Start push command in CONTRIBUTING.md to include `-u origin feat/my-contribution`, so first-time contributors set upstream tracking correctly.

- Scope: docs only
- Behavior change: none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Quick Start push command in CONTRIBUTING.md to use `git push -u origin feat/my-contribution`. This sets upstream tracking for first-time contributors so later pulls and pushes work smoothly.

<sup>Written for commit 97c80b09c228602132373acb036f887603a4cdc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to reflect improved Git workflow for branch management with upstream tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->