### PR TITLE
docs: update skill count 119 → 125 in README.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Everything Claude Code (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 28 specialized agents, 119 skills, 60 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 28 specialized agents, 125 skills, 60 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ For manual install instructions see the README in the `rules/` folder.
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-✨ **That's it!** You now have access to 28 agents, 119 skills, and 60 commands.
+✨ **That's it!** You now have access to 28 agents, 125 skills, and 60 commands.
 
 ---
 
@@ -1085,7 +1085,7 @@ The configuration is automatically detected from `.opencode/opencode.json`.
 |---------|-------------|----------|--------|
 | Agents | ✅ 28 agents | ✅ 12 agents | **Claude Code leads** |
 | Commands | ✅ 60 commands | ✅ 31 commands | **Claude Code leads** |
-| Skills | ✅ 119 skills | ✅ 37 skills | **Claude Code leads** |
+| Skills | ✅ 125 skills | ✅ 37 skills | **Claude Code leads** |
 | Hooks | ✅ 8 event types | ✅ 11 events | **OpenCode has more!** |
 | Rules | ✅ 29 rules | ✅ 13 instructions | **Claude Code leads** |
 | MCP Servers | ✅ 14 servers | ✅ Full | **Full parity** |


### PR DESCRIPTION
## Summary

- CI `Validate Components` check fails on **all branches** (including `main`) because 6 skills were added without updating documented counts
- Updates the 3 occurrences of `119` → `125` in README.md and AGENTS.md

## Changes

| File | Location | Change |
|------|----------|--------|
| `README.md` | Quick-start summary (line 215) | 119 → 125 |
| `README.md` | Comparison table (line 1088) | 119 → 125 |
| `AGENTS.md` | Summary (line 3) | 119 → 125 |

## Test plan

- [x] `node scripts/ci/catalog.js --text` passes after change
- [x] No other content changes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed CI failures by updating the documented skills count from 119 to 125. Aligns `README.md` and `AGENTS.md` with the current catalog so the `Validate Components` check passes on all branches.

- **Bug Fixes**
  - Updated three occurrences of the skills count in `README.md` (quick start and comparison table) and `AGENTS.md`.

<sup>Written for commit 2afcce7e28dd9bdce8b9822d62bb6eb4b4e08420. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect expanded plugin capability catalog, now supporting 125 workflow skills (increased from 119).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->