### PR TITLE
fix: using variable interpolation `${{ in reusable-release.yml (yaml....

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -28,8 +28,10 @@ jobs:
           fetch-depth: 0
 
       - name: Validate version tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version tag format. Expected vX.Y.Z"
             exit 1
           fi


### PR DESCRIPTION
## Summary
Fix high severity security issue in `.github/workflows/reusable-release.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `.github/workflows/reusable-release.yml:31` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `.github/workflows/reusable-release.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shell injection risk in `.github/workflows/reusable-release.yml` by moving `${{ inputs.tag }}` into an env var and quoting it in the script. The validation now uses `INPUT_TAG` (i.e., "$INPUT_TAG") to avoid executing untrusted input.

<sup>Written for commit a6a797da1dabf27b5df64ef784baa673968a6860. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow version tag validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->