### PR TITLE
feat(mcp): add novyx-mcp persistent memory server

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -142,6 +142,14 @@
         "CONFLUENCE_API_TOKEN": "YOUR_CONFLUENCE_TOKEN_HERE"
       },
       "description": "Confluence Cloud integration — search pages, retrieve content, explore spaces"
+    },
+    "novyx": {
+      "command": "uvx",
+      "args": ["novyx-mcp"],
+      "env": {
+        "NOVYX_API_KEY": "YOUR_NOVYX_API_KEY_HERE"
+      },
+      "description": "Persistent agent memory — 64 tools for remember, recall, rollback, cryptographic audit trails, knowledge graph, governed actions, context spaces, execution tracing, and memory eval. Local-first SQLite mode (no API key needed) or cloud via Novyx Core API. Install: pip install novyx-mcp. Repo: https://github.com/novyxlabs/novyx-mcp"
     }
   },
   "_comments": {


### PR DESCRIPTION
## Summary

Add [novyx-mcp](https://github.com/novyxlabs/novyx-mcp) to MCP server configurations — persistent agent memory with 64 MCP tools covering remember, recall, rollback, cryptographic audit trails, knowledge graph, governed actions, context spaces, execution tracing, and memory eval.

- **Install**: `uvx novyx-mcp` or `pip install novyx-mcp`
- **Local-first**: Runs on SQLite with zero config, no API key needed
- **Cloud mode**: Connect to Novyx Core API for cloud persistence
- **PyPI**: [novyx-mcp](https://pypi.org/project/novyx-mcp/)
- **Repo**: [novyxlabs/novyx-mcp](https://github.com/novyxlabs/novyx-mcp)

## Type
- [x] MCP Server Configuration

## Testing
- Verified `uvx novyx-mcp` launches successfully
- Tested local SQLite mode (zero config) and cloud mode with API key
- 64 tools, 6 resources, 3 prompts confirmed via MCP inspector

## Checklist
- [x] Follows mcp-servers.json format
- [x] No sensitive info (uses YOUR_*_HERE placeholder)
- [x] Clear description
- [x] Tested with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `novyx-mcp` persistent memory server to `mcp-servers.json`, providing 64 tools for remember/recall, rollback, and cryptographic audit trails. Supports local SQLite (no API key) and optional cloud via Novyx Core.

- **New Features**
  - Added `novyx` server config with `uvx` + `novyx-mcp` command and `NOVYX_API_KEY` env placeholder.

- **Migration**
  - Install `novyx-mcp` via `uvx novyx-mcp` or `pip install novyx-mcp`. Set NOVYX_API_KEY only for cloud mode.

<sup>Written for commit 9f3f43c587e690f2756d30fc6cec3a2ebe095036. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Novyx MCP server integration for persistent agent memory capabilities. Configure the `NOVYX_API_KEY` environment variable to enable this feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->