### PR TITLE
fix(ci): harden codex hook regression test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Everything Claude Code (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 30 specialized agents, 135 skills, 60 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 30 specialized agents, 136 skills, 60 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 
@@ -142,7 +142,7 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 
 ```
 agents/          — 30 specialized subagents
-skills/          — 135 workflow skills and domain knowledge
+skills/          — 136 workflow skills and domain knowledge
 commands/        — 60 slash commands
 hooks/           — Trigger-based automations
 rules/           — Always-follow guidelines (common + per-language)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For manual install instructions see the README in the `rules/` folder. When copy
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-**That's it!** You now have access to 30 agents, 135 skills, and 60 commands.
+**That's it!** You now have access to 30 agents, 136 skills, and 60 commands.
 
 ### Multi-model commands require additional setup
 
@@ -1111,7 +1111,7 @@ The configuration is automatically detected from `.opencode/opencode.json`.
 |---------|-------------|----------|--------|
 | Agents | PASS: 30 agents | PASS: 12 agents | **Claude Code leads** |
 | Commands | PASS: 60 commands | PASS: 31 commands | **Claude Code leads** |
-| Skills | PASS: 135 skills | PASS: 37 skills | **Claude Code leads** |
+| Skills | PASS: 136 skills | PASS: 37 skills | **Claude Code leads** |
 | Hooks | PASS: 8 event types | PASS: 11 events | **OpenCode has more!** |
 | Rules | PASS: 29 rules | PASS: 13 instructions | **Claude Code leads** |
 | MCP Servers | PASS: 14 servers | PASS: Full | **Full parity** |

--- a/tests/scripts/codex-hooks.test.js
+++ b/tests/scripts/codex-hooks.test.js
@@ -11,7 +11,6 @@ const { spawnSync } = require('child_process');
 const repoRoot = path.join(__dirname, '..', '..');
 const installScript = path.join(repoRoot, 'scripts', 'codex', 'install-global-git-hooks.sh');
 const syncScript = path.join(repoRoot, 'scripts', 'sync-ecc-to-codex.sh');
-const checkScript = path.join(repoRoot, 'scripts', 'codex', 'check-codex-global-state.sh');
 
 function test(name, fn) {
   try {
@@ -51,11 +50,15 @@ function makeHermeticCodexEnv(homeDir, codexDir, extraEnv = {}) {
   return {
     HOME: homeDir,
     USERPROFILE: homeDir,
+    XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+    GIT_CONFIG_GLOBAL: path.join(homeDir, '.gitconfig'),
     CODEX_HOME: codexDir,
     AGENTS_HOME: agentsHome,
     ECC_GLOBAL_HOOKS_DIR: hooksDir,
     CLAUDE_PACKAGE_MANAGER: 'npm',
     CLAUDE_CODE_PACKAGE_MANAGER: 'npm',
+    LANG: 'C.UTF-8',
+    LC_ALL: 'C.UTF-8',
     ...extraEnv,
   };
 }
@@ -86,10 +89,11 @@ if (
 else failed++;
 
 if (
-  test('sync and global sanity checks accept the legacy context7 MCP section', () => {
+  test('sync preserves baseline config and accepts the legacy context7 MCP section', () => {
     const homeDir = createTempDir('codex-sync-home-');
     const codexDir = path.join(homeDir, '.codex');
     const configPath = path.join(codexDir, 'config.toml');
+    const agentsPath = path.join(codexDir, 'AGENTS.md');
     const config = [
       'approval_policy = "on-request"',
       'sandbox_mode = "workspace-write"',
@@ -133,12 +137,19 @@ if (
 
       const syncResult = runBash(syncScript, ['--update-mcp'], makeHermeticCodexEnv(homeDir, codexDir));
       assert.strictEqual(syncResult.status, 0, `${syncResult.stdout}\n${syncResult.stderr}`);
-      const syncedConfig = fs.readFileSync(configPath, 'utf8');
-      assert.match(syncedConfig, /^\[mcp_servers\.context7\]$/m);
 
-      const checkResult = runBash(checkScript, [], makeHermeticCodexEnv(homeDir, codexDir));
-      assert.strictEqual(checkResult.status, 0, checkResult.stderr || checkResult.stdout);
-      assert.match(checkResult.stdout, /MCP section \[mcp_servers\.context7\] or \[mcp_servers\.context7-mcp\] exists/);
+      const syncedAgents = fs.readFileSync(agentsPath, 'utf8');
+      assert.match(syncedAgents, /^# Everything Claude Code \(ECC\) — Agent Instructions/m);
+      assert.match(syncedAgents, /^# Codex Supplement \(From ECC \.codex\/AGENTS\.md\)/m);
+
+      const syncedConfig = fs.readFileSync(configPath, 'utf8');
+      assert.match(syncedConfig, /^multi_agent\s*=\s*true$/m);
+      assert.match(syncedConfig, /^\[profiles\.strict\]$/m);
+      assert.match(syncedConfig, /^\[profiles\.yolo\]$/m);
+      assert.match(syncedConfig, /^\[mcp_servers\.github\]$/m);
+      assert.match(syncedConfig, /^\[mcp_servers\.memory\]$/m);
+      assert.match(syncedConfig, /^\[mcp_servers\.sequential-thinking\]$/m);
+      assert.match(syncedConfig, /^\[mcp_servers\.context7\]$/m);
     } finally {
       cleanup(homeDir);
     }


### PR DESCRIPTION
## Summary\n- make the Codex hook regression test fully hermetic in Actions\n- assert sync invariants directly from generated AGENTS/config output\n- fix stale catalog counts in README and AGENTS so mainline CI stays green\n\n## Testing\n- node tests/scripts/codex-hooks.test.js\n- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Codex hook regression test to be fully hermetic in GitHub Actions and fixed stale skill counts in docs to keep CI green.

- **Bug Fixes**
  - Run tests in a hermetic env: set `HOME`, `USERPROFILE`, `XDG_CONFIG_HOME`, `GIT_CONFIG_GLOBAL`, `LANG`, and `LC_ALL`.
  - Removed reliance on the external check script; assert invariants directly from generated `.codex/AGENTS.md` and `config.toml`.
  - Verified sync preserves baseline config and accepts the legacy `[mcp_servers.context7]` section.
  - Updated skill counts from 135 → 136 in `AGENTS.md` and `README.md`.

<sup>Written for commit 09530804395ebae56c4ba323d17522911e1cc521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill count from 135 to 136 across project documentation.
  * Refreshed feature parity table with current capability metrics.

* **Tests**
  * Strengthened test environment setup and configuration validation.
  * Enhanced test assertions for agent instruction content verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->