### PR TITLE
fix: stop pinning o4-mini in codex config

### DIFF
--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,4 +1,4 @@
-model = "o4-mini"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,8 +10,9 @@
 # - https://developers.openai.com/codex/multi-agent
 
 # Model selection
-model = "o4-mini"
-model_provider = "openai"
+# Leave `model` and `model_provider` unset so Codex CLI uses its current
+# built-in defaults. Uncomment and pin them only if you intentionally want
+# repo-local or global model overrides.
 
 # Top-level runtime settings (current Codex schema)
 approval_policy = "on-request"

--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@ Codex macOS app:
 - Open this repository as your workspace.
 - The root `AGENTS.md` is auto-detected.
 - `.codex/config.toml` and `.codex/agents/*.toml` work best when kept project-local.
+- The reference `.codex/config.toml` intentionally does not pin `model` or `model_provider`, so Codex uses its own current default unless you override it.
 - Optional: copy `.codex/config.toml` to `~/.codex/config.toml` for global defaults; keep the multi-agent role files project-local unless you also copy `.codex/agents/`.
 
 ### What's Included

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -939,13 +939,14 @@ Codex macOS 应用：
 
 * 将此仓库作为您的工作区打开。
 * 根目录的 `AGENTS.md` 会被自动检测。
+* 参考 `.codex/config.toml` 故意不固定 `model` 或 `model_provider`，因此 Codex 会使用它自己的当前默认值，除非您显式覆盖。
 * 可选：将 `.codex/config.toml` 复制到 `~/.codex/config.toml` 以实现 CLI/应用行为一致性。
 
 ### 包含内容
 
 | 组件 | 数量 | 详情 |
 |-----------|-------|---------|
-| 配置 | 1 | `.codex/config.toml` — 模型、权限、MCP 服务器、持久指令 |
+| 配置 | 1 | `.codex/config.toml` — 权限、MCP 服务器、通知和配置文件 |
 | AGENTS.md | 2 | 根目录（通用）+ `.codex/AGENTS.md`（Codex 特定补充） |
 | 技能 | 16 | `.agents/skills/` — 每个技能包含 SKILL.md + agents/openai.yaml |
 | MCP 服务器 | 4 | GitHub、Context7、Memory、Sequential Thinking（基于命令） |

--- a/tests/codex-config.test.js
+++ b/tests/codex-config.test.js
@@ -1,0 +1,70 @@
+/**
+ * Tests for `.codex/config.toml` reference defaults.
+ *
+ * Run with: node tests/codex-config.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+const repoRoot = path.join(__dirname, '..');
+const configPath = path.join(repoRoot, '.codex', 'config.toml');
+const config = fs.readFileSync(configPath, 'utf8');
+const codexAgentsDir = path.join(repoRoot, '.codex', 'agents');
+
+let passed = 0;
+let failed = 0;
+
+if (
+  test('reference config does not pin a top-level model', () => {
+    assert.ok(!/^model\s*=/m.test(config), 'Expected `.codex/config.toml` to inherit the CLI default model');
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('reference config does not pin a top-level model provider', () => {
+    assert.ok(
+      !/^model_provider\s*=/m.test(config),
+      'Expected `.codex/config.toml` to inherit the CLI default provider',
+    );
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('sample Codex role configs do not use o4-mini', () => {
+    const roleFiles = fs.readdirSync(codexAgentsDir).filter(file => file.endsWith('.toml'));
+    assert.ok(roleFiles.length > 0, 'Expected sample role config files under `.codex/agents`');
+
+    for (const roleFile of roleFiles) {
+      const rolePath = path.join(codexAgentsDir, roleFile);
+      const roleConfig = fs.readFileSync(rolePath, 'utf8');
+      assert.ok(
+        !/^model\s*=\s*"o4-mini"$/m.test(roleConfig),
+        `Expected sample role config to avoid o4-mini: ${roleFile}`,
+      );
+    }
+  })
+)
+  passed++;
+else failed++;
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Description
<!-- Brief description of changes -->

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Checklist
- [ ] Tests pass locally (`node tests/run-all.js`)
- [ ] Validation scripts pass
- [ ] Follows conventional commits format
- [ ] Updated relevant documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop pinning the Codex model so the CLI’s current default is used, and remove `o4-mini` from sample configs. Adds a small test to prevent regressions and updates docs to explain the behavior.

- **Bug Fixes**
  - Unset `model` and `model_provider` in `.codex/config.toml` to inherit CLI defaults.
  - Update `.codex/agents/explorer.toml` to avoid `o4-mini` (uses gpt-5.4).
  - Add `tests/codex-config.test.js` to ensure the reference config doesn’t pin a model/provider and sample roles don’t use `o4-mini`.
  - Update `README.md` and `docs/zh-CN/README.md` to note the intentional lack of model/provider pinning and adjust the config description.

<sup>Written for commit 7d48b908a06fb82d5a23cf103e6647a12e193cee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Configuration now uses built-in defaults for streamlined setup when models aren't explicitly specified
  * Explorer agent updated

* **Documentation**
  * Added clarification explaining how default models are applied in configuration
  * Updated documentation across multiple languages

* **Tests**
  * Added test coverage to validate default configuration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->