### PR TITLE
feat(skills): add codebase-onboarding skill

### DIFF
--- a/skills/codebase-onboarding/SKILL.md
+++ b/skills/codebase-onboarding/SKILL.md
@@ -102,7 +102,7 @@ Identify patterns the codebase already follows:
 - Branch naming from recent branches
 - Commit message style from recent commits
 - PR workflow (squash, merge, rebase)
-- If the repo has no commits yet, skip this section and note "No git history available"
+- If the repo has no commits yet or only a shallow history (e.g. `git clone --depth 1`), skip this section and note "Git history unavailable or too shallow to detect conventions"
 
 ### Phase 4: Generate Onboarding Artifacts
 


### PR DESCRIPTION
## Summary
- Adds a new `codebase-onboarding` skill that analyzes unfamiliar codebases and generates structured onboarding guides + starter CLAUDE.md files
- Canonical location: `skills/codebase-onboarding/SKILL.md`

## Motivation
Every developer joining a new project faces the same ramp-up friction. This skill turns "help me understand this codebase" into a systematic 4-phase workflow that produces two actionable artifacts in under 2 minutes.

## What It Does
1. **Reconnaissance** — parallel detection of package manifests, frameworks, entry points, directory structure, tooling, and test setup
2. **Architecture mapping** — identifies tech stack, architecture pattern, key directories, and traces one request end-to-end
3. **Convention detection** — naming patterns, error handling style, async patterns, git workflow from recent history
4. **Artifact generation** — produces a scannable onboarding guide + project-specific CLAUDE.md

## Key Design Decisions
- Uses Glob/Grep for reconnaissance, not exhaustive file reads — fast even on large repos
- Enhances existing CLAUDE.md rather than replacing it
- Flags unknowns explicitly rather than guessing
- Onboarding guide targets 2-minute scannability

## Type
- [x] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command

## Checklist
- [x] Follows format guidelines
- [x] Under 500 lines
- [x] Includes practical examples
- [x] Uses clear section headers
- [x] No sensitive info