### PR TITLE
fix: skip pre-push checks on branch deletion

### DIFF
--- a/scripts/codex-git-hooks/pre-push
+++ b/scripts/codex-git-hooks/pre-push
@@ -16,6 +16,20 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 0
 fi
 
+# Skip checks for branch deletion pushes (e.g., git push origin --delete <branch>).
+# The pre-push hook receives lines on stdin: <local ref> <local sha> <remote ref> <remote sha>.
+# For deletions, the local sha is the zero OID.
+is_delete_only=true
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  if [[ "$local_sha" != "0000000000000000000000000000000000000000" ]]; then
+    is_delete_only=false
+    break
+  fi
+done
+if [[ "$is_delete_only" == "true" ]]; then
+  exit 0
+fi
+
 ran_any_check=0
 
 log() {


### PR DESCRIPTION
## Summary
- Fix pre-push hook blocking `git push origin --delete <branch>` operations
- Detect deletion pushes by reading stdin (local sha is all zeros for deletes) and exit early
- No behavior change for normal code pushes

## Problem
The pre-push hook runs lint/typecheck/test/build checks on every push, including branch deletions (`git push origin --delete <branch>`). Since branch deletion does not push any code, running verification checks is unnecessary and blocks the operation, forcing users to use workarounds like `gh api` to delete remote branches.

## Solution
Read the pre-push hook's stdin to detect deletion pushes. Git provides push info in the format `<local ref> <local sha> <remote ref> <remote sha>`. For deletions, the local sha is the zero OID (`0000000000000000000000000000000000000000`). When all pushed refs are deletions, skip checks and exit early.

## Test plan
- [ ] `git push origin --delete <branch>` completes without running checks
- [ ] Normal `git push` still runs lint/typecheck/test/build as expected
- [ ] `git push origin <branch> --delete <other-branch>` (mixed) still runs checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip pre-push checks when deleting remote branches to unblock `git push origin --delete <branch>`. Normal and mixed pushes still run checks.

- **Bug Fixes**
  - Parse pre-push stdin; if all local SHAs are zero OIDs, exit before running checks.
  - If any ref has a real SHA, run lint/typecheck/test/build as before.

<sup>Written for commit 0c166e14da278428da93868508869f7f3c8c4242. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-push hook to detect deletion-only pushes and skip verification checks for such operations, improving the speed of branch deletion workflows. Non-deletion pushes continue with existing lint, type-check, test, build, and audit verification checks for Node projects; Go test for Go projects; and pytest for Python projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->