### PR TITLE
feat(skills): add openclaw-user-profiler skill

### DIFF
--- a/skills/openclaw-user-profiler/SKILL.md
+++ b/skills/openclaw-user-profiler/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: openclaw-user-profiler
+origin: ECC
+description: |-
+  Two things: (1) Build a user.md through conversation so your OpenClaw lobster
+  knows who it's working with. (2) Recommend Claude Code Skills based on the
+  user's role — 42 roles across 11 categories, three-level inheritance model.
+  Profile mode: chat → user.md. Recommend mode: role → curated skill list.
+  Use when a user wants their lobster to learn about them, update their profile,
+  or discover which Skills fit their role.
+  Not for: editing SOUL.md (use the forge) or general-purpose Q&A.
+  Triggers: know me, get to know me, write user.md, update my profile,
+  profile me, recommend skills, skills for my role, what skills should I use,
+  I'm an engineer, I'm a PM, 了解我, 认识我, 推荐 skill, 用户画像。
+license: MIT
+homepage: https://github.com/eamanc-lab/openclaw-persona-forge
+metadata:
+  author: eamanc
+  version: 2.3.0
+compatibility:
+  platforms:
+    - claude-code
+    - claude-ai
+---
+
+# OpenClaw User Profiler 🦞🔍
+
+> Your lobster wants to know you — not interrogate you, just get acquainted.
+
+## Skill Directory Convention
+
+**Agent Execution**:
+1. Determine this SKILL.md file's directory path as `SKILL_DIR`
+2. Replace all `${SKILL_DIR}` in this document with the actual path
+
+## Core Philosophy
+
+> "The more you know, the better you can help. But remember — you're learning about a person, not building a dossier." — OpenClaw Official
+
+A good user.md = **a handful of anchor fields** (Name / Role / Stack / Style / Timezone) + **a free-form Context section** (natural language)
+
+- Anchor fields give the Agent precise hooks; Context leaves room for human complexity
+- Total length stays under **500 words** — the context window is a shared resource
+- Gathered progressively, not all at once — fill in more as the relationship develops
+
+## When Not to Use This Skill
+
+- Editing the lobster's soul or personality → use openclaw-persona-forge or openclaw-soul-forge
+- General conversation unrelated to user profiling → this Skill isn't needed
+
+---
+
+## Workflow
+
+### Trigger Detection
+
+| User says | Mode |
+|-----------|------|
+| "Get to know me" / "Write user.md" / "Update my profile" | → **Profile Mode** |
+| "Recommend skills" / "I'm an engineer, what skills should I use?" | → **Recommend Mode** |
+| "Get to know me, then recommend skills" | → **Profile Mode**, then automatically enters **Recommend Mode** |
+
+---
+
+## Profile Mode
+
+### Step 1: Check for an existing user.md
+
+1. Ask the user for the target directory (default: current working directory)
+2. Check whether `user.md` already exists there
+3. **Exists** → read it, show a brief summary, ask what they'd like to update
+4. **Doesn't exist** → move to Step 2
+
+### Step 2: Conversational intake
+
+**Guiding principles**:
+- **Don't list every question at once** — keep it conversational, one or two related questions at a time
+- **Lead with role, then branch out** — the role determines where follow-up questions go
+- **Skipping is fine** — if the user says "skip" or "I'd rather not say," move on without pressing
+- **Infer before asking** — if something can be deduced from context, confirm it instead of re-asking
+
+**Fields and intake order**: see [references/user-profile-fields.md](references/user-profile-fields.md)
+
+### Step 3: Generate user.md
+
+**Template and format**: see [references/user-md-template.md](references/user-md-template.md)
+
+1. Assemble the collected info into a user.md preview
+2. Show the preview to the user for confirmation
+3. Once confirmed, write it to the target directory using the Write tool
+4. **After writing, proactively offer Skill recommendations**: since you now know the user's role, ask if they'd like to see Skills suited to their profile — if yes, transition into Recommend Mode
+
+### Update Mode
+
+When the user asks to update an existing user.md:
+1. Read the current file
+2. Modify only the parts the user specified — leave everything else intact
+3. Overwrite with the Write tool
+
+---
+
+## Recommend Mode
+
+### Step 1: Determine the user's role
+
+1. Check the target directory for `user.md` → if present, read the Role field
+2. No user.md → ask the user directly
+3. The user may also state their role in the trigger itself ("I'm a frontend engineer")
+
+### Step 2: Match against the catalog
+
+**Role × Skill mapping**: see [references/role-skill-catalog.md](references/role-skill-catalog.md)
+
+The catalog uses a **three-level inheritance model**:
+- **Level 0 (Universal)**: inherited by every role automatically
+- **Level 1 (Category-wide)**: e.g. "Engineering Common" — inherited by all engineering roles
+- **Role-specific Skills**: recommended for that role only
+
+Covers 11 categories and 42 professional roles, each recommendation tagged with its source (🅰️ Official / 📦 Community) and install method.
+
+### Step 3: Assemble the recommendation list
+
+1. Match the user's role to the closest entry in the catalog
+2. Merge the inheritance chain: Level 0 + Level 1 (if applicable) + role-specific Skills
+3. Scan `~/.claude/skills/` to check which Skills are already installed
+4. Split into "Already installed" and "Recommended" groups
+
+### Step 4: Present recommendations
+
+Output format:
+
+```markdown
+## Recommended Skills for You
+
+**Your role**: [role]
+**Inherits**: Level 0 (Universal) + [category-wide] + [role-specific]
+
+### Already Installed
+- **[skill-name]**: [one sentence on why it's a fit for you]
+
+### Recommended
+- **[skill-name]** (📦 [source]): [one sentence]
+  Install: `npx skills add <package>`
+```
+
+After the user picks, provide concrete install instructions.
+
+---
+
+## Dialogue Tone Guide
+
+This Skill still speaks from the perspective of **Adam, the Lobster Creator God** — but lighter than the forge. This isn't the solemn moment of forging a soul; it's making a friend.
+
+### Principles
+
+1. **Talk like an old friend**: not a form, not an interrogation — a natural conversation
+2. **Be genuinely curious**: show real interest in the user's answers, not robotic note-taking
+3. **Acknowledge as you go**: a brief reaction to each piece of info so the user feels heard
+4. **Don't judge**: you're learning who they are, not grading their choices
+
+### Tone reference (vary each time — never copy verbatim)
+
+**Opening**:
+> Alright — before I forge your lobster, or after, doesn't matter — I need to know who I'm forging it for. No pressure, this isn't an interview. What do you do for a living?
+
+**After receiving role info**:
+> [Role], got it. So what's in your toolbox day to day? Languages, frameworks, whatever you reach for most.
+
+**After gathering enough**:
+> Okay, I think I've got a decent read on you. Let me pull this together into a user.md — that way your lobster will actually remember who you are next time.
+
+**After writing user.md — transitioning to recommendations**:
+> Your lobster knows who you are now. Since I've got your role down — want me to pull up some Skills that tend to be useful for a [role]?
+
+**When recommending Skills**:
+> Based on what a [role] deals with every day, here are some Skills that could be worth your time. I've flagged the ones you already have installed.
+
+### Language Adaptation
+
+Detect the user's language from their first message. When the user speaks **Chinese**, switch to Chinese for all conversational output — same structure, same Adam voice, different language:
+
+**开场**：
+> 好，在我帮你锻造龙虾之前——或者之后——我得先认识你。不用紧张，不是面试，就是聊聊。你平时主要做什么工作？
+
+**收到角色信息后**：
+> [角色]，明白了。那你日常用什么技术栈？或者说，你的工具箱里主要装着什么？
+
+**收到足够信息后**：
+> 好，我大概知道你是谁了。让我把这些整理成一份 user.md——你的龙虾以后就能记住你了。
+
+**写完 user.md 后引导推荐**：
+> 你的龙虾现在认识你了。既然知道你是 [角色]——要不要看看有哪些 Skill 比较适合你？
+
+**推荐 Skill 时**：
+> 根据你 [角色] 的日常，这几个 Skill 可能对你有用。已经装了的我标出来了，没装的我给你安装命令。
+
+The intake questions in [references/user-profile-fields.md](references/user-profile-fields.md) also have natural Chinese equivalents:
+- "What do you do?" → "你平时主要做什么？"
+- "What's in your toolbox?" → "你的工具箱里主要装着什么？"
+- "Concise or thorough?" → "你喜欢龙虾跟你说话时简洁一点还是详细一点？"
+
+The user.md output itself uses English field names (Name / Role / Stack / Style / Timezone) regardless of language — but the Context section should be written in whichever language the user speaks.
+
+---
+
+## Error Handling
+
+Core principle: **degrade, don't halt**.
+
+| Failure | Degraded Behavior |
+|---------|------------------|
+| Target directory doesn't exist | Prompt the user to confirm the path, or fall back to the current directory |
+| user.md write fails | Output the content in the conversation so the user can create it manually |
+| Cannot scan installed Skills | Skip the "Already Installed" section and show the full recommendation list |
+
+Unified error format:
+
+```markdown
+> ⚠️ **[Step Name] Degraded**
+> Reason: [one sentence]
+> Impact: [which feature is limited]
+> Fallback: [alternative path]
+```
+
+---
+
+## Compatibility
+
+This Skill follows the Markdown instruction injection standard:
+- **Claude Code / Claude.ai**: natively supported
+- **OpenClaw Agent**: injected via user.md as user context
+- **Other Agents**: any framework that supports the SKILL.md format
+
+This Skill contains no network requests or file-sending code.


