### PR TITLE
docs: add npm install step before running install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Get up and running in under 2 minutes:
 git clone https://github.com/affaan-m/everything-claude-code.git
 cd everything-claude-code
 
+# Install dependencies (pick your package manager)
+npm install        # or: pnpm install | yarn install | bun install
+
 # macOS/Linux
 ./install.sh typescript    # or python or golang or swift or php
 # ./install.sh typescript python golang swift php


### PR DESCRIPTION
## Description
<!-- Brief description of changes -->
docs: add npm install step before running install.sh

The install script requires the ajv package (a devDependency) for
config validation. Without running npm install first, users get
"Cannot find module 'ajv'" when running ./install.sh.

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Checklist
- [x] Tests pass locally (`node tests/run-all.js`)
- [x] Validation scripts pass
- [x] Follows conventional commits format
- [x] Updated relevant documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dependency install step to the README quickstart (supports `npm`, `pnpm`, `yarn`, `bun`) before running `install.sh`. This ensures `ajv` used by the installer is installed and avoids "Cannot find module 'ajv'" errors.

<sup>Written for commit 81f6dbc85778182f811494f3d0551868d0ee5df0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the quick start guide by adding an explicit dependency-install step ("npm install") before running the installer and noted alternative package managers (pnpm, yarn, bun). This clarifies initial setup without changing installer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->