### PR TITLE
feat: add /aside command

### DIFF
--- a/commands/aside.md
+++ b/commands/aside.md
@@ -64,7 +64,14 @@ After delivering the answer, immediately continue the active task from the exact
 ## Edge Cases
 
 **No question provided (`/aside` with nothing after it):**
-Respond: "What would you like to know? (ask your question and I'll answer without losing the current task context)"
+Respond:
+```
+ASIDE: no question provided
+
+What would you like to know? (ask your question and I'll answer without losing the current task context)
+
+— Back to task: [one-line description of what was being done]
+```
 
 **Question reveals a potential problem with the current task:**
 Flag it clearly before resuming:
@@ -89,13 +96,14 @@ Wait for the user's answer — do not make assumptions.
 Answer from the live context. If the file was read earlier in the session, reference it directly. If not, read it now (read-only) and answer with a file:line reference.
 
 **No active task (nothing in progress when `/aside` is invoked):**
-Use a reduced wrapper that omits the "Back to task" line since there is nothing to resume:
+Still use the standard wrapper so the response shape stays consistent:
 ```
 ASIDE: [restate the question briefly]
 
 [Your answer here]
+
+— Back to task: no active task to resume
 ```
-Do not include `— Back to task:` when there is no active task.
 
 **Question requires a long answer:**
 Give the essential answer concisely, then offer:

--- a/skills/videodb/reference/capture-reference.md
+++ b/skills/videodb/reference/capture-reference.md
@@ -107,7 +107,7 @@ Use [scripts/ws_listener.py](../scripts/ws_listener.py) to connect and dump even
 }
 ```
 
-> For latest details, see [the realtime context docs](https://docs.videodb.io/pages/ingest/capture-sdks/realtime-context.md).
+> For latest details, see [VideoDB Realtime Context docs](https://docs.videodb.io/pages/ingest/capture-sdks/realtime-context.md).
 
 ---
 


### PR DESCRIPTION
  Claude Code's native /btw feature. Allows users to ask a question while
  Claude is actively working without losing task context or touching any files.

  Key behaviors:
  - Freezes current task state before answering (read-only during aside)
  - Delivers answers in a consistent ASIDE / Back to task format
  - Auto-resumes the active task after answering
  - Handles edge cases: no question given, answer reveals a blocker, question implies a task redirect, chained asides, ambiguous questions, and answers that suggest code changes without making them

## Description
<!-- Brief description of changes -->

## Type of Change
- [x] `fix:` Bug fix
- [x] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Checklist
- [x] Tests pass locally (`node tests/run-all.js`)
- [ ] Validation scripts pass
- [ ] Follows conventional commits format
- [ ] Updated relevant documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `/aside`, a mid-task side conversation command that answers quick questions without interrupting or changing the current task. Also cleans up `skills/videodb` docs and lint errors to restore CI.

- **New Features**
  - Read-only during aside; auto-resume after answering.
  - Consistent "ASIDE …" + "— Back to task: …" output format.
  - Handles common edge cases; docs with usage, process, and examples in `commands/aside.md`.

- **Bug Fixes**
  - Resolved markdown lint errors in `skills/videodb` (`SKILL.md`, `reference/api-reference.md`, `reference/capture-reference.md`) to unblock CI.
  - Fixed minor docs inconsistencies and clarified link text (e.g., "VideoDB Realtime Context") and polished `commands/aside.md`.

<sup>Written for commit 0579716d4945c2cffa7a730efeabb725b39e3e51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced new documentation for the Aside Command feature, covering workflow details, edge-case handling, practical examples, and comprehensive user guidance.
  * Updated reference link formatting in technical documentation to enhance readability and improve user experience when accessing resource materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->