### PR TITLE
feat: add php rule pack

### DIFF
--- a/.cursor/rules/php-coding-style.md
+++ b/.cursor/rules/php-coding-style.md
@@ -1,0 +1,25 @@
+---
+description: "PHP coding style extending common rules"
+globs: ["**/*.php", "**/composer.json"]
+alwaysApply: false
+---
+# PHP Coding Style
+
+> This file extends the common coding style rule with PHP specific content.
+
+## Standards
+
+- Follow **PSR-12** formatting and naming conventions.
+- Prefer `declare(strict_types=1);` in application code.
+- Use scalar type hints, return types, and typed properties everywhere new code permits.
+
+## Immutability
+
+- Prefer immutable DTOs and value objects for data crossing service boundaries.
+- Use `readonly` properties or immutable constructors for request/response payloads where possible.
+- Keep arrays for simple maps; promote business-critical structures into explicit classes.
+
+## Formatting
+
+- Use **PHP-CS-Fixer** or **Laravel Pint** for formatting.
+- Use **PHPStan** or **Psalm** for static analysis.

--- a/.cursor/rules/php-hooks.md
+++ b/.cursor/rules/php-hooks.md
@@ -1,0 +1,21 @@
+---
+description: "PHP hooks extending common rules"
+globs: ["**/*.php", "**/composer.json", "**/phpstan.neon", "**/phpstan.neon.dist", "**/psalm.xml"]
+alwaysApply: false
+---
+# PHP Hooks
+
+> This file extends the common hooks rule with PHP specific content.
+
+## PostToolUse Hooks
+
+Configure in `~/.claude/settings.json`:
+
+- **Pint / PHP-CS-Fixer**: Auto-format edited `.php` files.
+- **PHPStan / Psalm**: Run static analysis after PHP edits in typed codebases.
+- **PHPUnit / Pest**: Run targeted tests for touched files or modules when edits affect behavior.
+
+## Warnings
+
+- Warn on `var_dump`, `dd`, `dump`, or `die()` left in edited files.
+- Warn when edited PHP files add raw SQL or disable CSRF/session protections.

--- a/.cursor/rules/php-patterns.md
+++ b/.cursor/rules/php-patterns.md
@@ -1,0 +1,23 @@
+---
+description: "PHP patterns extending common rules"
+globs: ["**/*.php", "**/composer.json"]
+alwaysApply: false
+---
+# PHP Patterns
+
+> This file extends the common patterns rule with PHP specific content.
+
+## Thin Controllers, Explicit Services
+
+- Keep controllers focused on transport: auth, validation, serialization, status codes.
+- Move business rules into application/domain services that are easy to test without HTTP bootstrapping.
+
+## DTOs and Value Objects
+
+- Replace shape-heavy associative arrays with DTOs for requests, commands, and external API payloads.
+- Use value objects for money, identifiers, and constrained concepts.
+
+## Dependency Injection
+
+- Depend on interfaces or narrow service contracts, not framework globals.
+- Pass collaborators through constructors so services are testable without service-locator lookups.

--- a/.cursor/rules/php-security.md
+++ b/.cursor/rules/php-security.md
@@ -1,0 +1,24 @@
+---
+description: "PHP security extending common rules"
+globs: ["**/*.php", "**/composer.lock", "**/composer.json"]
+alwaysApply: false
+---
+# PHP Security
+
+> This file extends the common security rule with PHP specific content.
+
+## Database Safety
+
+- Use prepared statements (`PDO`, Doctrine, Eloquent query builder) for all dynamic queries.
+- Scope ORM mass-assignment carefully and whitelist writable fields.
+
+## Secrets and Dependencies
+
+- Load secrets from environment variables or a secret manager, never from committed config files.
+- Run `composer audit` in CI and review package trust before adding dependencies.
+
+## Auth and Session Safety
+
+- Use `password_hash()` / `password_verify()` for password storage.
+- Regenerate session identifiers after authentication and privilege changes.
+- Enforce CSRF protection on state-changing web requests.

