### PR TITLE
fix: correct SOURCE_KIRO path in Kiro installer

### DIFF
--- a/.kiro/install.sh
+++ b/.kiro/install.sh
@@ -14,9 +14,13 @@ set -euo pipefail
 # When globs match nothing, expand to empty list instead of the literal pattern
 shopt -s nullglob
 
-# Resolve the directory where this script lives (the repo root)
+# Resolve the directory where this script lives
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SOURCE_KIRO="$SCRIPT_DIR/.kiro"
+
+# The script lives inside .kiro/, so SCRIPT_DIR *is* the source.
+# If invoked from the repo root (e.g., .kiro/install.sh), SCRIPT_DIR already
+# points to the .kiro directory — no need to append /.kiro again.
+SOURCE_KIRO="$SCRIPT_DIR"
 
 # Target directory: argument or current working directory
 TARGET="${1:-.}"


### PR DESCRIPTION
## Problem

Running `.kiro/install.sh` from inside the `.kiro/` directory produces an incorrect source path.

`SCRIPT_DIR` resolves to the `.kiro/` directory, then `SOURCE_KIRO="$SCRIPT_DIR/.kiro"` appends `/.kiro` again, resulting in `.kiro/.kiro` which does not exist. The installer silently copies nothing.

## Fix

Change `SOURCE_KIRO="$SCRIPT_DIR/.kiro"` to `SOURCE_KIRO="$SCRIPT_DIR"` since the script already lives inside `.kiro/`.

## Testing

Verified the installer correctly resolves the source path when invoked as:
- `./install.sh` (from inside `.kiro/`)
- `bash .kiro/install.sh` (from repo root)
- `.kiro/install.sh /path/to/target` (with explicit target)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect source path resolution in `.kiro/install.sh`. The installer now uses the script’s directory as the source, avoiding `.kiro/.kiro` and copying files as expected.

- **Bug Fixes**
  - Set `SOURCE_KIRO="$SCRIPT_DIR"` since the installer runs from `.kiro/`.
  - Verified correct behavior when run from `.kiro/`, from repo root, and with an explicit target.

<sup>Written for commit 6a4bbd52b43b7acbc711073afc21ae1956dc9285. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer script source directory resolution to improve file copy logic during installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->