### PR TITLE
fix: resolve MINGW64 double-path conversion in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,4 +20,13 @@ if [ ! -d "$SCRIPT_DIR/node_modules" ]; then
     (cd "$SCRIPT_DIR" && npm install --no-audit --no-fund --loglevel=error)
 fi
 
-exec node "$SCRIPT_DIR/scripts/install-apply.js" "$@"
+# On MSYS2/Git Bash, convert the POSIX path to a Windows path so Node.js
+# (a native Windows binary) receives a valid path instead of a doubled one
+# like G:\g\projects\... that results from Git Bash's auto path conversion.
+if command -v cygpath &>/dev/null; then
+    NODE_SCRIPT="$(cygpath -w "$SCRIPT_DIR/scripts/install-apply.js")"
+else
+    NODE_SCRIPT="$SCRIPT_DIR/scripts/install-apply.js"
+fi
+
+exec node "$NODE_SCRIPT" "$@"


### PR DESCRIPTION
Closes #1016

## Problem

On Windows with Git Bash (MINGW64), `./install.sh --profile full` fails immediately:

```
Error: Cannot find module 'G:\g\projects\everything-claude-code\scripts\install-apply.js'
    ...
  code: 'MODULE_NOT_FOUND',
```

## Root Cause

`install.sh` computes `SCRIPT_DIR` via `pwd`, which returns a POSIX-style path (e.g. `/g/projects/everything-claude-code`). This is then passed directly to Node.js, which on Windows is a **native Win32 binary**. Git Bash's automatic POSIX→Windows path conversion converts `/g/projects/...` → `G:\g\projects\...` — **doubling** the drive prefix — resulting in an invalid path that Node.js cannot resolve.

## Fix

Use `cygpath -w` (available in all MSYS2/Cygwin environments including Git Bash) to explicitly convert the POSIX path to a proper Windows path before it reaches Node.js. Falls back gracefully to the original value on Linux/macOS where `cygpath` is not present.

```bash
if command -v cygpath &>/dev/null; then
    NODE_SCRIPT="$(cygpath -w "$SCRIPT_DIR/scripts/install-apply.js")"
else
    NODE_SCRIPT="$SCRIPT_DIR/scripts/install-apply.js"
fi

exec node "$NODE_SCRIPT" "$@"
```

## Verification

Tested and confirmed working on Windows 11, Git Bash (MINGW64), Node.js v22.22.0 — `./install.sh --profile full` completes successfully, processing all 597 file operations.