### PR TITLE
fix: sync catalog counts with filesystem (27 agents, 113 skills, 58 commands)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Everything Claude Code (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 27 specialized agents, 109 skills, 57 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 27 specialized agents, 113 skills, 58 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 
@@ -142,8 +142,8 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 
 ```
 agents/          — 27 specialized subagents
-skills/          — 109 workflow skills and domain knowledge
-commands/        — 57 slash commands
+skills/          — 113 workflow skills and domain knowledge
+commands/        — 58 slash commands
 hooks/           — Trigger-based automations
 rules/           — Always-follow guidelines (common + per-language)
 scripts/         — Cross-platform Node.js utilities

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For manual install instructions see the README in the `rules/` folder.
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-✨ **That's it!** You now have access to 27 agents, 109 skills, and 57 commands.
+✨ **That's it!** You now have access to 27 agents, 113 skills, and 58 commands.
 
 ---
 
@@ -1070,8 +1070,8 @@ The configuration is automatically detected from `.opencode/opencode.json`.
 | Feature | Claude Code | OpenCode | Status |
 |---------|-------------|----------|--------|
 | Agents | ✅ 27 agents | ✅ 12 agents | **Claude Code leads** |
-| Commands | ✅ 57 commands | ✅ 31 commands | **Claude Code leads** |
-| Skills | ✅ 109 skills | ✅ 37 skills | **Claude Code leads** |
+| Commands | ✅ 58 commands | ✅ 31 commands | **Claude Code leads** |
+| Skills | ✅ 113 skills | ✅ 37 skills | **Claude Code leads** |
 | Hooks | ✅ 8 event types | ✅ 11 events | **OpenCode has more!** |
 | Rules | ✅ 29 rules | ✅ 13 instructions | **Claude Code leads** |
 | MCP Servers | ✅ 14 servers | ✅ Full | **Full parity** |


### PR DESCRIPTION
## Summary
- The v1.9.0 release and subsequent merges left AGENTS.md and README.md with stale catalog counts (109 skills, 57 commands)
- Actual filesystem has 113 skills and 58 commands
- This was causing the `catalog.js` CI validator to fail on main and every branch based on it
- Updates all documented counts to match the filesystem

## Test plan
- [x] All 1462 tests pass
- [x] `node scripts/ci/catalog.js --text` shows "Documentation counts match the repository catalog"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update AGENTS.md and README.md to reflect 27 agents, 113 skills, and 58 commands, matching the repository. Fixes CI failures from the `scripts/ci/catalog.js` doc-count validator due to stale counts.

<sup>Written for commit 7f0cb0b1c6930bd78ba341f191d0f555bbe2c334. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