--- a/.cursor/rules/php-testing.md
+++ b/.cursor/rules/php-testing.md
@@ -1,0 +1,26 @@
+---
+description: "PHP testing extending common rules"
+globs: ["**/*.php", "**/phpunit.xml", "**/phpunit.xml.dist", "**/composer.json"]
+alwaysApply: false
+---
+# PHP Testing
+
+> This file extends the common testing rule with PHP specific content.
+
+## Framework
+
+Use **PHPUnit** as the default test framework. **Pest** is also acceptable when the project already uses it.
+
+## Coverage
+
+```bash
+vendor/bin/phpunit --coverage-text
+# or
+vendor/bin/pest --coverage
+```
+
+## Test Organization
+
+- Separate fast unit tests from framework/database integration tests.
+- Use factory/builders for fixtures instead of large hand-written arrays.
+- Keep HTTP/controller tests focused on transport and validation; move business rules into service-level tests.

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ git clone https://github.com/affaan-m/everything-claude-code.git
 cd everything-claude-code
 
 # Recommended: use the installer (handles common + language rules safely)
-./install.sh typescript    # or python or golang or perl
+./install.sh typescript    # or python or golang or swift or php
 # You can pass multiple languages:
-# ./install.sh typescript python golang perl
+# ./install.sh typescript python golang swift php
 # or target cursor:
 # ./install.sh --target cursor typescript
 # or target antigravity:
@@ -365,8 +365,8 @@ everything-claude-code/
 |   |-- typescript/          # TypeScript/JavaScript specific
 |   |-- python/              # Python specific
 |   |-- golang/              # Go specific
-|   |-- perl/                # Perl specific (NEW)
 |   |-- swift/               # Swift specific
+|   |-- php/                 # PHP specific (NEW)
 |
 |-- hooks/            # Trigger-based automations
 |   |-- README.md                 # Hook documentation, recipes, and customization guide
