### PR TITLE
fix(scripts): add os.homedir() fallback for Windows compatibility

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const os = require('os');
 const { buildDoctorReport } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 
@@ -88,7 +89,7 @@ function main() {
 
     const report = buildDoctorReport({
       repoRoot: require('path').join(__dirname, '..'),
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
     });

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -6,6 +6,7 @@
  * target-specific mutation logic into testable Node code.
  */
 
+const os = require('os');
 const {
   SUPPORTED_INSTALL_TARGETS,
   listLegacyCompatibilityLanguages,
@@ -118,7 +119,7 @@ function main() {
     });
     const plan = createInstallPlanFromRequest(request, {
       projectRoot: process.cwd(),
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
       claudeRulesDir: process.env.CLAUDE_RULES_DIR || null,
     });
 

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
@@ -442,7 +443,7 @@ function planAntigravityLegacyInstall(context) {
 function createLegacyInstallPlan(options = {}) {
   const sourceRoot = options.sourceRoot || getSourceRoot();
   const projectRoot = options.projectRoot || process.cwd();
-  const homeDir = options.homeDir || process.env.HOME;
+  const homeDir = options.homeDir || process.env.HOME || os.homedir();
   const target = options.target || 'claude';
 
   validateLegacyTarget(target);

--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const { resolveInstallPlan, loadInstallManifests } = require('./install-manifests');
@@ -696,7 +697,7 @@ function buildDiscoveryRecord(adapter, context) {
 
 function discoverInstalledStates(options = {}) {
   const context = {
-    homeDir: options.homeDir || process.env.HOME,
+    homeDir: options.homeDir || process.env.HOME || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
   };
   const targets = normalizeTargets(options.targets);
@@ -904,7 +905,7 @@ function buildDoctorReport(options = {}) {
   }).filter(record => record.exists);
   const context = {
     repoRoot,
-    homeDir: options.homeDir || process.env.HOME,
+    homeDir: options.homeDir || process.env.HOME || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
     manifestVersion: manifests.modulesVersion,
     packageVersion: readPackageVersion(repoRoot),
@@ -988,7 +989,7 @@ function repairInstalledStates(options = {}) {
   const manifests = loadInstallManifests({ repoRoot });
   const context = {
     repoRoot,
-    homeDir: options.homeDir || process.env.HOME,
+    homeDir: options.homeDir || process.env.HOME || os.homedir(),
     projectRoot: options.projectRoot || process.cwd(),
     manifestVersion: manifests.modulesVersion,
     packageVersion: readPackageVersion(repoRoot),

--- a/scripts/list-installed.js
+++ b/scripts/list-installed.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const os = require('os');
 const { discoverInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 
@@ -70,7 +71,7 @@ function main() {
     }
 
     const records = discoverInstalledStates({
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
     }).filter(record => record.exists);

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const os = require('os');
 const { repairInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 
@@ -74,7 +75,7 @@ function main() {
 
     const result = repairInstalledStates({
       repoRoot: require('path').join(__dirname, '..'),
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
       dryRun: options.dryRun,

--- a/scripts/sessions-cli.js
+++ b/scripts/sessions-cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const os = require('os');
 const { createStateStore } = require('./lib/state-store');
 
 function showHelp(exitCode = 0) {
@@ -134,7 +135,7 @@ async function main() {
 
     store = await createStateStore({
       dbPath: options.dbPath,
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
     });
 
     if (!options.sessionId) {

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const os = require('os');
 const { createStateStore } = require('./lib/state-store');
 
 function showHelp(exitCode = 0) {
@@ -139,7 +140,7 @@ async function main() {
 
     store = await createStateStore({
       dbPath: options.dbPath,
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
     });
 
     const payload = {

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const os = require('os');
 const { uninstallInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 
@@ -73,7 +74,7 @@ function main() {
     }
 
     const result = uninstallInstalledStates({
-      homeDir: process.env.HOME,
+      homeDir: process.env.HOME || os.homedir(),
       projectRoot: process.cwd(),
       targets: options.targets,
       dryRun: options.dryRun,


### PR DESCRIPTION
## Summary

On Windows (native cmd/PowerShell), `process.env.HOME` is `undefined`. Seven CLI entry points and two library files pass `process.env.HOME` directly as `homeDir` without a cross-platform fallback, causing all path resolutions to silently resolve to `undefined/.claude/...` — which doesn't exist, so commands like `doctor`, `status`, `list-installed`, `repair`, and `uninstall` silently return empty results instead of operating on the correct home directory.

This PR adds `os.homedir()` as a fallback to all 9 affected locations. Node.js `os.homedir()` correctly handles all platforms (`HOME` on Unix, `USERPROFILE` on Windows, OS-level fallback).

**Note:** The project already uses this correct pattern in `scripts/lib/state-store/index.js:22` and has a `getHomeDir()` utility in `scripts/lib/utils.js:27` — this fix brings the remaining CLI entry points and library functions into consistency.

## Affected Files

**7 CLI entry points** (each: +`require('os')`, change `process.env.HOME` → `process.env.HOME || os.homedir()`):
- `scripts/doctor.js`
- `scripts/install-apply.js`
- `scripts/repair.js`
- `scripts/uninstall.js`
- `scripts/list-installed.js`
- `scripts/sessions-cli.js`
- `scripts/status.js`

**2 library files** (each: +`require('os')`, add `|| os.homedir()` to existing fallback chain):
- `scripts/lib/install-lifecycle.js` (3 occurrences)
- `scripts/lib/install-executor.js` (1 occurrence)

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Bug fix (scripts)

## Testing

All 1621 tests pass after the change. Additionally, verified the fix by simulating a Windows-like environment where `HOME` is unset:

<details>
<summary>Before Fix: homeDir resolves to undefined when HOME is unset</summary>

```
=== Before Fix: tracing homeDir in discoverInstalledStates ===
CLI passes homeDir: undefined
Library resolves homeDir: undefined

Install state path: undefined/.claude/ecc/install-state
This path does not exist, so all discovery/doctor/repair operations silently find nothing.
```

</details>

<details>
<summary>After Fix: homeDir correctly resolves via os.homedir()</summary>

```
=== After Fix: tracing homeDir in discoverInstalledStates ===
CLI passes homeDir: "/home/devuser"
Library resolves homeDir: "/home/devuser"

Install state path: /home/devuser/.claude/ecc/install-state
Path correctly resolves to the actual home directory via os.homedir().
```

</details>

<details>
<summary>Before Fix: doctor.js (HOME unset) — runs but operates on wrong path</summary>

```
=== Before Fix: doctor.js (HOME unset) ===
{
  "generatedAt": "2026-03-28T03:25:40.874Z",
  "packageVersion": "1.9.0",
  "manifestVersion": 1,
  "results": [],
  "summary": {
    "checkedCount": 0,
    "okCount": 0,
    "errorCount": 0,
    "warningCount": 0
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>After Fix: doctor.js (HOME unset) — correctly resolves home directory</summary>

```
=== After Fix: doctor.js (HOME unset) ===
{
  "generatedAt": "2026-03-28T03:26:43.377Z",
  "packageVersion": "1.9.0",
  "manifestVersion": 1,
  "results": [],
  "summary": {
    "checkedCount": 0,
    "okCount": 0,
    "errorCount": 0,
    "warningCount": 0
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>Before Fix: status.js (HOME unset)</summary>

```
=== Before Fix: status.js (HOME unset) ===
{
  "dbPath": "/home/devuser/.claude/ecc/state.db",
  "generatedAt": "2026-03-28T03:25:41.762Z",
  "activeSessions": {
    "activeCount": 0,
    "sessions": []
  },
  "skillRuns": {
    "windowSize": 20,
    "summary": {
      "totalCount": 0,
      "knownCount": 0,
      "successCount": 0,
      "failureCount": 0,
      "unknownCount": 0,
      "successRate": null,
      "failureRate": null
    },
    "recent": []
  },
  "installHealth": {
    "status": "missing",
    "totalCount": 0,
    "healthyCount": 0,
    "warningCount": 0,
    "installations": []
  },
  "governance": {
    "pendingCount": 0,
    "events": []
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>After Fix: status.js (HOME unset)</summary>

```
=== After Fix: status.js (HOME unset) ===
{
  "dbPath": "/home/devuser/.claude/ecc/state.db",
  "generatedAt": "2026-03-28T03:26:44.308Z",
  "activeSessions": {
    "activeCount": 0,
    "sessions": []
  },
  "skillRuns": {
    "windowSize": 20,
    "summary": {
      "totalCount": 0,
      "knownCount": 0,
      "successCount": 0,
      "failureCount": 0,
      "unknownCount": 0,
      "successRate": null,
      "failureRate": null
    },
    "recent": []
  },
  "installHealth": {
    "status": "missing",
    "totalCount": 0,
    "healthyCount": 0,
    "warningCount": 0,
    "installations": []
  },
  "governance": {
    "pendingCount": 0,
    "events": []
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>Before Fix: list-installed.js (HOME unset)</summary>

```
=== Before Fix: list-installed.js (HOME unset) ===
{
  "records": []
}
EXIT CODE: 0
```

</details>

<details>
<summary>After Fix: list-installed.js (HOME unset)</summary>

```
=== After Fix: list-installed.js (HOME unset) ===
{
  "records": []
}
EXIT CODE: 0
```

</details>

<details>
<summary>Before Fix: sessions-cli.js (HOME unset)</summary>

```
=== Before Fix: sessions-cli.js (HOME unset) ===
{
  "totalCount": 0,
  "sessions": []
}
EXIT CODE: 0
```

</details>

<details>
<summary>After Fix: sessions-cli.js (HOME unset)</summary>

```
=== After Fix: sessions-cli.js (HOME unset) ===
{
  "totalCount": 0,
  "sessions": []
}
EXIT CODE: 0
```

</details>

<details>
<summary>Before Fix: repair.js (HOME unset)</summary>

```
=== Before Fix: repair.js (HOME unset) ===
{
  "dryRun": false,
  "generatedAt": "2026-03-28T03:25:44.032Z",
  "results": [],
  "summary": {
    "checkedCount": 0,
    "repairedCount": 0,
    "plannedRepairCount": 0,
    "errorCount": 0
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>After Fix: repair.js (HOME unset)</summary>

```
=== After Fix: repair.js (HOME unset) ===
{
  "dryRun": false,
  "generatedAt": "2026-03-28T03:26:46.485Z",
  "results": [],
  "summary": {
    "checkedCount": 0,
    "repairedCount": 0,
    "plannedRepairCount": 0,
    "errorCount": 0
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>Before Fix: uninstall.js --dry-run (HOME unset)</summary>

```
=== Before Fix: uninstall.js --dry-run (HOME unset) ===
{
  "dryRun": true,
  "generatedAt": "2026-03-28T03:25:44.920Z",
  "results": [],
  "summary": {
    "checkedCount": 0,
    "uninstalledCount": 0,
    "plannedRemovalCount": 0,
    "errorCount": 0
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>After Fix: uninstall.js --dry-run (HOME unset)</summary>

```
=== After Fix: uninstall.js --dry-run (HOME unset) ===
{
  "dryRun": true,
  "generatedAt": "2026-03-28T03:26:47.391Z",
  "results": [],
  "summary": {
    "checkedCount": 0,
    "uninstalledCount": 0,
    "plannedRemovalCount": 0,
    "errorCount": 0
  }
}
EXIT CODE: 0
```

</details>

<details>
<summary>Before Fix: install-apply.js --dry-run (HOME unset)</summary>

```
=== Before Fix: install-apply.js --dry-run (HOME unset) ===
Error: No install profile, module IDs, included components, or legacy languages were provided
EXIT CODE: 1
```

</details>

<details>
<summary>After Fix: install-apply.js --dry-run (HOME unset)</summary>

```
=== After Fix: install-apply.js --dry-run (HOME unset) ===
Error: No install profile, module IDs, included components, or legacy languages were provided
EXIT CODE: 1
```

(This error is expected — `install-apply.js` requires explicit install arguments. The fix ensures `homeDir` resolves correctly when those arguments are provided.)

</details>

<details>
<summary>After Fix: Full test suite (1621/1621 pass)</summary>

```
╔══════════════════════════════════════════════════════════╗
║           Everything Claude Code - Test Suite            ║
╚══════════════════════════════════════════════════════════╝

[... 1621 tests executed ...]

╔══════════════════════════════════════════════════════════╗
║                     Final Results                        ║
╠══════════════════════════════════════════════════════════╣
║  Total Tests: 1621                                       ║
║  Passed:      1621  ✓                                    ║
║  Failed:         0                                       ║
╚══════════════════════════════════════════════════════════╝
```

</details>

## Checklist
- [x] Follows format guidelines (conventional commit, `fix(scripts):` prefix)
- [x] Tested with all 1621 tests passing
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
- [x] Minimal change (each file: +1 import line, +1 `|| os.homedir()` fallback)
- [x] Consistent with existing patterns (`state-store/index.js`, `utils.js`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CLI behavior by falling back to `os.homedir()` when `process.env.HOME` is missing, so path resolution uses the real home directory instead of `undefined/.claude/...`. Affects `doctor`, `status`, `list-installed`, `repair`, `uninstall`, `sessions-cli`, and `install-apply`.

- **Bug Fixes**
  - Use `process.env.HOME || os.homedir()` to compute `homeDir` in 7 CLI entry points and 2 library functions.
  - Aligns with existing pattern in `scripts/lib/state-store` and `scripts/lib/utils#getHomeDir()`.

<sup>Written for commit ae21a8df854773b58693280bbc150b1b55e70b38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced home directory detection with an automatic fallback mechanism. The system now gracefully handles environments where the HOME environment variable is unset or unavailable, improving compatibility across diverse configurations, containerized environments, and continuous integration platforms. This ensures consistent and reliable functionality regardless of the execution environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->