### PR TITLE
feat: add C# reviewer agent and .NET pattern/testing skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Everything Claude Code (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 30 specialized agents, 136 skills, 60 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 31 specialized agents, 138 skills, 60 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 
@@ -141,8 +141,8 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 ## Project Structure
 
 ```
-agents/          — 30 specialized subagents
-skills/          — 136 workflow skills and domain knowledge
+agents/          — 31 specialized subagents
+skills/          — 138 workflow skills and domain knowledge
 commands/        — 60 slash commands
 hooks/           — Trigger-based automations
 rules/           — Always-follow guidelines (common + per-language)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For manual install instructions see the README in the `rules/` folder. When copy
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-**That's it!** You now have access to 30 agents, 136 skills, and 60 commands.
+**That's it!** You now have access to 31 agents, 138 skills, and 60 commands.
 
 ### Multi-model commands require additional setup
 
@@ -295,7 +295,7 @@ everything-claude-code/
 |   |-- plugin.json         # Plugin metadata and component paths
 |   |-- marketplace.json    # Marketplace catalog for /plugin marketplace add
 |
-|-- agents/           # 30 specialized subagents for delegation
+|-- agents/           # 31 specialized subagents for delegation
 |   |-- planner.md           # Feature implementation planning
 |   |-- architect.md         # System design decisions
 |   |-- tdd-guide.md         # Test-driven development
@@ -1109,9 +1109,9 @@ The configuration is automatically detected from `.opencode/opencode.json`.
 
 | Feature | Claude Code | OpenCode | Status |
 |---------|-------------|----------|--------|
-| Agents | PASS: 30 agents | PASS: 12 agents | **Claude Code leads** |
+| Agents | PASS: 31 agents | PASS: 12 agents | **Claude Code leads** |
 | Commands | PASS: 60 commands | PASS: 31 commands | **Claude Code leads** |
-| Skills | PASS: 136 skills | PASS: 37 skills | **Claude Code leads** |
+| Skills | PASS: 138 skills | PASS: 37 skills | **Claude Code leads** |
 | Hooks | PASS: 8 event types | PASS: 11 events | **OpenCode has more!** |
 | Rules | PASS: 29 rules | PASS: 13 instructions | **Claude Code leads** |
 | MCP Servers | PASS: 14 servers | PASS: Full | **Full parity** |

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,7 +1,7 @@
 # Soul
 
 ## Core Identity
-Everything Claude Code (ECC) is a production-ready AI coding plugin with 30 specialized agents, 135 skills, 60 commands, and automated hook workflows for software development.
+Everything Claude Code (ECC) is a production-ready AI coding plugin with 31 specialized agents, 138 skills, 60 commands, and automated hook workflows for software development.
 
 ## Core Principles
 1. **Agent-First** — route work to the right specialist as early as possible.

--- a/agents/csharp-reviewer.md
+++ b/agents/csharp-reviewer.md
@@ -1,0 +1,101 @@
+---
+name: csharp-reviewer
+description: Expert C# code reviewer specializing in .NET conventions, async patterns, security, nullable reference types, and performance. Use for all C# code changes. MUST BE USED for C# projects.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: sonnet
+---
+
+You are a senior C# code reviewer ensuring high standards of idiomatic .NET code and best practices.
+
+When invoked:
+1. Run `git diff -- '*.cs'` to see recent C# file changes
+2. Run `dotnet build` and `dotnet format --verify-no-changes` if available
+3. Focus on modified `.cs` files
+4. Begin review immediately
+
+## Review Priorities
+
+### CRITICAL — Security
+- **SQL Injection**: String concatenation/interpolation in queries — use parameterized queries or EF Core
+- **Command Injection**: Unvalidated input in `Process.Start` — validate and sanitize
+- **Path Traversal**: User-controlled file paths — use `Path.GetFullPath` + prefix check
+- **Insecure Deserialization**: `BinaryFormatter`, `JsonSerializer` with `TypeNameHandling.All`
+- **Hardcoded secrets**: API keys, connection strings in source — use configuration/secret manager
+- **CSRF/XSS**: Missing `[ValidateAntiForgeryToken]`, unencoded output in Razor
+
+### CRITICAL — Error Handling
+- **Empty catch blocks**: `catch { }` or `catch (Exception) { }` — handle or rethrow
+- **Swallowed exceptions**: `catch { return null; }` — log context, throw specific
+- **Missing `using`/`await using`**: Manual disposal of `IDisposable`/`IAsyncDisposable`
+- **Blocking async**: `.Result`, `.Wait()`, `.GetAwaiter().GetResult()` — use `await`
+
+### HIGH — Async Patterns
+- **Missing CancellationToken**: Public async APIs without cancellation support
+- **Fire-and-forget**: `async void` except event handlers — return `Task`
+- **ConfigureAwait misuse**: Library code missing `ConfigureAwait(false)`
+- **Sync-over-async**: Blocking calls in async context causing deadlocks
+
+### HIGH — Type Safety
+- **Nullable reference types**: Nullable warnings ignored or suppressed with `!`
+- **Unsafe casts**: `(T)obj` without type check — use `obj is T t` or `obj as T`
+- **Raw strings as identifiers**: Magic strings for config keys, routes — use constants or `nameof`
+- **`dynamic` usage**: Avoid `dynamic` in application code — use generics or explicit models
+
+### HIGH — Code Quality
+- **Large methods**: Over 50 lines — extract helper methods
+- **Deep nesting**: More than 4 levels — use early returns, guard clauses
+- **God classes**: Classes with too many responsibilities — apply SRP
+- **Mutable shared state**: Static mutable fields — use `ConcurrentDictionary`, `Interlocked`, or DI scoping
+
+### MEDIUM — Performance
+- **String concatenation in loops**: Use `StringBuilder` or `string.Join`
+- **LINQ in hot paths**: Excessive allocations — consider `for` loops with pre-allocated buffers
+- **N+1 queries**: EF Core lazy loading in loops — use `Include`/`ThenInclude`
+- **Missing `AsNoTracking`**: Read-only queries tracking entities unnecessarily
+
+### MEDIUM — Best Practices
+- **Naming conventions**: PascalCase for public members, `_camelCase` for private fields
+- **Record vs class**: Value-like immutable models should be `record` or `record struct`
+- **Dependency injection**: `new`-ing services instead of injecting — use constructor injection
+- **`IEnumerable` multiple enumeration**: Materialize with `.ToList()` when enumerated more than once
+- **Missing `sealed`**: Non-inherited classes should be `sealed` for clarity and performance
+
+## Diagnostic Commands
+
+```bash
+dotnet build                                          # Compilation check
+dotnet format --verify-no-changes                     # Format check
+dotnet test --no-build                                # Run tests
+dotnet test --collect:"XPlat Code Coverage"           # Coverage
+```
+
+## Review Output Format
+
+```text
+[SEVERITY] Issue title
+File: path/to/File.cs:42
+Issue: Description
+Fix: What to change
+```
+
+## Approval Criteria
+
+- **Approve**: No CRITICAL or HIGH issues
+- **Warning**: MEDIUM issues only (can merge with caution)
+- **Block**: CRITICAL or HIGH issues found
+
+## Framework Checks
+
+- **ASP.NET Core**: Model validation, auth policies, middleware order, `IOptions<T>` pattern
+- **EF Core**: Migration safety, `Include` for eager loading, `AsNoTracking` for reads
+- **Minimal APIs**: Route grouping, endpoint filters, proper `TypedResults`
+- **Blazor**: Component lifecycle, `StateHasChanged` usage, JS interop disposal
+
+## Reference
+
+For detailed C# patterns, see skill: `dotnet-patterns`.
+For testing guidelines, see skill: `csharp-testing`.
+
+---
+
+Review with the mindset: "Would this code pass review at a top .NET shop or open-source project?"

--- a/skills/csharp-testing/SKILL.md
+++ b/skills/csharp-testing/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: csharp-testing
+description: C# and .NET testing patterns with xUnit, FluentAssertions, mocking, integration tests, and test organization best practices.
+origin: ECC
+---
+
+# C# Testing Patterns
+
+Comprehensive testing patterns for .NET applications using xUnit, FluentAssertions, and modern testing practices.
+
+## When to Activate
+
+- Writing new tests for C# code
+- Reviewing test quality and coverage
+- Setting up test infrastructure for .NET projects
+- Debugging flaky or slow tests
+
+## Test Framework Stack
+
+| Tool | Purpose |
+|---|---|
+| **xUnit** | Test framework (preferred for .NET) |
+| **FluentAssertions** | Readable assertion syntax |
+| **NSubstitute** or **Moq** | Mocking dependencies |
+| **Testcontainers** | Real infrastructure in integration tests |
+| **WebApplicationFactory** | ASP.NET Core integration tests |
+| **Bogus** | Realistic test data generation |
+
+## Unit Test Structure
+
+### Arrange-Act-Assert
+
+```csharp
+public sealed class OrderServiceTests
+{
+    private readonly IOrderRepository _repository = Substitute.For<IOrderRepository>();
+    private readonly ILogger<OrderService> _logger = Substitute.For<ILogger<OrderService>>();
+    private readonly OrderService _sut;
+
+    public OrderServiceTests()
+    {
+        _sut = new OrderService(_repository, _logger);
+    }
+
+    [Fact]
+    public async Task PlaceOrderAsync_ReturnsSuccess_WhenRequestIsValid()
+    {
+        // Arrange
+        var request = new CreateOrderRequest
+        {
+            CustomerId = "cust-123",
+            Items = [new OrderItem("SKU-001", 2, 29.99m)]
+        };
+
+        // Act
+        var result = await _sut.PlaceOrderAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.CustomerId.Should().Be("cust-123");
+    }
+
+    [Fact]
+    public async Task PlaceOrderAsync_ReturnsFailure_WhenNoItems()
+    {
+        // Arrange
+        var request = new CreateOrderRequest
+        {
+            CustomerId = "cust-123",
+            Items = []
+        };
+
+        // Act
+        var result = await _sut.PlaceOrderAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("at least one item");
+    }
+}
+```
+
+### Parameterized Tests with Theory
+
+```csharp
+[Theory]
+[InlineData("", false)]
+[InlineData("a", false)]
+[InlineData("ab@c.d", false)]
+[InlineData("user@example.com", true)]
+[InlineData("user+tag@example.co.uk", true)]
+public void IsValidEmail_ReturnsExpected(string email, bool expected)
+{
+    EmailValidator.IsValid(email).Should().Be(expected);
+}
+
+[Theory]
+[MemberData(nameof(InvalidOrderCases))]
+public async Task PlaceOrderAsync_RejectsInvalidOrders(CreateOrderRequest request, string expectedError)
+{
+    var result = await _sut.PlaceOrderAsync(request, CancellationToken.None);
+
+    result.IsSuccess.Should().BeFalse();
+    result.Error.Should().Contain(expectedError);
+}
+
+public static TheoryData<CreateOrderRequest, string> InvalidOrderCases => new()
+{
+    { new() { CustomerId = "", Items = [ValidItem()] }, "CustomerId" },
+    { new() { CustomerId = "c1", Items = [] }, "at least one item" },
+    { new() { CustomerId = "c1", Items = [new("", 1, 10m)] }, "SKU" },
+};
+```
+
+## Mocking with NSubstitute
+
+```csharp
+[Fact]
+public async Task GetOrderAsync_ReturnsNull_WhenNotFound()
+{
+    // Arrange
+    var orderId = Guid.NewGuid();
+    _repository.FindByIdAsync(orderId, Arg.Any<CancellationToken>())
+        .Returns((Order?)null);
+
+    // Act
+    var result = await _sut.GetOrderAsync(orderId, CancellationToken.None);
+
+    // Assert
+    result.Should().BeNull();
+}
+
+[Fact]
+public async Task PlaceOrderAsync_PersistsOrder()
+{
+    // Arrange
+    var request = ValidOrderRequest();
+
+    // Act
+    await _sut.PlaceOrderAsync(request, CancellationToken.None);
+
+    // Assert — verify the repository was called
+    await _repository.Received(1).AddAsync(
+        Arg.Is<Order>(o => o.CustomerId == request.CustomerId),
+        Arg.Any<CancellationToken>());
+}
+```
+
+## ASP.NET Core Integration Tests
+
+### WebApplicationFactory Setup
+
+```csharp
+public sealed class OrderApiTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public OrderApiTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                // Replace real DB with in-memory for tests
+                services.RemoveAll<DbContextOptions<AppDbContext>>();
+                services.AddDbContext<AppDbContext>(options =>
+                    options.UseInMemoryDatabase("TestDb"));
+            });
+        }).CreateClient();
+    }
+
+    [Fact]
+    public async Task GetOrder_Returns404_WhenNotFound()
+    {
+        var response = await _client.GetAsync($"/api/orders/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateOrder_Returns201_WithValidRequest()
+    {
+        var request = new CreateOrderRequest
+        {
+            CustomerId = "cust-1",
+            Items = [new("SKU-001", 1, 19.99m)]
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/orders", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+    }
+}
+```
+
+### Testing with Testcontainers
+
+```csharp
+public sealed class PostgresOrderRepositoryTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder()
+        .WithImage("postgres:16-alpine")
+        .Build();
+
+    private AppDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(_postgres.GetConnectionString())
+            .Options;
+        _db = new AppDbContext(options);
+        await _db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _postgres.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsOrder()
+    {
+        var repo = new SqlOrderRepository(_db);
+        var order = Order.Create("cust-1", [new OrderItem("SKU-001", 2, 10m)]);
+
+        await repo.AddAsync(order, CancellationToken.None);
+
+        var found = await repo.FindByIdAsync(order.Id, CancellationToken.None);
+        found.Should().NotBeNull();
+        found!.Items.Should().HaveCount(1);
+    }
+}
+```
+
+## Test Organization
+
+```
+tests/
+  MyApp.UnitTests/
+    Services/
+      OrderServiceTests.cs
+      PaymentServiceTests.cs
+    Validators/
+      EmailValidatorTests.cs
+  MyApp.IntegrationTests/
+    Api/
+      OrderApiTests.cs
+    Repositories/
+      OrderRepositoryTests.cs
+  MyApp.TestHelpers/
+    Builders/
+      OrderBuilder.cs
+    Fixtures/
+      DatabaseFixture.cs
+```
+
+## Test Data Builders
+
+```csharp
+public sealed class OrderBuilder
+{
+    private string _customerId = "cust-default";
+    private readonly List<OrderItem> _items = [new("SKU-001", 1, 10m)];
+
+    public OrderBuilder WithCustomer(string customerId)
+    {
+        _customerId = customerId;
+        return this;
+    }
+
+    public OrderBuilder WithItem(string sku, int quantity, decimal price)
+    {
+        _items.Add(new OrderItem(sku, quantity, price));
+        return this;
+    }
+
+    public Order Build() => Order.Create(_customerId, _items);
+}
+
+// Usage in tests
+var order = new OrderBuilder()
+    .WithCustomer("cust-vip")
+    .WithItem("SKU-PREMIUM", 3, 99.99m)
+    .Build();
+```
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Fix |
+|---|---|
+| Testing implementation details | Test behavior and outcomes |
+| Shared mutable test state | Fresh instance per test (xUnit does this via constructors) |
+| `Thread.Sleep` in async tests | Use `Task.Delay` with timeout, or polling helpers |
+| Asserting on `ToString()` output | Assert on typed properties |
+| One giant assertion per test | One logical assertion per test |
+| Test names describing implementation | Name by behavior: `Method_ExpectedResult_WhenCondition` |
+| Ignoring `CancellationToken` | Always pass and verify cancellation |
+
+## Running Tests
+
+```bash
+# Run all tests
+dotnet test
+
+# Run with coverage
+dotnet test --collect:"XPlat Code Coverage"
+
+# Run specific project
+dotnet test tests/MyApp.UnitTests/
+
+# Filter by test name
+dotnet test --filter "FullyQualifiedName~OrderService"
+
+# Watch mode during development
+dotnet watch test --project tests/MyApp.UnitTests/
+```

--- a/skills/dotnet-patterns/SKILL.md
+++ b/skills/dotnet-patterns/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: dotnet-patterns
+description: Idiomatic C# and .NET patterns, conventions, dependency injection, async/await, and best practices for building robust, maintainable .NET applications.
+origin: ECC
+---
+
+# .NET Development Patterns
+
+Idiomatic C# and .NET patterns for building robust, performant, and maintainable applications.
+
+## When to Activate
+
+- Writing new C# code
+- Reviewing C# code
+- Refactoring existing .NET applications
+- Designing service architectures with ASP.NET Core
+
+## Core Principles
+
+### 1. Prefer Immutability
+
+Use records and init-only properties for data models. Mutability should be an explicit, justified choice.
+
+```csharp
+// Good: Immutable value object
+public sealed record Money(decimal Amount, string Currency);
+
+// Good: Immutable DTO with init setters
+public sealed class CreateOrderRequest
+{
+    public required string CustomerId { get; init; }
+    public required IReadOnlyList<OrderItem> Items { get; init; }
+}
+
+// Bad: Mutable model with public setters
+public class Order
+{
+    public string CustomerId { get; set; }
+    public List<OrderItem> Items { get; set; }
+}
+```
+
+### 2. Explicit Over Implicit
+
+Be clear about nullability, access modifiers, and intent.
+
+```csharp
+// Good: Explicit access modifiers and nullability
+public sealed class UserService
+{
+    private readonly IUserRepository _repository;
+    private readonly ILogger<UserService> _logger;
+
+    public UserService(IUserRepository repository, ILogger<UserService> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<User?> FindByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return await _repository.FindByIdAsync(id, cancellationToken);
+    }
+}
+```
+
+### 3. Depend on Abstractions
+
+Use interfaces for service boundaries. Register via DI container.
+
+```csharp
+// Good: Interface-based dependency
+public interface IOrderRepository
+{
+    Task<Order?> FindByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<IReadOnlyList<Order>> FindByCustomerAsync(string customerId, CancellationToken cancellationToken);
+    Task AddAsync(Order order, CancellationToken cancellationToken);
+}
+
+// Registration
+builder.Services.AddScoped<IOrderRepository, SqlOrderRepository>();
+```
+
+## Async/Await Patterns
+
+### Proper Async Usage
+
+```csharp
+// Good: Async all the way, with CancellationToken
+public async Task<OrderSummary> GetOrderSummaryAsync(
+    Guid orderId,
+    CancellationToken cancellationToken)
+{
+    var order = await _repository.FindByIdAsync(orderId, cancellationToken)
+        ?? throw new NotFoundException($"Order {orderId} not found");
+
+    var customer = await _customerService.GetAsync(order.CustomerId, cancellationToken);
+
+    return new OrderSummary(order, customer);
+}
+
+// Bad: Blocking on async
+public OrderSummary GetOrderSummary(Guid orderId)
+{
+    var order = _repository.FindByIdAsync(orderId, CancellationToken.None).Result; // Deadlock risk
+    return new OrderSummary(order);
+}
+```
+
+### Parallel Async Operations
+
+```csharp
+// Good: Concurrent independent operations
+public async Task<DashboardData> LoadDashboardAsync(CancellationToken cancellationToken)
+{
+    var ordersTask = _orderService.GetRecentAsync(cancellationToken);
+    var metricsTask = _metricsService.GetCurrentAsync(cancellationToken);
+    var alertsTask = _alertService.GetActiveAsync(cancellationToken);
+
+    await Task.WhenAll(ordersTask, metricsTask, alertsTask);
+
+    return new DashboardData(
+        Orders: await ordersTask,
+        Metrics: await metricsTask,
+        Alerts: await alertsTask);
+}
+```
+
+## Options Pattern
+
+Bind configuration sections to strongly-typed objects.
+
+```csharp
+public sealed class SmtpOptions
+{
+    public const string SectionName = "Smtp";
+
+    public required string Host { get; init; }
+    public required int Port { get; init; }
+    public required string Username { get; init; }
+    public bool UseSsl { get; init; } = true;
+}
+
+// Registration
+builder.Services.Configure<SmtpOptions>(
+    builder.Configuration.GetSection(SmtpOptions.SectionName));
+
+// Usage via injection
+public class EmailService(IOptions<SmtpOptions> options)
+{
+    private readonly SmtpOptions _smtp = options.Value;
+}
+```
+
+## Result Pattern
+
+Return explicit success/failure instead of throwing for expected failures.
+
+```csharp
+public sealed record Result<T>
+{
+    public bool IsSuccess { get; }
+    public T? Value { get; }
+    public string? Error { get; }
+
+    private Result(T value) { IsSuccess = true; Value = value; }
+    private Result(string error) { IsSuccess = false; Error = error; }
+
+    public static Result<T> Success(T value) => new(value);
+    public static Result<T> Failure(string error) => new(error);
+}
+
+// Usage
+public async Task<Result<Order>> PlaceOrderAsync(CreateOrderRequest request)
+{
+    if (request.Items.Count == 0)
+        return Result<Order>.Failure("Order must contain at least one item");
+
+    var order = Order.Create(request);
+    await _repository.AddAsync(order, CancellationToken.None);
+    return Result<Order>.Success(order);
+}
+```
+
+## Repository Pattern with EF Core
+
+```csharp
+public sealed class SqlOrderRepository : IOrderRepository
+{
+    private readonly AppDbContext _db;
+
+    public SqlOrderRepository(AppDbContext db) => _db = db;
+
+    public async Task<Order?> FindByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return await _db.Orders
+            .Include(o => o.Items)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Order>> FindByCustomerAsync(
+        string customerId,
+        CancellationToken cancellationToken)
+    {
+        return await _db.Orders
+            .Where(o => o.CustomerId == customerId)
+            .OrderByDescending(o => o.CreatedAt)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Order order, CancellationToken cancellationToken)
+    {
+        _db.Orders.Add(order);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}
+```
+
+## Middleware and Pipeline
+
+```csharp
+// Custom middleware
+public sealed class RequestTimingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RequestTimingMiddleware> _logger;
+
+    public RequestTimingMiddleware(RequestDelegate next, ILogger<RequestTimingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Request {Method} {Path} completed in {ElapsedMs}ms with status {StatusCode}",
+                context.Request.Method,
+                context.Request.Path,
+                stopwatch.ElapsedMilliseconds,
+                context.Response.StatusCode);
+        }
+    }
+}
+```
+
+## Minimal API Patterns
+
+```csharp
+// Organized with route groups
+var orders = app.MapGroup("/api/orders")
+    .RequireAuthorization()
+    .WithTags("Orders");
+
+orders.MapGet("/{id:guid}", async (
+    Guid id,
+    IOrderRepository repository,
+    CancellationToken cancellationToken) =>
+{
+    var order = await repository.FindByIdAsync(id, cancellationToken);
+    return order is not null
+        ? TypedResults.Ok(order)
+        : TypedResults.NotFound();
+});
+
+orders.MapPost("/", async (
+    CreateOrderRequest request,
+    IOrderService service,
+    CancellationToken cancellationToken) =>
+{
+    var result = await service.PlaceOrderAsync(request, cancellationToken);
+    return result.IsSuccess
+        ? TypedResults.Created($"/api/orders/{result.Value!.Id}", result.Value)
+        : TypedResults.BadRequest(result.Error);
+});
+```
+
+## Guard Clauses
+
+```csharp
+// Good: Early returns with clear validation
+public async Task<ProcessResult> ProcessPaymentAsync(
+    PaymentRequest request,
+    CancellationToken cancellationToken)
+{
+    ArgumentNullException.ThrowIfNull(request);
+
+    if (request.Amount <= 0)
+        throw new ArgumentOutOfRangeException(nameof(request.Amount), "Amount must be positive");
+
+    if (string.IsNullOrWhiteSpace(request.Currency))
+        throw new ArgumentException("Currency is required", nameof(request.Currency));
+
+    // Happy path continues here without nesting
+    var gateway = _gatewayFactory.Create(request.Currency);
+    return await gateway.ChargeAsync(request, cancellationToken);
+}
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Fix |
+|---|---|
+| `async void` methods | Return `Task` (except event handlers) |
+| `.Result` or `.Wait()` | Use `await` |
+| `catch (Exception) { }` | Handle or rethrow with context |
+| `new Service()` in constructors | Use constructor injection |
+| `public` fields | Use properties with appropriate accessors |
+| `dynamic` in business logic | Use generics or explicit types |
+| Mutable `static` state | Use DI scoping or `ConcurrentDictionary` |
+| `string.Format` in loops | Use `StringBuilder` or interpolated string handlers |


