### PR TITLE
fix: add 62 missing skills to install manifests

### DIFF
--- a/manifests/install-components.json
+++ b/manifests/install-components.json
@@ -168,6 +168,88 @@
       "modules": [
         "orchestration"
       ]
+    },
+    {
+      "id": "lang:swift",
+      "family": "language",
+      "description": "Swift, SwiftUI, and Apple platform engineering guidance.",
+      "modules": [
+        "swift-apple"
+      ]
+    },
+    {
+      "id": "lang:cpp",
+      "family": "language",
+      "description": "C++ coding standards and testing guidance. Currently resolves through the shared framework-language module.",
+      "modules": [
+        "framework-language"
+      ]
+    },
+    {
+      "id": "lang:kotlin",
+      "family": "language",
+      "description": "Kotlin, Ktor, Exposed, Coroutines, and Compose Multiplatform guidance. Currently resolves through the shared framework-language module.",
+      "modules": [
+        "framework-language"
+      ]
+    },
+    {
+      "id": "lang:perl",
+      "family": "language",
+      "description": "Modern Perl patterns, testing, and security guidance. Currently resolves through framework-language and security modules.",
+      "modules": [
+        "framework-language",
+        "security"
+      ]
+    },
+    {
+      "id": "lang:rust",
+      "family": "language",
+      "description": "Rust patterns and testing guidance. Currently resolves through the shared framework-language module.",
+      "modules": [
+        "framework-language"
+      ]
+    },
+    {
+      "id": "framework:laravel",
+      "family": "framework",
+      "description": "Laravel patterns, TDD, verification, and security guidance. Resolves through framework-language and security modules.",
+      "modules": [
+        "framework-language",
+        "security"
+      ]
+    },
+    {
+      "id": "capability:agentic",
+      "family": "capability",
+      "description": "Agentic engineering, autonomous loops, and LLM pipeline optimization.",
+      "modules": [
+        "agentic-patterns"
+      ]
+    },
+    {
+      "id": "capability:devops",
+      "family": "capability",
+      "description": "Deployment, Docker, and infrastructure patterns.",
+      "modules": [
+        "devops-infra"
+      ]
+    },
+    {
+      "id": "capability:supply-chain",
+      "family": "capability",
+      "description": "Supply chain, logistics, procurement, and manufacturing domain skills.",
+      "modules": [
+        "supply-chain-domain"
+      ]
+    },
+    {
+      "id": "capability:documents",
+      "family": "capability",
+      "description": "Document processing, conversion, and translation skills.",
+      "modules": [
+        "document-processing"
+      ]
     }
   ]
 }

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -103,18 +103,36 @@
       "kind": "skills",
       "description": "Core framework, language, and application-engineering skills.",
       "paths": [
+        "skills/android-clean-architecture",
+        "skills/api-design",
         "skills/backend-patterns",
         "skills/coding-standards",
+        "skills/compose-multiplatform-patterns",
+        "skills/cpp-coding-standards",
+        "skills/cpp-testing",
+        "skills/django-patterns",
+        "skills/django-tdd",
+        "skills/django-verification",
         "skills/frontend-patterns",
         "skills/frontend-slides",
         "skills/golang-patterns",
         "skills/golang-testing",
+        "skills/java-coding-standards",
+        "skills/kotlin-coroutines-flows",
+        "skills/kotlin-exposed-patterns",
+        "skills/kotlin-ktor-patterns",
+        "skills/kotlin-patterns",
+        "skills/kotlin-testing",
+        "skills/laravel-patterns",
+        "skills/laravel-tdd",
+        "skills/laravel-verification",
+        "skills/mcp-server-patterns",
+        "skills/perl-patterns",
+        "skills/perl-testing",
         "skills/python-patterns",
         "skills/python-testing",
-        "skills/django-patterns",
-        "skills/django-tdd",
-        "skills/django-verification",
-        "skills/java-coding-standards",
+        "skills/rust-patterns",
+        "skills/rust-testing",
         "skills/springboot-patterns",
         "skills/springboot-tdd",
         "skills/springboot-verification"
@@ -142,6 +160,7 @@
       "description": "Database and persistence-focused skills.",
       "paths": [
         "skills/clickhouse-io",
+        "skills/database-migrations",
         "skills/jpa-patterns",
         "skills/postgres-patterns"
       ],
@@ -164,10 +183,16 @@
       "kind": "skills",
       "description": "Evaluation, TDD, verification, learning, and compaction skills.",
       "paths": [
+        "skills/ai-regression-testing",
+        "skills/configure-ecc",
         "skills/continuous-learning",
         "skills/continuous-learning-v2",
+        "skills/e2e-testing",
         "skills/eval-harness",
         "skills/iterative-retrieval",
+        "skills/plankton-code-quality",
+        "skills/project-guidelines-example",
+        "skills/skill-stocktake",
         "skills/strategic-compact",
         "skills/tdd-workflow",
         "skills/verification-loop"
@@ -191,9 +216,11 @@
       "kind": "skills",
       "description": "Security review and security-focused framework guidance.",
       "paths": [
+        "skills/django-security",
+        "skills/laravel-security",
+        "skills/perl-security",
         "skills/security-review",
         "skills/security-scan",
-        "skills/django-security",
         "skills/springboot-security",
         "the-security-guide.md"
       ],
@@ -330,6 +357,141 @@
       "defaultInstall": false,
       "cost": "medium",
       "stability": "beta"
+    },
+    {
+      "id": "swift-apple",
+      "kind": "skills",
+      "description": "Swift, SwiftUI, and Apple platform skills including concurrency, persistence, and design patterns.",
+      "paths": [
+        "skills/foundation-models-on-device",
+        "skills/liquid-glass-design",
+        "skills/swift-actor-persistence",
+        "skills/swift-concurrency-6-2",
+        "skills/swift-protocol-di-testing",
+        "skills/swiftui-patterns"
+      ],
+      "targets": [
+        "claude",
+        "cursor",
+        "antigravity",
+        "codex",
+        "opencode"
+      ],
+      "dependencies": [
+        "platform-configs"
+      ],
+      "defaultInstall": false,
+      "cost": "medium",
+      "stability": "stable"
+    },
+    {
+      "id": "agentic-patterns",
+      "kind": "skills",
+      "description": "Agentic engineering, autonomous loops, agent harness construction, and LLM pipeline optimization skills.",
+      "paths": [
+        "skills/agent-harness-construction",
+        "skills/agentic-engineering",
+        "skills/ai-first-engineering",
+        "skills/autonomous-loops",
+        "skills/blueprint",
+        "skills/claude-devfleet",
+        "skills/content-hash-cache-pattern",
+        "skills/continuous-agent-loop",
+        "skills/cost-aware-llm-pipeline",
+        "skills/data-scraper-agent",
+        "skills/enterprise-agent-ops",
+        "skills/nanoclaw-repl",
+        "skills/prompt-optimizer",
+        "skills/ralphinho-rfc-pipeline",
+        "skills/regex-vs-llm-structured-text",
+        "skills/search-first",
+        "skills/team-builder"
+      ],
+      "targets": [
+        "claude",
+        "cursor",
+        "antigravity",
+        "codex",
+        "opencode"
+      ],
+      "dependencies": [
+        "platform-configs"
+      ],
+      "defaultInstall": false,
+      "cost": "medium",
+      "stability": "stable"
+    },
+    {
+      "id": "devops-infra",
+      "kind": "skills",
+      "description": "Deployment workflows, Docker patterns, and infrastructure skills.",
+      "paths": [
+        "skills/deployment-patterns",
+        "skills/docker-patterns"
+      ],
+      "targets": [
+        "claude",
+        "cursor",
+        "antigravity",
+        "codex",
+        "opencode"
+      ],
+      "dependencies": [
+        "platform-configs"
+      ],
+      "defaultInstall": false,
+      "cost": "medium",
+      "stability": "stable"
+    },
+    {
+      "id": "supply-chain-domain",
+      "kind": "skills",
+      "description": "Supply chain, logistics, procurement, and manufacturing domain skills.",
+      "paths": [
+        "skills/carrier-relationship-management",
+        "skills/customs-trade-compliance",
+        "skills/energy-procurement",
+        "skills/inventory-demand-planning",
+        "skills/logistics-exception-management",
+        "skills/production-scheduling",
+        "skills/quality-nonconformance",
+        "skills/returns-reverse-logistics"
+      ],
+      "targets": [
+        "claude",
+        "cursor",
+        "antigravity",
+        "codex",
+        "opencode"
+      ],
+      "dependencies": [
+        "platform-configs"
+      ],
+      "defaultInstall": false,
+      "cost": "heavy",
+      "stability": "stable"
+    },
+    {
+      "id": "document-processing",
+      "kind": "skills",
+      "description": "Document processing, conversion, and translation skills.",
+      "paths": [
+        "skills/nutrient-document-processing",
+        "skills/visa-doc-translate"
+      ],
+      "targets": [
+        "claude",
+        "cursor",
+        "antigravity",
+        "codex",
+        "opencode"
+      ],
+      "dependencies": [
+        "platform-configs"
+      ],
+      "defaultInstall": false,
+      "cost": "medium",
+      "stability": "stable"
     }
   ]
 }

