### PR TITLE
docs: fix rule installation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,8 @@ Yes. Use Option 2 (manual installation) and copy only what you need:
 cp everything-claude-code/agents/*.md ~/.claude/agents/
 
 # Just rules
-cp -r everything-claude-code/rules/common/* ~/.claude/rules/
+mkdir -p ~/.claude/rules/
+cp -r everything-claude-code/rules/common ~/.claude/rules/
 ```
 
 Each component is fully independent.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -355,11 +355,20 @@ everything-claude-code/
 > git clone https://github.com/affaan-m/everything-claude-code.git
 >
 > # 选项 A：用户级规则（应用于所有项目）
-> cp -r everything-claude-code/rules/* ~/.claude/rules/
+> mkdir -p ~/.claude/rules
+> cp -r everything-claude-code/rules/common ~/.claude/rules/
+> cp -r everything-claude-code/rules/typescript ~/.claude/rules/
+> cp -r everything-claude-code/rules/python ~/.claude/rules/
+> cp -r everything-claude-code/rules/golang ~/.claude/rules/
+> cp -r everything-claude-code/rules/perl ~/.claude/rules/
 >
 > # 选项 B：项目级规则（仅应用于当前项目）
 > mkdir -p .claude/rules
-> cp -r everything-claude-code/rules/* .claude/rules/
+> cp -r everything-claude-code/rules/common .claude/rules/
+> cp -r everything-claude-code/rules/typescript .claude/rules/
+> cp -r everything-claude-code/rules/python .claude/rules/
+> cp -r everything-claude-code/rules/golang .claude/rules/
+> cp -r everything-claude-code/rules/perl .claude/rules/
 > ```
 
 ---


### PR DESCRIPTION
Clarify that manual rule installation should preserve the rules directory structure so references keep working and filename collisions are avoided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation steps in English and Chinese READMEs: create the destination rules directory first, then copy entire rule directories (e.g., rules/common, rules/<language>) rather than individual files. This preserves relative references and prevents filename collisions across rule sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->