### PR TITLE
test: isolate codex hook sync env

### DIFF
--- a/tests/scripts/codex-hooks.test.js
+++ b/tests/scripts/codex-hooks.test.js
@@ -45,6 +45,21 @@ function runBash(scriptPath, args = [], env = {}, cwd = repoRoot) {
   });
 }
 
+function makeHermeticCodexEnv(homeDir, codexDir, extraEnv = {}) {
+  const agentsHome = path.join(homeDir, '.agents');
+  const hooksDir = path.join(codexDir, 'git-hooks');
+  return {
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    CODEX_HOME: codexDir,
+    AGENTS_HOME: agentsHome,
+    ECC_GLOBAL_HOOKS_DIR: hooksDir,
+    CLAUDE_PACKAGE_MANAGER: 'npm',
+    CLAUDE_CODE_PACKAGE_MANAGER: 'npm',
+    ...extraEnv,
+  };
+}
+
 let passed = 0;
 let failed = 0;
 
@@ -116,12 +131,12 @@ if (
       fs.mkdirSync(codexDir, { recursive: true });
       fs.writeFileSync(configPath, config);
 
-      const syncResult = runBash(syncScript, ['--update-mcp'], { HOME: homeDir, CODEX_HOME: codexDir });
+      const syncResult = runBash(syncScript, ['--update-mcp'], makeHermeticCodexEnv(homeDir, codexDir));
       assert.strictEqual(syncResult.status, 0, `${syncResult.stdout}\n${syncResult.stderr}`);
       const syncedConfig = fs.readFileSync(configPath, 'utf8');
       assert.match(syncedConfig, /^\[mcp_servers\.context7\]$/m);
 
-      const checkResult = runBash(checkScript, [], { HOME: homeDir, CODEX_HOME: codexDir });
+      const checkResult = runBash(checkScript, [], makeHermeticCodexEnv(homeDir, codexDir));
       assert.strictEqual(checkResult.status, 0, checkResult.stderr || checkResult.stdout);
       assert.match(checkResult.stdout, /MCP section \[mcp_servers\.context7\] or \[mcp_servers\.context7-mcp\] exists/);
     } finally {


### PR DESCRIPTION
## Summary
- make codex hook sync tests hermetic by setting explicit Codex/package-manager env
- stop  from inheriting ambient runner state
- restore full-suite stability for the shared CI matrix

## Testing
- node tests/scripts/codex-hooks.test.js
- CI=true node tests/run-all.js


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Codex hook sync tests run in a hermetic environment by setting explicit Codex and package manager env. Prevents CI runner state from leaking in and stabilizes the suite.

- **Bug Fixes**
  - Added `makeHermeticCodexEnv()` to build an isolated env (HOME/USERPROFILE, `CODEX_HOME`, `.agents`, `ECC_GLOBAL_HOOKS_DIR`, `CLAUDE_PACKAGE_MANAGER`, `CLAUDE_CODE_PACKAGE_MANAGER=npm`).
  - Applied the helper to both sync and check steps in `tests/scripts/codex-hooks.test.js`.

<sup>Written for commit d8c940f2e7cd22722d89960b7941fb998e57fb09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test environment configuration for shell script integration testing to ensure more consistent and reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->