--- a/manifests/install-profiles.json
+++ b/manifests/install-profiles.json
@@ -68,7 +68,12 @@
         "business-content",
         "social-distribution",
         "media-generation",
-        "orchestration"
+        "orchestration",
+        "swift-apple",
+        "agentic-patterns",
+        "devops-infra",
+        "supply-chain-domain",
+        "document-processing"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Closes #520. The "full" install profile only referenced 43 of 105 skills in `install-modules.json`, leaving 62 skills unreachable through any install profile.

**Changes:**
- Extended 4 existing modules with 27 missing skills (framework-language +18, database +1, workflow-quality +6, security +2)
- Created 5 new modules for the remaining 35 skills: `swift-apple` (6), `agentic-patterns` (17), `devops-infra` (2), `supply-chain-domain` (8), `document-processing` (2)
- Updated the `full` profile to include all 19 modules (was 14)
- Added 11 new install-components entries for language/framework/capability discovery (lang:swift, lang:cpp, lang:kotlin, lang:perl, lang:rust, framework:laravel, capability:agentic, capability:devops, capability:supply-chain, capability:documents)

**Validation:**
- `node scripts/ci/validate-install-manifests.js` passes: 19 modules, 31 components, 5 profiles
- All 105 skills in `skills/` are now covered by exactly one module
- `node tests/run-all.js` passes (1 pre-existing catalog count failure unrelated to this PR)

