### PR TITLE
fix(install): prefix language-specific rules to prevent overwriting common rules

### DIFF
--- a/docs/ja-JP/skills/configure-ecc/SKILL.md
+++ b/docs/ja-JP/skills/configure-ecc/SKILL.md
@@ -159,9 +159,9 @@ cp -r $ECC_ROOT/rules/common/* $TARGET/rules/
 
 # 言語固有のルール（共通ルールの上書きを防ぐためプレフィックス付き）
 # coding-style.md は typescript-coding-style.md のようになります
-for f in $ECC_ROOT/rules/typescript/*; do cp "$f" "$TARGET/rules/typescript-$(basename "$f")"; done   # 選択された場合
-for f in $ECC_ROOT/rules/python/*; do cp "$f" "$TARGET/rules/python-$(basename "$f")"; done           # 選択された場合
-for f in $ECC_ROOT/rules/golang/*; do cp "$f" "$TARGET/rules/golang-$(basename "$f")"; done           # 選択された場合
+for f in "$ECC_ROOT"/rules/typescript/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/typescript-$(basename "$f")"; done   # 選択された場合
+for f in "$ECC_ROOT"/rules/python/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/python-$(basename "$f")"; done           # 選択された場合
+for f in "$ECC_ROOT"/rules/golang/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/golang-$(basename "$f")"; done           # 選択された場合
 ```
 
 **重要**: ユーザーが言語固有のルールを選択したが、共通ルールを選択しなかった場合、警告します：

--- a/docs/zh-CN/skills/configure-ecc/SKILL.md
+++ b/docs/zh-CN/skills/configure-ecc/SKILL.md
@@ -226,9 +226,9 @@ cp -r $ECC_ROOT/rules/common/* $TARGET/rules/
 
 # Language-specific rules (prefixed to avoid overwriting common rules)
 # Files like coding-style.md become typescript-coding-style.md, etc.
-for f in $ECC_ROOT/rules/typescript/*; do cp "$f" "$TARGET/rules/typescript-$(basename "$f")"; done   # if selected
-for f in $ECC_ROOT/rules/python/*; do cp "$f" "$TARGET/rules/python-$(basename "$f")"; done           # if selected
-for f in $ECC_ROOT/rules/golang/*; do cp "$f" "$TARGET/rules/golang-$(basename "$f")"; done           # if selected
+for f in "$ECC_ROOT"/rules/typescript/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/typescript-$(basename "$f")"; done   # if selected
+for f in "$ECC_ROOT"/rules/python/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/python-$(basename "$f")"; done           # if selected
+for f in "$ECC_ROOT"/rules/golang/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/golang-$(basename "$f")"; done           # if selected
 ```
 
 **重要**：如果用户选择了任何特定语言的规则但**没有**选择通用规则，警告他们：

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -223,9 +223,9 @@ cp -r $ECC_ROOT/rules/common/* $TARGET/rules/
 
 # Language-specific rules (prefixed to avoid overwriting common rules)
 # Files like coding-style.md become typescript-coding-style.md, etc.
-for f in $ECC_ROOT/rules/typescript/*; do cp "$f" "$TARGET/rules/typescript-$(basename "$f")"; done   # if selected
-for f in $ECC_ROOT/rules/python/*; do cp "$f" "$TARGET/rules/python-$(basename "$f")"; done           # if selected
-for f in $ECC_ROOT/rules/golang/*; do cp "$f" "$TARGET/rules/golang-$(basename "$f")"; done           # if selected
+for f in "$ECC_ROOT"/rules/typescript/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/typescript-$(basename "$f")"; done   # if selected
+for f in "$ECC_ROOT"/rules/python/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/python-$(basename "$f")"; done           # if selected
+for f in "$ECC_ROOT"/rules/golang/*; do [ -e "$f" ] && cp -r "$f" "$TARGET/rules/golang-$(basename "$f")"; done           # if selected
 ```
 
 **Important**: If the user selects any language-specific rules but NOT common rules, warn them:


### PR DESCRIPTION
## Summary
- Prefix language-specific rule files during install to prevent overwriting common rules
- Fix applied to the `configure-ecc` skill (English, Japanese, Chinese versions)
- Added troubleshooting note about the prefixed naming convention

## Why
When installing common + multiple language-specific rules via the `configure-ecc` skill, files with identical names (`coding-style.md`, `security.md`, `testing.md`, `hooks.md`, `patterns.md`) exist in both `rules/common/` and `rules/<language>/`. The `cp -r` in Step 3 silently overwrites common rules with language-specific ones, so the last language installed "wins" and common rules are lost.

The fix prefixes language-specific files at copy time (e.g., `python-coding-style.md` instead of `coding-style.md`), matching the approach already used by the Antigravity install target adapter in `install-executor.js`.

Closes #432

## Test plan
- [x] Install common + python + go rules — verify all three sets of files are present
- [x] Verify no filename collisions between common and language-specific rules
- [x] `validate-rules.js` and `validate-skills.js` CI validators pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix language-specific rule files during install to stop overwriting common rules, and harden the copy commands for reliability. Updates the `configure-ecc` skill instructions (EN/JA/ZH) and troubleshooting for the new prefixed naming.

- **Bug Fixes**
  - Step 3 now copies language rules into `$TARGET/rules/` with a `<lang>-` prefix (e.g., `python-coding-style.md`), preserving common rules and matching the install target adapter in `install-executor.js`.
  - Copy loops now use `cp -r`, quote `$ECC_ROOT`, and add `[ -e "$f" ]` guards to handle subdirectories, paths with spaces, and empty globs.

<sup>Written for commit f7a3311e6a588763ecc974a3ec6d793e6e50ad50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified skill configuration docs to explain language-specific rule files are now copied with language-prefixed names to avoid overwriting common rules.
  * Updated troubleshooting section with corrected examples showing the new prefixed naming and how to verify installed rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->