### PR TITLE
Fix SOURCE_KIRO path in install.sh

### DIFF
--- a/.kiro/install.sh
+++ b/.kiro/install.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # When globs match nothing, expand to empty list instead of the literal pattern
 shopt -s nullglob
 
-# Resolve the directory where this script lives (the repo root)
+# Resolve the directory where this script lives
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_KIRO="$SCRIPT_DIR"
 


### PR DESCRIPTION
## What Changed
Update SOURCE_KIRO to point to the script directory.

## Why This Change
Otherwise, the install script cannot find anything to install due to wrong path (`.../everything-claude-code/.kiro/.kiro`) due to duplicate `/.kiro`.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

A duplicate with #1025 (but that PR seems modifying to be the CRLF line ending, which is not expected.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `SOURCE_KIRO` to the script directory so `install.sh` can find files. Removes the extra "/.kiro" in paths (.../.kiro/.kiro) and corrects the misleading script-dir comment.

<sup>Written for commit 9df7e729a0f49dd4298294070a937acb580a168f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now sources setup assets from the repository root instead of a nested subdirectory, changing where files are looked for during setup while leaving installed target locations unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->