### PR TITLE
fix: compare hook roots by file identity

### DIFF
--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -120,6 +120,22 @@ function normalizeComparablePath(targetPath) {
   return path.normalize(normalizedPath).replace(/\\/g, '/').replace(/^([a-z]):/, (_, drive) => `${drive.toUpperCase()}:`);
 }
 
+function pathsReferToSameLocation(leftPath, rightPath) {
+  const normalizedLeftPath = normalizeComparablePath(leftPath);
+  const normalizedRightPath = normalizeComparablePath(rightPath);
+
+  if (!normalizedLeftPath || !normalizedRightPath) return false;
+  if (normalizedLeftPath === normalizedRightPath) return true;
+
+  try {
+    const leftStats = fs.statSync(normalizedLeftPath);
+    const rightStats = fs.statSync(normalizedRightPath);
+    return leftStats.dev === rightStats.dev && leftStats.ino === rightStats.ino;
+  } catch {
+    return false;
+  }
+}
+
 function createCommandShim(binDir, baseName, logFile) {
   fs.mkdirSync(binDir, { recursive: true });
 
@@ -2224,7 +2240,10 @@ async function runTests() {
         const normalizedMetadataRoot = normalizeComparablePath(metadata.root);
         const normalizedRepoDir = normalizeComparablePath(repoDir);
         assert.ok(normalizedMetadataRoot, 'project.json should include a non-empty repo root');
-        assert.strictEqual(normalizedMetadataRoot, normalizedRepoDir, 'project.json should include the repo root');
+        assert.ok(
+          pathsReferToSameLocation(normalizedMetadataRoot, normalizedRepoDir),
+          `project.json should include the repo root (expected ${normalizedRepoDir}, got ${normalizedMetadataRoot})`,
+        );
         assert.strictEqual(metadata.remote, 'https://github.com/example/ecc-test.git', 'project.json should include the sanitized remote');
         assert.ok(metadata.created_at, 'project.json should include created_at');
         assert.ok(metadata.last_seen, 'project.json should include last_seen');


### PR DESCRIPTION
## Summary
- fix the remaining Windows-only `detect-project` hook assertion after `#415` merged
- compare repo roots by actual filesystem identity instead of strict normalized string equality
- keep the patch scoped to the single failing hook test

## Root cause
- `#415` correctly stopped using bash-emitted `PROJECT_DIR`, but the follow-up strict string comparison still fails on Windows when two path strings refer to the same directory through different Windows aliases.
- The failure shows up across every Windows matrix job in run `23025465862`, all on `detect-project writes project metadata to the registry and project directory`.

## Files changed
- `tests/hooks/hooks.test.js`

## Test plan
- `node tests/hooks/hooks.test.js`

## Notes
- This is a follow-up repair after `#415` merged with the Windows matrix still red.
- The assertion remains strict about correctness: it now requires both paths to resolve to the same filesystem location instead of merely sharing a matching string form.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows-only failure in the detect-project hook test by comparing repo roots by filesystem identity instead of path strings. Handles Windows path aliases so the test recognizes the same directory reliably.

- **Bug Fixes**
  - Added `pathsReferToSameLocation` to normalize paths and compare `dev`/`ino` via `fs.statSync`.
  - Replaced strict string equality in the test with the identity check and a clearer assertion message.
  - Scoped to tests only; no production code changes.

<sup>Written for commit fe9f8772adcd91267fbb9da23cf5342a527df5f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved path comparison logic in test suite to handle edge cases including symlinks and alternative path representations more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->