### PR TITLE
fix: raise observer analysis turn budget

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -78,9 +78,20 @@ Rules:
 PROMPT
 
   timeout_seconds="${ECC_OBSERVER_TIMEOUT_SECONDS:-120}"
+  max_turns="${ECC_OBSERVER_MAX_TURNS:-10}"
   exit_code=0
 
-  claude --model haiku --max-turns 3 --print < "$prompt_file" >> "$LOG_FILE" 2>&1 &
+  case "$max_turns" in
+    ''|*[!0-9]*)
+      max_turns=10
+      ;;
+  esac
+
+  if [ "$max_turns" -lt 4 ]; then
+    max_turns=10
+  fi
+
+  claude --model haiku --max-turns "$max_turns" --print < "$prompt_file" >> "$LOG_FILE" 2>&1 &
   claude_pid=$!
 
   (

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2106,6 +2106,21 @@ async function runTests() {
   else failed++;
 
   if (
+    test('observer-loop uses a configurable max-turn budget with safe default', () => {
+      const observerLoopSource = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'agents', 'observer-loop.sh'),
+        'utf8'
+      );
+
+      assert.ok(observerLoopSource.includes('ECC_OBSERVER_MAX_TURNS'), 'observer-loop should allow max-turn overrides');
+      assert.ok(observerLoopSource.includes('max_turns="${ECC_OBSERVER_MAX_TURNS:-10}"'), 'observer-loop should default to 10 turns');
+      assert.ok(!observerLoopSource.includes('--max-turns 3'), 'observer-loop should not hardcode a 3-turn limit');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     await asyncTest('detect-project exports the resolved Python command for downstream scripts', async () => {
       const detectProjectPath = path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'scripts', 'detect-project.sh');
       const shellCommand = [`source "${detectProjectPath}" >/dev/null 2>&1`, 'printf "%s\\n" "${CLV2_PYTHON_CMD:-}"'].join('; ');


### PR DESCRIPTION
## Summary
- raise the observer Claude turn budget from a hardcoded 3-turn ceiling to a configurable max-turn budget with a safe default of 10
- add validation so invalid or undersized  values fall back to the safe default
- add hook-suite coverage for the observer loop max-turn contract

## Testing
- node tests/hooks/hooks.test.js

Closes #386

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the observer analysis loop to a configurable `ECC_OBSERVER_MAX_TURNS` (default 10) instead of the hardcoded 3. Invalid or undersized values fall back to 10, with new tests to enforce the contract, addressing #386.

<sup>Written for commit 16bc7436c5fa9a4527b4f6a00c4b61d5db2e1597. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made observer loop execution configurable with a maximum turns parameter, controlled via environment variable (default: 10 turns).
  * Added validation to ensure configured values meet minimum requirements.

* **Tests**
  * Added validation tests for observer loop configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->