### PR TITLE
fix: declare exa MCP transport type

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,26 +2,43 @@
   "mcpServers": {
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ]
     },
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@2.1.4"]
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@2.1.4"
+      ]
     },
     "exa": {
-      "url": "https://mcp.exa.ai/mcp"
+      "url": "https://mcp.exa.ai/mcp",
+      "type": "http"
     },
     "memory": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ]
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@0.0.68", "--extension"]
+      "args": [
+        "-y",
+        "@playwright/mcp@0.0.68",
+        "--extension"
+      ]
     },
     "sequential-thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
     }
   }
 }

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -216,6 +216,14 @@ test('.mcp.json includes at least github, context7, and exa servers', () => {
   assert.ok(servers.includes('exa'), 'Expected exa MCP server');
 });
 
+test('.mcp.json remote Exa server declares its transport type', () => {
+  assert.strictEqual(
+    mcpConfig.mcpServers.exa?.type,
+    'http',
+    'Expected Exa MCP server to declare type="http" for Claude Code schema compliance',
+  );
+});
+
 // ── Codex marketplace file ────────────────────────────────────────────────────
 // Per official docs: repo marketplace lives at $REPO_ROOT/.agents/plugins/marketplace.json
 console.log('\n=== .agents/plugins/marketplace.json ===\n');


### PR DESCRIPTION
## Summary\n- declare the Exa remote MCP server as type="http" in .mcp.json\n- add a regression test so project config stays Claude Code schema-compliant\n\n## Testing\n- node tests/plugin-manifest.test.js\n\nFixes #1003

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Exa MCP server `type` to `http` in `.mcp.json` to meet the Claude Code schema and avoid validation errors; adds a regression test to enforce it. Fixes #1003.

<sup>Written for commit 734c94ebdc1e48b43ab62d9f905548311327a36f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test case to validate remote server configuration declarations for protocol type consistency.

* **Chores**
  * Standardized MCP server configuration file formatting by restructuring argument array declarations across multiple server entries for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->