### PR TITLE
feat(skills): add Kysely migration patterns to database-migrations

### DIFF
--- a/skills/database-migrations/SKILL.md
+++ b/skills/database-migrations/SKILL.md
@@ -228,7 +228,7 @@ kysely migrate list
 ### Migration File
 
 ```typescript
-// migrations/2024_01_15_001_add_user_avatar.ts
+// migrations/2024_01_15_001_create_user_profile.ts
 import { type Kysely, sql } from 'kysely'
 
 // IMPORTANT: Always use Kysely<any>, not your typed DB interface.
@@ -260,13 +260,14 @@ export async function down(db: Kysely<any>): Promise<void> {
 
 ```typescript
 import { Migrator, FileMigrationProvider } from 'kysely'
-import { fileURLToPath } from 'url'
-import * as path from 'path'
 import { promises as fs } from 'fs'
-
-// ESM: use import.meta.url (CJS: use __dirname instead)
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+import * as path from 'path'
+// ESM only — CJS can use __dirname directly
+import { fileURLToPath } from 'url'
+const migrationFolder = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './migrations',
+)
 
 // `db` is your Kysely<any> database instance
 const migrator = new Migrator({
@@ -274,7 +275,7 @@ const migrator = new Migrator({
   provider: new FileMigrationProvider({
     fs,
     path,
-    migrationFolder: path.join(__dirname, './migrations'),
+    migrationFolder,
   }),
   // WARNING: Only enable in development. Disables timestamp-ordering
   // validation, which can cause schema drift between environments.


### PR DESCRIPTION
## Summary
- Add Kysely (TypeScript/Node.js) section to database-migrations skill
- Covers kysely-ctl CLI workflow (`init`, `migrate make/latest/down/list`)
- Includes migration file structure with `up`/`down` using `Kysely<any>` pattern
- Documents programmatic `Migrator` + `FileMigrationProvider` setup with `allowUnorderedMigrations` option
- Updates frontmatter description to include Kysely in the ORM list

## Test plan
- [x] `node tests/run-all.js` passes (no new failures)
- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Kysely` migration patterns to the `database-migrations` skill (CLI via `kysely-ctl`, `up`/`down` with `Kysely<any>`, programmatic `Migrator` + `FileMigrationProvider`). Updates examples with ESM-only imports (CJS `__dirname` note), renames the sample to `create_user_profile`, keeps `allowUnorderedMigrations` commented with a prod warning, switches to an `avatar_url` index, and updates the frontmatter to include `Kysely`.

<sup>Written for commit e2cdf0747a0391a6ac5f1dc79ab21f533c3dcbc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Kysely as a supported migration tool alongside Prisma, Drizzle, Django, TypeORM, and golang-migrate.
  * Added a Kysely (TypeScript/Node.js) section with CLI workflows for init, generate, apply, rollback, and status.
  * Included a sample Kysely migration (user_profile table, index, constraints) and a programmatic migrator example for automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->