### PR TITLE
fix: remove redundant skill copy from sync-ecc-to-codex.sh

### DIFF
--- a/scripts/codex/check-codex-global-state.sh
+++ b/scripts/codex/check-codex-global-state.sh
@@ -11,7 +11,7 @@ CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 CONFIG_FILE="$CODEX_HOME/config.toml"
 AGENTS_FILE="$CODEX_HOME/AGENTS.md"
 PROMPTS_DIR="$CODEX_HOME/prompts"
-SKILLS_DIR="$CODEX_HOME/skills"
+SKILLS_DIR="${AGENTS_HOME:-$HOME/.agents}/skills"
 HOOKS_DIR_EXPECT="${ECC_GLOBAL_HOOKS_DIR:-$CODEX_HOME/git-hooks}"
 
 failures=0
@@ -144,12 +144,12 @@ if [[ -d "$SKILLS_DIR" ]]; then
   done
 
   if [[ "$missing_skills" -eq 0 ]]; then
-    ok "All 16 ECC Codex skills are present"
+    ok "All 16 ECC skills are present in $SKILLS_DIR"
   else
-    fail "$missing_skills required skills are missing"
+    warn "$missing_skills ECC skills missing from $SKILLS_DIR (install via ECC installer or npx skills)"
   fi
 else
-  fail "Skills directory missing ($SKILLS_DIR)"
+  warn "Skills directory missing ($SKILLS_DIR) — install via ECC installer or npx skills"
 fi
 
 if [[ -f "$PROMPTS_DIR/ecc-prompts-manifest.txt" ]]; then

--- a/scripts/sync-ecc-to-codex.sh
+++ b/scripts/sync-ecc-to-codex.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # Sync Everything Claude Code (ECC) assets into a local Codex CLI setup.
 # - Backs up ~/.codex config and AGENTS.md
 # - Merges ECC AGENTS.md into existing AGENTS.md (marker-based, preserves user content)
-# - Syncs Codex-ready skills from .agents/skills
 # - Generates prompt files from commands/*.md
 # - Generates Codex QA wrappers and optional language rule-pack prompts
 # - Installs global git safety hooks (pre-commit and pre-push)
@@ -28,8 +27,6 @@ CONFIG_FILE="$CODEX_HOME/config.toml"
 AGENTS_FILE="$CODEX_HOME/AGENTS.md"
 AGENTS_ROOT_SRC="$REPO_ROOT/AGENTS.md"
 AGENTS_CODEX_SUPP_SRC="$REPO_ROOT/.codex/AGENTS.md"
-SKILLS_SRC="$REPO_ROOT/.agents/skills"
-SKILLS_DEST="$CODEX_HOME/skills"
 PROMPTS_SRC="$REPO_ROOT/commands"
 PROMPTS_DEST="$CODEX_HOME/prompts"
 HOOKS_INSTALLER="$REPO_ROOT/scripts/codex/install-global-git-hooks.sh"
@@ -133,7 +130,6 @@ MCP_MERGE_SCRIPT="$REPO_ROOT/scripts/codex/merge-mcp-config.js"
 
 require_path "$REPO_ROOT/AGENTS.md" "ECC AGENTS.md"
 require_path "$AGENTS_CODEX_SUPP_SRC" "ECC Codex AGENTS supplement"
-require_path "$SKILLS_SRC" "ECC skills directory"
 require_path "$PROMPTS_SRC" "ECC commands directory"
 require_path "$HOOKS_INSTALLER" "ECC global git hooks installer"
 require_path "$SANITY_CHECKER" "ECC global sanity checker"
@@ -235,17 +231,9 @@ else
   fi
 fi
 
