### PR TITLE
fix(harness-audit): use cwd instead of __dirname for REPO_ROOT

### DIFF
--- a/.opencode/commands/harness-audit.md
+++ b/.opencode/commands/harness-audit.md
@@ -8,7 +8,7 @@ Run a deterministic repository harness audit and return a prioritized scorecard.
 
 - `scope` (optional): `repo` (default), `hooks`, `skills`, `commands`, `agents`
 - `--format`: output style (`text` default, `json` for automation)
-- `AUDIT_ROOT` (env var, optional): override the target directory (defaults to `cwd`)
+- `AUDIT_ROOT` (env var, optional): override the target directory (defaults to `cwd/.claude`)
 
 ## Deterministic Engine
 

--- a/commands/harness-audit.md
+++ b/commands/harness-audit.md
@@ -8,7 +8,7 @@ Run a deterministic repository harness audit and return a prioritized scorecard.
 
 - `scope` (optional): `repo` (default), `hooks`, `skills`, `commands`, `agents`
 - `--format`: output style (`text` default, `json` for automation)
-- `AUDIT_ROOT` (env var, optional): override the target directory (defaults to `cwd`)
+- `AUDIT_ROOT` (env var, optional): override the target directory (defaults to `cwd/.claude`)
 
 ## Deterministic Engine
 

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const REPO_ROOT = process.env.AUDIT_ROOT || process.cwd();
+const REPO_ROOT = process.env.AUDIT_ROOT || path.join(process.cwd(), '.claude');
 
 const CATEGORIES = [
   'Tool Coverage',

--- a/tests/scripts/harness-audit.test.js
+++ b/tests/scripts/harness-audit.test.js
@@ -9,14 +9,16 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'harness-audit.js');
+const ECC_ROOT = path.join(__dirname, '..', '..');
 const TMP_BASE = process.env.TMPDIR || os.tmpdir();
 
-function run(args = []) {
+function run(args = [], opts = {}) {
   const stdout = execFileSync('node', [SCRIPT, ...args], {
-    cwd: path.join(__dirname, '..', '..'),
+    cwd: ECC_ROOT,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 10000,
+    env: { ...process.env, AUDIT_ROOT: ECC_ROOT, ...opts.env },
   });
 
   return stdout;


### PR DESCRIPTION
## Summary

- `REPO_ROOT` was hardcoded to `path.join(__dirname, '..')`, so running the audit from an external repository always scored the ECC repo itself instead of the target directory
- Default to `process.cwd()`; allow `AUDIT_ROOT` env var override
- Use `safeRead` for `package.json` to avoid crash when it is absent (e.g. non-Node projects)
- Guard `JSON.parse` for malformed `package.json` to prevent unhandled SyntaxError
- Add tests for empty-directory scoring and `AUDIT_ROOT` override
- Document `AUDIT_ROOT` in `commands/harness-audit.md`
- Sync `.opencode/commands/harness-audit.md` with primary command doc

Relates to #522 (the deterministic audit script introduced there had this latent bug).

Supersedes #973 (clean rebase on upstream main, no .history files).

## Test plan

- [x] Existing 4 tests still pass
- [x] New test: empty directory → `overall_score === 0`, all checks fail
- [x] New test: `AUDIT_ROOT` env var overrides cwd
- [x] Full test suite (`node tests/run-all.js`) passes with 0 failures

> **Note:** pnpm/yarn CI jobs may fail until #976 is merged (Corepack fix).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes harness-audit scoring the wrong repo by targeting `cwd/.claude` for `REPO_ROOT`, with an optional `AUDIT_ROOT` override. Adds guards for missing/malformed `package.json`, plus tests and docs.

- **Bug Fixes**
  - Default repo root to `path.join(process.cwd(), '.claude')`; support `AUDIT_ROOT` env var override.
  - Read `package.json` safely and guard `JSON.parse` to prevent crashes.
  - Add tests for empty directory (overall_score = 0, checks present and all fail) and `AUDIT_ROOT` override.
  - Document `AUDIT_ROOT` and the `cwd/.claude` default in `commands/harness-audit.md` and `.opencode/commands/harness-audit.md`.

<sup>Written for commit 65c7d447bd6a763a82672550dc8a0fa49f0af113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `AUDIT_ROOT` environment variable to override the audit target directory.

* **Bug Fixes**
  * Improved error handling when package.json is missing or malformed.

* **Documentation**
  * Updated harness audit command documentation with new `AUDIT_ROOT` environment variable details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->