### PR TITLE
fix(codex): remove duplicate agents table from reference config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -102,7 +102,6 @@ sandbox_mode = "workspace-write"
 web_search = "live"
 
 [agents]
-[agents]
 # Multi-agent role limits and local role definitions.
 # These map to `.codex/agents/*.toml` and mirror the repo's explorer/reviewer/docs workflow.
 max_threads = 6


### PR DESCRIPTION
  ## Summary
  Fix the Codex reference config by removing a duplicated `[agents]` table header in `.codex/config.toml`.

  This prevents TOML parsing errors during the Codex App/CLI quick-start flow when users copy or load the reference config.

  ## Type
  - [ ] Skill
  - [ ] Agent
  - [ ] Hook
  - [ ] Command
  - [x] Other: Codex config fix

  ## Testing
  - Reproduced the issue from the Codex App + CLI quick-start flow using the reference `.codex/config.toml`
  - Verified the config no longer contains a duplicated `[agents]` table header
  - Verified the config can now be loaded without the duplicate key / duplicate table TOML error

  ## Checklist
  - [x] Follows format guidelines
  - [x] Tested locally
  - [x] No sensitive info (API keys, paths)
  - [x] Clear descriptions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a duplicate `[agents]` table header in `.codex/config.toml` to prevent TOML duplicate-table errors. This fixes loading the reference config in the Codex App and CLI quick-start.

<sup>Written for commit ff6ba1ff0b9709d431745be71a43268779ed1aa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate configuration entry to improve configuration file clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->