### PR TITLE
docs: clarify custom endpoint support

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -3,3 +3,15 @@
 If you plan to edit `.claude-plugin/plugin.json`, be aware that the Claude plugin validator enforces several **undocumented but strict constraints** that can cause installs to fail with vague errors (for example, `agents: Invalid input`). In particular, component fields must be arrays, `agents` must use explicit file paths rather than directories, and a `version` field is required for reliable validation and installation.
 
 These constraints are not obvious from public examples and have caused repeated installation failures in the past. They are documented in detail in `.claude-plugin/PLUGIN_SCHEMA_NOTES.md`, which should be reviewed before making any changes to the plugin manifest.
+
+### Custom Endpoints and Gateways
+
+ECC does not override Claude Code transport settings. If Claude Code is configured to run through an official LLM gateway or a compatible custom endpoint, the plugin continues to work because hooks, commands, and skills execute locally after the CLI starts successfully.
+
+Use Claude Code's own environment/configuration for transport selection, for example:
+
+```bash
+export ANTHROPIC_BASE_URL=https://your-gateway.example.com
+export ANTHROPIC_AUTH_TOKEN=your-token
+claude
+```

--- a/README.md
+++ b/README.md
@@ -749,6 +749,31 @@ This is the most common issue. **Do NOT add a `"hooks"` field to `.claude-plugin
 </details>
 
 <details>
+<summary><b>Can I use ECC with Claude Code on a custom API endpoint or model gateway?</b></summary>
+
+Yes. ECC does not hardcode Anthropic-hosted transport settings. It runs locally through Claude Code's normal CLI/plugin surface, so it works with:
+
+- Anthropic-hosted Claude Code
+- Official Claude Code gateway setups using `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`
+- Compatible custom endpoints that speak the Anthropic API Claude Code expects
+
+Minimal example:
+
+```bash
+export ANTHROPIC_BASE_URL=https://your-gateway.example.com
+export ANTHROPIC_AUTH_TOKEN=your-token
+claude
+```
+
+If your gateway remaps model names, configure that in Claude Code rather than in ECC. ECC's hooks, skills, commands, and rules are model-provider agnostic once the `claude` CLI is already working.
+
+Official references:
+- [Claude Code LLM gateway docs](https://docs.anthropic.com/en/docs/claude-code/llm-gateway)
+- [Claude Code model configuration docs](https://docs.anthropic.com/en/docs/claude-code/model-config)
+
+</details>
+
+<details>
 <summary><b>My context window is shrinking / Claude is running out of context</b></summary>
 
 Too many MCP servers eat your context. Each MCP tool description consumes tokens from your 200k window, potentially reducing it to ~70k.


### PR DESCRIPTION
## Summary
- document that ECC works with Claude Code custom endpoints and official gateways
- add minimal environment examples using ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN
- clarify that transport selection belongs to Claude Code, not ECC

## Testing
- docs only

Closes #383

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that ECC works with Claude Code when using official gateways or compatible custom endpoints, and adds a minimal example using `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`. Also states that transport selection is configured in Claude Code (not ECC); ECC hooks/skills/commands run locally once the CLI starts.

<sup>Written for commit e0f8f914eef61349d73e171158026da9c41ca2a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Expanded documentation with comprehensive guidance on custom API endpoints and model gateway compatibility
* Clarified the system is transport-agnostic and operates independently of Claude Code transport configuration
* Added environment variable examples and configuration guidance for custom endpoint integration
* Included reference links and minimal usage examples for official gateways and custom endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->