### PR TITLE
Docs/zh cn prune command

### DIFF
--- a/docs/zh-CN/commands/prune.md
+++ b/docs/zh-CN/commands/prune.md
@@ -1,4 +1,5 @@
 ---
+name: prune
 description: 删除超过 30 天且从未被提升的待处理本能
 command: true
 ---
@@ -9,13 +10,13 @@ command: true
 
 ## 实现
 
-使用插件根目录路径运行 instinct CLI：
+使用插件根目录路径运行本能 CLI：
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/scripts/instinct-cli.py" prune
 ```
 
-或者当 `CLAUDE_PLUGIN_ROOT` 未设置时（手动安装）：
+或者如果 `CLAUDE_PLUGIN_ROOT` 未设置（手动安装）：
 
 ```bash
 python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py prune
@@ -28,8 +29,3 @@ python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py prune
 /prune --max-age 60       # 自定义年龄阈值（天）
 /prune --dry-run          # 仅预览，不实际删除
 ```
----
-name: prune
-description: 删除超过 30 天且从未被提升的待处理本能
-command: true
----


### PR DESCRIPTION
## What Changed
Added the missing Simplified Chinese translation for the prune command documentation in docs/zh-CN/commands/prune.md.

## Why This Change
The zh-CN documentation was complete except for this single file. Adding this ensures consistency across the translated documentation set and helps Chinese-speaking users understand the prune command.

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Simplified Chinese docs for the prune command and corrected the frontmatter (`name: prune`, `description`, `command: true`) so the page renders correctly as a command.
Covers the default 30‑day cleanup of never‑promoted pending instincts, shows CLI paths using `CLAUDE_PLUGIN_ROOT` or manual install, and includes examples for `/prune`, `--max-age`, and `--dry-run`.

<sup>Written for commit 1e3572becff43522b2d7a3b37d37053b6738c61d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Simplified Chinese documentation for the prune command, covering purpose, behavior, and usage examples.
  * Describes default behavior (removes pending items older than 30 days that were never boosted), execution guidance for running the command, and available flags such as --max-age and --dry-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->