### PR TITLE
fix: read tool_response field in observe.sh

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -124,7 +124,9 @@ try:
     # Extract fields - Claude Code hook format
     tool_name = data.get("tool_name", data.get("tool", "unknown"))
     tool_input = data.get("tool_input", data.get("input", {}))
-    tool_output = data.get("tool_response", data.get("tool_output", data.get("output", "")))
+    tool_output = data.get("tool_response")
+    if tool_output is None:
+        tool_output = data.get("tool_output", data.get("output", ""))
     session_id = data.get("session_id", "unknown")
     tool_use_id = data.get("tool_use_id", "")
     cwd = data.get("cwd", "")

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -63,6 +63,29 @@ function runScript(scriptPath, input = '', env = {}) {
   });
 }
 
+function runShellScript(scriptPath, args = [], input = '', env = {}, cwd = process.cwd()) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('bash', [scriptPath, ...args], {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    if (input) {
+      proc.stdin.write(input);
+    }
+    proc.stdin.end();
+
+    proc.stdout.on('data', data => stdout += data);
+    proc.stderr.on('data', data => stderr += data);
+    proc.on('close', code => resolve({ code, stdout, stderr }));
+    proc.on('error', reject);
+  });
+}
+
 // Create a temporary test directory
 function createTestDir() {
   const testDir = path.join(os.tmpdir(), `hooks-test-${Date.now()}`);
@@ -1775,6 +1798,43 @@ async function runTests() {
 
     assert.strictEqual(code, 0, `detect-project.sh should source cleanly, stderr: ${stderr}`);
     assert.ok(stdout.trim().length > 0, 'CLV2_PYTHON_CMD should export a resolved interpreter path');
+  })) passed++; else failed++;
+
+  if (await asyncTest('observe.sh falls back to legacy output fields when tool_response is null', async () => {
+    const homeDir = createTestDir();
+    const projectDir = createTestDir();
+    const observePath = path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'hooks', 'observe.sh');
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+      tool_response: null,
+      tool_output: 'legacy output',
+      session_id: 'session-123',
+      cwd: projectDir
+    });
+
+    try {
+      const result = await runShellScript(observePath, ['post'], payload, {
+        HOME: homeDir,
+        CLAUDE_PROJECT_DIR: projectDir
+      }, projectDir);
+
+      assert.strictEqual(result.code, 0, `observe.sh should exit successfully, stderr: ${result.stderr}`);
+
+      const projectsDir = path.join(homeDir, '.claude', 'homunculus', 'projects');
+      const projectIds = fs.readdirSync(projectsDir);
+      assert.strictEqual(projectIds.length, 1, 'observe.sh should create one project-scoped observation directory');
+
+      const observationsPath = path.join(projectsDir, projectIds[0], 'observations.jsonl');
+      const observations = fs.readFileSync(observationsPath, 'utf8').trim().split('\n').filter(Boolean);
+      assert.ok(observations.length > 0, 'observe.sh should append at least one observation');
+
+      const observation = JSON.parse(observations[0]);
+      assert.strictEqual(observation.output, 'legacy output', 'observe.sh should fall back to legacy tool_output when tool_response is null');
+    } finally {
+      cleanupTestDir(homeDir);
+      cleanupTestDir(projectDir);
+    }
   })) passed++; else failed++;
 
   if (await asyncTest('matches .tsx extension for type checking', async () => {


### PR DESCRIPTION
Fixes #377

## Summary

- `observe.sh` line 127 reads `tool_output` from Claude Code's PostToolUse hook payload, but Claude Code actually sends the field as `tool_response`
- Since neither `tool_output` nor the fallback `output` exist in the payload, every observation gets an empty string for its output field
- This one-line fix adds `tool_response` as the primary key to check, with backward-compatible fallback to the existing field names

## The Bug

**Current code (line 127):**
```python
tool_output = data.get("tool_output", data.get("output", ""))
```

**Actual Claude Code PostToolUse payload:**
```json
{
  "session_id": "...",
  "tool_name": "Bash",
  "tool_input": {"command": "echo hello"},
  "tool_response": {"stdout": "hello\n", "stderr": "", "exitCode": 0},
  "tool_use_id": "toolu_..."
}
```

The code looks for `tool_output` (doesn't exist), falls back to `output` (doesn't exist), and defaults to `""`.

## The Fix

```python
tool_output = data.get("tool_response", data.get("tool_output", data.get("output", "")))
```

Checks `tool_response` first (the actual field Claude Code sends), then falls back to `tool_output` and `output` for backward compatibility.

## Impact

- **All observations recorded by the hook have empty output fields** — the observer/analysis pipeline has had no tool output content to learn from
- Instinct creation is severely degraded because it can't see what tools returned (successes, errors, file contents)
- Affects v1.7.0+ through current main
- Historical archived observations (63MB+) all have this same issue

## Verification

- All 1024 existing tests pass (`node tests/run-all.js`)
- Manually tested with a simulated Claude Code PostToolUse payload — output is now captured correctly
- Backward compatible — payloads using the old `tool_output` field name still work

## Test Plan

- [x] `node tests/run-all.js` — 1024/1024 passed
- [x] Manual test: simulated PostToolUse payload with `tool_response` field → output captured
- [x] Manual test: simulated payload with old `tool_output` field → backward compatible
- [x] Verified locally in a live Claude Code session — observations now include tool output content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #377: Update `observe.sh` to read the `tool_response` field from Claude Code PostToolUse payloads, with correct fallback to `tool_output`/`output` when `tool_response` is missing or null to prevent empty outputs and remain backward compatible.

<sup>Written for commit 496f29f19d5176a456c2d5eb20cee2bd0231456f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool results in generated events now prefer the most current response field while falling back to legacy fields when needed, improving accuracy of reported outputs.
* **Tests**
  * Added an automated test to verify correct fallback behavior and to ensure observed outputs are recorded reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->