### PR TITLE
Add Prism Scanner to Ecosystem Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,23 @@ Use `/security-scan` in Claude Code to run it, or add to CI with the [GitHub Act
 
 [GitHub](https://github.com/affaan-m/agentshield) | [npm](https://www.npmjs.com/package/ecc-agentshield)
 
+### Prism Scanner — Agent Supply Chain Security
+
+Open-source security scanner for AI Agent skills, plugins, and MCP servers. Complements AgentShield (which focuses on your local Claude Code config) by scanning third-party code *before* you install it.
+
+```bash
+pip install prism-scanner
+prism scan https://github.com/user/some-skill
+```
+
+**What it scans:** Agent skills, plugins, and MCP servers across ClawHub, npm, and pip with 39+ detection rules — AST-level taint tracking, malicious signature matching, metadata analysis, and post-uninstall system residue detection.
+
+**Grading:** A-F letter grades with severity breakdown and actionable recommendations.
+
+**Output formats:** Terminal, JSON, HTML, SARIF (GitHub Code Scanning integration).
+
+[GitHub](https://github.com/aidongise-cell/prism-scanner) | [PyPI](https://pypi.org/project/prism-scanner/) | [MCP Server](https://mcp.so/server/prism-scanner)
+
 ### 🔬 Plankton — Write-Time Code Quality Enforcement
 
 Plankton (credit: @alxfazio) is a recommended companion for write-time code quality enforcement. It runs formatters and 20+ linters on every file edit via PostToolUse hooks, then spawns Claude subprocesses (routed to Haiku/Sonnet/Opus by violation complexity) to fix issues the main agent missed. Three-phase architecture: auto-format silently (40-50% of issues), collect remaining violations as structured JSON, delegate fixes to a subprocess. Includes config protection hooks that prevent agents from modifying linter configs to pass instead of fixing code. Supports Python, TypeScript, Shell, YAML, JSON, TOML, Markdown, and Dockerfile. Use alongside AgentShield for security + quality coverage. See `skills/plankton-code-quality/` for full integration guide.


### PR DESCRIPTION
## Summary

Adds [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) to the **Ecosystem Tools** section alongside AgentShield and Plankton.

(Previous PR #562 incorrectly placed the entry in the v1.6.0 changelog. This PR puts it in the right section.)

**Prism Scanner** complements AgentShield by focusing on a different attack surface:
- **AgentShield** scans your local Claude Code config (CLAUDE.md, settings, hooks, MCP configs)
- **Prism Scanner** scans third-party code (skills, plugins, MCP servers) *before* you install them

Key features:
- 39+ detection rules with AST taint tracking
- A-F grading with actionable recommendations
- Post-uninstall system residue cleanup
- Open source, Apache 2.0

Install: `pip install prism-scanner`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `prism-scanner` to the Ecosystem Tools section of the README as a supply-chain security scanner for third‑party agent skills, plugins, and MCP servers. Includes install and quick usage example, key features (39+ rules, A–F grading, residue cleanup), supported outputs (terminal/JSON/HTML/SARIF), and links to GitHub, PyPI, and its MCP server.

<sup>Written for commit 02c1080969acc5407eb952f241eae800ea8b5f12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive documentation for Prism Scanner, a new open-source security scanning tool designed specifically for AI Agent skills, plugins, and MCP servers. Covers detailed installation instructions, full scanning capabilities including 39+ security rules, AST taint tracking, signature matching, metadata analysis, post-uninstall residue detection, grading system, and multiple output format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->