### PR TITLE
fix: resolve CI test failures across 6 test files

### DIFF
--- a/scripts/ecc.js
+++ b/scripts/ecc.js
@@ -150,6 +150,7 @@ function runCommand(commandName, args) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
     }
   );
 

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -83,6 +83,11 @@ function validateLegacyTarget(target) {
   }
 }
 
+const IGNORED_DIRECTORY_NAMES = new Set([
+  'node_modules',
+  '.git',
+]);
+
 function listFilesRecursive(dirPath) {
   if (!fs.existsSync(dirPath)) {
     return [];
@@ -94,6 +99,9 @@ function listFilesRecursive(dirPath) {
   for (const entry of entries) {
     const absolutePath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
+      if (IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+        continue;
+      }
       const childFiles = listFilesRecursive(absolutePath);
       for (const childFile of childFiles) {
         files.push(path.join(entry.name, childFile));

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -348,7 +348,10 @@ function persistCanonicalSnapshot(snapshot, options = {}) {
   const writer = resolveStateStoreWriter(stateStore);
 
   if (stateStore && !writer) {
-    throw new Error('State store does not expose a supported session snapshot writer');
+    // The loaded object is a factory module (e.g. has createStateStore but no
+    // writer methods).  Treat it the same as a missing state store and fall
+    // through to the JSON-file recording path below.
+    return writeFallbackSessionRecording(snapshot, options);
   }
 
   if (writer) {

--- a/scripts/orchestrate-codex-worker.sh
+++ b/scripts/orchestrate-codex-worker.sh
@@ -31,6 +31,21 @@ EOF
 }
 
 mkdir -p "$(dirname "$handoff_file")" "$(dirname "$status_file")"
+
+if [[ ! -r "$task_file" ]]; then
+  write_status "failed" "- Error: task file is missing or unreadable (\`$task_file\`)"
+  {
+    echo "# Handoff"
+    echo
+    echo "- Failed: $(timestamp)"
+    echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
+    echo "- Worktree: \`$(pwd)\`"
+    echo
+    echo "Task file is missing or unreadable: \`$task_file\`"
+  } > "$handoff_file"
+  exit 1
+fi
+
 write_status "running" "- Task file: \`$task_file\`"
 
 prompt_file="$(mktemp)"

--- a/tests/scripts/ecc.test.js
+++ b/tests/scripts/ecc.test.js
@@ -14,6 +14,7 @@ function runCli(args, options = {}) {
   return spawnSync('node', [SCRIPT, ...args], {
     encoding: 'utf8',
     cwd: options.cwd || process.cwd(),
+    maxBuffer: 10 * 1024 * 1024,
     env: {
       ...process.env,
       ...(options.env || {}),

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -126,8 +126,8 @@ function runTests() {
       const result = run(['--target', 'cursor', 'typescript'], { cwd: projectDir, homeDir });
       assert.strictEqual(result.code, 0, result.stderr);
 
-      assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'rules', 'common', 'coding-style.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'rules', 'typescript', 'testing.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'rules', 'common-coding-style.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'rules', 'typescript-testing.md')));
       assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'agents', 'architect.md')));
       assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'commands', 'plan.md')));
       assert.ok(fs.existsSync(path.join(projectDir, '.cursor', 'hooks.json')));
@@ -163,10 +163,10 @@ function runTests() {
       const result = run(['--target', 'antigravity', 'typescript'], { cwd: projectDir, homeDir });
       assert.strictEqual(result.code, 0, result.stderr);
 
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'common', 'coding-style.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'typescript', 'testing.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'commands', 'plan.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'agents', 'architect.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'common-coding-style.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'typescript-testing.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'workflows', 'plan.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'skills', 'architect.md')));
 
       const statePath = path.join(projectDir, '.agent', 'ecc-install-state.json');
       const state = readJson(statePath);
@@ -176,7 +176,7 @@ function runTests() {
       assert.deepStrictEqual(state.resolution.selectedModules, ['rules-core', 'agents-core', 'commands-core']);
       assert.ok(
         state.operations.some(operation => (
-          operation.destinationPath.endsWith(path.join('.agent', 'commands', 'plan.md'))
+          operation.destinationPath.endsWith(path.join('.agent', 'workflows', 'plan.md'))
         )),
         'Should record manifest command file copy operation'
       );
@@ -266,9 +266,9 @@ function runTests() {
       const result = run(['--target', 'antigravity', '--profile', 'core'], { cwd: projectDir, homeDir });
       assert.strictEqual(result.code, 0, result.stderr);
 
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'common', 'coding-style.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'agents', 'architect.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'commands', 'plan.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'common-coding-style.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'skills', 'architect.md')));
+      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'workflows', 'plan.md')));
       assert.ok(!fs.existsSync(path.join(projectDir, '.agent', 'skills', 'tdd-workflow', 'SKILL.md')));
 
       const state = readJson(path.join(projectDir, '.agent', 'ecc-install-state.json'));


### PR DESCRIPTION
## Summary

- **canonical-session.js**: When `sql.js` is installed, `loadStateStore` returns the raw module (a factory), not an initialized instance. `resolveStateStoreWriter` found no writer methods and threw. Fixed by falling back to JSON file recording when the loaded object lacks writer methods, matching behavior when the module is absent entirely.
- **install-executor.js**: `listFilesRecursive` traversed into `node_modules` and `.git` inside `.opencode/`, producing 1600+ copy operations that caused ETIMEDOUT in tests with 10s timeouts. Added `IGNORED_DIRECTORY_NAMES` skip set.
- **ecc.js**: Internal `spawnSync` of `install-apply.js` hit the default 1MB `maxBuffer`, causing ENOBUFS on the 2MB JSON plan output. Raised to 10MB.
- **ecc.test.js**: Same `maxBuffer` fix in the test runner's `runCli` helper.
- **install-apply.test.js**: Cursor and Antigravity target adapters now flatten rules (`common/coding-style.md` -> `common-coding-style.md`) and remap directories (`commands` -> `workflows`, `agents` -> `skills`). Updated assertions to match.
- **orchestrate-codex-worker.sh**: `set -e` caused the script to abort at `cat "$task_file"` before writing failure artifacts. Added a readability guard that writes status/handoff files before exiting.

## Test plan

- [x] `node tests/run-all.js` passes all 1194 tests locally (0 failures)
- [x] ESLint clean on all modified files
- [x] Markdownlint clean
- [ ] CI matrix (ubuntu/macos/windows x node 18/20/22 x npm/pnpm/yarn/bun)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI test failures by hardening the install flow and test harness. Prevents timeouts and ENOBUFS, adds safe fallbacks, and updates tests to match the current layout.

- **Bug Fixes**
  - Session store: fall back to JSON snapshot recording when a factory module is loaded without writer methods.
  - Install executor: skip `node_modules` and `.git` in recursive listing to avoid thousands of unnecessary copies and timeouts.
  - ECC CLI/tests: raise `spawnSync` `maxBuffer` to 10 MB to handle large JSON plan output.
  - Tests: update Cursor and Antigravity expectations for flattened rule files and remapped dirs (`workflows`, `skills`).
  - Worker script: guard unreadable task file, write status/handoff artifacts, then exit cleanly.

<sup>Written for commit 64892be668b0654140116353938e789d6644b627. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-flight validation for missing task files with comprehensive error reporting and handoff details
  * Implemented fallback mechanism for session state storage when primary writer is unavailable

* **Chores**
  * Increased output buffer capacity for enhanced command execution and output handling
  * Optimized file traversal by automatically skipping common ignored directories during installation
  * Updated test references and file path configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->