### PR TITLE
feat: active hours + idle detection gates for session-guardian

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -33,14 +33,14 @@ analyze_observations() {
     return
   fi
 
-  # session-guardian: gate observer cycle (cooldown log — see session-guardian.sh)
-  if ! bash "$(dirname "$0")/session-guardian.sh"; then
-    echo "[$(date)] Observer cycle skipped by session-guardian" >> "$LOG_FILE"
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "[$(date)] claude CLI not found, skipping analysis" >> "$LOG_FILE"
     return
   fi
 
-  if ! command -v claude >/dev/null 2>&1; then
-    echo "[$(date)] claude CLI not found, skipping analysis" >> "$LOG_FILE"
+  # session-guardian: gate observer cycle (active hours, cooldown, idle detection)
+  if ! bash "$(dirname "$0")/session-guardian.sh"; then
+    echo "[$(date)] Observer cycle skipped by session-guardian" >> "$LOG_FILE"
     return
   fi
 

--- a/skills/continuous-learning-v2/agents/session-guardian.sh
+++ b/skills/continuous-learning-v2/agents/session-guardian.sh
@@ -26,11 +26,26 @@ MAX_IDLE="${OBSERVER_MAX_IDLE_SECONDS:-1800}"
 # ── Gate 1: Time Window ───────────────────────────────────────────────────────
 # Skip observer cycles outside configured active hours (local system time).
 # Uses HHMM integer comparison. Works on BSD date (macOS) and GNU date (Linux).
+# Supports overnight windows such as 2200-0600.
 # Set both ACTIVE_START and ACTIVE_END to 0 to disable this gate.
 if [ "$ACTIVE_START" -ne 0 ] || [ "$ACTIVE_END" -ne 0 ]; then
   current_hhmm=$(date +%k%M | tr -d ' ')
-  if [ $(( 10#${current_hhmm:-0} )) -lt $(( 10#${ACTIVE_START:-800} )) ] || \
-     [ $(( 10#${current_hhmm:-0} )) -ge $(( 10#${ACTIVE_END:-2300} )) ]; then
+  current_hhmm_num=$(( 10#${current_hhmm:-0} ))
+  active_start_num=$(( 10#${ACTIVE_START:-800} ))
+  active_end_num=$(( 10#${ACTIVE_END:-2300} ))
+
+  within_active_hours=0
+  if [ "$active_start_num" -lt "$active_end_num" ]; then
+    if [ "$current_hhmm_num" -ge "$active_start_num" ] && [ "$current_hhmm_num" -lt "$active_end_num" ]; then
+      within_active_hours=1
+    fi
+  else
+    if [ "$current_hhmm_num" -ge "$active_start_num" ] || [ "$current_hhmm_num" -lt "$active_end_num" ]; then
+      within_active_hours=1
+    fi
+  fi
+
+  if [ "$within_active_hours" -ne 1 ]; then
     echo "session-guardian: outside active hours (${current_hhmm}, window ${ACTIVE_START}-${ACTIVE_END})" >&2
     exit 1
   fi
@@ -38,11 +53,14 @@ fi
 
 # ── Gate 2: Project Cooldown Log ─────────────────────────────────────────────
 # Prevent the same project being observed faster than OBSERVER_INTERVAL_SECONDS.
-# Key: git root path. Falls back to $PWD outside a git repo.
-# Uses mkdir-based lock for safe concurrent access. Fails open on lock contention.
+# Key: PROJECT_DIR when provided by the observer, otherwise git root path.
+# Uses mkdir-based lock for safe concurrent access. Skips the cycle on lock contention.
 # stderr uses basename only — never prints the full absolute path.
 
-project_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+project_root="${PROJECT_DIR:-}"
+if [ -z "$project_root" ] || [ ! -d "$project_root" ]; then
+  project_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+fi
 project_name="$(basename "$project_root")"
 now="$(date +%s)"
 
@@ -53,13 +71,14 @@ mkdir -p "$(dirname "$LOG_PATH")" || {
 
 _lock_dir="${LOG_PATH}.lock"
 if ! mkdir "$_lock_dir" 2>/dev/null; then
-  # Another observer holds the lock — fail open, let this cycle proceed
-  echo "session-guardian: log locked by concurrent process, proceeding" >&2
+  # Another observer holds the lock — skip this cycle to avoid double-spawns
+  echo "session-guardian: log locked by concurrent process, skipping cycle" >&2
+  exit 1
 else
   trap 'rm -rf "$_lock_dir"' EXIT INT TERM
 
   last_spawn=0
-  last_spawn=$(grep -F "$project_root" "$LOG_PATH" 2>/dev/null | tail -n1 | awk '{print $NF}') || true
+  last_spawn=$(awk -F '\t' -v key="$project_root" '$1 == key { value = $2 } END { if (value != "") print value }' "$LOG_PATH" 2>/dev/null) || true
   last_spawn="${last_spawn:-0}"
   [[ "$last_spawn" =~ ^[0-9]+$ ]] || last_spawn=0
 
@@ -73,7 +92,7 @@ else
 
   # Update log: remove old entry for this project, append new timestamp (tab-delimited)
   tmp_log="$(mktemp "$(dirname "$LOG_PATH")/observer-last-run.XXXXXX")"
-  grep -vF "$project_root" "$LOG_PATH" > "$tmp_log" 2>/dev/null || true
+  awk -F '\t' -v key="$project_root" '$1 != key' "$LOG_PATH" > "$tmp_log" 2>/dev/null || true
   printf '%s\t%s\n' "$project_root" "$now" >> "$tmp_log"
   mv "$tmp_log" "$LOG_PATH"
 
@@ -109,7 +128,7 @@ get_idle_seconds() {
           Add-Type -MemberDefinition '[DllImport(\"user32.dll\")] public static extern bool GetLastInputInfo(ref LASTINPUTINFO p); [StructLayout(LayoutKind.Sequential)] public struct LASTINPUTINFO { public uint cbSize; public int dwTime; }' -Name WinAPI -Namespace PInvoke; \
           \$l = New-Object PInvoke.WinAPI+LASTINPUTINFO; \$l.cbSize = 8; \
           [PInvoke.WinAPI]::GetLastInputInfo([ref]\$l) | Out-Null; \
-          [Math]::Max(0, [long]([Environment]::TickCount - [long]\$l.dwTime) / 1000) \
+          [int][Math]::Max(0, [long]([Environment]::TickCount - [long]\$l.dwTime) / 1000) \
         } catch { 0 }" \
         2>/dev/null | tr -d '\r') || true
       printf '%s\n' "${_raw:-0}" | head -n1


### PR DESCRIPTION
## Summary

Extends `session-guardian.sh` (introduced in #412) with two additional guard gates that prevent observer sessions from spawning when no human is present:

- **Gate 1 — Active Hours:** blocks observer cycles outside a configurable time window (default 8 AM – 11 PM local time). Uses `date +%k%M` with base-10 arithmetic prefix to avoid octal crash on midnight minutes (`00:08`, `00:09`, etc.). Works toollessly on BSD date (macOS) and GNU date (Linux). Set both vars to `0` to disable.
- **Gate 3 — Idle Detection:** skips cycles when the user has been idle beyond a configurable threshold (default 30 min). Detects system idle time via OS-native APIs — no additional tools required on macOS or Windows:
  - **macOS:** `/usr/sbin/ioreg` + `awk` (built-in)
  - **Linux:** `xprintidle` if installed, else fail open
  - **Windows (Git Bash/MSYS2):** PowerShell `GetLastInputInfo` via `Add-Type` (Win32 API, pre-installed)
  - **Headless/unknown:** always returns 0 (fail open)
- **Gate 2** (per-project cooldown log, from #412) is unchanged and still runs between Gates 1 and 3.

Execution order is cheapest-first: time window (~0 ms) → cooldown log (~1 ms) → idle detection (~5–50 ms).

**Motivation:** Observer sessions that spawn outside working hours (overnight, while the user is away) consume licensed usage with no benefit. This PR gives users a simple, zero-dependency way to ensure observers only run while they are actively present.

> **Note:** This PR builds on #412. It can be reviewed independently but should be merged after #412 since it references `session-guardian.sh`.

## Configuration

All settings are optional env vars with sensible defaults:

```bash
OBSERVER_ACTIVE_HOURS_START=800   # 8:00 AM local (set to 0 to disable)
OBSERVER_ACTIVE_HOURS_END=2300    # 11:00 PM local (set to 0 to disable)
OBSERVER_MAX_IDLE_SECONDS=1800    # 30 min idle threshold (set to 0 to disable)
```

## Correctness fixes included

- `10#` base-10 prefix on all HHMM arithmetic to prevent octal crash on midnight minutes containing digits 8 or 9
- PowerShell output stripped of `\r` via `tr -d '\r'` (Windows CRLF); uses `[long]` cast to prevent 32-bit `TickCount` overflow after 24.9 days uptime
- `mktemp` uses log file's own directory (not `$TMPDIR`) so `mv` is always same-filesystem on Linux
- `mkdir -p` failure exits 0 (fail open) rather than propagating a non-zero exit under `set -e`
- Numeric validation on `last_spawn` guards against corrupt log entries causing arithmetic errors

## Test plan

- [ ] `OBSERVER_ACTIVE_HOURS_START=0 OBSERVER_ACTIVE_HOURS_END=0 OBSERVER_MAX_IDLE_SECONDS=0 bash session-guardian.sh` → exit 0 (all gates disabled)
- [ ] `OBSERVER_ACTIVE_HOURS_START=0 OBSERVER_ACTIVE_HOURS_END=1 OBSERVER_MAX_IDLE_SECONDS=0 bash session-guardian.sh` → exit 1 with "outside active hours" on stderr
- [ ] `OBSERVER_MAX_IDLE_SECONDS=1 bash session-guardian.sh` → exit 0 on macOS with ioreg idle < 1 s
- [ ] No absolute paths containing usernames appear on stderr in any gate
- [ ] `bash -c 'x="008"; echo $(( 10#$x < 800 ))'` → outputs `1` (octal fix)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds active-hours and idle-detection gates to `session-guardian.sh` and wires it into `observer-loop.sh` to skip observer cycles when no one is around. This cuts wasted usage by stopping spawns outside set hours, during cooldown, or while the user is idle.

- **New Features**
  - Gate 1 — Active Hours: blocks cycles outside a local time window (default 08:00–23:00). Uses HHMM with base-10 math. Disable with `OBSERVER_ACTIVE_HOURS_START=0` and `OBSERVER_ACTIVE_HOURS_END=0`.
  - Gate 3 — Idle Detection: skips when idle > threshold (default 30m). macOS via `ioreg`, Linux via `xprintidle` if available (else fail open), Windows via PowerShell `GetLastInputInfo`. Disable with `OBSERVER_MAX_IDLE_SECONDS=0`.
  - Integrated guard call in `observer-loop.sh`. Gate order: time window → per-project cooldown (unchanged, default `OBSERVER_INTERVAL_SECONDS=300`) → idle. Config vars: `OBSERVER_INTERVAL_SECONDS`, `OBSERVER_LAST_RUN_LOG`, `OBSERVER_ACTIVE_HOURS_START/END`, `OBSERVER_MAX_IDLE_SECONDS`.

- **Bug Fixes**
  - Gate hardening: base-10 prefix for HHMM arithmetic; Windows CRLF stripped and `[long]` cast; same-filesystem `mv` for log updates; fail-open if `mkdir -p` cannot create the log dir; numeric validation of log entries.
  - Concurrency and privacy: mkdir lock now skips on contention to avoid double spawns; stderr avoids absolute paths (only basenames).

<sup>Written for commit a46e644365568de0440df0e987603fed22809808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observer loop now runs a session-guardian gate before analysis: configurable active time windows (including overnight), per-project cooldown to avoid duplicate observations, and idle-time detection to skip cycles when the user is inactive. The gate can be configured or disabled and will skip an analysis cycle when conditions dictate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->