@@ -569,7 +569,7 @@ This gives you instant access to all commands, agents, skills, and hooks.
 > cp -r everything-claude-code/rules/typescript/* ~/.claude/rules/   # pick your stack
 > cp -r everything-claude-code/rules/python/* ~/.claude/rules/
 > cp -r everything-claude-code/rules/golang/* ~/.claude/rules/
-> cp -r everything-claude-code/rules/perl/* ~/.claude/rules/
+> cp -r everything-claude-code/rules/php/* ~/.claude/rules/
 >
 > # Option B: Project-level rules (applies to current project only)
 > mkdir -p .claude/rules
@@ -595,7 +595,7 @@ cp -r everything-claude-code/rules/common/* ~/.claude/rules/
 cp -r everything-claude-code/rules/typescript/* ~/.claude/rules/   # pick your stack
 cp -r everything-claude-code/rules/python/* ~/.claude/rules/
 cp -r everything-claude-code/rules/golang/* ~/.claude/rules/
-cp -r everything-claude-code/rules/perl/* ~/.claude/rules/
+cp -r everything-claude-code/rules/php/* ~/.claude/rules/
 
 # Copy commands
 cp everything-claude-code/commands/*.md ~/.claude/commands/
@@ -678,7 +678,8 @@ rules/
   typescript/      # TS/JS specific patterns and tools
   python/          # Python specific patterns and tools
   golang/          # Go specific patterns and tools
-  perl/            # Perl specific patterns and tools
+  swift/           # Swift specific patterns and tools
+  php/             # PHP specific patterns and tools
 ```
 
 See [`rules/README.md`](rules/README.md) for installation and structure details.
@@ -850,7 +851,7 @@ ECC provides **full Cursor IDE support** with hooks, rules, agents, skills, comm
 ```bash
 # Install for your language(s)
 ./install.sh --target cursor typescript
-./install.sh --target cursor python golang swift perl
+./install.sh --target cursor python golang swift php
 ```
 
 ### What's Included
@@ -859,7 +860,7 @@ ECC provides **full Cursor IDE support** with hooks, rules, agents, skills, comm
 |-----------|-------|---------|
 | Hook Events | 15 | sessionStart, beforeShellExecution, afterFileEdit, beforeMCPExecution, beforeSubmitPrompt, and 10 more |
 | Hook Scripts | 16 | Thin Node.js scripts delegating to `scripts/hooks/` via shared adapter |
-| Rules | 34 | 9 common (alwaysApply) + 25 language-specific (TypeScript, Python, Go, Swift, Perl) |
+| Rules | 34 | 9 common (alwaysApply) + 25 language-specific (TypeScript, Python, Go, Swift, PHP) |
 | Agents | Shared | Via AGENTS.md at root (read by Cursor natively) |
 | Skills | Shared + Bundled | Via AGENTS.md at root and `.cursor/skills/` for translated additions |
 | Commands | Shared | `.cursor/commands/` if installed |

--- a/rules/README.md
+++ b/rules/README.md
@@ -18,7 +18,7 @@ rules/
 ├── python/          # Python specific
 ├── golang/          # Go specific
 ├── swift/           # Swift specific
-└── perl/            # Perl specific
+└── php/             # PHP specific
 ```
 
 - **common/** contains universal principles — no language-specific code examples.
@@ -34,7 +34,7 @@ rules/
 ./install.sh python
 ./install.sh golang
 ./install.sh swift
-./install.sh perl
+./install.sh php
 
 # Install multiple languages at once
 ./install.sh typescript python
@@ -57,7 +57,7 @@ cp -r rules/typescript ~/.claude/rules/typescript
 cp -r rules/python ~/.claude/rules/python
 cp -r rules/golang ~/.claude/rules/golang
 cp -r rules/swift ~/.claude/rules/swift
-cp -r rules/perl ~/.claude/rules/perl
+cp -r rules/php ~/.claude/rules/php
 
 # Attention ! ! ! Configure according to your actual project requirements; the configuration here is for reference only.
 ```
@@ -91,7 +91,7 @@ To add support for a new language (e.g., `rust/`):
 When language-specific rules and common rules conflict, **language-specific rules take precedence** (specific overrides general). This follows the standard layered configuration pattern (similar to CSS specificity or `.gitignore` precedence).
 
 - `rules/common/` defines universal defaults applicable to all projects.
-- `rules/golang/`, `rules/python/`, `rules/perl/`, `rules/typescript/`, etc. override those defaults where language idioms differ.
+- `rules/golang/`, `rules/python/`, `rules/swift/`, `rules/php/`, `rules/typescript/`, etc. override those defaults where language idioms differ.
 
 ### Example
 

--- a/rules/php/coding-style.md
+++ b/rules/php/coding-style.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "**/*.php"
+  - "**/composer.json"
+---
+# PHP Coding Style
+
+> This file extends [common/coding-style.md](../common/coding-style.md) with PHP specific content.
+
+## Standards
+
+- Follow **PSR-12** formatting and naming conventions.
+- Prefer `declare(strict_types=1);` in application code.
+- Use scalar type hints, return types, and typed properties everywhere new code permits.
+
+## Immutability
+
+- Prefer immutable DTOs and value objects for data crossing service boundaries.
+- Use `readonly` properties or immutable constructors for request/response payloads where possible.
+- Keep arrays for simple maps; promote business-critical structures into explicit classes.
+
+## Formatting
+
+- Use **PHP-CS-Fixer** or **Laravel Pint** for formatting.
+- Use **PHPStan** or **Psalm** for static analysis.
+- Keep Composer scripts checked in so the same commands run locally and in CI.
+
+## Error Handling
+
+- Throw exceptions for exceptional states; avoid returning `false`/`null` as hidden error channels in new code.
+- Convert framework/request input into validated DTOs before it reaches domain logic.
+
+## Reference
+
+See skill: `backend-patterns` for broader service/repository layering guidance.

--- a/rules/php/hooks.md
+++ b/rules/php/hooks.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "**/*.php"
+  - "**/composer.json"
+  - "**/phpstan.neon"
+  - "**/phpstan.neon.dist"
+  - "**/psalm.xml"
+---
+# PHP Hooks
+
+> This file extends [common/hooks.md](../common/hooks.md) with PHP specific content.
+
+## PostToolUse Hooks
+
+Configure in `~/.claude/settings.json`:
+
+- **Pint / PHP-CS-Fixer**: Auto-format edited `.php` files.
+- **PHPStan / Psalm**: Run static analysis after PHP edits in typed codebases.
+- **PHPUnit / Pest**: Run targeted tests for touched files or modules when edits affect behavior.
+
+## Warnings
+
+- Warn on `var_dump`, `dd`, `dump`, or `die()` left in edited files.
+- Warn when edited PHP files add raw SQL or disable CSRF/session protections.

