### PR TITLE
chore: ignore .claude/*.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ tasks/
 personal/
 private/
 
+# Claude Code local settings (user-specific, not shared config)
+.claude/*.local.json
+
 # Session templates (not committed)
 examples/sessions/*.tmp
 


### PR DESCRIPTION
## Summary

- Add `.claude/*.local.json` to `.gitignore`
- Claude Code creates per-project `settings.local.json` files for user-specific tool permissions — these are machine-local and should not be committed
- The pattern is scoped to `*.local.json` rather than blanket `.claude/` to preserve committed shared config like `package-manager.json`

## Test plan

- [x] Verified `git status` no longer shows `.claude/settings.local.json` as untracked
- [x] Confirmed `.claude/package-manager.json` is not affected by the glob pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .claude/*.local.json to .gitignore to stop committing machine-local Claude Code settings. Shared config like .claude/package-manager.json remains tracked.

<sup>Written for commit 26c11b5c6e7bbc5b65ecd328642f5727318a4fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude local configuration files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->