### PR TITLE
fix(observe): allow sdk-ts entrypoint in observation hook

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -97,8 +97,11 @@ fi
 #   - automated sessions creating project-scoped homunculus metadata
 
 # Layer 1: entrypoint. Only interactive terminal sessions should continue.
+# sdk-ts: Agent SDK sessions can be human-interactive (e.g. via Happy).
+# Non-interactive SDK automation is still filtered by Layers 2-5 below
+# (ECC_HOOK_PROFILE=minimal, ECC_SKIP_OBSERVE=1, agent_id, path exclusions).
 case "${CLAUDE_CODE_ENTRYPOINT:-cli}" in
-  cli) ;;
+  cli|sdk-ts) ;;
   *) exit 0 ;;
 esac
 


### PR DESCRIPTION
## Summary
- When running Claude Code via the Agent SDK (e.g. [Happy](https://happy.engineering)), `CLAUDE_CODE_ENTRYPOINT` is set to `sdk-ts` instead of `cli`
- The Layer 1 entrypoint guard in `observe.sh` only allowed `cli`, causing **all observations to be silently dropped** for SDK users — the continuous learning system was completely non-functional
- This adds `sdk-ts` to the allowlist since Agent SDK sessions can be human-interactive

## Changes
- `skills/continuous-learning-v2/hooks/observe.sh`: Add `sdk-ts` to the Layer 1 `case` entrypoint allowlist (1 line changed)
- Added comment documenting that non-interactive SDK automation is still filtered by the remaining 4 safety layers (ECC_HOOK_PROFILE, ECC_SKIP_OBSERVE, agent_id, path exclusions)

## Test plan
- [x] Verified `CLAUDE_CODE_ENTRYPOINT=sdk-ts` no longer causes `observe.sh` to exit early
- [x] Verified project-scoped observations are written to `~/.claude/homunculus/projects/<hash>/observations.jsonl`
- [x] Verified non-interactive layers (2-5) still filter automated sessions
- [x] Codex review PASSED

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped observations for Agent SDK sessions by allowing the `sdk-ts` entrypoint in the observation hook. Restores continuous learning for interactive SDK runs while non-interactive automation stays blocked by later layers.

- **Bug Fixes**
  - Allow `cli|sdk-ts` in Layer 1 entrypoint check in `skills/continuous-learning-v2/hooks/observe.sh`.
  - Add comment noting layers 2–5 (`ECC_HOOK_PROFILE`, `ECC_SKIP_OBSERVE`, `agent_id`, path exclusions) still filter automation.

<sup>Written for commit 2fb047dcb7b95d8027a7e2f3505d1837e59da275. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SDK TypeScript sessions to allow them to continue processing instead of being prematurely stopped, enabling better support for non-interactive SDK workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->