### PR TITLE
Add AKF — The AI Native File Format skill

### DIFF
--- a/skills/akf-trust-metadata/SKILL.md
+++ b/skills/akf-trust-metadata/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: akf-trust-metadata
+description: >-
+  The AI native file format. EXIF for AI — stamps every file with trust scores,
+  source provenance, and compliance metadata. Use after creating or modifying
+  any file. Use before modifying existing files to check trust context.
+globs:
+  - "**/*.md"
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+  - "**/*.json"
+  - "**/*.yaml"
+  - "**/*.html"
+---
+
+# AKF — The AI Native File Format
+
+Every photo has EXIF. Every song has ID3. AKF is the native metadata format for AI-generated content.
+
+## After creating or modifying files
+
+```bash
+akf stamp <file> --agent claude-code --evidence "<what you did>"
+```
+
+## Before modifying existing files
+
+```bash
+akf read <file>
+akf inspect <file>
+```
+
+## Compliance auditing
+
+```bash
+akf audit <file> --regulation eu_ai_act
+akf audit <file> --regulation hipaa
+akf audit <file> --regulation sox
+```
+
+## Classification
+
+- --label confidential for finance/secret/internal paths
+- --label public for README, docs, examples
+
+## Install
+
+```bash
+pip install akf
+```
+
+https://akf.dev | https://github.com/HMAKT99/AKF


### PR DESCRIPTION
Adds AKF (Agent Knowledge Format) as a skill — the AI native file format.

**What it does:** EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata (~15 tokens of JSON). Embeds natively into 20+ formats.

**How it fits:** After Claude Code creates/modifies files, the AKF skill guides it to stamp trust metadata. Before modifying files, it checks existing trust context.

**Compliance:** One-command audit for EU AI Act (Aug 2, 2026), SOX, HIPAA.

**Install:** `pip install akf`
**Docs:** https://akf.dev
**GitHub:** https://github.com/HMAKT99/AKF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the akf-trust-metadata skill, detailing capabilities for stamping files with provenance and trust evidence, reading and inspecting file metadata, performing compliance audits with regulatory selection, and applying security classifications. Includes installation via pip and comprehensive command usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `akf-trust-metadata` skill docs to stamp files with trust, provenance, and compliance metadata using `akf`, and to read/inspect metadata before edits. Includes install and basic commands (stamp/read/inspect/audit), classification labels, and audits for EU AI Act, HIPAA, and SOX.

<sup>Written for commit dc54a936108b439a4ff2b9f36b7067faf5afa8bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

