### PR TITLE
fix(hooks): merge hooks config into settings.json for claude target

### DIFF
--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -23,7 +23,8 @@ function mergeHooksIntoSettings(plan) {
   let hooksConfig;
   try {
     hooksConfig = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
-  } catch {
+  } catch (error) {
+    process.stderr.write(`[ECC Install] Warning: failed to parse ${hooksJsonPath}: ${error.message}\n`);
     return;
   }
 
@@ -36,12 +37,13 @@ function mergeHooksIntoSettings(plan) {
   if (fs.existsSync(settingsPath)) {
     try {
       settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    } catch {
+    } catch (error) {
+      process.stderr.write(`[ECC Install] Warning: failed to parse ${settingsPath}, hooks will be written to a fresh file: ${error.message}\n`);
       settings = {};
     }
   }
 
-  settings.hooks = hooksConfig.hooks;
+  settings.hooks = { ...settings.hooks, ...hooksConfig.hooks };
 
   fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -360,7 +360,13 @@ function runTests() {
       fs.mkdirSync(claudeRoot, { recursive: true });
       fs.writeFileSync(
         path.join(claudeRoot, 'settings.json'),
-        JSON.stringify({ effortLevel: 'high', env: { MY_VAR: '1' } }, null, 2)
+        JSON.stringify({
+          effortLevel: 'high',
+          env: { MY_VAR: '1' },
+          hooks: {
+            UserPromptSubmit: [{ matcher: '*', hooks: [{ type: 'command', command: 'echo custom' }] }],
+          },
+        }, null, 2)
       );
 
       const result = run(['--profile', 'core'], { cwd: projectDir, homeDir });
@@ -370,7 +376,13 @@ function runTests() {
       assert.strictEqual(settings.effortLevel, 'high', 'existing effortLevel should be preserved');
       assert.deepStrictEqual(settings.env, { MY_VAR: '1' }, 'existing env should be preserved');
       assert.ok(settings.hooks, 'hooks should be merged in');
-      assert.ok(settings.hooks.PreToolUse, 'PreToolUse hooks should exist');
+      assert.ok(settings.hooks.PreToolUse, 'ECC PreToolUse hooks should exist');
+      assert.ok(settings.hooks.UserPromptSubmit, 'user-defined hook event types should be preserved');
+      assert.deepStrictEqual(
+        settings.hooks.UserPromptSubmit,
+        [{ matcher: '*', hooks: [{ type: 'command', command: 'echo custom' }] }],
+        'user-defined hook entries should be intact'
+      );
     } finally {
       cleanup(homeDir);
       cleanup(projectDir);


### PR DESCRIPTION
## Summary

The installer copies `hooks/hooks.json` to `~/.claude/hooks/hooks.json`, but Claude Code only reads hooks from `~/.claude/settings.json`. This means all 28 hooks (PreToolUse, PostToolUse, Stop, SessionStart, etc.) are silently inactive after installation for the `claude` target.

This fix adds a post-install merge step in `applyInstallPlan()` that writes the `hooks` field from `hooks.json` into `settings.json`, preserving any existing user settings. The merge only runs for the `claude` target — Cursor and other targets are unaffected.

### Root cause

- `hooks-runtime` module paths (`hooks`, `scripts/hooks`, `scripts/lib`) are copied to `~/.claude/` as-is
- The generic Claude adapter (`claude-home.js`) has no custom `planOperations()` to handle hooks specially
- Unlike Cursor (which reads a standalone `hooks.json`), Claude Code requires hooks in `settings.json`

### Changes

- **`scripts/lib/install/apply.js`**: Added `mergeHooksIntoSettings(plan)` — after file copies complete, reads `~/.claude/hooks/hooks.json`, extracts the `hooks` object, and merges it into `~/.claude/settings.json` (preserving existing settings)
- **`tests/scripts/install-apply.test.js`**: Added 3 test cases — hooks merge for claude target, preserving existing settings, and skipping for non-claude targets

## Type
- [x] Bug fix (installer)

## Testing
- All 15 install-apply tests pass (12 existing + 3 new)
- Verified with real `--profile full` install on Windows
- Confirmed hooks appear in `settings.json` after install

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inactive hooks for the `claude` target by merging hooks from `~/.claude/hooks/hooks.json` into `~/.claude/settings.json` after install. Preserves user-defined hook event types on reinstall; other targets are unaffected.

- **Bug Fixes**
  - Added post-install per-event merge in `applyInstallPlan()` to write `hooks` into `settings.json`; preserves existing fields and user-defined hook types, creates `settings.json` if missing, and warns to stderr on JSON parse errors.
  - Expanded tests to cover per-event merge, settings preservation with pre-existing hooks, and non-`claude` skip.

<sup>Written for commit 46329ae103ee89ff123d1599f60bf43725c3b1b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hooks are now automatically merged into application settings when installing to the Claude target.
  * Existing top-level settings are preserved when hooks are integrated; merge does not overwrite existing hook entries.

* **Bug Fixes**
  * Merge step is skipped for non-Claude targets (no settings file created).

* **Tests**
  * Added tests validating hooks integration behavior across targets and preserving existing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->