### PR TITLE
fix: sanitize SessionStart session summaries (#642)

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -40,11 +40,10 @@ async function main() {
     log(`[SessionStart] Latest: ${latest.path}`);
 
     // Read and inject the latest session content into Claude's context
-    const content = readFile(latest.path);
+    const content = stripAnsi(readFile(latest.path));
     if (content && !content.includes('[Session context goes here]')) {
       // Only inject if the session has actual content (not the blank template)
-      // Strip ANSI escape codes that may have leaked from terminal output (#642)
-      output(`Previous session summary:\n${stripAnsi(content)}`);
+      output(`Previous session summary:\n${content}`);
     }
   }
 

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -416,6 +416,36 @@ async function runTests() {
   else failed++;
 
   if (
+    await asyncTest('strips ANSI escape codes from injected session content', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-ansi-start-${Date.now()}`);
+      const sessionsDir = path.join(isoHome, '.claude', 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
+
+      const sessionFile = path.join(sessionsDir, '2026-02-11-winansi00-session.tmp');
+      fs.writeFileSync(
+        sessionFile,
+        '\x1b[H\x1b[2J\x1b[3J# Real Session\n\nI worked on \x1b[1;36mWindows terminal handling\x1b[0m.\x1b[K\n'
+      );
+
+      try {
+        const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome
+        });
+        assert.strictEqual(result.code, 0);
+        assert.ok(result.stdout.includes('Previous session summary'), 'Should inject real session content');
+        assert.ok(result.stdout.includes('Windows terminal handling'), 'Should preserve sanitized session text');
+        assert.ok(!result.stdout.includes('\x1b['), 'Should not emit ANSI escape codes');
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     await asyncTest('reports learned skills count', async () => {
       const isoHome = path.join(os.tmpdir(), `ecc-skills-start-${Date.now()}`);
       const learnedDir = path.join(isoHome, '.claude', 'skills', 'learned');


### PR DESCRIPTION
Strip ANSI escape codes from session.tmp when injecting into SessionStart hook. Fixes #642.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip ANSI escape codes from session summaries before injecting them in the SessionStart hook to keep the context clean. Adds a test to verify sanitization and fixes #642.

<sup>Written for commit 11e9f257370b098df3747b18eb126e7f1e68cf79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where terminal formatting codes from previous session files were leaking into the injected session summary, causing unwanted formatting artifacts in the output.

* **Tests**
  * Added test coverage to verify that terminal formatting codes are properly removed from session content and do not appear in console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->