--- a/rules/php/patterns.md
+++ b/rules/php/patterns.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "**/*.php"
+  - "**/composer.json"
+---
+# PHP Patterns
+
+> This file extends [common/patterns.md](../common/patterns.md) with PHP specific content.
+
+## Thin Controllers, Explicit Services
+
+- Keep controllers focused on transport: auth, validation, serialization, status codes.
+- Move business rules into application/domain services that are easy to test without HTTP bootstrapping.
+
+## DTOs and Value Objects
+
+- Replace shape-heavy associative arrays with DTOs for requests, commands, and external API payloads.
+- Use value objects for money, identifiers, date ranges, and other constrained concepts.
+
+## Dependency Injection
+
+- Depend on interfaces or narrow service contracts, not framework globals.
+- Pass collaborators through constructors so services are testable without service-locator lookups.
+
+## Boundaries
+
+- Isolate ORM models from domain decisions when the model layer is doing more than persistence.
+- Wrap third-party SDKs behind small adapters so the rest of the codebase depends on your contract, not theirs.
+
+## Reference
+
+See skill: `api-design` for endpoint conventions and response-shape guidance.

--- a/rules/php/security.md
+++ b/rules/php/security.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "**/*.php"
+  - "**/composer.lock"
+  - "**/composer.json"
+---
+# PHP Security
+
+> This file extends [common/security.md](../common/security.md) with PHP specific content.
+
+## Input and Output
+
+- Validate request input at the framework boundary (`FormRequest`, Symfony Validator, or explicit DTO validation).
+- Escape output in templates by default; treat raw HTML rendering as an exception that must be justified.
+- Never trust query params, cookies, headers, or uploaded file metadata without validation.
+
+## Database Safety
+
+- Use prepared statements (`PDO`, Doctrine, Eloquent query builder) for all dynamic queries.
+- Avoid string-building SQL in controllers/views.
+- Scope ORM mass-assignment carefully and whitelist writable fields.
+
+## Secrets and Dependencies
+
+- Load secrets from environment variables or a secret manager, never from committed config files.
+- Run `composer audit` in CI and review new package maintainer trust before adding dependencies.
+- Pin major versions deliberately and remove abandoned packages quickly.
+
+## Auth and Session Safety
+
+- Use `password_hash()` / `password_verify()` for password storage.
+- Regenerate session identifiers after authentication and privilege changes.
+- Enforce CSRF protection on state-changing web requests.

--- a/rules/php/testing.md
+++ b/rules/php/testing.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "**/*.php"
+  - "**/phpunit.xml"
+  - "**/phpunit.xml.dist"
+  - "**/composer.json"
+---
+# PHP Testing
+
+> This file extends [common/testing.md](../common/testing.md) with PHP specific content.
+
+## Framework
+
+Use **PHPUnit** as the default test framework. **Pest** is also acceptable when the project already uses it.
+
+## Coverage
+
+```bash
+vendor/bin/phpunit --coverage-text
+# or
+vendor/bin/pest --coverage
+```
+
+Prefer **pcov** or **Xdebug** in CI, and keep coverage thresholds in CI rather than as tribal knowledge.
+
+## Test Organization
+
+- Separate fast unit tests from framework/database integration tests.
+- Use factory/builders for fixtures instead of large hand-written arrays.
+- Keep HTTP/controller tests focused on transport and validation; move business rules into service-level tests.
+
+## Reference
+
+See skill: `tdd-workflow` for the repo-wide RED -> GREEN -> REFACTOR loop.


### PR DESCRIPTION
## Summary
- add PHP rule files for coding style, testing, security, patterns, and hooks
- add Cursor-flattened PHP rules for parity with the installer target
- update install and README docs so PHP rules are actually discoverable

## Testing
- node scripts/ci/validate-rules.js

Closes #318

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PHP rule pack (coding style, testing, security, patterns, hooks) with `.cursor` flattened rules, and updates docs/installer so PHP rules are discoverable. Addresses #318 by adding first-class PHP support across rules and Cursor.

- **New Features**
  - Added `rules/php/*` and `.cursor/rules/php-*` for coding style, testing, security, patterns, and hooks.
  - Updated `README.md` and `rules/README.md` with PHP install steps and directory listings.
  - Enabled `./install.sh php` for installer parity.

- **Migration**
  - Install via `./install.sh php` or copy `rules/php/*` to `~/.claude/rules/php`.
  - Optional: validate with `node scripts/ci/validate-rules.js`.

<sup>Written for commit ed366bddbb9b23ae532800397da4a120e98c0b00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive PHP development guides covering coding standards, design patterns, security best practices, testing strategies, and development tools.
  * Updated project documentation and installation instructions to include PHP support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->