### PR TITLE
fix: declare http transport in mcp config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,6 +9,7 @@
       "args": ["-y", "@upstash/context7-mcp@2.1.4"]
     },
     "exa": {
+      "type": "http",
       "url": "https://mcp.exa.ai/mcp"
     },
     "memory": {

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -216,6 +216,20 @@ test('.mcp.json includes at least github, context7, and exa servers', () => {
   assert.ok(servers.includes('exa'), 'Expected exa MCP server');
 });
 
+test('.mcp.json HTTP transport servers declare type=http when they use url', () => {
+  for (const [name, server] of Object.entries(mcpConfig.mcpServers)) {
+    if (!server || typeof server !== 'object' || !('url' in server)) {
+      continue;
+    }
+
+    assert.strictEqual(
+      server.type,
+      'http',
+      `Expected ${name} MCP server to declare type=http when using url transport`,
+    );
+  }
+});
+
 // ── Codex marketplace file ────────────────────────────────────────────────────
 // Per official docs: repo marketplace lives at $REPO_ROOT/.agents/plugins/marketplace.json
 console.log('\n=== .agents/plugins/marketplace.json ===\n');


### PR DESCRIPTION
## Summary
- add the missing `type: "http"` field to the root `.mcp.json` Exa server entry
- add a manifest regression test that rejects URL-based MCP servers without `type: "http"`

## Test Plan
- node tests/plugin-manifest.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare the HTTP transport for the `exa` MCP server by adding `type: "http"` in `.mcp.json`, and add a regression test to require `type: "http"` for any MCP server using `url`.
This prevents misconfigured URL-based MCP servers and aligns the config with the HTTP transport schema.

<sup>Written for commit bcc88191d0ad702b67f8580547401c81da74d800. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration to specify HTTP protocol type.

* **Tests**
  * Added validation tests for MCP server configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->