### PR TITLE
fix: pin 6 actions to commit SHA, extract 1 expression to env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       # Package manager setup
       - name: Setup pnpm
         if: matrix.pm == 'pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: latest
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup Bun
         if: matrix.pm == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       # Cache configuration
       - name: Get npm cache directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,13 @@ jobs:
 
       - name: Validate version tag
         run: |
-          if ! [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version tag format. Expected vX.Y.Z"
             exit 1
           fi
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Verify plugin.json version matches tag
         env:
           TAG_NAME: ${{ github.ref_name }}
@@ -61,7 +63,7 @@ jobs:
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           body_path: release_body.md
           generate_release_notes: true

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -49,7 +49,7 @@ jobs:
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ inputs.tag }}
           body_path: release_body.md

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup pnpm
         if: inputs.package-manager == 'pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: latest
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Setup Bun
         if: inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Get npm cache directory
         if: inputs.package-manager == 'npm'


### PR DESCRIPTION
Re-submission of #949. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts expressions from `run:` blocks into `env:` mappings.

- Pin 6 unpinned actions to full 40-character SHAs
- Add version comments for readability
- Extract 1 expression from run block to env var

## Changes by file

| File | Changes |
|------|---------|
| release.yml | Pinned softprops/action-gh-release (x2), extracted github.ref_name to env var |
| ci.yml | Pinned pnpm/action-setup, oven-sh/setup-bun |
| reusable-test.yml | Pinned pnpm/action-setup, oven-sh/setup-bun |

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I wrote a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. Also put up a link to my research on [Twitter](https://x.com/vigilance_one/status/2036581210663616729) if you're interested.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris Nyhuis (dagecko)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI by pinning six GitHub Actions to immutable SHAs and moving one inline tag expression to an env var. This removes mutable tags and keeps builds and releases reproducible with no behavior changes.

- **Dependencies**
  - Pinned `pnpm/action-setup`, `oven-sh/setup-bun`, and `softprops/action-gh-release` to SHAs in `ci.yml`, `reusable-test.yml`, `release.yml`, and `reusable-release.yml`.
  - Added version comments next to SHAs for readability.

- **Refactors**
  - Moved `${{ github.ref_name }}` into `REF_NAME` env in `release.yml` for tag validation.

<sup>Written for commit 28a1fbc3f2e18b73aa34afdd970a465bf11f086c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and release workflows to use pinned dependency versions for improved stability and security.
  * Refactored release validation to use environment variables for better workflow maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->