### PR TITLE
feat(ecc2): agent status panel with Table widget

### DIFF
--- a/ecc2/src/session/manager.rs
+++ b/ecc2/src/session/manager.rs
@@ -281,6 +281,8 @@ mod tests {
             session_timeout_secs: 60,
             heartbeat_interval_secs: 5,
             default_agent: "claude".to_string(),
+            cost_budget_usd: 10.0,
+            token_budget: 500_000,
             theme: Theme::Dark,
         }
     }

--- a/ecc2/src/tui/dashboard.rs
+++ b/ecc2/src/tui/dashboard.rs
@@ -1,6 +1,8 @@
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, List, ListItem, Paragraph, Tabs, Wrap},
+    widgets::{
+        Block, Borders, Cell, HighlightSpacing, Paragraph, Row, Table, TableState, Tabs, Wrap,
+    },
 };
 
 use super::widgets::{budget_state, format_currency, format_token_count, BudgetState, TokenMeter};
@@ -16,6 +18,18 @@ pub struct Dashboard {
     selected_session: usize,
     show_help: bool,
     scroll_offset: usize,
+    session_table_state: TableState,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SessionSummary {
+    total: usize,
+    pending: usize,
+    running: usize,
+    idle: usize,
+    completed: usize,
+    failed: usize,
+    stopped: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -37,6 +51,11 @@ struct AggregateUsage {
 impl Dashboard {
     pub fn new(db: StateStore, cfg: Config) -> Self {
         let sessions = db.list_sessions().unwrap_or_default();
+        let mut session_table_state = TableState::default();
+        if !sessions.is_empty() {
+            session_table_state.select(Some(0));
+        }
+
         Self {
             db,
             cfg,
@@ -45,16 +64,17 @@ impl Dashboard {
             selected_session: 0,
             show_help: false,
             scroll_offset: 0,
+            session_table_state,
         }
     }
 
-    pub fn render(&self, frame: &mut Frame) {
+    pub fn render(&mut self, frame: &mut Frame) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Header
-                Constraint::Min(10),   // Main content
-                Constraint::Length(3), // Status bar
+                Constraint::Length(3),
+                Constraint::Min(10),
+                Constraint::Length(3),
             ])
             .split(frame.area());
 
@@ -65,20 +85,14 @@ impl Dashboard {
         } else {
             let main_chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Percentage(35), // Session list
-                    Constraint::Percentage(65), // Output/details
-                ])
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(chunks[1]);
 
             self.render_sessions(frame, main_chunks[0]);
 
             let right_chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Percentage(70), // Output
-                    Constraint::Percentage(30), // Metrics
-                ])
+                .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
                 .split(main_chunks[1]);
 
             self.render_output(frame, right_chunks[0]);
@@ -92,7 +106,7 @@ impl Dashboard {
         let running = self
             .sessions
             .iter()
-            .filter(|s| s.state == SessionState::Running)
+            .filter(|session| session.state == SessionState::Running)
             .count();
         let total = self.sessions.len();
 
@@ -113,50 +127,65 @@ impl Dashboard {
         frame.render_widget(tabs, area);
     }
 
-    fn render_sessions(&self, frame: &mut Frame, area: Rect) {
-        let items: Vec<ListItem> = self
-            .sessions
-            .iter()
-            .enumerate()
-            .map(|(i, s)| {
-                let state_icon = match s.state {
-                    SessionState::Running => "●",
-                    SessionState::Idle => "○",
-                    SessionState::Completed => "✓",
-                    SessionState::Failed => "✗",
-                    SessionState::Stopped => "■",
-                    SessionState::Pending => "◌",
-                };
-                let style = if i == self.selected_session {
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                };
-                let text = format!(
-                    "{state_icon} {} [{}] {}",
-                    &s.id[..8.min(s.id.len())],
-                    s.agent_type,
-                    s.task
-                );
-                ListItem::new(text).style(style)
-            })
-            .collect();
-
+    fn render_sessions(&mut self, frame: &mut Frame, area: Rect) {
         let border_style = if self.selected_pane == Pane::Sessions {
             Style::default().fg(Color::Cyan)
         } else {
             Style::default()
         };
 
-        let list = List::new(items).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Sessions ")
-                .border_style(border_style),
-        );
-        frame.render_widget(list, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" Sessions ")
+            .border_style(border_style);
+        let inner_area = block.inner(area);
+        frame.render_widget(block, area);
+
+        if inner_area.is_empty() {
+            return;
+        }
+
+        let summary = SessionSummary::from_sessions(&self.sessions);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(3)])
+            .split(inner_area);
+
+        frame.render_widget(Paragraph::new(summary_line(&summary)), chunks[0]);
+
+        let rows = self.sessions.iter().map(session_row);
+        let header = Row::new(["ID", "Agent", "State", "Branch", "Tokens", "Duration"])
+            .style(Style::default().add_modifier(Modifier::BOLD));
+        let widths = [
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Min(12),
+            Constraint::Length(8),
+            Constraint::Length(8),
+        ];
+
+        let table = Table::new(rows, widths)
+            .header(header)
+            .column_spacing(1)
+            .highlight_symbol(">> ")
+            .highlight_spacing(HighlightSpacing::Always)
+            .row_highlight_style(
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            );
+
+        let selected = if self.sessions.is_empty() {
+            None
+        } else {
+            Some(self.selected_session.min(self.sessions.len() - 1))
+        };
+        if self.session_table_state.selected() != selected {
+            self.session_table_state.select(selected);
+        }
+
+        frame.render_stateful_widget(table, chunks[1], &mut self.session_table_state);
     }
 
     fn render_output(&self, frame: &mut Frame, area: Rect) {
@@ -311,6 +340,7 @@ impl Dashboard {
     pub fn scroll_down(&mut self) {
         if self.selected_pane == Pane::Sessions && !self.sessions.is_empty() {
             self.selected_session = (self.selected_session + 1).min(self.sessions.len() - 1);
+            self.session_table_state.select(Some(self.selected_session));
         } else {
             self.scroll_offset = self.scroll_offset.saturating_add(1);
         }
@@ -319,13 +349,15 @@ impl Dashboard {
     pub fn scroll_up(&mut self) {
         if self.selected_pane == Pane::Sessions {
             self.selected_session = self.selected_session.saturating_sub(1);
+            if !self.sessions.is_empty() {
+                self.session_table_state.select(Some(self.selected_session));
+            }
         } else {
             self.scroll_offset = self.scroll_offset.saturating_sub(1);
         }
     }
 
     pub fn new_session(&mut self) {
-        // TODO: Open a dialog to create a new session
         tracing::info!("New session dialog requested");
     }
 
@@ -338,6 +370,7 @@ impl Dashboard {
 
     pub fn refresh(&mut self) {
         self.sessions = self.db.list_sessions().unwrap_or_default();
+        self.sync_selection();
     }
 
     pub fn toggle_help(&mut self) {
@@ -345,8 +378,18 @@ impl Dashboard {
     }
 
     pub async fn tick(&mut self) {
-        // Periodic refresh every few ticks
         self.sessions = self.db.list_sessions().unwrap_or_default();
+        self.sync_selection();
+    }
+
+    fn sync_selection(&mut self) {
+        if self.sessions.is_empty() {
+            self.selected_session = 0;
+            self.session_table_state.select(None);
+        } else {
+            self.selected_session = self.selected_session.min(self.sessions.len() - 1);
+            self.session_table_state.select(Some(self.selected_session));
+        }
     }
 
     fn aggregate_usage(&self) -> AggregateUsage {
@@ -419,17 +462,263 @@ impl Dashboard {
     }
 }
 
+impl SessionSummary {
+    fn from_sessions(sessions: &[Session]) -> Self {
+        sessions.iter().fold(
+            Self {
+                total: sessions.len(),
+                ..Self::default()
+            },
+            |mut summary, session| {
+                match session.state {
+                    SessionState::Pending => summary.pending += 1,
+                    SessionState::Running => summary.running += 1,
+                    SessionState::Idle => summary.idle += 1,
+                    SessionState::Completed => summary.completed += 1,
+                    SessionState::Failed => summary.failed += 1,
+                    SessionState::Stopped => summary.stopped += 1,
+                }
+                summary
+            },
+        )
+    }
+}
+
+fn session_row(session: &Session) -> Row<'static> {
+    Row::new(vec![
+        Cell::from(format_session_id(&session.id)),
+        Cell::from(session.agent_type.clone()),
+        Cell::from(session_state_label(&session.state)).style(
+            Style::default()
+                .fg(session_state_color(&session.state))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from(session_branch(session)),
+        Cell::from(session.metrics.tokens_used.to_string()),
+        Cell::from(format_duration(session.metrics.duration_secs)),
+    ])
+}
+
+fn summary_line(summary: &SessionSummary) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("Total {}  ", summary.total),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        summary_span("Running", summary.running, Color::Green),
+        summary_span("Idle", summary.idle, Color::Yellow),
+        summary_span("Completed", summary.completed, Color::Blue),
+        summary_span("Failed", summary.failed, Color::Red),
+        summary_span("Stopped", summary.stopped, Color::DarkGray),
+        summary_span("Pending", summary.pending, Color::Reset),
+    ])
+}
+
+fn summary_span(label: &str, value: usize, color: Color) -> Span<'static> {
+    Span::styled(
+        format!("{label} {value}  "),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )
+}
+
+fn session_state_label(state: &SessionState) -> &'static str {
+    match state {
+        SessionState::Pending => "Pending",
+        SessionState::Running => "Running",
+        SessionState::Idle => "Idle",
+        SessionState::Completed => "Completed",
+        SessionState::Failed => "Failed",
+        SessionState::Stopped => "Stopped",
+    }
+}
+
+fn session_state_color(state: &SessionState) -> Color {
+    match state {
+        SessionState::Running => Color::Green,
+        SessionState::Idle => Color::Yellow,
+        SessionState::Failed => Color::Red,
+        SessionState::Stopped => Color::DarkGray,
+        SessionState::Completed => Color::Blue,
+        SessionState::Pending => Color::Reset,
+    }
+}
+
+fn format_session_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn session_branch(session: &Session) -> String {
+    session
+        .worktree
+        .as_ref()
+        .map(|worktree| worktree.branch.clone())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn format_duration(duration_secs: u64) -> String {
+    let hours = duration_secs / 3600;
+    let minutes = (duration_secs % 3600) / 60;
+    let seconds = duration_secs % 60;
+    format!("{hours:02}:{minutes:02}:{seconds:02}")
+}
+
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use chrono::Utc;
+    use ratatui::{backend::TestBackend, widgets::TableState, Terminal};
 
-    use super::Dashboard;
+    use super::*;
     use crate::config::Config;
     use crate::session::store::StateStore;
-    use crate::session::{Session, SessionMetrics, SessionState};
+    use crate::session::{SessionMetrics, WorktreeInfo};
     use crate::tui::widgets::BudgetState;
+
+    #[test]
+    fn session_state_color_matches_requested_palette() {
+        assert_eq!(session_state_color(&SessionState::Running), Color::Green);
+        assert_eq!(session_state_color(&SessionState::Idle), Color::Yellow);
+        assert_eq!(session_state_color(&SessionState::Failed), Color::Red);
+        assert_eq!(session_state_color(&SessionState::Stopped), Color::DarkGray);
+        assert_eq!(session_state_color(&SessionState::Completed), Color::Blue);
+    }
+
+    #[test]
+    fn session_summary_counts_each_state() {
+        let sessions = vec![
+            sample_session(
+                "run-12345678",
+                "planner",
+                SessionState::Running,
+                Some("feat/run"),
+                128,
+                15,
+            ),
+            sample_session(
+                "idle-12345678",
+                "reviewer",
+                SessionState::Idle,
+                Some("feat/idle"),
+                256,
+                30,
+            ),
+            sample_session(
+                "done-12345678",
+                "architect",
+                SessionState::Completed,
+                Some("feat/done"),
+                512,
+                45,
+            ),
+            sample_session(
+                "fail-12345678",
+                "worker",
+                SessionState::Failed,
+                Some("feat/fail"),
+                1024,
+                60,
+            ),
+            sample_session(
+                "stop-12345678",
+                "security",
+                SessionState::Stopped,
+                None,
+                64,
+                10,
+            ),
+            sample_session(
+                "pend-12345678",
+                "tdd",
+                SessionState::Pending,
+                Some("feat/pending"),
+                32,
+                5,
+            ),
+        ];
+
+        let summary = SessionSummary::from_sessions(&sessions);
+
+        assert_eq!(summary.total, 6);
+        assert_eq!(summary.running, 1);
+        assert_eq!(summary.idle, 1);
+        assert_eq!(summary.completed, 1);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.stopped, 1);
+        assert_eq!(summary.pending, 1);
+    }
+
+    #[test]
+    fn render_sessions_shows_summary_headers_and_selected_row() {
+        let dashboard = test_dashboard(
+            vec![
+                sample_session(
+                    "run-12345678",
+                    "planner",
+                    SessionState::Running,
+                    Some("feat/run"),
+                    128,
+                    15,
+                ),
+                sample_session(
+                    "done-87654321",
+                    "reviewer",
+                    SessionState::Completed,
+                    Some("release/v1"),
+                    2048,
+                    125,
+                ),
+            ],
+            1,
+        );
+
+        let rendered = render_dashboard_text(dashboard, 150, 24);
+
+        assert!(rendered.contains("ID"));
+        assert!(rendered.contains("Agent"));
+        assert!(rendered.contains("State"));
+        assert!(rendered.contains("Branch"));
+        assert!(rendered.contains("Tokens"));
+        assert!(rendered.contains("Duration"));
+        assert!(rendered.contains("Total 2"));
+        assert!(rendered.contains("Running 1"));
+        assert!(rendered.contains("Completed 1"));
+        assert!(rendered.contains(">> done-876"));
+        assert!(rendered.contains("reviewer"));
+        assert!(rendered.contains("release/v1"));
+        assert!(rendered.contains("00:02:05"));
+    }
+
+    #[test]
+    fn sync_selection_preserves_table_offset_for_selected_rows() {
+        let mut dashboard = test_dashboard(
+            vec![
+                sample_session(
+                    "run-12345678",
+                    "planner",
+                    SessionState::Running,
+                    Some("feat/run"),
+                    128,
+                    15,
+                ),
+                sample_session(
+                    "done-87654321",
+                    "reviewer",
+                    SessionState::Completed,
+                    Some("release/v1"),
+                    2048,
+                    125,
+                ),
+            ],
+            1,
+        );
+        *dashboard.session_table_state.offset_mut() = 3;
+
+        dashboard.sync_selection();
+
+        assert_eq!(dashboard.session_table_state.selected(), Some(1));
+        assert_eq!(dashboard.session_table_state.offset(), 3);
+    }
 
     #[test]
     fn aggregate_usage_sums_tokens_and_cost_with_warning_state() {
@@ -440,8 +729,8 @@ mod tests {
 
         let mut dashboard = Dashboard::new(db, cfg);
         dashboard.sessions = vec![
-            session("sess-1", 4_000, 3.50),
-            session("sess-2", 4_500, 4.80),
+            budget_session("sess-1", 4_000, 3.50),
+            budget_session("sess-2", 4_500, 4.80),
         ];
 
         let aggregate = dashboard.aggregate_usage();
@@ -460,7 +749,7 @@ mod tests {
         cfg.cost_budget_usd = 10.0;
 
         let mut dashboard = Dashboard::new(db, cfg);
-        dashboard.sessions = vec![session("sess-1", 3_500, 8.25)];
+        dashboard.sessions = vec![budget_session("sess-1", 3_500, 8.25)];
 
         assert_eq!(
             dashboard.aggregate_cost_summary_text(),
@@ -468,13 +757,68 @@ mod tests {
         );
     }
 
-    fn session(id: &str, tokens_used: u64, cost_usd: f64) -> Session {
+    fn test_dashboard(sessions: Vec<Session>, selected_session: usize) -> Dashboard {
+        let selected_session = selected_session.min(sessions.len().saturating_sub(1));
+        let mut session_table_state = TableState::default();
+        if !sessions.is_empty() {
+            session_table_state.select(Some(selected_session));
+        }
+
+        Dashboard {
+            db: test_store(),
+            cfg: Config::default(),
+            sessions,
+            selected_pane: Pane::Sessions,
+            selected_session,
+            show_help: false,
+            scroll_offset: 0,
+            session_table_state,
+        }
+    }
+
+    fn test_store() -> StateStore {
+        StateStore::open(Path::new(":memory:")).expect("open test db")
+    }
+
+    fn sample_session(
+        id: &str,
+        agent_type: &str,
+        state: SessionState,
+        branch: Option<&str>,
+        tokens_used: u64,
+        duration_secs: u64,
+    ) -> Session {
+        Session {
+            id: id.to_string(),
+            task: "Render dashboard rows".to_string(),
+            agent_type: agent_type.to_string(),
+            state,
+            pid: None,
+            worktree: branch.map(|branch| WorktreeInfo {
+                path: PathBuf::from(format!("/tmp/{branch}")),
+                branch: branch.to_string(),
+                base_branch: "main".to_string(),
+            }),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            metrics: SessionMetrics {
+                tokens_used,
+                tool_calls: 4,
+                files_changed: 2,
+                duration_secs,
+                cost_usd: 0.42,
+            },
+        }
+    }
+
+    fn budget_session(id: &str, tokens_used: u64, cost_usd: f64) -> Session {
         let now = Utc::now();
         Session {
             id: id.to_string(),
             task: "Budget tracking".to_string(),
             agent_type: "claude".to_string(),
             state: SessionState::Running,
+            pid: None,
             worktree: None,
             created_at: now,
             updated_at: now,
@@ -486,5 +830,22 @@ mod tests {
                 cost_usd,
             },
         }
+    }
+
+    fn render_dashboard_text(mut dashboard: Dashboard, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("create terminal");
+
+        terminal
+            .draw(|frame| dashboard.render(frame))
+            .expect("render dashboard");
+
+        let buffer = terminal.backend().buffer();
+        buffer
+            .content
+            .chunks(buffer.area.width as usize)
+            .map(|cells| cells.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }


### PR DESCRIPTION
Supersedes closed #823 after #762 merged and the scaffold branch was deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an agent status panel to the dashboard with a sessions table for faster, clearer monitoring. Shows key details, color-coded states, and supports row selection with stable syncing.

- **New Features**
  - Sessions table with columns: ID, Agent, State, Branch, Tokens, Duration.
  - Color-coded states and a summary bar with per-state counts.
  - Row selection highlight with selection synced to bounds.
  - Tests for state palette, summary counts, table rendering, and selection sync.

- **Refactors**
  - Updated dashboard split to 50/50 between sessions and output.
  - Refresh/tick now syncs selection and preserves table offset.

<sup>Written for commit 3f02fa439abef852827a5827b75d410f9aff7d8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard sessions view from list to detailed table format with columns displaying session ID, Agent, State, Branch, Tokens, and Duration.
  * Added session summary statistics showing counts by state.
  * Improved session layout proportions and selection handling with enhanced visual feedback.

* **Tests**
  * Updated test configuration setup with additional budget-related fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->