### PR TITLE
fix: resolve Windows CI and lint failures

### DIFF
--- a/skills/rust-patterns/SKILL.md
+++ b/skills/rust-patterns/SKILL.md
@@ -43,7 +43,6 @@ fn process_bad(data: &Vec<u8>) -> usize {
 }
 ```
 
-
 ### Use `Cow` for Flexible Ownership
 
 ```rust

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -53,6 +53,34 @@ function writeInstallComponentsManifest(testDir, components) {
 }
 
 /**
+ * Run modified source via a temp file (avoids Windows node -e shebang issues).
+ * The temp file is written inside the repo so require() can resolve node_modules.
+ * @param {string} source - JavaScript source to execute
+ * @returns {{code: number, stdout: string, stderr: string}}
+ */
+function runSourceViaTempFile(source) {
+  const tmpFile = path.join(repoRoot, `.tmp-validator-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+  try {
+    fs.writeFileSync(tmpFile, source, 'utf8');
+    const stdout = execFileSync('node', [tmpFile], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+      cwd: repoRoot,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status || 1,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
+  }
+}
+
+/**
  * Run a validator script via a wrapper that overrides its directory constant.
  * This allows testing error cases without modifying real project files.
  *
@@ -67,27 +95,14 @@ function runValidatorWithDir(validatorName, dirConstant, overridePath) {
   // Read the validator source, replace the directory constant, and run as a wrapper
   let source = fs.readFileSync(validatorPath, 'utf8');
 
-  // Remove the shebang line
+  // Remove the shebang line (Windows node cannot parse shebangs in eval/inline mode)
   source = source.replace(/^#!.*\n/, '');
 
   // Replace the directory constant with our override path
   const dirRegex = new RegExp(`const ${dirConstant} = .*?;`);
   source = source.replace(dirRegex, `const ${dirConstant} = ${JSON.stringify(overridePath)};`);
 
-  try {
-    const stdout = execFileSync('node', ['-e', source], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (err) {
-    return {
-      code: err.status || 1,
-      stdout: err.stdout || '',
-      stderr: err.stderr || '',
-    };
-  }
+  return runSourceViaTempFile(source);
 }
 
 /**
@@ -103,20 +118,7 @@ function runValidatorWithDirs(validatorName, overrides) {
     const dirRegex = new RegExp(`const ${constant} = .*?;`);
     source = source.replace(dirRegex, `const ${constant} = ${JSON.stringify(overridePath)};`);
   }
-  try {
-    const stdout = execFileSync('node', ['-e', source], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (err) {
-    return {
-      code: err.status || 1,
-      stdout: err.stdout || '',
-      stderr: err.stderr || '',
-    };
-  }
+  return runSourceViaTempFile(source);
 }
 
 /**
@@ -158,20 +160,7 @@ function runCatalogValidator(overrides = {}) {
     source = source.replace(dirRegex, `const ${constant} = ${JSON.stringify(overridePath)};`);
   }
 
-  try {
-    const stdout = execFileSync('node', ['-e', source], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (err) {
-    return {
-      code: err.status || 1,
-      stdout: err.stdout || '',
-      stderr: err.stderr || '',
-    };
-  }
+  return runSourceViaTempFile(source);
 }
 
 function writeCatalogFixture(testDir, options = {}) {


### PR DESCRIPTION
## Summary

- **Windows CI fix**: Replace `node -e <source>` with temp file execution in `tests/ci/validators.test.js`. The `runValidatorWithDir`, `runValidatorWithDirs`, and `runCatalogValidator` helpers read CI scripts, strip shebangs, modify constants, then execute the modified source. On Windows, `node -e` cannot parse scripts that originally contained `#!/usr/bin/env node` shebangs even after stripping, and large inline scripts can hit command-line length limits. Writing to a temp file and running `node <file>` avoids both issues.
- **Markdown lint fix**: Remove duplicate blank line at line 46 in `skills/rust-patterns/SKILL.md` (MD012/no-multiple-blanks).

## Test plan

- [x] All 1421 tests pass locally (`node tests/run-all.js`)
- [x] `npx markdownlint-cli skills/rust-patterns/SKILL.md` passes with no warnings
- [ ] CI passes on all platforms (Linux, macOS, Windows)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CI by running modified validator scripts via temp files instead of `node -e`, and resolves a markdown lint error in the Rust patterns skill.

- **Bug Fixes**
  - `tests/ci/validators.test.js`: Add `runSourceViaTempFile` to write modified validator code to a temp file in the repo and execute with `node <file>`. Replace `node -e` in all validator helpers. Avoids Windows shebang parsing and command length limits, and ensures `node_modules` resolution.
  - `skills/rust-patterns/SKILL.md`: Remove an extra blank line to satisfy MD012.

<sup>Written for commit 88ee4646699736becb928891179aaed19029bdfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed formatting in Rust patterns guide.

* **Tests**
  * Refactored validator test execution to use temporary files instead of inline mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->