## Test plan

- [x] `node scripts/ci/validate-install-manifests.js` validates all modules, profiles, and components
- [x] Python script confirms 105/105 skill directories are referenced in manifests
- [x] `node tests/run-all.js` shows no new test failures
- [ ] CI passes on push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 62 missing skills to the install manifests so all 105 skills are installable; updates the `full` profile to include all 19 modules. Closes #520.

- **New Features**
  - Extended modules: `framework-language` (+18), `database` (+1), `workflow-quality` (+6), `security` (+2).
  - Added modules: `swift-apple` (6), `agentic-patterns` (17), `devops-infra` (2), `supply-chain-domain` (8), `document-processing` (2).
  - Added new `install-components` for discovery: `lang:swift`, `lang:cpp`, `lang:kotlin`, `lang:perl`, `lang:rust`, `framework:laravel`, `capability:agentic`, `capability:devops`, `capability:supply-chain`, `capability:documents`.
  - Updated `full` profile to include all 19 modules; all 105 skills are now covered by exactly one module.

<sup>Written for commit 8ce10bc63bed796fa2580fb144fdc7df2c2721a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added language support for Swift, C++, Kotlin, Perl, and Rust with platform-specific patterns and testing guidance
  * Added Laravel framework support including patterns, testing, and verification
  * Introduced four new capability areas: agentic engineering and autonomous loops, DevOps and infrastructure patterns, supply chain and manufacturing domain skills, and document processing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->