### PR TITLE
docs(readme): fix agent count in repo tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ everything-claude-code/
 |   |-- plugin.json         # Plugin metadata and component paths
 |   |-- marketplace.json    # Marketplace catalog for /plugin marketplace add
 |
-|-- agents/           # 29 specialized subagents for delegation
+|-- agents/           # 30 specialized subagents for delegation
 |   |-- planner.md           # Feature implementation planning
 |   |-- architect.md         # System design decisions
 |   |-- tdd-guide.md         # Test-driven development


### PR DESCRIPTION
## Summary
- fix the stale agent count in the README repository tree

## Testing
- node scripts/ci/catalog.js --text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README repository tree to show 30 agents (was 29) so the count matches the current catalog. This keeps the docs accurate and avoids confusion.

<sup>Written for commit 65c4a0f6ba2a3350dc38df01c9b13b8a5a0f82cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect the addition of a new specialized delegation subagent in the directory listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->