### PR TITLE
fix(hooks): pass phase argument from hook ID to observe.sh

### DIFF
--- a/scripts/hooks/run-with-flags-shell.sh
+++ b/scripts/hooks/run-with-flags-shell.sh
@@ -29,4 +29,8 @@ if [[ ! -f "$SCRIPT_PATH" ]]; then
   exit 0
 fi
 
-printf '%s' "$INPUT" | "$SCRIPT_PATH"
+# Extract phase prefix from hook ID (e.g., "pre:observe" -> "pre", "post:observe" -> "post")
+# This is needed by scripts like observe.sh that behave differently for PreToolUse vs PostToolUse
+HOOK_PHASE="${HOOK_ID%%:*}"
+
+printf '%s' "$INPUT" | "$SCRIPT_PATH" "$HOOK_PHASE"


### PR DESCRIPTION
## Summary

- Fixes `run-with-flags-shell.sh` to extract the phase prefix from the hook ID (e.g., `"pre:observe"` → `"pre"`, `"post:observe"` → `"post"`) and pass it as `$1` to the invoked script
- Without this fix, `observe.sh` always defaults to `"post"`, causing all observations to be recorded as `tool_complete` events — no `tool_start` events are ever captured

## Root Cause

In `hooks.json`, the PreToolUse observe hook is registered with hook ID `"pre:observe"` and PostToolUse with `"post:observe"`. The shell wrapper receives this ID as `$1` but never extracts the phase and forwards it to the script. The JS wrapper (`run-with-flags.js`) doesn't have this issue because the JS hook scripts receive the hook ID directly.

## Fix

Added phase extraction using `${HOOK_ID%%:*}` (bash parameter expansion to get everything before the first colon) and passes it as an argument to the script.

## Test plan

- [x] All 1695/1696 tests pass (1 pre-existing failure in `codex-hooks.test.js` unrelated to this change)
- [ ] Verify observations now capture both `tool_start` and `tool_complete` events

Fixes #1018

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the shell hook runner to pass the phase ("pre"/"post") from the hook ID to `observe.sh`. This restores recording of both `tool_start` and `tool_complete` events.

- **Bug Fixes**
  - Extract phase from `HOOK_ID` with `${HOOK_ID%%:*}` and pass it as `$1` to the script.
  - Previously, `observe.sh` defaulted to "post", recording only `tool_complete` events.

<sup>Written for commit 749a11dbe9f152b3f02a2bc3aec6f1f0c53c535d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced hook processing to improve phase handling during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->