### PR TITLE
fix(docs): repair healthcare eval harness examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Everything Claude Code (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 28 specialized agents, 126 skills, 60 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 29 specialized agents, 132 skills, 60 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 
@@ -141,8 +141,8 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 ## Project Structure
 
 ```
-agents/          — 28 specialized subagents
-skills/          — 126 workflow skills and domain knowledge
+agents/          — 29 specialized subagents
+skills/          — 132 workflow skills and domain knowledge
 commands/        — 60 slash commands
 hooks/           — Trigger-based automations
 rules/           — Always-follow guidelines (common + per-language)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-**Language:** English | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md)
- [Türkçe](docs/tr/README.md)
-
+**Language:** English | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md) | [Türkçe](docs/tr/README.md)
 
 # Everything Claude Code
 
@@ -222,7 +220,7 @@ For manual install instructions see the README in the `rules/` folder. When copy
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-✨ **That's it!** You now have access to 28 agents, 126 skills, and 60 commands.
+✨ **That's it!** You now have access to 29 agents, 132 skills, and 60 commands.
 
 ### Multi-model commands require additional setup
 
@@ -297,7 +295,7 @@ everything-claude-code/
 |   |-- plugin.json         # Plugin metadata and component paths
 |   |-- marketplace.json    # Marketplace catalog for /plugin marketplace add
 |
-|-- agents/           # 28 specialized subagents for delegation
+|-- agents/           # 29 specialized subagents for delegation
 |   |-- planner.md           # Feature implementation planning
 |   |-- architect.md         # System design decisions
 |   |-- tdd-guide.md         # Test-driven development
@@ -1111,9 +1109,9 @@ The configuration is automatically detected from `.opencode/opencode.json`.
 
 | Feature | Claude Code | OpenCode | Status |
 |---------|-------------|----------|--------|
-| Agents | ✅ 28 agents | ✅ 12 agents | **Claude Code leads** |
+| Agents | ✅ 29 agents | ✅ 12 agents | **Claude Code leads** |
 | Commands | ✅ 60 commands | ✅ 31 commands | **Claude Code leads** |
-| Skills | ✅ 126 skills | ✅ 37 skills | **Claude Code leads** |
+| Skills | ✅ 132 skills | ✅ 37 skills | **Claude Code leads** |
 | Hooks | ✅ 8 event types | ✅ 11 events | **OpenCode has more!** |
 | Rules | ✅ 29 rules | ✅ 13 instructions | **Claude Code leads** |
 | MCP Servers | ✅ 14 servers | ✅ Full | **Full parity** |

--- a/skills/healthcare-eval-harness/SKILL.md
+++ b/skills/healthcare-eval-harness/SKILL.md
@@ -57,7 +57,16 @@ npx jest --testPathPattern='tests/data-integrity' --bail --ci
 Tests end-to-end flows: encounter lifecycle, template rendering, medication sets, drug/diagnosis search, prescription PDF, red flag alerts.
 
 ```bash
-npx jest --testPathPattern='tests/clinical' --ci 2>&1 | node scripts/check-pass-rate.js 95
+tmp_json=$(mktemp)
+npx jest --testPathPattern='tests/clinical' --ci --json --outputFile="$tmp_json" || true
+total=$(jq '.numTotalTests // 0' "$tmp_json")
+passed=$(jq '.numPassedTests // 0' "$tmp_json")
+if [ "$total" -eq 0 ]; then
+  echo "No clinical tests found" >&2
+  exit 1
+fi
+rate=$(echo "scale=2; $passed * 100 / $total" | bc)
+echo "Clinical pass rate: ${rate}% ($passed/$total)"
 ```
 
 **5. Integration Compliance (HIGH — 95%+ required)**
@@ -65,7 +74,16 @@ npx jest --testPathPattern='tests/clinical' --ci 2>&1 | node scripts/check-pass-
 Tests external systems: HL7 message parsing (v2.x), FHIR validation, lab result mapping, malformed message handling.
 
 ```bash
-npx jest --testPathPattern='tests/integration' --ci 2>&1 | node scripts/check-pass-rate.js 95
+tmp_json=$(mktemp)
+npx jest --testPathPattern='tests/integration' --ci --json --outputFile="$tmp_json" || true
+total=$(jq '.numTotalTests // 0' "$tmp_json")
+passed=$(jq '.numPassedTests // 0' "$tmp_json")
+if [ "$total" -eq 0 ]; then
+  echo "No integration tests found" >&2
+  exit 1
+fi
+rate=$(echo "scale=2; $passed * 100 / $total" | bc)
+echo "Integration pass rate: ${rate}% ($passed/$total)"
 ```
 
 ### Pass/Fail Matrix
@@ -108,9 +126,10 @@ jobs:
       # HIGH gates — 95%+ required
       - name: Clinical Workflows
         run: |
-          RESULT=$(npx jest --testPathPattern='tests/clinical' --ci --json 2>&1) || true
-          TOTAL=$(echo "$RESULT" | jq '.numTotalTests // 0')
-          PASSED=$(echo "$RESULT" | jq '.numPassedTests // 0')
+          TMP_JSON=$(mktemp)
+          npx jest --testPathPattern='tests/clinical' --ci --json --outputFile="$TMP_JSON" || true
+          TOTAL=$(jq '.numTotalTests // 0' "$TMP_JSON")
+          PASSED=$(jq '.numPassedTests // 0' "$TMP_JSON")
           if [ "$TOTAL" -eq 0 ]; then
             echo "::error::No clinical tests found"; exit 1
           fi
@@ -122,9 +141,10 @@ jobs:
 
       - name: Integration Compliance
         run: |
-          RESULT=$(npx jest --testPathPattern='tests/integration' --ci --json 2>&1) || true
-          TOTAL=$(echo "$RESULT" | jq '.numTotalTests // 0')
-          PASSED=$(echo "$RESULT" | jq '.numPassedTests // 0')
+          TMP_JSON=$(mktemp)
+          npx jest --testPathPattern='tests/integration' --ci --json --outputFile="$TMP_JSON" || true
+          TOTAL=$(jq '.numTotalTests // 0' "$TMP_JSON")
+          PASSED=$(jq '.numPassedTests // 0' "$TMP_JSON")
           if [ "$TOTAL" -eq 0 ]; then
             echo "::error::No integration tests found"; exit 1
           fi
@@ -157,8 +177,13 @@ npx jest --testPathPattern='tests/data-integrity' --bail --ci
 ### Example 2: Check HIGH Gate Pass Rate
 
 ```bash
-npx jest --testPathPattern='tests/clinical' --ci --json | \
-  jq '{passed: .numPassedTests, total: .numTotalTests, rate: (.numPassedTests/.numTotalTests*100)}'
+tmp_json=$(mktemp)
+npx jest --testPathPattern='tests/clinical' --ci --json --outputFile="$tmp_json" || true
+jq '{
+  passed: (.numPassedTests // 0),
+  total: (.numTotalTests // 0),
+  rate: (if (.numTotalTests // 0) == 0 then 0 else ((.numPassedTests // 0) / (.numTotalTests // 1) * 100) end)
+}' "$tmp_json"
 # Expected: { "passed": 21, "total": 22, "rate": 95.45 }
 ```
 


### PR DESCRIPTION
Follow-up to #955.

This fixes the post-merge documentation issues in the healthcare eval harness and reconciles the repo catalog counts:
- replace references to a nonexistent `scripts/check-pass-rate.js` helper
- use `--json --outputFile` examples instead of mixing stderr into JSON pipes
- add explicit zero-test guards in HIGH-gate examples
- update README/AGENTS counts to the current catalog (`29` agents, `132` skills)
- fix the stale README structure label for the agents directory

Verification:
- `node scripts/ci/catalog.js --text`
- `npx markdownlint-cli skills/healthcare-eval-harness/SKILL.md README.md AGENTS.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken examples in the healthcare eval harness docs and aligns catalog counts across `README.md` and `AGENTS.md`. Replaces invalid pass-rate script references and makes HIGH-gate recipes reliable.

- **Bug Fixes**
  - Replace nonexistent `scripts/check-pass-rate.js` with `jest --json --outputFile` + `jq` parsing (no stderr in JSON pipes).
  - Add zero-test guards for HIGH gates (clinical, integration) and use temp JSON files in local/CI examples.
  - Update catalog counts and labels: 29 agents, 132 skills; fix agents directory label and language list formatting.

<sup>Written for commit 9406f35fab84132616c95d9b90fae0918a86d36d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated catalog documentation: plugin now includes 29 agents and 132 skills
  * Improved language selector formatting
  * Enhanced healthcare skill workflow evaluation documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->