### PR TITLE
fix: session commnad path issue

### DIFF
--- a/commands/sessions.md
+++ b/commands/sessions.md
@@ -25,8 +25,9 @@ Use `/sessions info` when you need operator-surface context for a swarm: branch,
 **Script:**
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 const path = require('path');
 
 const result = sm.getAllSessions({ limit: 20 });
@@ -66,8 +67,9 @@ Load and display a session's content (by ID or alias).
 **Script:**
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 const id = process.argv[1];
 
 // First try to resolve as alias
@@ -139,8 +141,9 @@ Create a memorable alias for a session.
 **Script:**
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const sessionId = process.argv[1];
 const aliasName = process.argv[2];
@@ -179,7 +182,8 @@ Delete an existing alias.
 **Script:**
 ```bash
 node -e "
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const aliasName = process.argv[1];
 if (!aliasName) {
@@ -208,8 +212,9 @@ Show detailed information about a session.
 **Script:**
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const id = process.argv[1];
 const resolved = aa.resolveAlias(id);
@@ -263,7 +268,8 @@ Show all session aliases.
 **Script:**
 ```bash
 node -e "
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const aliases = aa.listAliases();
 console.log('Session Aliases (' + aliases.length + '):');

--- a/docs/zh-CN/commands/sessions.md
+++ b/docs/zh-CN/commands/sessions.md
@@ -26,8 +26,9 @@
 
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 const path = require('path');
 
 const result = sm.getAllSessions({ limit: 20 });
