### PR TITLE
docs: add guidance for project documentation capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,12 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 1. **Plan** — Use planner agent, identify dependencies and risks, break into phases
 2. **TDD** — Use tdd-guide agent, write tests first, implement, refactor
 3. **Review** — Use code-reviewer agent immediately, address CRITICAL/HIGH issues
-4. **Commit** — Conventional commits format, comprehensive PR summaries
+4. **Capture knowledge in the right place**
+   - Personal debugging notes, preferences, and temporary context → auto memory
+   - Team/project knowledge (architecture decisions, API changes, runbooks) → the project's existing docs structure
+   - If the current task already produces the relevant docs or code comments, do not duplicate the same information elsewhere
+   - If there is no obvious project doc location, ask before creating a new top-level file
+5. **Commit** — Conventional commits format, comprehensive PR summaries
 
 ## Git Workflow
 

--- a/examples/user-CLAUDE.md
+++ b/examples/user-CLAUDE.md
@@ -79,6 +79,12 @@ Located in `~/.claude/agents/`:
 - 80% minimum coverage
 - Unit + integration + E2E for critical flows
 
+### Knowledge Capture
+- Personal debugging notes, preferences, and temporary context → auto memory
+- Team/project knowledge (architecture decisions, API changes, implementation runbooks) → follow the project's existing docs structure
+- If the current task already produces the relevant docs, comments, or examples, do not duplicate the same knowledge elsewhere
+- If there is no obvious project doc location, ask before creating a new top-level doc
+
 ---
 
 ## Editor Integration


### PR DESCRIPTION
## Summary
- add repo-level guidance on where personal notes vs project knowledge should be written
- add the same reminder to the example user-level `CLAUDE.md`
- discourage duplicate knowledge capture when the task output already records it

## Validation
- `git diff --check`

Fixes #322

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add guidance on where to capture personal notes vs project knowledge to reduce duplication and keep docs organized (fixes #322). Updates AGENTS.md and example user-CLAUDE.md to: send personal context to auto memory, put team decisions in existing project docs, avoid restating info already produced by the task, and ask before creating new top-level docs.

<sup>Written for commit eb840abcaaabe651f7eba7bca3c2f6a27f14d2b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow documentation with enhanced guidance on capturing and organizing knowledge, including best practices for storing personal debugging notes, team and project documentation, and coordination on creating new resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->