### PR TITLE
fix: restore ci compatibility on windows

### DIFF
--- a/skills/videodb/SKILL.md
+++ b/skills/videodb/SKILL.md
@@ -108,7 +108,7 @@ The user must set `VIDEO_DB_API_KEY` using **either** method:
 - **Export in terminal** (before starting Claude): `export VIDEO_DB_API_KEY=your-key`
 - **Project `.env` file**: Save `VIDEO_DB_API_KEY=your-key` in the project's `.env` file
 
-Get a free API key at https://console.videodb.io (50 free uploads, no credit card).
+Get a free API key at [console.videodb.io](https://console.videodb.io) (50 free uploads, no credit card).
 
 **Do NOT** read, write, or handle the API key yourself. Always let the user set it.
 
@@ -353,7 +353,6 @@ Reference documentation is in the `reference/` directory adjacent to this SKILL.
 - [reference/capture.md](reference/capture.md) - Desktop capture workflow
 - [reference/capture-reference.md](reference/capture-reference.md) - Capture SDK and WebSocket events
 - [reference/use-cases.md](reference/use-cases.md) - Common video processing patterns and examples
-
 
 **Do not use ffmpeg, moviepy, or local encoding tools** when VideoDB supports the operation. The following are all handled server-side by VideoDB — trimming, combining clips, overlaying audio or music, adding subtitles, text/image overlays, transcoding, resolution changes, aspect-ratio conversion, resizing for platform requirements, transcription, and media generation. Only fall back to local tools for operations listed under Limitations in reference/editor.md (transitions, speed changes, crop/zoom, colour grading, volume mixing).
 

--- a/skills/videodb/reference/api-reference.md
+++ b/skills/videodb/reference/api-reference.md
@@ -380,7 +380,7 @@ results = video.search(
 ```
 
 > **Note:** `filter` is an explicit named parameter in `video.search()`. `scene_index_id` is passed through `**kwargs` to the API.
-
+>
 > **Important:** `video.search()` raises `InvalidRequestError` with message `"No results found"` when there are no matches. Always wrap search calls in try/except. For scene search, use `score_threshold=0.3` or higher to filter low-relevance noise.
 
 For scene search, use `search_type=SearchType.semantic` with `index_type=IndexType.scene`. Pass `scene_index_id` when targeting a specific scene index. See [search.md](search.md) for details.

--- a/skills/videodb/reference/capture-reference.md
+++ b/skills/videodb/reference/capture-reference.md
@@ -107,7 +107,7 @@ Use [scripts/ws_listener.py](../scripts/ws_listener.py) to connect and dump even
 }
 ```
 
-> For latest details, see https://docs.videodb.io/pages/ingest/capture-sdks/realtime-context.md
+> For latest details, see [the realtime context docs](https://docs.videodb.io/pages/ingest/capture-sdks/realtime-context.md).
 
 ---
 

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2185,9 +2185,9 @@ async function runTests() {
 
         assert.strictEqual(code, 0, `detect-project should source cleanly, stderr: ${stderr}`);
 
-        const [projectId, projectDir] = stdout.trim().split(/\r?\n/);
+        const [projectId] = stdout.trim().split(/\r?\n/);
         const registryPath = path.join(homeDir, '.claude', 'homunculus', 'projects.json');
-        const projectMetadataPath = path.join(projectDir, 'project.json');
+        const projectMetadataPath = path.join(homeDir, '.claude', 'homunculus', 'projects', projectId, 'project.json');
 
         assert.ok(projectId, 'detect-project should emit a project id');
         assert.ok(fs.existsSync(registryPath), 'projects.json should be created');


### PR DESCRIPTION
## Summary
- fix the Windows hook regression test to resolve `project.json` from the actual homunculus registry path
- clean up inherited VideoDB markdownlint violations so CI passes against current `main`

## Test Plan
- `node tests/hooks/hooks.test.js`
- `npx markdownlint "skills/videodb/**/*.md"`
- `npm test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Windows CI by fixing the hook regression test to read project metadata from the Homunculus registry and cleaning up markdownlint errors in VideoDB docs. Ensures tests pass on current `main` across platforms.

- **Bug Fixes**
  - Updated `tests/hooks/hooks.test.js` to parse only the `projectId` from stdout and resolve `~/.claude/homunculus/projects/<projectId>/project.json` instead of relying on a reported project dir.
  - Fixed markdownlint issues in VideoDB docs:
    - Converted bare URLs to links and adjusted copy in `skills/videodb/SKILL.md` and `reference/capture-reference.md`.
    - Added blockquote continuation in `reference/api-reference.md`.
    - Removed a stray blank line in `SKILL.md`.

<sup>Written for commit d15f0c7334f1d4540ff384fe249153c5ad5cd14f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