@@ -68,8 +69,9 @@ for (const s of result.sessions) {
 
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 const id = process.argv[1];
 
 // First try to resolve as alias
@@ -142,8 +144,9 @@ if (session.metadata.worktree) {
 
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const sessionId = process.argv[1];
 const aliasName = process.argv[2];
@@ -183,7 +186,8 @@ if (result.success) {
 
 ```bash
 node -e "
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const aliasName = process.argv[1];
 if (!aliasName) {
@@ -213,8 +217,9 @@ if (result.success) {
 
 ```bash
 node -e "
-const sm = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-manager');
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const sm = require(_r+'/scripts/lib/session-manager');
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const id = process.argv[1];
 const resolved = aa.resolveAlias(id);
@@ -269,7 +274,8 @@ if (aliases.length > 0) {
 
 ```bash
 node -e "
-const aa = require((process.env.CLAUDE_PLUGIN_ROOT||require('path').join(require('os').homedir(),'.claude'))+'/scripts/lib/session-aliases');
+const _r=((e,p,f,h)=>{if(e&&e.trim())return e;const m='scripts/lib/session-manager.js';const cs=[p.join(h,'.claude'),p.join(h,'.claude','plugins','everything-claude-code'),p.join(h,'.claude','plugins','everything-claude-code@everything-claude-code'),p.join(h,'.claude','plugins','marketplace','everything-claude-code')];for(const c of cs)if(f.existsSync(p.join(c,m)))return c;const cd=p.join(h,'.claude','plugins','cache','everything-claude-code');try{for(const e of f.readdirSync(cd)){const n=p.join(cd,e);if(f.existsSync(p.join(n,m)))return n;try{for(const i of f.readdirSync(n)){const x=p.join(n,i);if(f.existsSync(p.join(x,m)))return x}}catch(_){}}}catch(_){}return p.join(h,'.claude')})(process.env.CLAUDE_PLUGIN_ROOT,require('path'),require('fs'),require('os').homedir());
+const aa = require(_r+'/scripts/lib/session-aliases');
 
 const aliases = aa.listAliases();
 console.log('Session Aliases (' + aliases.length + '):');

--- a/scripts/lib/resolve-plugin-root.js
+++ b/scripts/lib/resolve-plugin-root.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const MARKER = path.join('scripts', 'lib', 'session-manager.js');
+
+function resolvePluginRoot() {
+  const home = require('os').homedir();
+
+  // 1. Env var (always wins)
+  if (process.env.CLAUDE_PLUGIN_ROOT && process.env.CLAUDE_PLUGIN_ROOT.trim()) {
+    return process.env.CLAUDE_PLUGIN_ROOT;
+  }
+
+  // 2. Relative to this file (works for direct clones and local installs)
+  const relativeRoot = path.resolve(__dirname, '..', '..');
+  if (fs.existsSync(path.join(relativeRoot, MARKER))) {
+    return relativeRoot;
+  }
+
+  // 3. Known plugin marketplace paths
+  const candidates = [
+    path.join(home, '.claude', 'plugins', 'everything-claude-code'),
+    path.join(home, '.claude', 'plugins', 'everything-claude-code@everything-claude-code'),
+    path.join(home, '.claude', 'plugins', 'marketplace', 'everything-claude-code'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(path.join(c, MARKER))) {
+      return c;
+    }
+  }
+
+  // 4. Search plugin cache (versioned directories like ~/.claude/plugins/cache/everything-claude-code/everything-claude-code/1.8.0)
+  const cacheDir = path.join(home, '.claude', 'plugins', 'cache', 'everything-claude-code');
+  if (fs.existsSync(cacheDir)) {
+    try {
+      for (const entry of fs.readdirSync(cacheDir)) {
+        const nested = path.join(cacheDir, entry);
+        if (!fs.statSync(nested).isDirectory()) continue;
+        if (fs.existsSync(path.join(nested, MARKER))) return nested;
+        // One level deeper (e.g. cache/everything-claude-code/everything-claude-code/1.8.0)
+        try {
+          for (const inner of fs.readdirSync(nested)) {
+            const deep = path.join(nested, inner);
+            if (fs.statSync(deep).isDirectory() && fs.existsSync(path.join(deep, MARKER))) {
+              return deep;
+            }
+          }
+        } catch (_) { /* ignore */ }
+      }
+    } catch (_) { /* ignore */ }
+  }
+
+  // 5. Broad search in plugins directories
+  const pluginDirs = [
+    path.join(home, '.claude', 'plugins'),
+    path.join(home, '.claude', 'plugins', 'marketplace'),
+  ];
+  for (const dir of pluginDirs) {
+    try {
+      for (const entry of fs.readdirSync(dir)) {
+        const candidate = path.join(dir, entry);
+        if (fs.statSync(candidate).isDirectory() && fs.existsSync(path.join(candidate, MARKER))) {
+          return candidate;
+        }
+      }
+    } catch (_) { /* ignore */ }
+  }
+
+  // 6. Fallback to ~/.claude (original behavior)
+  return path.join(home, '.claude');
+}
+
+module.exports = { resolvePluginRoot };


### PR DESCRIPTION
## Summary
  - Fix session commands failing after plugin marketplace install when `CLAUDE_PLUGIN_ROOT` is not set
  - Replace broken `~/.claude` fallback with multi-path plugin root resolver

  ## Problem
  When ECC is installed via the Claude Code plugin marketplace, `/everything-claude-code:sessions` commands fail with:
  Cannot find module '/home/.../.claude/scripts/lib/session-manager'
  The inline scripts fall back to `~/.claude` when `CLAUDE_PLUGIN_ROOT` is not set, but the plugin scripts actually live in
  `~/.claude/plugins/cache/everything-claude-code/everything-claude-code/<version>/`.

  ## Changes
  - Replace the broken `CLAUDE_PLUGIN_ROOT || ~/.claude` fallback in all 6 inline script blocks in `commands/sessions.md` with a self-contained multi-path resolver that searches:
    1. `CLAUDE_PLUGIN_ROOT` env var (if set)
    2. `~/.claude` (manual/local install)
    3. Known plugin paths (`plugins/everything-claude-code`, `plugins/marketplace/everything-claude-code`, etc.)
    4. Plugin cache directories (`plugins/cache/everything-claude-code/**/`)
  - Add `scripts/lib/resolve-plugin-root.js` — shared resolver utility for file-based scripts
  - Apply the same fix to `docs/zh-CN/commands/sessions.md`

  ## Test Plan
  - [x] Verified resolver finds plugin in cache directory without `CLAUDE_PLUGIN_ROOT` set
  - [x] Verified resolver uses env var when `CLAUDE_PLUGIN_ROOT` is set
  - [x] Both `session-manager` and `session-aliases` modules load successfully
  - [x] Existing test suite passes (1183/1186, 3 pre-existing failures in install-apply)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken session commands after marketplace install by replacing the `~/.claude` fallback with a multi-path plugin root resolver. `/everything-claude-code:sessions` now works even when `CLAUDE_PLUGIN_ROOT` is not set.

- **Bug Fixes**
  - Added `scripts/lib/resolve-plugin-root.js` to resolve the plugin root via `CLAUDE_PLUGIN_ROOT`, local installs, known marketplace paths, and cache directories; falls back to `~/.claude`.
  - Replaced path logic in all session command inline scripts in `commands/sessions.md`; mirrored in `docs/zh-CN/commands/sessions.md`.
  - Verified both `session-manager` and `session-aliases` load across install modes.

<sup>Written for commit 2e9c3ea3078d6fa94f0c185cc176d7f07f2d00da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session command documentation with new code examples reflecting standardized module resolution patterns.

* **Improvements**
  * Implemented enhanced plugin discovery mechanism that supports multiple installation paths and configurations, improving system reliability and compatibility across diverse deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->