### PR TITLE
feat(skills): add blueprint skill for multi-session construction planning

### DIFF
--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -74,12 +74,13 @@ Produces a plan with parallel steps where possible (e.g., "implement Anthropic p
 
 This skill ships with Everything Claude Code. No separate installation is needed when ECC is installed.
 
-```bash
-# Verify the skill is present in your ECC checkout
-ls ~/.claude/plugins/ecc/skills/blueprint/SKILL.md
-```
+### Full ECC install
 
-If you are vendoring only this skill outside the full ECC install, copy the reviewed file from this repository into `~/.claude/skills/blueprint/SKILL.md` and keep it pinned to a reviewed ECC commit.
+If you are working from the ECC repository checkout, verify the skill is present with:
+
+```bash
+test -f skills/blueprint/SKILL.md
+```
 
 To update later, review the ECC diff before updating:
 
@@ -90,6 +91,10 @@ git log --oneline HEAD..origin/main       # review new commits before updating
 git checkout <reviewed-full-sha>          # pin to a specific reviewed commit
 ```
 
+### Vendored standalone install
+
+If you are vendoring only this skill outside the full ECC install, copy the reviewed file from the ECC repository into `~/.claude/skills/blueprint/SKILL.md`. Vendored copies do not have a git remote, so update them by re-copying the file from a reviewed ECC commit rather than running `git pull`.
+
 ## Requirements
 
 - Claude Code (for `/blueprint` slash command)
@@ -97,4 +102,4 @@ git checkout <reviewed-full-sha>          # pin to a specific reviewed commit
 
 ## Source
 
-Inspired by [github.com/antbotlab/blueprint](https://github.com/antbotlab/blueprint) — upstream project and reference design.
+Inspired by antbotlab/blueprint — upstream project and reference design.


### PR DESCRIPTION
## Summary

Adds the [Blueprint](https://github.com/antbotlab/blueprint) skill to the skills collection.

## Type

- [x] Skill

## What Blueprint Does

Blueprint turns a one-line objective into a step-by-step construction plan that any coding agent can execute cold. It's purpose-built for multi-session, multi-agent engineering projects — the kind that are too large for a single Claude Code session.

**Key differentiators:**

- **Cold-start execution**: Every step includes a self-contained context brief. A fresh agent in a new session can execute any step without reading prior steps or conversation history.
- **Adversarial review gate**: Every plan is reviewed by a strongest-model sub-agent (e.g., Opus) against a checklist covering completeness, dependency correctness, cold-start viability, and anti-pattern detection.
- **Zero runtime risk**: Pure markdown skill — no hooks, no shell scripts, no executable code. No `PreToolUse`/`PostToolUse` hooks that run on every tool call. What you install is what you read.
- **Branch/PR/CI workflow**: Built into every step. Detects git/gh availability and degrades gracefully to direct mode when absent.
- **Plan mutation protocol**: Steps can be split, inserted, skipped, reordered, or abandoned with formal protocols and an audit trail.
- **Parallel step detection**: Dependency graph identifies steps with no shared files or output dependencies.

## Testing

1. Install: `git clone https://github.com/antbotlab/blueprint.git ~/.claude/skills/blueprint`
2. Open any multi-module project in Claude Code
3. Run: `/blueprint myapp "migrate database to PostgreSQL"`
4. Verify Blueprint generates a plan in `plans/` with cold-start context briefs on each step

## Checklist

- [x] Follows format guidelines (SKILL.md with frontmatter)
- [x] Tested with Claude Code
- [x] No sensitive info
- [x] Clear descriptions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Blueprint skill for multi-session construction planning. Generates cold-start plans with an adversarial review gate and optional Git/PR workflow, plus safer install/update guidance and vendored install support.

- **New Features**
  - Adds `skills/blueprint/SKILL.md`; provides `/blueprint <project> <objective>` with trigger rules.
  - Writes a Markdown plan in `plans/` with one-PR steps, a dependency graph, and parallel step detection.
  - Each step includes a context brief, task list, verification commands, and exit criteria.
  - Auto-detects git/`gh` for branch/PR/CI flow; falls back to direct mode when absent.
  - Docs: ships with ECC; includes When to Use/How It Works/Examples; safe updates via `git fetch` + pinned `git checkout <full-sha>`; vendored install at `~/.claude/skills/blueprint/SKILL.md`; pure `.md` only (no executable code).

<sup>Written for commit 91cd7472866eb96081c04e5a529652a27c5a690b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Blueprint Construction Plan Generator skill: purpose and usage triggers; basic and multi-agent examples; five-phase workflow (Research, Design, Draft, Review, Register); automatic git/gh detection with direct-mode fallback; zero-runtime, Markdown-first design; cold-start execution, adversarial review gate, plan mutation, and parallelism; guidance on branch/PR/CI workflow, installation, requirements, version pinning, and licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->