### PR TITLE
docs: clarify multi-model command setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ For manual install instructions see the README in the `rules/` folder.
 
 ✨ **That's it!** You now have access to 28 agents, 125 skills, and 60 commands.
 
+### Multi-model commands require additional setup
+
+> ⚠️ `multi-*` commands are **not** covered by the base plugin/rules install above.
+>
+> To use `/multi-plan`, `/multi-execute`, `/multi-backend`, `/multi-frontend`, and `/multi-workflow`, you must also install the `ccg-workflow` runtime.
+>
+> Initialize it with `npx ccg-workflow`.
+>
+> That runtime provides the external dependencies these commands expect, including:
+> - `~/.claude/bin/codeagent-wrapper`
+> - `~/.claude/.ccg/prompts/*`
+>
+> Without `ccg-workflow`, these `multi-*` commands will not run correctly.
+
 ---
 
 ## 🌐 Cross-Platform Support

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,6 +105,20 @@ cp -r everything-claude-code/rules/perl/* ~/.claude/rules/
 
 ✨ **完成！** 你现在可以使用 13 个代理、43 个技能和 31 个命令。
 
+### multi-* 命令需要额外配置
+
+> ⚠️ 上面的基础插件 / rules 安装**不包含** `multi-*` 命令所需的运行时。
+>
+> 如果要使用 `/multi-plan`、`/multi-execute`、`/multi-backend`、`/multi-frontend` 和 `/multi-workflow`，还需要额外安装 `ccg-workflow` 运行时。
+>
+> 可通过 `npx ccg-workflow` 完成初始化安装。
+>
+> 该运行时会提供这些命令依赖的关键组件，包括：
+> - `~/.claude/bin/codeagent-wrapper`
+> - `~/.claude/.ccg/prompts/*`
+>
+> 未安装 `ccg-workflow` 时，这些 `multi-*` 命令将无法正常运行。
+
 ---
 
 ## 🌐 跨平台支持


### PR DESCRIPTION
Document that multi-* commands require the ccg-workflow runtime so users know they must initialize the extra wrapper and prompt assets before use.