-log "Syncing ECC Codex skills"
-run_or_echo mkdir -p "$SKILLS_DEST"
-skills_count=0
-for skill_dir in "$SKILLS_SRC"/*; do
-  [[ -d "$skill_dir" ]] || continue
-  skill_name="$(basename "$skill_dir")"
-  dest="$SKILLS_DEST/$skill_name"
-  run_or_echo rm -rf "$dest"
-  run_or_echo cp -R "$skill_dir" "$dest"
-  skills_count=$((skills_count + 1))
-done
+# Skills are NOT synced here — Codex CLI reads directly from
+# ~/.agents/skills/ (installed by ECC installer / npx skills).
+# Copying into ~/.codex/skills/ was unnecessary.
 
 log "Generating prompt files from ECC commands"
 run_or_echo mkdir -p "$PROMPTS_DEST"
@@ -486,7 +474,6 @@ fi
 
 log "Sync complete"
 log "Backup saved at: $BACKUP_DIR"
-log "Skills synced: $skills_count"
 log "Prompts generated: $((prompt_count + extension_count)) (commands: $prompt_count, extensions: $extension_count)"
 
 if [[ "$MODE" == "apply" ]]; then

--- a/tests/scripts/sync-ecc-to-codex.test.js
+++ b/tests/scripts/sync-ecc-to-codex.test.js
@@ -69,8 +69,9 @@ function runTests() {
 
   if (test('filesystem-changing calls use argv-form run_or_echo invocations', () => {
     assert.ok(source.includes('run_or_echo mkdir -p "$BACKUP_DIR"'), 'mkdir should use argv form');
-    assert.ok(source.includes('run_or_echo rm -rf "$dest"'), 'rm should use argv form');
-    assert.ok(source.includes('run_or_echo cp -R "$skill_dir" "$dest"'), 'recursive copy should use argv form');
+    // Skills sync rm/cp calls were removed — Codex reads from ~/.agents/skills/ natively
+    assert.ok(!source.includes('run_or_echo rm -rf "$dest"'), 'skill sync rm should be removed');
+    assert.ok(!source.includes('run_or_echo cp -R "$skill_dir" "$dest"'), 'skill sync cp should be removed');
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Summary

- Remove redundant skill copy from `sync-ecc-to-codex.sh` — Codex CLI already reads skills natively from `~/.agents/skills/` (installed by ECC installer / `npx skills`). Copying them to `~/.codex/skills/` was a no-op for users who already have ECC installed, which is a prerequisite for running the sync script.
- Update `check-codex-global-state.sh` to validate `~/.agents/skills/` instead of `~/.codex/skills/`, and downgrade missing skills from FAIL to WARN since skills are installed by the ECC installer, not the sync script.

## Details

The sync script copies skills from `.agents/skills/` (inside the ECC plugin) to `~/.codex/skills/`. But:

1. **Codex CLI reads from `~/.agents/skills/` natively** — this is the standard global skill path
2. **The sync script requires ECC to be installed** — you can't run it without ECC, which means `~/.agents/skills/` is already populated by the ECC installer
3. **`~/.codex/skills/` is not the canonical skill path** — skills there are redundant copies

Net change: 8 lines added (comments + updated sanity check), 20 lines removed.

## Test plan

- [x] `bash -n` syntax check passes
- [x] `node tests/run-all.js` — all 1566 tests pass
- [x] Codex review PASS (commit + PR mode)
- [ ] CI (catalog count, hooks, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant skill sync in `sync-ecc-to-codex.sh` (dropped copy loop, related vars/checks, and "Skills synced" log; clarified comment). Updated `check-codex-global-state.sh` to validate `${AGENTS_HOME:-$HOME/.agents}/skills`, warn (not fail), and reference `$SKILLS_DIR`; updated tests to assert the skill-copy commands are removed.

<sup>Written for commit d170cdd1750cd26a8eea1ccb9bb6d6d342e5bdd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default skills location now resolves to ~/.agents/skills.
  * Missing skills or directories now produce warnings (with install guidance) instead of hard failures.
  * Status messages now show the resolved skills path and refer to “ECC skills.”

* **Chores**
  * Removed automated skill synchronization and the synced-count summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->