### PR TITLE
fix(#843): session-manager hooks — ecc-sessions dir + hookSpecificOutput format

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -11,6 +11,7 @@
 
 const {
   getSessionsDir,
+  getSessionSearchDirs,
   getLearnedSkillsDir,
   findFiles,
   ensureDir,
@@ -21,34 +22,60 @@ const {
 const { getPackageManager, getSelectionPrompt } = require('../lib/package-manager');
 const { listAliases } = require('../lib/session-aliases');
 const { detectProjectType } = require('../lib/project-detect');
+const path = require('path');
 
-/**
- * Write a single JSON envelope to stdout and exit.
- * Claude Code SessionStart hooks must output exactly one JSON object to stdout —
- * multiple writes or plain strings are silently discarded.
- * See: https://github.com/affaan-m/everything-claude-code/issues/843
- */
-function emitContext(additionalContext) {
-  const payload = { hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext } };
-  process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
-  process.exit(0);
+function dedupeRecentSessions(searchDirs) {
+  const recentSessionsByName = new Map();
+
+  for (const [dirIndex, dir] of searchDirs.entries()) {
+    const matches = findFiles(dir, '*-session.tmp', { maxAge: 7 });
+
+    for (const match of matches) {
+      const basename = path.basename(match.path);
+      const current = {
+        ...match,
+        basename,
+        dirIndex,
+      };
+      const existing = recentSessionsByName.get(basename);
+
+      if (
+        !existing
+        || current.mtime > existing.mtime
+        || (current.mtime === existing.mtime && current.dirIndex < existing.dirIndex)
+      ) {
+        recentSessionsByName.set(basename, current);
+      }
+    }
+  }
+
+  return Array.from(recentSessionsByName.values())
+    .sort((left, right) => right.mtime - left.mtime || left.dirIndex - right.dirIndex);
 }
 
 async function main() {
   const sessionsDir = getSessionsDir();
   const learnedDir = getLearnedSkillsDir();
+  const additionalContextParts = [];
 
   // Ensure directories exist
   ensureDir(sessionsDir);
   ensureDir(learnedDir);
 
   // Check for recent session files (last 7 days)
-  const recentSessions = findFiles(sessionsDir, '*-session.tmp', { maxAge: 7 });
+  const recentSessions = dedupeRecentSessions(getSessionSearchDirs());
 
   if (recentSessions.length > 0) {
     const latest = recentSessions[0];
     log(`[SessionStart] Found ${recentSessions.length} recent session(s)`);
     log(`[SessionStart] Latest: ${latest.path}`);
+
+    // Read and inject the latest session content into Claude's context
+    const content = stripAnsi(readFile(latest.path));
+    if (content && !content.includes('[Session context goes here]')) {
+      // Only inject if the session has actual content (not the blank template)
+      additionalContextParts.push(`Previous session summary:\n${content}`);
+    }
   }
 
   // Check for learned skills
@@ -88,47 +115,49 @@ async function main() {
       parts.push(`frameworks: ${projectInfo.frameworks.join(', ')}`);
     }
     log(`[SessionStart] Project detected — ${parts.join('; ')}`);
+    additionalContextParts.push(`Project type: ${JSON.stringify(projectInfo)}`);
   } else {
     log('[SessionStart] No specific project type detected');
   }
 
-  // Build a single context string from all collected information.
-  // This is emitted as ONE JSON object via hookSpecificOutput so Claude
-  // Code accepts it (plain stdout / multiple writes are silently discarded).
-  const lines = [];
+  await writeSessionStartPayload(additionalContextParts.join('\n\n'));
+}
 
-  if (recentSessions.length > 0) {
-    const latest = recentSessions[0];
-    const content = stripAnsi(readFile(latest.path));
-    if (content && !content.includes('[Session context goes here]')) {
-      lines.push(`Previous session summary:\n${content}`);
-    }
-  }
+function writeSessionStartPayload(additionalContext) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const payload = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext
+      }
+    });
 
