### PR TITLE
fix: filter session-start injection by cwd/project to prevent cross-project contamination

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -24,6 +24,25 @@ const { getPackageManager, getSelectionPrompt } = require('../lib/package-manage
 const { listAliases } = require('../lib/session-aliases');
 const { detectProjectType } = require('../lib/project-detect');
 const path = require('path');
+const fs = require('fs');
+
+/**
+ * Resolve a filesystem path to its canonical (real) form.
+ *
+ * Handles symlinks and, on case-insensitive filesystems (macOS, Windows),
+ * normalizes casing so that path comparisons are reliable.
+ * Falls back to the original path if resolution fails (e.g. path no longer exists).
+ *
+ * @param {string} p - The path to normalize.
+ * @returns {string} The canonical path, or the original if resolution fails.
+ */
+function normalizePath(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
 
 function dedupeRecentSessions(searchDirs) {
   const recentSessionsByName = new Map();
@@ -83,6 +102,9 @@ function dedupeRecentSessions(searchDirs) {
 function selectMatchingSession(sessions, cwd, currentProject) {
   if (sessions.length === 0) return null;
 
+  // Normalize cwd once outside the loop to avoid repeated syscalls
+  const normalizedCwd = normalizePath(cwd);
+
   let projectMatch = null;
   let projectMatchContent = null;
   let fallbackSession = null;
@@ -103,7 +125,8 @@ function selectMatchingSession(sessions, cwd, currentProject) {
     const sessionWorktree = worktreeMatch ? worktreeMatch[1].trim() : '';
 
     // Exact worktree match — best possible, return immediately
-    if (sessionWorktree && sessionWorktree === cwd) {
+    // Normalize both paths to handle symlinks and case-insensitive filesystems
+    if (sessionWorktree && normalizePath(sessionWorktree) === normalizedCwd) {
       return { session, content, matchReason: 'worktree' };
     }
 


### PR DESCRIPTION
## What Changed

Added `selectMatchingSession()` to `scripts/hooks/session-start.js` that matches session files against the current working directory and project name before injecting into Claude's context.

Priority:
1. Exact worktree (cwd) match — most recent
2. Same project name match — most recent
3. Fallback to overall most recent (preserves backward compatibility)

## Why This Change

The `SessionStart` hook previously always injected the most recent session summary regardless of the current working directory. When users switch between projects, Claude receives the wrong project's session context (including file paths, project metadata, and task history) and incorrectly believes it's still in the previous project.

`session-end.js` already writes `**Project:**` and `**Worktree:**` header fields into each session file — this PR simply uses them for matching.

## Testing Done

- [x] Manual testing completed
  - Verified correct session selected when switching between two projects
  - Verified fallback to most recent when no matching session exists
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested
  - No session files exist → no change
  - Session files without headers → graceful fallback
  - Only one session file → selected regardless

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Added comments for complex logic (JSDoc on selectMatchingSession)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters session injection by current working directory and project to prevent cross‑project contamination. Normalizes worktree/cwd paths for reliable matching, keeps fallback session and content in sync, and only injects readable summaries.

- **Bug Fixes**
  - Added `selectMatchingSession()` returning `{ session, content, matchReason }`; avoids duplicate I/O and keeps session/content aligned on fallbacks.
  - Match order: exact worktree (cwd) > same project name > most recent readable.
  - Normalized worktree and cwd with `fs.realpathSync()` to handle symlinks and case differences; cwd normalized once.
  - Safer flow: null/empty guards, no input mutation, and log/inject only when content is readable; full JSDoc added.

<sup>Written for commit f610b38638e638b8f188532711ea389ae0ac7414. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration: selection now prioritizes exact worktree matches, then project-name matches, and falls back to the most recent readable session.
  * Path comparisons are canonicalized to handle symlinks and case-insensitive filesystems.
  * Session contents are cached to avoid extra reads when restoring.
  * Restoration now uses the current working directory and detected project name.
  * Added logs recording which session was chosen and the reason, and when no suitable session is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->