### PR TITLE
fix: move session storage to ~/.claude/ecc-sessions/ to prevent CLI cleanup

### DIFF
--- a/commands/resume-session.md
+++ b/commands/resume-session.md
@@ -1,5 +1,5 @@
 ---
-description: Load the most recent session file from ~/.claude/sessions/ and resume work with full context from where the last session ended.
+description: Load the most recent session file from ~/.claude/ecc-sessions/ and resume work with full context from where the last session ended.
 ---
 
 # Resume Session Command
@@ -17,10 +17,10 @@ This command is the counterpart to `/save-session`.
 ## Usage
 
 ```
-/resume-session                                                      # loads most recent file in ~/.claude/sessions/
+/resume-session                                                      # loads most recent file in ~/.claude/ecc-sessions/
 /resume-session 2024-01-15                                           # loads most recent session for that date
-/resume-session ~/.claude/sessions/2024-01-15-session.tmp           # loads a specific legacy-format file
-/resume-session ~/.claude/sessions/2024-01-15-abc123de-session.tmp  # loads a current short-id session file
+/resume-session ~/.claude/ecc-sessions/2024-01-15-session.tmp           # loads a specific legacy-format file
+/resume-session ~/.claude/ecc-sessions/2024-01-15-abc123de-session.tmp  # loads a current short-id session file
 ```
 
 ## Process
@@ -29,18 +29,18 @@ This command is the counterpart to `/save-session`.
 
 If no argument provided:
 
-1. Check `~/.claude/sessions/`
+1. Check `~/.claude/ecc-sessions/`
 2. Pick the most recently modified `*-session.tmp` file
 3. If the folder does not exist or has no matching files, tell the user:
    ```
-   No session files found in ~/.claude/sessions/
+   No session files found in ~/.claude/ecc-sessions/
    Run /save-session at the end of a session to create one.
    ```
    Then stop.
 
 If an argument is provided:
 
-- If it looks like a date (`YYYY-MM-DD`), search `~/.claude/sessions/` for files matching
+- If it looks like a date (`YYYY-MM-DD`), search `~/.claude/ecc-sessions/` for files matching
   `YYYY-MM-DD-session.tmp` (legacy format) or `YYYY-MM-DD-<shortid>-session.tmp` (current format)
   and load the most recently modified variant for that date
 - If it looks like a file path, read that file directly

--- a/commands/save-session.md
+++ b/commands/save-session.md
@@ -1,5 +1,5 @@
 ---
-description: Save current session state to a dated file in ~/.claude/sessions/ so work can be resumed in a future session with full context.
+description: Save current session state to a dated file in ~/.claude/ecc-sessions/ so work can be resumed in a future session with full context.
 ---
 
 # Save Session Command
@@ -29,12 +29,12 @@ Before writing the file, collect:
 Create the canonical sessions folder in the user's Claude home directory:
 
 ```bash
-mkdir -p ~/.claude/sessions
+mkdir -p ~/.claude/ecc-sessions
 ```
 
 ### Step 3: Write the session file
 
-Create `~/.claude/sessions/YYYY-MM-DD-<short-id>-session.tmp`, using today's actual date and a short-id that satisfies the rules enforced by `SESSION_FILENAME_REGEX` in `session-manager.js`:
+Create `~/.claude/ecc-sessions/YYYY-MM-DD-<short-id>-session.tmp`, using today's actual date and a short-id that satisfies the rules enforced by `SESSION_FILENAME_REGEX` in `session-manager.js`:
 
 - Allowed characters: lowercase `a-z`, digits `0-9`, hyphens `-`
 - Minimum length: 8 characters
@@ -271,5 +271,5 @@ Then test with Postman — the response should include a `Set-Cookie` header.
 - The "What Did NOT Work" section is the most critical — future sessions will blindly retry failed approaches without it
 - If the user asks to save mid-session (not just at the end), save what's known so far and mark in-progress items clearly
 - The file is meant to be read by Claude at the start of the next session via `/resume-session`
-- Use the canonical global session store: `~/.claude/sessions/`
+- Use the canonical global session store: `~/.claude/ecc-sessions/`
 - Prefer the short-id filename form (`YYYY-MM-DD-<short-id>-session.tmp`) for any new session file

