### PR TITLE
fix: resolve orchestrator slug collision and template variable bugs

### DIFF
--- a/scripts/lib/tmux-worktree-orchestrator.js
+++ b/scripts/lib/tmux-worktree-orchestrator.js
@@ -190,6 +190,7 @@ function buildOrchestrationPlan(config = {}) {
     throw new Error('buildOrchestrationPlan requires at least one worker');
   }
 
+  const seenSlugs = new Set();
   const workerPlans = workers.map((worker, index) => {
     if (!worker || typeof worker.task !== 'string' || worker.task.trim().length === 0) {
       throw new Error(`Worker ${index + 1} is missing a task`);
@@ -197,6 +198,12 @@ function buildOrchestrationPlan(config = {}) {
 
     const workerName = worker.name || `worker-${index + 1}`;
     const workerSlug = slugify(workerName, `worker-${index + 1}`);
+
+    if (seenSlugs.has(workerSlug)) {
+      throw new Error(`Workers must have unique slugs — duplicate: ${workerSlug}`);
+    }
+    seenSlugs.add(workerSlug);
+
     const branchName = `orchestrator-${sessionName}-${workerSlug}`;
     const worktreePath = path.join(worktreeRoot, `${repoName}-${sessionName}-${workerSlug}`);
     const workerCoordinationDir = path.join(coordinationDir, workerSlug);
@@ -206,7 +213,7 @@ function buildOrchestrationPlan(config = {}) {
     const launcherCommand = worker.launcherCommand || defaultLauncher;
     const workerSeedPaths = normalizeSeedPaths(worker.seedPaths, repoRoot);
     const seedPaths = normalizeSeedPaths([...globalSeedPaths, ...workerSeedPaths], repoRoot);
-    const templateVariables = {
+    const templateVariables = buildTemplateVariables({
       branch_name: branchName,
       handoff_file: handoffFilePath,
       repo_root: repoRoot,
@@ -216,7 +223,7 @@ function buildOrchestrationPlan(config = {}) {
       worker_name: workerName,
       worker_slug: workerSlug,
       worktree_path: worktreePath
-    };
+    });
 
     if (!launcherCommand) {
       throw new Error(`Worker ${workerName} is missing a launcherCommand`);


### PR DESCRIPTION
## Summary
- Add duplicate slug validation to `buildOrchestrationPlan()` — workers with names that collapse to the same slug (e.g., 'Docs A' and 'Docs/A' → 'docs-a') now throw
- Wire `buildTemplateVariables()` into plan construction so `{repo_root_sh}`, `{task_file_sh}`, `{worker_name_sh}` template variables resolve correctly

## Test plan
- [x] 1408/1408 tests passing locally
- [x] `buildOrchestrationPlan rejects worker names that collapse to the same slug` — PASS
- [x] `buildOrchestrationPlan exposes shell-safe launcher aliases alongside raw defaults` — PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes worker slug collisions in the tmux worktree orchestrator and restores correct template variable interpolation in launcher commands. Prevents ambiguous worktrees/branches and ensures shell-safe variables resolve as expected.

- **Bug Fixes**
  - Reject workers whose names collapse to the same slug in `buildOrchestrationPlan` (e.g., "Docs A" and "Docs/A" → "docs-a").
  - Use `buildTemplateVariables()` so `{repo_root_sh}`, `{task_file_sh}`, `{worker_name_sh}` and raw variants resolve in launcher templates.

- **Migration**
  - Ensure worker names produce unique slugs; rename any that collide before running the orchestrator.

<sup>Written for commit 7f435855d9b9de131330852d894950e42fb4830f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent duplicate worker configurations from being processed.

* **Refactor**
  * Improved internal template variable construction for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->