### PR TITLE
fix: repair malformed skill frontmatter metadata

### DIFF
--- a/skills/django-verification/SKILL.md
+++ b/skills/django-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: django-verification
-description: Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR.
+description: "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR."
 ---
 
 # Django Verification Loop

--- a/skills/java-coding-standards/SKILL.md
+++ b/skills/java-coding-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: java-coding-standards
-description: Java coding standards for Spring Boot services: naming, immutability, Optional usage, streams, exceptions, generics, and project layout.
+description: "Java coding standards for Spring Boot services: naming, immutability, Optional usage, streams, exceptions, generics, and project layout."
 ---
 
 # Java Coding Standards

--- a/skills/project-guidelines-example/SKILL.md
+++ b/skills/project-guidelines-example/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: project-guidelines-example
+description: "Example project-specific skill template covering architecture, file structure, code patterns, testing requirements, and deployment workflow for adapting to a real codebase."
+---
+
 # Project Guidelines Skill (Example)
 
 This is an example of a project-specific skill. Use this as a template for your own projects.

--- a/skills/springboot-verification/SKILL.md
+++ b/skills/springboot-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: springboot-verification
-description: Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR.
+description: "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR."
 ---
 
 # Spring Boot Verification Loop

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: verification-loop
+description: "General verification workflow for Claude Code sessions covering build, type check, lint, tests, security scans, and diff review before PRs or after significant changes."
+---
+
 # Verification Loop Skill
 
 A comprehensive verification system for Claude Code sessions.


### PR DESCRIPTION
## Summary

Fix malformed `SKILL.md` metadata in bundled skills so YAML/frontmatter validators can parse the repository consistently.

Changes:
- add missing frontmatter to `skills/project-guidelines-example/SKILL.md`
- add missing frontmatter to `skills/verification-loop/SKILL.md`
- quote `description` values containing `:` in:
  - `skills/springboot-verification/SKILL.md`
  - `skills/django-verification/SKILL.md`
  - `skills/java-coding-standards/SKILL.md`

Closes #339.

## Why

Downstream tooling that expects valid YAML frontmatter fails on these files with parser errors such as:

```text
mapping values are not allowed here
```

The fix is intentionally metadata-only and does not change any skill body instructions.

## Validation

- parsed the repaired frontmatter with a YAML parser
- re-scanned the affected skill files to confirm there are no remaining missing/invalid frontmatter blocks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix malformed YAML frontmatter in several SKILL.md files so parsers can read them consistently. Adds missing blocks and quotes descriptions with colons; no instruction content changed.

- **Bug Fixes**
  - Added frontmatter (name, description) to skills/project-guidelines-example and skills/verification-loop.
  - Quoted description values with ":" in springboot-verification, django-verification, and java-coding-standards.
  - Validated with a YAML parser to ensure consistent frontmatter across skills.

<sup>Written for commit 6bec6c7364c89f1a4f9830f059f06e509b6cce69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata formatting in skill documentation files
  * Added metadata sections to additional skill documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->