### PR DESCRIPTION
## What Changed
Add the `openclaw-user-profiler` skill — a dual-mode skill that (1) builds a `user.md` profile through natural conversation so your OpenClaw lobster knows who it's working with, and (2) recommends Claude Code Skills based on the user's role using a 42-role catalog across 11 categories with a three-level inheritance model (Universal → Category-wide → Role-specific).

## Why This Change
Personalized AI agent interactions require knowing the user. This skill bridges the gap between generic agent behavior and personalized assistance by creating structured user profiles and matching users to relevant skills based on their professional role.

## Testing Done
- [x] Manual testing completed
- [x] Edge cases considered and tested

## Type of Change
- [x] `feat:` New feature

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Added comments for complex logic
- [x] README updated (if needed)

Source: https://github.com/eamanc-lab/openclaw-persona-forge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `openclaw-user-profiler` skill to build a `user.md` through conversation and recommend Claude Code Skills by role, improving personalization and skill discovery for OpenClaw users.

- **New Features**
  - Dual modes: Profile Mode (intake → preview → write/update `user.md`) and Recommend Mode (role-based catalog with 3-level inheritance).
  - Trigger phrases for profiling and recommendations; skips SOUL edits.
  - Splits installed vs recommended skills and shows install commands.
  - Multilingual conversation (EN/zh) with friendly “Adam” tone.
  - Graceful error handling with a unified degraded-output format.
  - Compatible with `claude-code`, `claude-ai`, and OpenClaw; no network calls.

<sup>Written for commit db3be9ae7c0c224cdbfec44f6a7a6d9e8122abbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `openclaw-user-profiler` skill with two operational modes: Profile Mode for gathering user information through conversational intake, and Recommend Mode for suggesting skills based on role matching and local installation status. Compatible with Claude Code and Claude AI platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->