### PR TITLE
docs: tighten tdd workflow red-green validation

### DIFF
--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -51,6 +51,9 @@ ALWAYS write tests first, then implement code to make tests pass.
 - If the repository is under Git, create a checkpoint commit after each TDD stage
 - Do not squash or rewrite these checkpoint commits until the workflow is complete
 - Each checkpoint commit message must describe the stage and the exact evidence captured
+- Count only commits created on the current active branch for the current task
+- Do not treat commits from other branches, earlier unrelated work, or distant branch history as valid checkpoint evidence
+- Before treating a checkpoint as satisfied, verify that the commit is reachable from the current `HEAD` on the active branch and belongs to the current task sequence
 - The preferred compact workflow is:
   - one commit for failing test added and RED validated
   - one commit for minimal fix applied and GREEN validated
@@ -118,6 +121,7 @@ If the repository is under Git, create a checkpoint commit immediately after thi
 Recommended commit message format:
 - `test: add reproducer for <feature or bug>`
 - This commit may also serve as the RED validation checkpoint if the reproducer was compiled and executed and failed for the intended reason
+- Verify that this checkpoint commit is on the current active branch before continuing
 
 ### Step 4: Implement Code
 Write minimal code to make tests pass:
@@ -145,6 +149,7 @@ If the repository is under Git, create a checkpoint commit immediately after GRE
 Recommended commit message format:
 - `fix: <feature or bug>`
 - The fix commit may also serve as the GREEN validation checkpoint if the same relevant test target was rerun and passed
+- Verify that this checkpoint commit is on the current active branch before continuing
 
 ### Step 6: Refactor
 Improve code quality while keeping tests green:
@@ -156,6 +161,7 @@ Improve code quality while keeping tests green:
 If the repository is under Git, create a checkpoint commit immediately after refactoring is complete and tests remain green.
 Recommended commit message format:
 - `refactor: clean up after <feature or bug> implementation`
+- Verify that this checkpoint commit is on the current active branch before considering the TDD cycle complete
 
 ### Step 7: Verify Coverage
 ```bash


### PR DESCRIPTION
## Why

In practice, the current `tdd-workflow` wording still leaves room for ambiguous behavior:
- moving into implementation before RED is actually validated
- treating unrelated build/setup failures as valid RED
- not making it clear that compile-time RED can be legitimate when a new test first instantiates buggy code

## What Changed

- require a validated RED before modifying production code
- clarify that RED must come from the intended bug, not unrelated setup/regression issues
- explicitly allow compile-time RED when a new test first exposes the buggy code path
- document a compact Git checkpoint flow: `test + RED`, `fix + GREEN`, optional `refactor`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the TDD workflow docs to require a validated RED before any production changes, with clear runtime vs compile-time criteria and guards against unrelated failures. Adds a Git checkpoint flow with commit-after-RED and defer-fix-until-GREEN rules, scoped to commits on the current active branch and reachable from HEAD, no squashing until complete, plus compact message templates that capture evidence; separate evidence-only commits aren’t needed when RED/GREEN is shown.

<sup>Written for commit 9cc5d085e13b31a07d5c95a7ba31ba8174f648f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Git Checkpoints” requirement: create immutable checkpoint commits after each TDD stage (RED, implement/GREEN, refactor) and avoid squashing/rebasing until the workflow completes.
  * Tightened evidence rules: checkpoint commits must be reachable from current HEAD on the active branch; other branches/history excluded.
  * Clarified RED/GREEN rules: RED must be demonstrated by executed runtime or deliberate compile-time failures (not unrelated errors); do not edit production code before RED. Re-run the same test target to verify GREEN before refactor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->