### PR TITLE
feat: add project cooldown log to prevent observer re-spawn loops

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -33,6 +33,12 @@ analyze_observations() {
     return
   fi
 
+  # session-guardian: gate observer cycle (cooldown log — see session-guardian.sh)
+  if ! bash "$(dirname "$0")/session-guardian.sh"; then
+    echo "[$(date)] Observer cycle skipped by session-guardian" >> "$LOG_FILE"
+    return
+  fi
+
   if ! command -v claude >/dev/null 2>&1; then
     echo "[$(date)] claude CLI not found, skipping analysis" >> "$LOG_FILE"
     return

--- a/skills/continuous-learning-v2/agents/session-guardian.sh
+++ b/skills/continuous-learning-v2/agents/session-guardian.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# session-guardian.sh — Observer session guard
+# Exit 0 = proceed. Exit 1 = skip this observer cycle.
+# Called by observer-loop.sh before spawning any Claude session.
+#
+# Config (env vars, all optional):
+#   OBSERVER_INTERVAL_SECONDS   default: 300  (per-project cooldown)
+#   OBSERVER_LAST_RUN_LOG       default: ~/.claude/observer-last-run.log
+#
+set -euo pipefail
+
+INTERVAL="${OBSERVER_INTERVAL_SECONDS:-300}"
+LOG_PATH="${OBSERVER_LAST_RUN_LOG:-$HOME/.claude/observer-last-run.log}"
+
+# ── Gate 2: Project Cooldown Log ─────────────────────────────────────────────
+# Prevent the same project being observed faster than OBSERVER_INTERVAL_SECONDS.
+# Key: git root path. Falls back to $PWD outside a git repo.
+# stderr uses basename only — never prints the full absolute path.
+
+project_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+project_name="$(basename "$project_root")"
+now="$(date +%s)"
+
+mkdir -p "$(dirname "$LOG_PATH")"
+
+# Acquire lock via mkdir (atomic on POSIX filesystems, portable cross-platform)
+_lock_dir="${LOG_PATH}.lock"
+if ! mkdir "$_lock_dir" 2>/dev/null; then
+  # Another observer holds the lock — fail open, let this cycle proceed
+  echo "session-guardian: log locked by concurrent process, proceeding" >&2
+else
+  trap 'rm -rf "$_lock_dir"' EXIT INT TERM
+
+  last_spawn=0
+  last_spawn=$(grep -F "$project_root" "$LOG_PATH" 2>/dev/null | tail -n1 | awk '{print $NF}') || true
+  last_spawn="${last_spawn:-0}"
+
+  elapsed=$(( now - last_spawn ))
+  if [ "$elapsed" -lt "$INTERVAL" ]; then
+    rm -rf "$_lock_dir"
+    trap - EXIT INT TERM
+    echo "session-guardian: cooldown active for '${project_name}' (last spawn ${elapsed}s ago, interval ${INTERVAL}s)" >&2
+    exit 1
+  fi
+
+  # Update log atomically: remove old entry, append new timestamp
+  tmp_log="$(mktemp "${TMPDIR:-/tmp}/observer-last-run.XXXXXX")"
+  grep -vF "$project_root" "$LOG_PATH" > "$tmp_log" 2>/dev/null || true
+  echo "${project_root}	${now}" >> "$tmp_log"
+  mv "$tmp_log" "$LOG_PATH"
+
+  rm -rf "$_lock_dir"
+  trap - EXIT INT TERM
+fi
+
+exit 0


### PR DESCRIPTION
## Problem

When ECC's observer loop spawns a Haiku session, that session can trigger
\`observe.sh\` hooks which signal the observer — causing a new analysis
cycle before the previous one has finished. Under some conditions this
creates a rapid re-spawn loop that consumes available licensed usage.

## Solution

Adds \`session-guardian.sh\`, a lightweight gatekeeper called by
\`observer-loop.sh\` before each Haiku spawn. It maintains a per-project
log of last spawn times and blocks new spawns if the cooldown window
hasn't elapsed.

**New file:** \`skills/continuous-learning-v2/agents/session-guardian.sh\`

| Env var | Default | Description |
|---------|---------|-------------|
| \`OBSERVER_INTERVAL_SECONDS\` | \`300\` | Per-project cooldown in seconds |
| \`OBSERVER_LAST_RUN_LOG\` | \`~/.claude/observer-last-run.log\` | Log path |

## How it works

1. Acquires a \`mkdir\`-based lock on the log file (safe for concurrent projects)
2. Reads the log for current project's last spawn timestamp (git root as key)
3. If \`(now - last_spawn) < OBSERVER_INTERVAL_SECONDS\` → exits 1 (skip cycle)
4. Otherwise → updates log with tab-delimited entry and exits 0 (proceed)

Debug output to stderr uses only the project basename — no full paths.
Fails open on lock contention (concurrent process holds the lock).

## Platform support

No external dependencies. Uses only \`date +%s\`, \`git\`, \`awk\`, \`grep\`,
\`mkdir\` — all pre-installed on macOS, Linux, and Windows (Git Bash/MSYS2).

## Testing

\`\`\`bash
# First call passes (exit 0)
OBSERVER_LAST_RUN_LOG=/tmp/test.log \
  ./skills/continuous-learning-v2/agents/session-guardian.sh; echo $?

# Immediate second call blocked (exit 1)
./skills/continuous-learning-v2/agents/session-guardian.sh; echo $?

# Expired cooldown passes (exit 0)
project=$(git rev-parse --show-toplevel)
printf '%s\t%s\n' "$project" "$(( $(date +%s) - 400 ))" > /tmp/test.log
OBSERVER_LAST_RUN_LOG=/tmp/test.log \
  ./skills/continuous-learning-v2/agents/session-guardian.sh; echo $?
\`\`\`

## Related

- Companion PR: \`feat/active-hours-idle-guard\` adds time-window and idle-detection gates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-project cooldown to the observer to stop rapid re-spawn loops triggered by `observe.sh` hooks. A new `session-guardian.sh` gate blocks cycles if the same project ran within the cooldown window to reduce wasted sessions.

- **New Features**
  - Added `skills/continuous-learning-v2/agents/session-guardian.sh`; called by `observer-loop.sh` before each spawn and logs skipped cycles.
  - Per-project last-run log at `~/.claude/observer-last-run.log` (tab-delimited); default cooldown `300s` via `OBSERVER_INTERVAL_SECONDS`.
  - Project key from `git rev-parse --show-toplevel` (fallback to `PWD`); exits 1 to skip, 0 to proceed; debug uses project basename only.
  - Concurrency-safe `mkdir` lock; fails open on lock contention. No external deps; works on macOS, Linux, and Windows (Git Bash/MSYS2).

<sup>Written for commit 332b8b4559fe364b685fdbf0c5524822327e12ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Observer runs now include a per-project cooldown mechanism (configurable, default 300 seconds).
  * Claude analysis is skipped when cooldown is active.
  * Lock-based synchronization ensures safe concurrent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->