### PR TITLE
fix: resolve ${CLAUDE_PLUGIN_ROOT} at install time for PreToolUse/PostToolUse hooks

### DIFF
--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -5,6 +5,63 @@ const path = require('path');
 
 const { writeInstallState } = require('../install-state');
 
+/**
+ * Replace all occurrences of `${CLAUDE_PLUGIN_ROOT}` in hook command strings
+ * with the actual resolved install root path.
+ *
+ * This prevents hook failures when CLAUDE_PLUGIN_ROOT is unset at runtime —
+ * the absolute path is baked in at install time instead.
+ *
+ * @param {object} hooks  The merged hooks object (mutated in-place on entries)
+ * @param {string} root   The resolved ECC install root (absolute path)
+ * @returns {object} New hooks object with paths resolved
+ */
+function resolvePluginRootInHooks(hooks, root) {
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) {
+    return hooks;
+  }
+
+  const placeholder = '${CLAUDE_PLUGIN_ROOT}';
+  const escapedRoot = root.replace(/\\/g, '\\\\');
+
+  function resolveValue(value) {
+    if (typeof value === 'string' && value.includes(placeholder)) {
+      // On Windows, backslashes in paths must be escaped inside double-quoted
+      // shell strings. Replace each backslash with two backslashes.
+      return value.split(placeholder).join(
+        process.platform === 'win32' ? escapedRoot : root
+      );
+    }
+    return value;
+  }
+
+  const resolved = {};
+  for (const [eventName, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) {
+      resolved[eventName] = entries;
+      continue;
+    }
+    resolved[eventName] = entries.map(entry => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        return entry;
+      }
+      if (!Array.isArray(entry.hooks)) {
+        return entry;
+      }
+      return {
+        ...entry,
+        hooks: entry.hooks.map(hook => {
+          if (!hook || typeof hook !== 'object' || typeof hook.command !== 'string') {
+            return hook;
+          }
+          return { ...hook, command: resolveValue(hook.command) };
+        }),
+      };
+    });
+  }
+  return resolved;
+}
+
 function readJsonObject(filePath, label) {
   let parsed;
   try {
@@ -129,9 +186,13 @@ function buildMergedSettings(plan) {
     mergedHooks[eventName] = mergeHookEntries(currentEntries, nextEntries);
   }
 
+  // Resolve ${CLAUDE_PLUGIN_ROOT} to the actual install path so hooks work
+  // even when the env var is unset at runtime. See: issue #547, #691.
+  const resolvedHooks = resolvePluginRootInHooks(mergedHooks, plan.targetRoot);
+
   const mergedSettings = {
     ...settings,
-    hooks: mergedHooks,
+    hooks: resolvedHooks,
   };
 
   return {
@@ -167,4 +228,5 @@ function applyInstallPlan(plan) {
 
 module.exports = {
   applyInstallPlan,
+  resolvePluginRootInHooks,
 };

--- a/scripts/repair-hooks.js
+++ b/scripts/repair-hooks.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Repair hook paths in an existing ECC installation.
+ *
+ * Replaces literal `${CLAUDE_PLUGIN_ROOT}` placeholders in ~/.claude/settings.json
+ * with the actual resolved ECC root path. This fixes hook failures when
+ * CLAUDE_PLUGIN_ROOT is unset at runtime.
+ *
+ * Usage:
+ *   node ~/.claude/scripts/repair-hooks.js [--dry-run] [--settings <path>]
+ *
+ * Options:
+ *   --dry-run          Show what would change without writing
+ *   --settings <path>  Path to settings.json (default: ~/.claude/settings.json)
+ *
+ * Fixes: https://github.com/affaan-m/everything-claude-code/issues/547
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { resolveEccRoot } = require('./lib/resolve-ecc-root');
+
+const PLACEHOLDER = '${CLAUDE_PLUGIN_ROOT}';
+
+function parseArgs(argv) {
+  const args = { dryRun: false, settingsPath: null };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--dry-run') {
+      args.dryRun = true;
+    } else if (argv[i] === '--settings' && argv[i + 1]) {
+      args.settingsPath = argv[++i];
+    }
+  }
+  return args;
+}
+
+function resolveValue(value, root, escapedRoot) {
+  if (typeof value !== 'string' || !value.includes(PLACEHOLDER)) {
+    return { value, changed: false };
+  }
+  const replacement = process.platform === 'win32' ? escapedRoot : root;
+  const resolved = value.split(PLACEHOLDER).join(replacement);
+  return { value: resolved, changed: true };
+}
+
+function repairHooks(hooks, root) {
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) {
+    return { hooks, count: 0 };
+  }
+
+  const escapedRoot = root.replace(/\\/g, '\\\\');
+  let count = 0;
+  const result = {};
+
+  for (const [eventName, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) {
+      result[eventName] = entries;
+      continue;
+    }
+    result[eventName] = entries.map(entry => {
+      if (!entry || typeof entry !== 'object' || !Array.isArray(entry.hooks)) {
+        return entry;
+      }
+      const repairedHooks = entry.hooks.map(hook => {
+        if (!hook || typeof hook !== 'object' || typeof hook.command !== 'string') {
+          return hook;
+        }
+        const { value: command, changed } = resolveValue(hook.command, root, escapedRoot);
+        if (changed) count++;
+        return changed ? { ...hook, command } : hook;
+      });
+      return { ...entry, hooks: repairedHooks };
+    });
+  }
+
+  return { hooks: result, count };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  const settingsPath = args.settingsPath
+    || path.join(os.homedir(), '.claude', 'settings.json');
+
+  if (!fs.existsSync(settingsPath)) {
+    console.error(`[repair-hooks] settings.json not found: ${settingsPath}`);
+    process.exit(1);
+  }
+
+  let settings;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  } catch (err) {
+    console.error(`[repair-hooks] Failed to parse settings.json: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!settings.hooks || typeof settings.hooks !== 'object') {
+    console.log('[repair-hooks] No hooks found in settings.json — nothing to repair.');
+    process.exit(0);
+  }
+
+  const root = resolveEccRoot();
+  console.log(`[repair-hooks] Resolved ECC root: ${root}`);
+
+  const { hooks: repairedHooks, count } = repairHooks(settings.hooks, root);
+
+  if (count === 0) {
+    console.log('[repair-hooks] No ${CLAUDE_PLUGIN_ROOT} placeholders found — already up to date.');
+    process.exit(0);
+  }
+
+  console.log(`[repair-hooks] Found ${count} command(s) with \${CLAUDE_PLUGIN_ROOT} placeholder.`);
+
+  if (args.dryRun) {
+    console.log('[repair-hooks] Dry run — no changes written.');
+    console.log('[repair-hooks] Run without --dry-run to apply.');
+    process.exit(0);
+  }
+
+  const repairedSettings = { ...settings, hooks: repairedHooks };
+  fs.writeFileSync(settingsPath, JSON.stringify(repairedSettings, null, 2) + '\n', 'utf8');
+  console.log(`[repair-hooks] Repaired ${count} hook command(s) in ${settingsPath}`);
+  console.log('[repair-hooks] Done. Restart Claude Code for changes to take effect.');
+}
+
+main();

--- a/tests/hooks/resolve-hook-paths.test.js
+++ b/tests/hooks/resolve-hook-paths.test.js
@@ -1,0 +1,305 @@
+/**
+ * Tests for ${CLAUDE_PLUGIN_ROOT} resolution at install time and repair.
+ *
+ * Verifies:
+ *  1. resolvePluginRootInHooks() replaces ${CLAUDE_PLUGIN_ROOT} with the resolved path
+ *  2. repair-hooks.js correctly repairs an existing installation
+ *  3. hooks.json template contains placeholders (installer resolves them at install time)
+ *
+ * Run with: node tests/hooks/resolve-hook-paths.test.js
+ *
+ * Fixes: https://github.com/affaan-m/everything-claude-code/issues/547
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const APPLY_JS = path.join(REPO_ROOT, 'scripts', 'lib', 'install', 'apply.js');
+const REPAIR_JS = path.join(REPO_ROOT, 'scripts', 'repair-hooks.js');
+const HOOKS_JSON = path.join(REPO_ROOT, 'hooks', 'hooks.json');
+const PLACEHOLDER = '${CLAUDE_PLUGIN_ROOT}';
+
+const { resolvePluginRootInHooks } = require(APPLY_JS);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-hook-path-test-'));
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+// ─── Helper: build a hooks object with a placeholder command ────────────────
+
+function hooksWithPlaceholder(extra) {
+  const base = {
+    PreToolUse: [
+      {
+        matcher: 'Bash',
+        hooks: [
+          {
+            type: 'command',
+            command: `node "${PLACEHOLDER}/scripts/hooks/run-with-flags.js" "test:hook" "scripts/hooks/test.js" "standard"`,
+          },
+        ],
+        id: 'test:hook',
+      },
+    ],
+    Stop: [
+      {
+        matcher: '*',
+        hooks: [
+          {
+            type: 'command',
+            // Already-resolved inline bootstrap (no placeholder) — should be unchanged
+            command: 'node -e "require(\'./scripts/hooks/run-with-flags.js\')"',
+          },
+        ],
+        id: 'test:stop',
+      },
+    ],
+  };
+  if (extra) {
+    base.PreToolUse.push(extra);
+  }
+  return base;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+function runTests() {
+  console.log('\n=== Testing ${CLAUDE_PLUGIN_ROOT} resolution at install time ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  // ── 1. Placeholder replaced in hook commands ──────────────────────────────
+
+  if (test('resolvePluginRootInHooks replaces ${CLAUDE_PLUGIN_ROOT} in PreToolUse hooks', () => {
+    const root = '/resolved/ecc/root';
+    const resolved = resolvePluginRootInHooks(hooksWithPlaceholder(), root);
+    const raw = JSON.stringify(resolved);
+    assert.ok(!raw.includes(PLACEHOLDER),
+      `Result must not contain "${PLACEHOLDER}"`);
+  })) passed++; else failed++;
+
+  // ── 2. Placeholder replaced with the supplied root ────────────────────────
+
+  if (test('resolvePluginRootInHooks inserts the actual root path', () => {
+    const root = '/my/custom/root';
+    const resolved = resolvePluginRootInHooks(hooksWithPlaceholder(), root);
+    const cmd = resolved.PreToolUse[0].hooks[0].command;
+    assert.ok(cmd.includes(root),
+      `command "${cmd}" should contain "${root}"`);
+  })) passed++; else failed++;
+
+  // ── 3. Stop hooks with no placeholder are left untouched ─────────────────
+
+  if (test('resolvePluginRootInHooks leaves commands without placeholder unchanged', () => {
+    const root = '/some/root';
+    const original = hooksWithPlaceholder();
+    const originalStopCmd = original.Stop[0].hooks[0].command;
+    const resolved = resolvePluginRootInHooks(original, root);
+    assert.strictEqual(
+      resolved.Stop[0].hooks[0].command,
+      originalStopCmd,
+      'Stop hook command with no placeholder must not be modified'
+    );
+  })) passed++; else failed++;
+
+  // ── 4. Commands without placeholder are not modified ─────────────────────
+
+  if (test('resolvePluginRootInHooks does not modify plain commands (no placeholder)', () => {
+    const plainCommand = 'npx block-no-verify@1.1.2';
+    const hooks = hooksWithPlaceholder({
+      matcher: 'Write',
+      hooks: [{ type: 'command', command: plainCommand }],
+      id: 'test:extra',
+    });
+    const resolved = resolvePluginRootInHooks(hooks, '/some/root');
+    const extra = resolved.PreToolUse.find(e => e.id === 'test:extra');
+    assert.ok(extra, 'extra entry should exist');
+    assert.strictEqual(extra.hooks[0].command, plainCommand);
+  })) passed++; else failed++;
+
+  // ── 5. Handles null/undefined/non-object input gracefully ─────────────────
+
+  if (test('resolvePluginRootInHooks returns input unchanged for null hooks', () => {
+    assert.strictEqual(resolvePluginRootInHooks(null, '/root'), null);
+    assert.strictEqual(resolvePluginRootInHooks(undefined, '/root'), undefined);
+  })) passed++; else failed++;
+
+  // ── 6. Handles event entries that are not arrays ──────────────────────────
+
+  if (test('resolvePluginRootInHooks handles non-array event entries gracefully', () => {
+    const hooks = { SomeEvent: 'not-an-array' };
+    const resolved = resolvePluginRootInHooks(hooks, '/root');
+    assert.strictEqual(resolved.SomeEvent, 'not-an-array');
+  })) passed++; else failed++;
+
+  // ── 7. Resolves multiple placeholders in one command string ───────────────
+
+  if (test('resolvePluginRootInHooks replaces all placeholder occurrences in a command', () => {
+    const root = '/ecc';
+    const hooks = {
+      PreToolUse: [
+        {
+          matcher: '*',
+          hooks: [
+            {
+              type: 'command',
+              command: `node "${PLACEHOLDER}/a.js" "${PLACEHOLDER}/b.js"`,
+            },
+          ],
+          id: 'test:multi',
+        },
+      ],
+    };
+    const resolved = resolvePluginRootInHooks(hooks, root);
+    const cmd = resolved.PreToolUse[0].hooks[0].command;
+    assert.ok(!cmd.includes(PLACEHOLDER));
+    assert.strictEqual(cmd, `node "${root}/a.js" "${root}/b.js"`);
+  })) passed++; else failed++;
+
+  // ── 8. hooks.json template keeps placeholders (installer resolves them) ───
+
+  if (test('hooks/hooks.json template contains ${CLAUDE_PLUGIN_ROOT} placeholders', () => {
+    assert.ok(fs.existsSync(HOOKS_JSON), `hooks.json not found at ${HOOKS_JSON}`);
+    const raw = fs.readFileSync(HOOKS_JSON, 'utf8');
+    assert.ok(
+      raw.includes(PLACEHOLDER),
+      'Template hooks.json should keep placeholders so the installer can resolve them at install time'
+    );
+  })) passed++; else failed++;
+
+  // ── 9. repair-hooks.js replaces placeholder in existing settings.json ─────
+
+  if (test('repair-hooks.js replaces ${CLAUDE_PLUGIN_ROOT} in existing settings.json', () => {
+    const dir = createTempDir();
+    try {
+      const settingsPath = path.join(dir, 'settings.json');
+      const fakeRoot = '/fake/ecc/root';
+      const settings = {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  type: 'command',
+                  command: `node "${PLACEHOLDER}/scripts/hooks/run-with-flags.js" "test" "test.js" "standard"`,
+                },
+              ],
+              id: 'test:repair',
+            },
+          ],
+        },
+      };
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+
+      execFileSync(process.execPath, [REPAIR_JS, '--settings', settingsPath], {
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PLUGIN_ROOT: fakeRoot },
+      });
+
+      const repaired = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      const raw = JSON.stringify(repaired);
+      assert.ok(!raw.includes(PLACEHOLDER), 'After repair, placeholder should be gone');
+      assert.ok(raw.includes(fakeRoot), 'After repair, fakeRoot should appear in commands');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  // ── 10. repair-hooks.js --dry-run does not write changes ──────────────────
+
+  if (test('repair-hooks.js --dry-run does not write changes', () => {
+    const dir = createTempDir();
+    try {
+      const settingsPath = path.join(dir, 'settings.json');
+      const original = JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  type: 'command',
+                  command: `node "${PLACEHOLDER}/scripts/hooks/run-with-flags.js" "test" "test.js"`,
+                },
+              ],
+              id: 'test:dryrun',
+            },
+          ],
+        },
+      }, null, 2);
+
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(settingsPath, original, 'utf8');
+
+      execFileSync(process.execPath, [REPAIR_JS, '--dry-run', '--settings', settingsPath], {
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PLUGIN_ROOT: '/some/root' },
+      });
+
+      const after = fs.readFileSync(settingsPath, 'utf8');
+      assert.strictEqual(after, original, 'settings.json must not change in dry-run mode');
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  // ── 11. repair-hooks.js exits cleanly when no placeholders exist ──────────
+
+  if (test('repair-hooks.js exits cleanly when no placeholders found', () => {
+    const dir = createTempDir();
+    try {
+      const settingsPath = path.join(dir, 'settings.json');
+      const alreadyFixed = {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [{ type: 'command', command: 'node /resolved/path/run-with-flags.js' }],
+              id: 'test:noop',
+            },
+          ],
+        },
+      };
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(settingsPath, JSON.stringify(alreadyFixed, null, 2), 'utf8');
+
+      // Should exit 0 without error
+      execFileSync(process.execPath, [REPAIR_JS, '--settings', settingsPath], {
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PLUGIN_ROOT: '/some/root' },
+      });
+    } finally {
+      cleanup(dir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

- **Problem**: All `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, and `SessionStart` hooks use `${CLAUDE_PLUGIN_ROOT}` in their command strings. When this env var is unset (common on Windows, or when hooks run as subprocesses that don't inherit `.bashrc`), every hook silently fails with "file not found" errors.
- **Root cause**: `${CLAUDE_PLUGIN_ROOT}` is a shell variable that only exists if the user's shell profile defines it. Hook subprocesses don't inherit it.
- **Existing partial fix**: Stop/SessionEnd hooks already have an inline fallback (via `INLINE_RESOLVE` from `resolve-ecc-root.js`), but PreToolUse/PostToolUse were never patched.

## Solution

Resolve `${CLAUDE_PLUGIN_ROOT}` **at install time** instead of at runtime:

1. **`scripts/lib/install/apply.js`** — Added `resolvePluginRootInHooks()` that replaces all `${CLAUDE_PLUGIN_ROOT}` placeholders with the actual install path during `buildMergedSettings()`. Exported for testing.
2. **`scripts/repair-hooks.js`** — Standalone repair script for existing installations: `node ~/.claude/scripts/repair-hooks.js [--dry-run]`. Reads `settings.json`, resolves placeholders, writes back.
3. **`tests/hooks/resolve-hook-paths.test.js`** — 11 tests covering both the installer fix and the repair script.

## Test plan

- [x] All 11 new tests pass
- [x] Existing `resolve-ecc-root`, `install-lifecycle`, and `install-state` tests still pass
- [ ] Manual verification: fresh install on Windows without `CLAUDE_PLUGIN_ROOT` set → hooks work
- [ ] Manual verification: `node ~/.claude/scripts/repair-hooks.js --dry-run` shows replacements

Relates to #547, #691

---

Contributed by [Tony Aguilar](https://neuracode.dev) · Sr. Engineer @ Neuracode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bake the absolute plugin root into hook commands at install time to prevent failures when `CLAUDE_PLUGIN_ROOT` is unset. Adds a repair script to fix existing installs and brings all non-Stop hooks in line with the Stop hook behavior.

- **Bug Fixes**
  - Resolve `CLAUDE_PLUGIN_ROOT` during install via `resolvePluginRootInHooks()` inside `buildMergedSettings()`, with Windows path escaping.
  - Added `scripts/repair-hooks.js` to update existing `settings.json` (supports `--dry-run` and `--settings`).
  - Added tests covering installer resolution and the repair script.

<sup>Written for commit 10bb734b2ae62274b6d74382b2f82c8da54a6bc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook command paths are now automatically resolved during installation to point to the correct plugin directory.
  * Added a repair utility that can fix hook paths in existing installations by replacing placeholder references with actual paths.

* **Tests**
  * Added comprehensive test coverage for hook path resolution, including multiple occurrences, edge cases, and repair utility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->