### PR TITLE
fix(clv2): honor CLV2_CONFIG in start-observer

### DIFF
--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -36,7 +36,11 @@ PYTHON_CMD="${CLV2_PYTHON_CMD:-}"
 # ─────────────────────────────────────────────
 
 CONFIG_DIR="${HOME}/.claude/homunculus"
-CONFIG_FILE="${SKILL_ROOT}/config.json"
+if [ -n "${CLV2_CONFIG:-}" ]; then
+  CONFIG_FILE="$CLV2_CONFIG"
+else
+  CONFIG_FILE="${SKILL_ROOT}/config.json"
+fi
 # PID file is project-scoped so each project can have its own observer
 PID_FILE="${PROJECT_DIR}/.observer.pid"
 LOG_FILE="${PROJECT_DIR}/observer.log"


### PR DESCRIPTION
## Summary
- make `start-observer.sh` honor `CLV2_CONFIG`, matching the override already supported in `observe.sh`
- keep the newer observer-loop sandbox/path handling from current `main` instead of reintroducing stale changes from `#890`

## Testing
- bash -n skills/continuous-learning-v2/agents/start-observer.sh

Supersedes #890.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `start-observer.sh` honor the `CLV2_CONFIG` env var so you can override the config path. This aligns behavior with `observe.sh` and avoids path handling regressions.

- **Bug Fixes**
  - Use `CLV2_CONFIG` when set, else fall back to `${SKILL_ROOT}/config.json`.
  - Keep current sandbox/path logic from `main` to prevent regressions.

<sup>Written for commit be76918850e435b5542a4cbb547466a99efcf818. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration file path can now be overridden via environment variable for greater deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->