### PR TITLE
fix: reduce CPU usage from typecheck hook (#558)

### DIFF
--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -7,90 +7,276 @@
  * Runs after Edit tool use on TypeScript files. Walks up from the file's
  * directory to find the nearest tsconfig.json, then runs tsc --noEmit
  * and reports only errors related to the edited file.
+ *
+ * To avoid CPU spikes during bursty edit sessions, checks are coalesced per
+ * tsconfig root: overlapping runs are skipped and recent runs are cooled down.
  */
 
+"use strict";
+
 const { execFileSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 const MAX_STDIN = 1024 * 1024; // 1MB limit
-let data = "";
-process.stdin.setEncoding("utf8");
+const DEFAULT_COOLDOWN_MS = 10000;
+const DEFAULT_LOCK_TTL_MS = 120000;
 
-process.stdin.on("data", (chunk) => {
-  if (data.length < MAX_STDIN) {
-    const remaining = MAX_STDIN - data.length;
-    data += chunk.substring(0, remaining);
+function parseNonNegativeInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ""), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
   }
-});
+  return parsed;
+}
 
-process.stdin.on("end", () => {
+function getStateDir() {
+  const configuredDir = String(process.env.ECC_TYPECHECK_STATE_DIR || "").trim();
+  if (configuredDir) {
+    return path.resolve(configuredDir);
+  }
+  return path.join(os.tmpdir(), "ecc-typecheck-hook");
+}
+
+function getStatePaths(tsconfigDir) {
+  const key = crypto
+    .createHash("sha1")
+    .update(path.resolve(tsconfigDir))
+    .digest("hex");
+  const stateDir = getStateDir();
+
+  return {
+    stateDir,
+    lockPath: path.join(stateDir, `${key}.lock`),
+    stampPath: path.join(stateDir, `${key}.json`),
+  };
+}
+
+function ensureDirectory(dirPath) {
   try {
-    const input = JSON.parse(data);
-    const filePath = input.tool_input?.file_path;
+    fs.mkdirSync(dirPath, { recursive: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-    if (filePath && /\.(ts|tsx)$/.test(filePath)) {
-      const resolvedPath = path.resolve(filePath);
-      if (!fs.existsSync(resolvedPath)) {
-        process.stdout.write(data);
-        process.exit(0);
-      }
-      // Find nearest tsconfig.json by walking up (max 20 levels to prevent infinite loop)
-      let dir = path.dirname(resolvedPath);
-      const root = path.parse(dir).root;
-      let depth = 0;
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
 
-      while (dir !== root && depth < 20) {
-        if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
-          break;
-        }
-        dir = path.dirname(dir);
-        depth++;
-      }
+function isCooldownActive(stampPath, cooldownMs) {
+  if (cooldownMs <= 0) {
+    return false;
+  }
 
-      if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
+  const stamp = readJsonFile(stampPath);
+  const finishedAt = Number(stamp?.finishedAt || 0);
+  if (finishedAt <= 0) {
+    return false;
+  }
+
+  return Date.now() - finishedAt < cooldownMs;
+}
+
+function acquireTypecheckLock(lockPath, lockTtlMs) {
+  const payload = JSON.stringify({
+    pid: process.pid,
+    startedAt: Date.now(),
+  });
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      fs.writeFileSync(fd, payload);
+      fs.closeSync(fd);
+
+      return () => {
         try {
-          // Use npx.cmd on Windows to avoid shell: true which enables command injection
-          const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
-          execFileSync(npxBin, ["tsc", "--noEmit", "--pretty", "false"], {
-            cwd: dir,
-            encoding: "utf8",
-            stdio: ["pipe", "pipe", "pipe"],
-            timeout: 30000,
-          });
-        } catch (err) {
-          // tsc exits non-zero when there are errors — filter to edited file
-          const output = (err.stdout || "") + (err.stderr || "");
-          // Compute paths that uniquely identify the edited file.
-          // tsc output uses paths relative to its cwd (the tsconfig dir),
-          // so check for the relative path, absolute path, and original path.
-          // Avoid bare basename matching — it causes false positives when
-          // multiple files share the same name (e.g., src/utils.ts vs tests/utils.ts).
-          const relPath = path.relative(dir, resolvedPath);
-          const candidates = new Set([filePath, resolvedPath, relPath]);
-          const relevantLines = output
-            .split("\n")
-            .filter((line) => {
-              for (const candidate of candidates) {
-                if (line.includes(candidate)) return true;
-              }
-              return false;
-            })
-            .slice(0, 10);
-
-          if (relevantLines.length > 0) {
-            console.error(
-              "[Hook] TypeScript errors in " + path.basename(filePath) + ":",
-            );
-            relevantLines.forEach((line) => console.error(line));
-          }
+          fs.unlinkSync(lockPath);
+        } catch {
+          // Best-effort cleanup only.
         }
+      };
+    } catch (error) {
+      if (!error || error.code !== "EEXIST") {
+        return null;
+      }
+
+      let stats = null;
+      try {
+        stats = fs.statSync(lockPath);
+      } catch {
+        continue;
+      }
+
+      if (Date.now() - stats.mtimeMs < lockTtlMs) {
+        return null;
+      }
+
+      try {
+        fs.unlinkSync(lockPath);
+      } catch {
+        return null;
       }
     }
-  } catch {
-    // Invalid input — pass through
   }
 
-  process.stdout.write(data);
-  process.exit(0);
-});
+  return null;
+}
+
+function writeCooldownStamp(stampPath) {
+  try {
+    fs.writeFileSync(
+      stampPath,
+      JSON.stringify({
+        finishedAt: Date.now(),
+        pid: process.pid,
+      }),
+    );
+  } catch {
+    // Best-effort cache only.
+  }
+}
+
+function findNearestTsconfig(resolvedPath) {
+  let dir = path.dirname(resolvedPath);
+  const root = path.parse(dir).root;
+  let depth = 0;
+
+  while (dir !== root && depth < 20) {
+    if (fs.existsSync(path.join(dir, "tsconfig.json"))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+    depth++;
+  }
+
+  return null;
+}
+
+function reportRelevantTypecheckErrors(tsconfigDir, filePath, resolvedPath, error) {
+  const output = (error.stdout || "") + (error.stderr || "");
+  const relPath = path.relative(tsconfigDir, resolvedPath);
+  const candidates = new Set([filePath, resolvedPath, relPath]);
+  const relevantLines = output
+    .split("\n")
+    .filter((line) => {
+      for (const candidate of candidates) {
+        if (line.includes(candidate)) return true;
+      }
+      return false;
+    })
+    .slice(0, 10);
+
+  if (relevantLines.length > 0) {
+    console.error("[Hook] TypeScript errors in " + path.basename(filePath) + ":");
+    relevantLines.forEach((line) => console.error(line));
+  }
+}
+
+function runTypecheck(tsconfigDir, filePath, resolvedPath) {
+  try {
+    // Use npx.cmd on Windows to avoid shell: true which enables command injection
+    const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
+    execFileSync(npxBin, ["tsc", "--noEmit", "--pretty", "false"], {
+      cwd: tsconfigDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 30000,
+    });
+  } catch (error) {
+    reportRelevantTypecheckErrors(tsconfigDir, filePath, resolvedPath, error);
+  }
+}
+
+function maybeRunTypecheck(filePath) {
+  if (!filePath || !/\.(ts|tsx)$/.test(filePath)) {
+    return;
+  }
+
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return;
+  }
+
+  const tsconfigDir = findNearestTsconfig(resolvedPath);
+  if (!tsconfigDir) {
+    return;
+  }
+
+  const cooldownMs = parseNonNegativeInt(
+    process.env.ECC_TYPECHECK_COOLDOWN_MS,
+    DEFAULT_COOLDOWN_MS,
+  );
+  const lockTtlMs = parseNonNegativeInt(
+    process.env.ECC_TYPECHECK_LOCK_TTL_MS,
+    DEFAULT_LOCK_TTL_MS,
+  );
+  const { stateDir, lockPath, stampPath } = getStatePaths(tsconfigDir);
+
+  if (!ensureDirectory(stateDir)) {
+    runTypecheck(tsconfigDir, filePath, resolvedPath);
+    return;
+  }
+
+  if (isCooldownActive(stampPath, cooldownMs)) {
+    return;
+  }
+
+  const releaseLock = acquireTypecheckLock(lockPath, lockTtlMs);
+  if (!releaseLock) {
+    return;
+  }
+
+  if (isCooldownActive(stampPath, cooldownMs)) {
+    releaseLock();
+    return;
+  }
+
+  try {
+    runTypecheck(tsconfigDir, filePath, resolvedPath);
+    writeCooldownStamp(stampPath);
+  } finally {
+    releaseLock();
+  }
+}
+
+function run(rawInput) {
+  try {
+    const input = JSON.parse(rawInput);
+    maybeRunTypecheck(input.tool_input?.file_path);
+  } catch {
+    // Invalid input — pass through.
+  }
+
+  return rawInput;
+}
+
+if (require.main === module) {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+
+  process.stdin.on("data", (chunk) => {
+    if (data.length < MAX_STDIN) {
+      const remaining = MAX_STDIN - data.length;
+      data += chunk.substring(0, remaining);
+    }
+  });
+
+  process.stdin.on("end", () => {
+    run(data);
+    process.stdout.write(data);
+    process.exit(0);
+  });
+}
+
+module.exports = {
+  run,
+};

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -203,6 +203,31 @@ function createCommandShim(binDir, baseName, logFile) {
   return shimPath;
 }
 
+function createDelayedCommandShim(binDir, baseName, logFile, delayMs) {
+  fs.mkdirSync(binDir, { recursive: true });
+
+  const shimJs = path.join(binDir, `${baseName}-delay-shim.js`);
+  fs.writeFileSync(
+    shimJs,
+    [
+      "const fs = require('fs');",
+      `fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify({ bin: ${JSON.stringify(baseName)}, args: process.argv.slice(2), cwd: process.cwd(), pid: process.pid }) + '\\n');`,
+      `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${Math.max(0, Number(delayMs) || 0)});`
+    ].join('\n')
+  );
+
+  if (process.platform === 'win32') {
+    const shimCmd = path.join(binDir, `${baseName}.cmd`);
+    fs.writeFileSync(shimCmd, `@echo off\r\nnode "${shimJs}" %*\r\n`);
+    return shimCmd;
+  }
+
+  const shimPath = path.join(binDir, baseName);
+  fs.writeFileSync(shimPath, `#!/usr/bin/env node\nrequire(${JSON.stringify(shimJs)});\n`);
+  fs.chmodSync(shimPath, 0o755);
+  return shimPath;
+}
+
 function readCommandLog(logFile) {
   if (!fs.existsSync(logFile)) return [];
   return fs
@@ -1385,6 +1410,77 @@ async function runTests() {
       const result = await runScript(path.join(scriptsDir, 'post-edit-typecheck.js'), stdinJson);
       assert.strictEqual(result.code, 0);
       assert.ok(result.stdout.includes('tool_input'), 'Should pass through stdin data on stdout');
+      cleanupTestDir(testDir);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('coalesces repeated typechecks within the cooldown window', async () => {
+      const testDir = createTestDir();
+      const testFile = path.join(testDir, 'cooled.ts');
+      const binDir = path.join(testDir, 'bin');
+      const logFile = path.join(testDir, 'npx.log');
+      const stateDir = path.join(testDir, 'state');
+
+      fs.writeFileSync(
+        path.join(testDir, 'tsconfig.json'),
+        JSON.stringify({ compilerOptions: { strict: true, noEmit: true } })
+      );
+      fs.writeFileSync(testFile, 'export const value: number = 1;\n');
+      createCommandShim(binDir, 'npx', logFile);
+
+      const stdinJson = JSON.stringify({ tool_input: { file_path: testFile } });
+      const env = withPrependedPath(binDir, {
+        ECC_TYPECHECK_COOLDOWN_MS: '60000',
+        ECC_TYPECHECK_STATE_DIR: stateDir
+      });
+
+      const first = await runScript(path.join(scriptsDir, 'post-edit-typecheck.js'), stdinJson, env);
+      const second = await runScript(path.join(scriptsDir, 'post-edit-typecheck.js'), stdinJson, env);
+
+      assert.strictEqual(first.code, 0, 'First run should exit 0');
+      assert.strictEqual(second.code, 0, 'Second run should exit 0');
+      const logEntries = readCommandLog(logFile);
+      assert.strictEqual(logEntries.length, 1, 'Should only run npx tsc once within cooldown');
+      cleanupTestDir(testDir);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('skips overlapping typechecks for the same tsconfig root', async () => {
+      const testDir = createTestDir();
+      const testFile = path.join(testDir, 'overlap.ts');
+      const binDir = path.join(testDir, 'bin');
+      const logFile = path.join(testDir, 'npx.log');
+      const stateDir = path.join(testDir, 'state');
+
+      fs.writeFileSync(
+        path.join(testDir, 'tsconfig.json'),
+        JSON.stringify({ compilerOptions: { strict: true, noEmit: true } })
+      );
+      fs.writeFileSync(testFile, 'export const value: number = 1;\n');
+      createDelayedCommandShim(binDir, 'npx', logFile, 300);
+
+      const stdinJson = JSON.stringify({ tool_input: { file_path: testFile } });
+      const env = withPrependedPath(binDir, {
+        ECC_TYPECHECK_COOLDOWN_MS: '0',
+        ECC_TYPECHECK_LOCK_TTL_MS: '60000',
+        ECC_TYPECHECK_STATE_DIR: stateDir
+      });
+
+      const firstPromise = runScript(path.join(scriptsDir, 'post-edit-typecheck.js'), stdinJson, env);
+      sleepMs(50);
+      const secondPromise = runScript(path.join(scriptsDir, 'post-edit-typecheck.js'), stdinJson, env);
+      const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+      assert.strictEqual(first.code, 0, 'First overlapping run should exit 0');
+      assert.strictEqual(second.code, 0, 'Second overlapping run should exit 0');
+      const logEntries = readCommandLog(logFile);
+      assert.strictEqual(logEntries.length, 1, 'Should not spawn concurrent npx tsc runs for the same tsconfig root');
       cleanupTestDir(testDir);
     })
   )


### PR DESCRIPTION
Fixes Copilot/agent CPU usage caused by aggressive typecheck hook. Adds debouncing and file-change filtering to prevent unnecessary tsc runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce CPU usage from the post-edit TypeScript typecheck hook by coalescing checks per tsconfig and adding a cooldown. This prevents bursty `tsc` runs during rapid edits.

- **Bug Fixes**
  - Coalesce runs per tsconfig root: skip overlapping runs via a lock file and apply a cooldown after each run (default 10s). Lock TTL defaults to 120s. Configurable via `ECC_TYPECHECK_COOLDOWN_MS`, `ECC_TYPECHECK_LOCK_TTL_MS`, and `ECC_TYPECHECK_STATE_DIR`.
  - Run only when needed: trigger on existing `.ts`/`.tsx` files with a nearby `tsconfig.json`. Filter `tsc` output to lines related to the edited file.
  - Add tests to verify cooldown coalescing and that overlapping runs are skipped.

<sup>Written for commit 9ac0414e5f172c8f3d209239867032d1315b2fe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type-checking hook performance by deduplicating repeated checks and preventing overlapping runs from executing simultaneously.

* **Tests**
  * Added test coverage for type-check coalescing and concurrent execution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->