### PR TITLE
feat: add omega-memory MCP server

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -29,7 +29,7 @@
     "omega-memory": {
       "command": "uvx",
       "args": ["omega-memory", "serve"],
-      "description": "Persistent agent memory with semantic search, multi-agent coordination, and knowledge graphs — pip install omega-memory"
+      "description": "Persistent agent memory with semantic search, multi-agent coordination, and knowledge graphs — run via uvx (richer than the basic memory store)"
     },
     "sequential-thinking": {
       "command": "npx",


### PR DESCRIPTION
## Summary
- Adds [omega-memory](https://github.com/omega-memory/omega-memory) to the MCP server configs
- Persistent agent memory with semantic search, multi-agent coordination, and knowledge graphs
- Available on PyPI: `pip install omega-memory` / `uvx omega-memory serve`
- 900+ GitHub stars, Apache-2.0 licensed

## Test plan
- [x] Valid JSON syntax in mcp-servers.json
- [x] `uvx omega-memory serve` starts MCP server successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `omega-memory` MCP server to `mcp-servers.json` for persistent agent memory with semantic search, multi-agent coordination, and knowledge graphs. Install from PyPI and run with `uvx omega-memory serve`; richer than the basic memory store.

- **Bug Fixes**
  - Aligned the `omega-memory` config description in `mcp-servers.json`.

<sup>Written for commit b575f2e3ebc67d3c143dd460e59ac19587d76cd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an "omega-memory" server integration to provide persistent agent memory, semantic search, multi-agent coordination, and knowledge graph capabilities.
  * This enables agents to retain and query long-term context, improve retrieval accuracy, and coordinate across tasks using enriched knowledge structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->