-  if (learnedSkills.length > 0) {
-    lines.push(`Note: ${learnedSkills.length} learned skill(s) are available in ${learnedDir}`);
-  }
+    const handleError = (err) => {
+      if (settled) return;
+      settled = true;
+      if (err) {
+        log(`[SessionStart] stdout write error: ${err.message}`);
+      }
+      reject(err || new Error('stdout stream error'));
+    };
 
-  if (aliases.length > 0) {
-    const aliasNames = aliases.map(a => a.name).join(', ');
-    lines.push(`Session aliases available: ${aliasNames} — use /sessions load <alias> to continue a previous session`);
-  }
-
-  if (projectInfo.languages.length > 0 || projectInfo.frameworks.length > 0) {
-    lines.push(`Project type: ${JSON.stringify(projectInfo)}`);
-  }
-
-  const additionalContext = lines.length > 0 ? lines.join('\n\n') : null;
-
-  if (additionalContext) {
-    emitContext(additionalContext);
-  } else {
-    // No context to inject — exit silently (don't write anything to stdout)
-    process.exit(0);
-  }
+    process.stdout.once('error', handleError);
+    process.stdout.write(payload, (err) => {
+      process.stdout.removeListener('error', handleError);
+      if (settled) return;
+      settled = true;
+      if (err) {
+        log(`[SessionStart] stdout write error: ${err.message}`);
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 main().catch(err => {
   console.error('[SessionStart] Error:', err.message);
-  process.exit(0); // Don't block on errors
+  process.exitCode = 0; // Don't block on errors
 });

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -6,12 +6,20 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 const { execSync, spawnSync } = require('child_process');
 
 // Platform detection
 const isWindows = process.platform === 'win32';
 const isMacOS = process.platform === 'darwin';
 const isLinux = process.platform === 'linux';
+const SESSION_DATA_DIR_NAME = 'session-data';
+const LEGACY_SESSIONS_DIR_NAME = 'sessions';
+const WINDOWS_RESERVED_SESSION_IDS = new Set([
+  'CON', 'PRN', 'AUX', 'NUL',
+  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+]);
 
 /**
  * Get the user's home directory (cross-platform)
@@ -31,10 +39,21 @@ function getClaudeDir() {
  * Get the sessions directory
  */
 function getSessionsDir() {
-  // Use 'ecc-sessions' instead of 'sessions' to avoid Claude Code's built-in
-  // session directory cleanup which removes files written by session-end hooks.
-  // See: https://github.com/affaan-m/everything-claude-code/issues/843
-  return path.join(getClaudeDir(), 'ecc-sessions');
+  return path.join(getClaudeDir(), SESSION_DATA_DIR_NAME);
+}
+
+/**
+ * Get the legacy sessions directory used by older ECC installs
+ */
+function getLegacySessionsDir() {
+  return path.join(getClaudeDir(), LEGACY_SESSIONS_DIR_NAME);
+}
+
+/**
+ * Get all session directories to search, in canonical-first order
+ */
+function getSessionSearchDirs() {
+  return Array.from(new Set([getSessionsDir(), getLegacySessionsDir()]));
 }
 
 /**
@@ -111,15 +130,51 @@ function getProjectName() {
 }
 
 /**
+ * Sanitize a string for use as a session filename segment.
+ * Replaces invalid characters with hyphens, collapses runs, strips
+ * leading/trailing hyphens, and removes leading dots so hidden-dir names
+ * like ".claude" map cleanly to "claude".
+ *
+ * Pure non-ASCII inputs get a stable 8-char hash so distinct names do not
+ * collapse to the same fallback session id. Mixed-script inputs retain their
+ * ASCII part and gain a short hash suffix for disambiguation.
+ */
+function sanitizeSessionId(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+
+  const hasNonAscii = Array.from(raw).some(char => char.codePointAt(0) > 0x7f);
+  const normalized = raw.replace(/^\.+/, '');
+  const sanitized = normalized
+    .replace(/[^a-zA-Z0-9_-]/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (sanitized.length > 0) {
+    const suffix = crypto.createHash('sha256').update(normalized).digest('hex').slice(0, 6);
+    if (WINDOWS_RESERVED_SESSION_IDS.has(sanitized.toUpperCase())) {
+      return `${sanitized}-${suffix}`;
+    }
+    if (!hasNonAscii) return sanitized;
+    return `${sanitized}-${suffix}`;
+  }
+
+  const meaningful = normalized.replace(/[\s\p{P}]/gu, '');
+  if (meaningful.length === 0) return null;
+
+  return crypto.createHash('sha256').update(normalized).digest('hex').slice(0, 8);
+}
+
+/**
  * Get short session ID from CLAUDE_SESSION_ID environment variable
- * Returns last 8 characters, falls back to project name then 'default'
+ * Returns last 8 characters, falls back to a sanitized project name then 'default'.
  */
 function getSessionIdShort(fallback = 'default') {
   const sessionId = process.env.CLAUDE_SESSION_ID;
   if (sessionId && sessionId.length > 0) {
-    return sessionId.slice(-8);
+    const sanitized = sanitizeSessionId(sessionId.slice(-8));
+    if (sanitized) return sanitized;
   }
-  return getProjectName() || fallback;
+  return sanitizeSessionId(getProjectName()) || sanitizeSessionId(fallback) || 'default';
 }
 
 /**
@@ -528,6 +583,8 @@ module.exports = {
   getHomeDir,
   getClaudeDir,
   getSessionsDir,
+  getLegacySessionsDir,
+  getSessionSearchDirs,
   getLearnedSkillsDir,
   getTempDir,
   ensureDir,
@@ -538,6 +595,7 @@ module.exports = {
   getDateTimeString,
 
   // Session/Project
+  sanitizeSessionId,
   getSessionIdShort,
   getGitRepoName,
   getProjectName,


### PR DESCRIPTION
## Summary

Fixes #843 — session hooks installed but not working out of the box.

Two root causes identified and fixed:

### Fix 1: Session directory collision with Claude Code cleanup
Claude Code performs cleanup on its built-in `~/.claude/sessions/` directory on exit, which removes files written by the `session-end` hook before the next session can read them.

**Fix:** Renamed the sessions directory from `sessions` to `ecc-sessions` so ECC-managed files live outside Claude Code's cleanup scope.

```js
// Before
return path.join(getClaudeDir(), 'sessions');
// After
return path.join(getClaudeDir(), 'ecc-sessions');
```

### Fix 2: SessionStart hook output format
Claude Code's `SessionStart` hooks require JSON output with a `hookSpecificOutput` envelope. Plain `console.log(string)` output is silently discarded — no context is injected.

**Fix:** Updated `session-start.js` to use `process.stdout.write(JSON.stringify({hookSpecificOutput: {hookEventName, additionalContext}}))` for context injection.

## Test plan
- [x] Install ECC, run a Claude session, end it
- [x] Verify `~/.claude/ecc-sessions/` contains a session file after session ends
- [x] Start a new session — verify previous session context appears in Claude's context window
- [x] Check `~/.claude/ecc-sessions/` still exists (not cleaned up by Claude Code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes session hooks work out of the box by moving session storage out of Claude Code’s cleanup, deduping recent sessions across directories, and emitting a single `hookSpecificOutput` JSON with accumulated context at session start. Fixes #843.

- Bug Fixes
  - Store session data in `~/.claude/session-data/` and search both canonical and legacy `sessions` dirs to dedupe recent files, avoiding cleanup-related losses.
  - Accumulate context (previous summary, learned skills, aliases, project info) and emit exactly one `hookSpecificOutput` JSON via a safe final write; remove early stdout writes and sanitize session IDs for valid, stable filenames.

<sup>Written for commit 2546f96896e8a7b9493c9a7785d39a9ae3da67de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Canonicalized and reorganized session storage locations with backwards-compatible search of legacy data.
  * Session startup now emits a single structured JSON payload containing combined session/context info instead of scattered text output.
  * Session IDs and derived identifiers are now sanitized for safety and consistency.

* **Bug Fixes**
  * Safer handling of standard output and process termination to avoid hangs on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->