--- a/commands/sessions.md
+++ b/commands/sessions.md
@@ -4,7 +4,7 @@ description: Manage Claude Code session history, aliases, and session metadata.
 
 # Sessions Command
 
-Manage Claude Code session history - list, load, alias, and edit sessions stored in `~/.claude/sessions/`.
+Manage Claude Code session history - list, load, alias, and edit sessions stored in `~/.claude/ecc-sessions/`.
 
 ## Usage
 
@@ -89,7 +89,7 @@ const size = sm.getSessionSize(session.sessionPath);
 const aliases = aa.getAliasesForSession(session.filename);
 
 console.log('Session: ' + session.filename);
-console.log('Path: ~/.claude/sessions/' + session.filename);
+console.log('Path: ~/.claude/ecc-sessions/' + session.filename);
 console.log('');
 console.log('Statistics:');
 console.log('  Lines: ' + stats.lineCount);
@@ -327,7 +327,7 @@ $ARGUMENTS:
 
 ## Notes
 
-- Sessions are stored as markdown files in `~/.claude/sessions/`
+- Sessions are stored as markdown files in `~/.claude/ecc-sessions/`
 - Aliases are stored in `~/.claude/session-aliases.json`
 - Session IDs can be shortened (first 4-8 characters usually unique enough)
 - Use aliases for frequently referenced sessions

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -11,6 +11,7 @@
 
 const {
   getSessionsDir,
+  getLegacySessionsDir,
   getLearnedSkillsDir,
   findFiles,
   ensureDir,
@@ -32,7 +33,14 @@ async function main() {
   ensureDir(learnedDir);
 
   // Check for recent session files (last 7 days)
-  const recentSessions = findFiles(sessionsDir, '*-session.tmp', { maxAge: 7 });
+  // Also check legacy directory (~/.claude/sessions/) for migration
+  let recentSessions = findFiles(sessionsDir, '*-session.tmp', { maxAge: 7 });
+  const legacyDir = getLegacySessionsDir();
+  const legacySessions = findFiles(legacyDir, '*-session.tmp', { maxAge: 7 });
+  if (legacySessions.length > 0) {
+    recentSessions = recentSessions.concat(legacySessions);
+    recentSessions.sort((a, b) => b.mtime - a.mtime);
+  }
 
   if (recentSessions.length > 0) {
     const latest = recentSessions[0];

--- a/scripts/lib/session-manager.d.ts
+++ b/scripts/lib/session-manager.d.ts
@@ -1,6 +1,6 @@
 /**
  * Session Manager Library for Claude Code.
- * Provides CRUD operations for session files stored as markdown in ~/.claude/sessions/.
+ * Provides CRUD operations for session files stored as markdown in ~/.claude/ecc-sessions/.
  */
 
 /** Parsed metadata from a session filename */

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -2,7 +2,7 @@
  * Session Manager Library for Claude Code
  * Provides core session CRUD operations for listing, loading, and managing sessions
  *
- * Sessions are stored as markdown files in ~/.claude/sessions/ with format:
+ * Sessions are stored as markdown files in ~/.claude/ecc-sessions/ with format:
  * - YYYY-MM-DD-session.tmp (old format)
  * - YYYY-MM-DD-<short-id>-session.tmp (new format)
  */
@@ -12,6 +12,7 @@ const path = require('path');
 
 const {
   getSessionsDir,
+  getLegacySessionsDir,
   readFile,
   log
 } = require('./utils');
@@ -229,52 +230,65 @@ function getAllSessions(options = {}) {
   const limit = Number.isNaN(limitNum) ? 50 : Math.max(1, Math.floor(limitNum));
 
   const sessionsDir = getSessionsDir();
+  const legacyDir = getLegacySessionsDir();
 
-  if (!fs.existsSync(sessionsDir)) {
+  // Scan both current and legacy directories for session files
+  const dirsToScan = [sessionsDir, legacyDir].filter(d => fs.existsSync(d));
+
+  if (dirsToScan.length === 0) {
     return { sessions: [], total: 0, offset, limit, hasMore: false };
   }
 
-  const entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
   const sessions = [];
+  const seenFilenames = new Set();
 
-  for (const entry of entries) {
-    // Skip non-files (only process .tmp files)
-    if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
+  for (const dir of dirsToScan) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
 
-    const filename = entry.name;
-    const metadata = parseSessionFilename(filename);
+    for (const entry of entries) {
+      // Skip non-files (only process .tmp files)
+      if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
 
-    if (!metadata) continue;
+      const filename = entry.name;
 
-    // Apply date filter
-    if (date && metadata.date !== date) {
-      continue;
+      // Deduplicate: prefer the file from the primary directory
+      if (seenFilenames.has(filename)) continue;
+      seenFilenames.add(filename);
+
+      const metadata = parseSessionFilename(filename);
+
+      if (!metadata) continue;
+
+      // Apply date filter
+      if (date && metadata.date !== date) {
+        continue;
+      }
+
+      // Apply search filter (search in short ID)
+      if (search && !metadata.shortId.includes(search)) {
+        continue;
+      }
+
+      const sessionPath = path.join(dir, filename);
+
+      // Get file stats (wrapped in try-catch to handle TOCTOU race where
+      // file is deleted between readdirSync and statSync)
+      let stats;
+      try {
+        stats = fs.statSync(sessionPath);
+      } catch {
+        continue; // File was deleted between readdir and stat
+      }
+
+      sessions.push({
+        ...metadata,
+        sessionPath,
+        hasContent: stats.size > 0,
+        size: stats.size,
+        modifiedTime: stats.mtime,
+        createdTime: stats.birthtime || stats.ctime
+      });
     }
-
-    // Apply search filter (search in short ID)
-    if (search && !metadata.shortId.includes(search)) {
-      continue;
-    }
-
-    const sessionPath = path.join(sessionsDir, filename);
-
-    // Get file stats (wrapped in try-catch to handle TOCTOU race where
-    // file is deleted between readdirSync and statSync)
-    let stats;
-    try {
-      stats = fs.statSync(sessionPath);
-    } catch {
-      continue; // File was deleted between readdir and stat
-    }
-
-    sessions.push({
-      ...metadata,
-      sessionPath,
-      hasContent: stats.size > 0,
-      size: stats.size,
-      modifiedTime: stats.mtime,
-      createdTime: stats.birthtime || stats.ctime
-    });
   }
 
   // Sort by modified time (newest first)
@@ -300,54 +314,60 @@ function getAllSessions(options = {}) {
  */
 function getSessionById(sessionId, includeContent = false) {
   const sessionsDir = getSessionsDir();
+  const legacyDir = getLegacySessionsDir();
 
-  if (!fs.existsSync(sessionsDir)) {
+  // Search both current and legacy directories
+  const dirsToScan = [sessionsDir, legacyDir].filter(d => fs.existsSync(d));
+
+  if (dirsToScan.length === 0) {
     return null;
   }
 
-  const entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  for (const dir of dirsToScan) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
 
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.tmp')) continue;
 
-    const filename = entry.name;
-    const metadata = parseSessionFilename(filename);
+      const filename = entry.name;
+      const metadata = parseSessionFilename(filename);
 
-    if (!metadata) continue;
+      if (!metadata) continue;
 
-    // Check if session ID matches (short ID or full filename without .tmp)
-    const shortIdMatch = sessionId.length > 0 && metadata.shortId !== 'no-id' && metadata.shortId.startsWith(sessionId);
-    const filenameMatch = filename === sessionId || filename === `${sessionId}.tmp`;
-    const noIdMatch = metadata.shortId === 'no-id' && filename === `${sessionId}-session.tmp`;
+      // Check if session ID matches (short ID or full filename without .tmp)
+      const shortIdMatch = sessionId.length > 0 && metadata.shortId !== 'no-id' && metadata.shortId.startsWith(sessionId);
+      const filenameMatch = filename === sessionId || filename === `${sessionId}.tmp`;
+      const noIdMatch = metadata.shortId === 'no-id' && filename === `${sessionId}-session.tmp`;
 
-    if (!shortIdMatch && !filenameMatch && !noIdMatch) {
-      continue;
+      if (!shortIdMatch && !filenameMatch && !noIdMatch) {
+        continue;
+      }
+
+      const sessionPath = path.join(dir, filename);
+      let stats;
+      try {
+        stats = fs.statSync(sessionPath);
+      } catch {
+        continue; // File was deleted between readdir and stat
+      }
+
+      const session = {
+        ...metadata,
+        sessionPath,
+        size: stats.size,
+        modifiedTime: stats.mtime,
+        createdTime: stats.birthtime || stats.ctime
+      };
+
+      if (includeContent) {
+        session.content = getSessionContent(sessionPath);
+        session.metadata = parseSessionMetadata(session.content);
+        // Pass pre-read content to avoid a redundant disk read
+        session.stats = getSessionStats(session.content || '');
+      }
+
+      return session;
     }
-
-    const sessionPath = path.join(sessionsDir, filename);
-    let stats;
-    try {
-      stats = fs.statSync(sessionPath);
-    } catch {
-      return null; // File was deleted between readdir and stat
-    }
-
-    const session = {
-      ...metadata,
-      sessionPath,
-      size: stats.size,
-      modifiedTime: stats.mtime,
-      createdTime: stats.birthtime || stats.ctime
-    };
-
-    if (includeContent) {
-      session.content = getSessionContent(sessionPath);
-      session.metadata = parseSessionMetadata(session.content);
-      // Pass pre-read content to avoid a redundant disk read
-      session.stats = getSessionStats(session.content || '');
-    }
-
-    return session;
   }
 
   return null;

--- a/scripts/lib/utils.d.ts
+++ b/scripts/lib/utils.d.ts
@@ -18,8 +18,11 @@ export function getHomeDir(): string;
 /** Get the Claude config directory (~/.claude) */
 export function getClaudeDir(): string;
 
-/** Get the sessions directory (~/.claude/sessions) */
+/** Get the sessions directory (~/.claude/ecc-sessions) */
 export function getSessionsDir(): string;
+
+/** Get the legacy sessions directory (~/.claude/sessions) for migration reads */
+export function getLegacySessionsDir(): string;
 
 /** Get the learned skills directory (~/.claude/skills/learned) */
 export function getLearnedSkillsDir(): string;

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -28,9 +28,26 @@ function getClaudeDir() {
 }
 
 /**
- * Get the sessions directory
+ * Get the sessions directory.
+ *
+ * Uses ~/.claude/ecc-sessions/ instead of ~/.claude/sessions/ because the
+ * Claude Code CLI internally manages ~/.claude/sessions/ (storing .json
+ * session-tracking files) and may clean up non-standard files from that
+ * directory, causing ECC session .tmp files to be silently deleted.
+ *
+ * For backwards compatibility, if ~/.claude/sessions/ contains .tmp files
+ * but ~/.claude/ecc-sessions/ does not, reads will still check the legacy
+ * directory. New writes always go to ~/.claude/ecc-sessions/.
  */
 function getSessionsDir() {
+  return path.join(getClaudeDir(), 'ecc-sessions');
+}
+
+/**
+ * Get the legacy sessions directory (~/.claude/sessions/).
+ * Used only for backwards-compatible reads during migration.
+ */
+function getLegacySessionsDir() {
   return path.join(getClaudeDir(), 'sessions');
 }
 
@@ -525,6 +542,7 @@ module.exports = {
   getHomeDir,
   getClaudeDir,
   getSessionsDir,
+  getLegacySessionsDir,
   getLearnedSkillsDir,
   getTempDir,
   ensureDir,

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -64,11 +64,19 @@ function runTests() {
     assert.ok(claudeDir.includes('.claude'), 'Should contain .claude');
   })) passed++; else failed++;
 
-  if (test('getSessionsDir returns path under Claude dir', () => {
+  if (test('getSessionsDir returns ecc-sessions path under Claude dir', () => {
     const sessionsDir = utils.getSessionsDir();
     const claudeDir = utils.getClaudeDir();
     assert.ok(sessionsDir.startsWith(claudeDir), 'Sessions should be under Claude dir');
-    assert.ok(sessionsDir.includes('sessions'), 'Should contain sessions');
+    assert.ok(sessionsDir.includes('ecc-sessions'), 'Should contain ecc-sessions');
+  })) passed++; else failed++;
+
+  if (test('getLegacySessionsDir returns sessions path under Claude dir', () => {
+    const legacyDir = utils.getLegacySessionsDir();
+    const claudeDir = utils.getClaudeDir();
+    assert.ok(legacyDir.startsWith(claudeDir), 'Legacy sessions should be under Claude dir');
+    assert.ok(legacyDir.endsWith('sessions'), 'Should end with sessions');
+    assert.ok(!legacyDir.includes('ecc-sessions'), 'Should not contain ecc-sessions');
   })) passed++; else failed++;
 
   if (test('getTempDir returns valid temp directory', () => {


### PR DESCRIPTION
## Summary

- **Bug**: ECC stores session `.tmp` files in `~/.claude/sessions/`, but the Claude Code CLI internally manages that directory (using `.json` files for session tracking) and silently deletes non-standard files. This causes `/save-session` data to be lost between sessions, making `/resume-session` unable to find any saved state.
- **Fix**: Changed `getSessionsDir()` to return `~/.claude/ecc-sessions/` instead, giving ECC its own dedicated directory that won't conflict with the CLI's internal session management.
- **Migration**: Added `getLegacySessionsDir()` and updated `session-start.js`, `listSessions()`, and `getSessionById()` to also check the legacy `~/.claude/sessions/` directory, so existing session files are still discoverable during migration.

## Files Changed

| File | Change |
|------|--------|
| `scripts/lib/utils.js` | `getSessionsDir()` → `ecc-sessions`, added `getLegacySessionsDir()` |
| `scripts/lib/utils.d.ts` | Updated type declarations |
| `scripts/lib/session-manager.js` | `listSessions`/`getSessionById` scan both dirs with dedup |
| `scripts/lib/session-manager.d.ts` | Updated doc comment |
| `scripts/hooks/session-start.js` | Check both dirs for recent sessions |
| `commands/save-session.md` | Updated path references |
| `commands/resume-session.md` | Updated path references |
| `commands/sessions.md` | Updated path references |
| `tests/lib/utils.test.js` | Updated + added `getLegacySessionsDir` test |

## Test plan

- [x] `utils.test.js` — 170/170 passed
- [x] `session-manager.test.js` — 166/166 passed
- [x] Verified `getSessionsDir()` returns `~/.claude/ecc-sessions/`
- [x] Verified `getLegacySessionsDir()` returns `~/.claude/sessions/`
- [x] Verified session-start hook merges files from both directories
- [ ] Manual test: run `/save-session`, exit, start new session, run `/resume-session` — file should persist

## Reproduction steps (original bug)

1. Run `/save-session` in a session — file is written to `~/.claude/sessions/YYYY-MM-DD-<id>-session.tmp`
2. End the session
3. Start a new session and run `/resume-session`
4. File is gone — only `.json` files remain in `~/.claude/sessions/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move ECC session storage from `~/.claude/sessions/` to `~/.claude/ecc-sessions/` to stop the Claude Code CLI from deleting our `.tmp` files. Legacy sessions are still readable so `/resume-session` works with old files.

- **Bug Fixes**
  - `getSessionsDir()` now returns `~/.claude/ecc-sessions/`.
  - Added `getLegacySessionsDir()`; `listSessions()` and `getSessionById()` scan both dirs with dedup.
  - `session-start` hook looks in both dirs for recent sessions; docs updated to the new path.

- **Migration**
  - No action needed. Existing files in `~/.claude/sessions/` are auto-discovered; all new writes go to `~/.claude/ecc-sessions/`.

<sup>Written for commit 58feb24e60218f5848e1bd682da7f48cd0a92a37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session-related documentation to reflect new session storage directory and paths.

* **Improvements**
  * Session handling now supports new storage location while maintaining compatibility with legacy session files.

* **Tests**
  * Updated and expanded test coverage for session directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->