### PR DESCRIPTION
## Summary

- Adds `csharp-reviewer.md` agent for dedicated C# code review (security, async patterns, nullable types, EF Core, ASP.NET Core, Blazor)
- Adds `dotnet-patterns` skill with idiomatic C# patterns (DI, Options pattern, Result pattern, repository pattern, Minimal APIs, middleware)
- Adds `csharp-testing` skill with xUnit, FluentAssertions, NSubstitute, WebApplicationFactory, Testcontainers, and test data builders
- Updates documentation counts: 30→31 agents, 136→138 skills in README.md, AGENTS.md, SOUL.md

C# rules already existed in `rules/csharp/` but lacked a dedicated reviewer agent and skills. This completes the C# language support to match the coverage of other languages like Python, Go, and Kotlin.

## New Files

| File | Type | Description |
|------|------|-------------|
| `agents/csharp-reviewer.md` | Agent | C#/.NET code reviewer with CRITICAL/HIGH/MEDIUM severity tiers |
| `skills/dotnet-patterns/SKILL.md` | Skill | Idiomatic .NET patterns and best practices |
| `skills/csharp-testing/SKILL.md` | Skill | Testing patterns with xUnit ecosystem |

## Test plan

- [x] All 1695/1696 tests pass (1 pre-existing failure in `codex-hooks.test.js`)
- [x] Catalog count validator passes with updated counts
- [x] Agent follows existing frontmatter format (name, description, tools, model)
- [x] Skills follow SKILL.md template (When to Activate, patterns, anti-patterns)

Closes #1026

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated C# reviewer agent and two .NET skills to complete first-class C# support. Improves review quality, patterns, and testing for ASP.NET Core and EF Core code.

- New Features
  - Added `agents/csharp-reviewer.md`: C#/.NET review agent with severity tiers, build/format checks, and focus on security, async, nullable types, and performance; includes checks for ASP.NET Core, EF Core, Minimal APIs, and Blazor.
  - Added `skills/dotnet-patterns`: idiomatic patterns (DI, Options, Result, repository, middleware, Minimal APIs, async/await).
  - Added `skills/csharp-testing`: testing with xUnit, FluentAssertions, NSubstitute, `WebApplicationFactory`, Testcontainers, and test data builders.
  - Updated docs counts to 31 agents and 138 skills.

<sup>Written for commit 96f709bbe840533ce8a3d5b88951a63c2da43d31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specialized C# code review agent for automated code inspections and quality checks
  * Added C# testing skill with comprehensive patterns and best practices guidance
  * Added .NET development patterns skill covering architectural and design guidance

* **Documentation**
  * Updated inventory counts: 31 agents and 138 skills (expanded from 30 agents, 136 skills)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->