### PR TITLE
feat(skills): add team-builder skill

### DIFF
--- a/skills/team-builder/SKILL.md
+++ b/skills/team-builder/SKILL.md
@@ -40,7 +40,9 @@ agents/
 ├── engineering-security-engineer.md
 ├── engineering-software-architect.md
 ├── marketing-seo-specialist.md
-└── sales-discovery-coach.md
+├── marketing-content-strategist.md
+├── sales-discovery-coach.md
+└── sales-outbound-strategist.md
 ```
 
 ## Configuration
@@ -59,7 +61,7 @@ Results from all locations are merged and deduplicated by agent name. Project-lo
 Glob agent directories using the probe order above. Exclude README files. For each file found:
 - **Subdirectory layout:** extract the domain from the parent folder name
 - **Flat layout:** collect all filename prefixes (text before the first `-`). A prefix qualifies as a domain only if it appears in 2 or more filenames (e.g., `engineering-security-engineer.md` and `engineering-software-architect.md` both start with `engineering` → Engineering domain). Files with unique prefixes (e.g., `code-reviewer.md`, `tdd-guide.md`) are grouped under "General"
-- Extract the agent name from the first `# Heading`
+- Extract the agent name from the first `# Heading`. If no heading is found, derive the name from the filename (strip `.md`, replace hyphens with spaces, title-case)
 - Extract a one-line summary from the first paragraph after the heading
 
 If no agent files are found after probing all locations, inform the user: "No agent files found. Checked: [list paths probed]. Expected: markdown files in one of those directories." Then stop.
@@ -101,6 +103,7 @@ What should they work on? (describe the task):
    - `subagent_type: "general-purpose"`
    - `prompt: "{agent file content}\n\nTask: {task description}"`
    - Each agent runs independently — no inter-agent communication needed
+4. If an agent fails (error, timeout, or empty output), note the failure inline (e.g., "Security Engineer: failed — [reason]") and continue with results from agents that succeeded
 
 ### Step 5: Synthesize Results
 


### PR DESCRIPTION
## Summary
Interactive agent picker skill that dynamically discovers agent markdown files organized by domain subdirectories, presents a browsable menu, lets users compose custom teams, and dispatches selected agents in parallel with synthesized results.

Fills a gap in the current skill collection: there's no way to browse and compose agent teams on the fly. Users either need to remember which agents exist or manually invoke them one by one.

## Type
- [x] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command

## Key Features
- **Dynamic discovery** — globs agent directories, no hardcoded lists. Adding a new `.md` file auto-adds it to the menu.
- **Flexible selection** — accepts domain numbers ("1,3"), agent names ("security + seo"), or "all from [domain]"
- **Parallel dispatch** — spawns all selected agents simultaneously via the Agent tool
- **Synthesis** — highlights agreements, tensions, and next steps across agent outputs
- **Generic** — works with any collection of agent markdown files, not tied to a specific agent set

## Testing
- Tested with 12 agent files across 5 domains (engineering, sales, marketing, support, specialized)
- Verified dynamic discovery picks up new files without skill edits
- Tested parallel dispatch with 2-4 agents simultaneously
- Validated fuzzy name matching and domain number selection

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
- [x] Focused on one domain
- [x] Under 500 lines (140 lines)
- [x] Includes practical example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new team-builder skill to browse agents by domain, assemble a custom team, and run them in parallel on a task. Outputs are merged into one report with agreements, tensions, and next steps.

- **New Features**
  - Dynamic discovery across `./agents` and `~/.claude/agents` (merged with local precedence). Supports domain subdirs and flat layout; flat domains are defined by shared filename prefixes (2+ files); singletons go to General; READMEs ignored; helpful message if none found; filename-based name fallback if no `# Heading`.
  - Flexible selection: domain numbers, fuzzy names, or “all from <domain>”. Enforces a max of 5; single-agent runs skip synthesis.
  - Parallel dispatch via the Agent tool for independent runs (not `TeamCreate`), with per-agent failure reporting and continued synthesis from successful agents.

- **Bug Fixes**
  - Consistent merge-all semantics across paths; local overrides global on duplicate names.
  - Deterministic overflow handling when >5 selected: alphabetical ordering for narrowing (e.g., “first 5”).
  - Clarified flat-layout limitation for multi-word domains and updated the example to reflect the 2+ prefix rule.

<sup>Written for commit 1aa25cb1b22a268e3fd90a26ae4fa9d7e87172ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Interactive Team Builder guide: explains discovering agents by domain, selecting domains and agents, spawning selected agents in parallel with custom task prompts, synthesizing results, prerequisites for persona files, support for subdirectory and flat layouts, configuration and probe ordering, operational rules (e.g., max agents, parallel dispatch), and example command flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->