### PR TITLE
ETA-553: Remove buzzword filler from SKILL.md descriptions

### DIFF
--- a/skills/ai-regression-testing/SKILL.md
+++ b/skills/ai-regression-testing/SKILL.md
@@ -12,7 +12,7 @@ Testing patterns specifically designed for AI-assisted development, where the sa
 
 - AI agent (Claude Code, Cursor, Codex) has modified API routes or backend logic
 - A bug was found and fixed — need to prevent re-introduction
-- Project has a sandbox/mock mode that can be leveraged for DB-free testing
+- Project has a sandbox/mock mode that can be used for DB-free testing
 - Running `/bug-check` or similar review commands after code changes
 - Multiple code paths exist (sandbox vs production, feature flags, etc.)
 

--- a/skills/clickhouse-io/SKILL.md
+++ b/skills/clickhouse-io/SKILL.md
@@ -436,4 +436,4 @@ pgClient.on('notification', async (msg) => {
 - Check merge operations
 - Review slow query log
 
-**Remember**: ClickHouse excels at analytical workloads. Design tables for your query patterns, batch inserts, and leverage materialized views for real-time aggregations.
+**Remember**: ClickHouse excels at analytical workloads. Design tables for your query patterns, batch inserts, and use materialized views for real-time aggregations.

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -117,7 +117,7 @@ For each selected category, print the full list of skills below and ask the user
 | `laravel-verification` | Laravel verification: linting, static analysis, tests, security scans |
 | `frontend-patterns` | React, Next.js, state management, performance, UI patterns |
 | `frontend-slides` | Zero-dependency HTML presentations, style previews, and PPTX-to-web conversion |
-| `golang-patterns` | Idiomatic Go patterns, conventions for robust Go applications |
+| `golang-patterns` | Idiomatic Go patterns, conventions for reliable Go applications |
 | `golang-testing` | Go testing: table-driven tests, subtests, benchmarks, fuzzing |
 | `java-coding-standards` | Java coding standards for Spring Boot: naming, immutability, Optional, streams |
 | `python-patterns` | Pythonic idioms, PEP 8, type hints, best practices |

--- a/skills/cpp-coding-standards/SKILL.md
+++ b/skills/cpp-coding-standards/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # C++ Coding Standards (C++ Core Guidelines)
 
-Comprehensive coding standards for modern C++ (C++17/20/23) derived from the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines). Enforces type safety, resource safety, immutability, and clarity.
+Coding standards for modern C++ (C++17/20/23) derived from the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines). Enforces type safety, resource safety, immutability, and clarity.
 
 ## When to Use
 

--- a/skills/data-scraper-agent/SKILL.md
+++ b/skills/data-scraper-agent/SKILL.md
@@ -6,7 +6,7 @@ origin: community
 
 # Data Scraper Agent
 
-Build a production-ready, AI-powered data collection agent for any public data source.
+Build an automated, AI-powered data collection agent for any public data source.
 Runs on a schedule, enriches results with a free LLM, stores to a database, and improves over time.
 
 **Stack: Python · Gemini Flash (free) · GitHub Actions (free) · Notion / Sheets / Supabase**

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Django Security Best Practices
 
-Comprehensive security guidelines for Django applications to protect against common vulnerabilities.
+Security guidelines for Django applications to protect against common vulnerabilities.
 
 ## When to Activate
 

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # E2E Testing Patterns
 
-Comprehensive Playwright patterns for building stable, fast, and maintainable E2E test suites.
+Playwright patterns for building stable, fast, and maintainable E2E test suites.
 
 ## Test File Organization
 

--- a/skills/flutter-dart-code-review/SKILL.md
+++ b/skills/flutter-dart-code-review/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Flutter/Dart Code Review Best Practices
 
-Comprehensive, library-agnostic checklist for reviewing Flutter/Dart applications. These principles apply regardless of which state management solution, routing library, or DI framework is used.
+Library-agnostic checklist for reviewing Flutter/Dart applications. These principles apply regardless of which state management solution, routing library, or DI framework is used.
 
 ---
 
@@ -387,7 +387,7 @@ class UserError extends UserState {
 ### Configuration:
 - [ ] `analysis_options.yaml` present with strict settings enabled
 - [ ] Strict analyzer settings: `strict-casts: true`, `strict-inference: true`, `strict-raw-types: true`
-- [ ] A comprehensive lint rule set is included (very_good_analysis, flutter_lints, or custom strict rules)
+- [ ] A thorough lint rule set is included (very_good_analysis, flutter_lints, or custom strict rules)
 - [ ] All sub-packages in monorepos inherit or share the root analysis options
 
 ### Enforcement:

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -74,7 +74,7 @@ main (production releases)
 ```
 
 **Rules:**
-- `main` contains production-ready code only
+- `main` contains release-ready code only
 - `develop` is the integration branch
 - Feature branches from `develop`, merge back to `develop`
 - Release branches from `develop`, merge to `main` and `develop`

--- a/skills/golang-patterns/SKILL.md
+++ b/skills/golang-patterns/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: golang-patterns
-description: Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.
+description: Idiomatic Go patterns, best practices, and conventions for building reliable, efficient, and maintainable Go applications.
 origin: ECC
 ---
 
 # Go Development Patterns
 
-Idiomatic Go patterns and best practices for building robust, efficient, and maintainable applications.
+Idiomatic Go patterns and best practices for building reliable, efficient, and maintainable applications.
 
 ## When to Activate
 

--- a/skills/golang-testing/SKILL.md
+++ b/skills/golang-testing/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Go Testing Patterns
 
-Comprehensive Go testing patterns for writing reliable, maintainable tests following TDD methodology.
+Go testing patterns for writing reliable, maintainable tests following TDD methodology.
 
 ## When to Activate
 
@@ -71,7 +71,7 @@ func Add(a, b int) int {
 
 ## Table-Driven Tests
 
-The standard pattern for Go tests. Enables comprehensive coverage with minimal code.
+The standard pattern for Go tests. Enables thorough coverage with minimal code.
 
 ```go
 func TestAdd(t *testing.T) {
@@ -682,7 +682,7 @@ go test -count=10 ./...
 
 **DO:**
 - Write tests FIRST (TDD)
-- Use table-driven tests for comprehensive coverage
+- Use table-driven tests for thorough coverage
 - Test behavior, not implementation
 - Use `t.Helper()` in helper functions
 - Use `t.Parallel()` for independent tests

--- a/skills/kotlin-exposed-patterns/SKILL.md
+++ b/skills/kotlin-exposed-patterns/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Kotlin Exposed Patterns
 
-Comprehensive patterns for database access with JetBrains Exposed ORM, including DSL queries, DAO, transactions, and production-ready configuration.
+Patterns for database access with JetBrains Exposed ORM, including DSL queries, DAO, transactions, and tested configuration.
 
 ## When to Use
 

--- a/skills/kotlin-ktor-patterns/SKILL.md
+++ b/skills/kotlin-ktor-patterns/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Ktor Server Patterns
 
-Comprehensive Ktor patterns for building robust, maintainable HTTP servers with Kotlin coroutines.
+Ktor patterns for building reliable, maintainable HTTP servers with Kotlin coroutines.
 
 ## When to Activate
 

--- a/skills/kotlin-patterns/SKILL.md
+++ b/skills/kotlin-patterns/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: kotlin-patterns
-description: Idiomatic Kotlin patterns, best practices, and conventions for building robust, efficient, and maintainable Kotlin applications with coroutines, null safety, and DSL builders.
+description: Idiomatic Kotlin patterns, best practices, and conventions for building reliable, efficient, and maintainable Kotlin applications with coroutines, null safety, and DSL builders.
 origin: ECC
 ---
 
 # Kotlin Development Patterns
 
-Idiomatic Kotlin patterns and best practices for building robust, efficient, and maintainable applications.
+Idiomatic Kotlin patterns and best practices for building reliable, efficient, and maintainable applications.
 
 ## When to Use
 
@@ -53,7 +53,7 @@ suspend fun fetchUserWithPosts(userId: String): UserProfile =
 
 ### 1. Null Safety
 
-Kotlin's type system distinguishes nullable and non-nullable types. Leverage it fully.
+Kotlin's type system distinguishes nullable and non-nullable types. Use it fully.
 
 ```kotlin
 // Good: Use non-nullable types by default
@@ -708,4 +708,4 @@ user?.let { u ->
 user?.address?.city?.let { process(it) }
 ```
 
-**Remember**: Kotlin code should be concise but readable. Leverage the type system for safety, prefer immutability, and use coroutines for concurrency. When in doubt, let the compiler help you.
+**Remember**: Kotlin code should be concise but readable. Use the type system for safety, prefer immutability, and use coroutines for concurrency. When in doubt, let the compiler help you.

--- a/skills/kotlin-testing/SKILL.md
+++ b/skills/kotlin-testing/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Kotlin Testing Patterns
 
-Comprehensive Kotlin testing patterns for writing reliable, maintainable tests following TDD methodology with Kotest and MockK.
+Kotlin testing patterns for writing reliable, maintainable tests following TDD methodology with Kotest and MockK.
 
 ## When to Use
 

--- a/skills/laravel-plugin-discovery/SKILL.md
+++ b/skills/laravel-plugin-discovery/SKILL.md
@@ -216,7 +216,7 @@ The detailed response includes:
 1. **Always filter by health** — Use `health_score: "Healthy"` for production projects
 2. **Match Laravel version** — Always check `laravel_compatibility` matches the target project
 3. **Check vendor reputation** — Prefer packages from known vendors (spatie, laravel, etc.)
-4. **Review before recommending** — Use GetPluginDetailsTool for a comprehensive assessment
+4. **Review before recommending** — Use GetPluginDetailsTool for a detailed assessment
 5. **No API key needed** — The MCP is free, no authentication required
 
 ---

--- a/skills/laravel-security/SKILL.md
+++ b/skills/laravel-security/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Laravel Security Best Practices
 
-Comprehensive security guidance for Laravel applications to protect against common vulnerabilities.
+Security guidance for Laravel applications to protect against common vulnerabilities.
 
 ## When to Activate
 

--- a/skills/perl-patterns/SKILL.md
+++ b/skills/perl-patterns/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: perl-patterns
-description: Modern Perl 5.36+ idioms, best practices, and conventions for building robust, maintainable Perl applications.
+description: Modern Perl 5.36+ idioms, best practices, and conventions for building reliable, maintainable Perl applications.
 origin: ECC
 ---
 
 # Modern Perl Development Patterns
 
-Idiomatic Perl 5.36+ patterns and best practices for building robust, maintainable applications.
+Idiomatic Perl 5.36+ patterns and best practices for building reliable, maintainable applications.
 
 ## When to Activate
 
@@ -501,4 +501,4 @@ use Module::Runtime 'require_module';    # Good: safe module loading
 require_module($module);
 ```
 
-**Remember**: Modern Perl is clean, readable, and safe. Let `use v5.36` handle the boilerplate, use Moo for objects, and prefer CPAN's battle-tested modules over hand-rolled solutions.
+**Remember**: Modern Perl is clean, readable, and safe. Let `use v5.36` handle the boilerplate, use Moo for objects, and prefer CPAN's well-tested modules over hand-rolled solutions.

--- a/skills/perl-security/SKILL.md
+++ b/skills/perl-security/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: perl-security
-description: Comprehensive Perl security covering taint mode, input validation, safe process execution, DBI parameterized queries, web security (XSS/SQLi/CSRF), and perlcritic security policies.
+description: Perl security covering taint mode, input validation, safe process execution, DBI parameterized queries, web security (XSS/SQLi/CSRF), and perlcritic security policies.
 origin: ECC
 ---
 
 # Perl Security Patterns
 
-Comprehensive security guidelines for Perl applications covering input validation, injection prevention, and secure coding practices.
+Security guidelines for Perl applications covering input validation, injection prevention, and secure coding practices.
 
 ## When to Activate
 

--- a/skills/perl-testing/SKILL.md
+++ b/skills/perl-testing/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Perl Testing Patterns
 
-Comprehensive testing strategies for Perl applications using Test2::V0, Test::More, prove, and TDD methodology.
+Testing strategies for Perl applications using Test2::V0, Test::More, prove, and TDD methodology.
 
 ## When to Activate
 

--- a/skills/python-patterns/SKILL.md
+++ b/skills/python-patterns/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: python-patterns
-description: Pythonic idioms, PEP 8 standards, type hints, and best practices for building robust, efficient, and maintainable Python applications.
+description: Pythonic idioms, PEP 8 standards, type hints, and best practices for building reliable, efficient, and maintainable Python applications.
 origin: ECC
 ---
 
 # Python Development Patterns
 
-Idiomatic Python patterns and best practices for building robust, efficient, and maintainable applications.
+Idiomatic Python patterns and best practices for building reliable, efficient, and maintainable applications.
 
 ## When to Activate
 

--- a/skills/python-testing/SKILL.md
+++ b/skills/python-testing/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Python Testing Patterns
 
-Comprehensive testing strategies for Python applications using pytest, TDD methodology, and best practices.
+Testing strategies for Python applications using pytest, TDD methodology, and best practices.
 
 ## When to Activate
 

--- a/skills/pytorch-patterns/SKILL.md
+++ b/skills/pytorch-patterns/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pytorch-patterns
-description: PyTorch deep learning patterns and best practices for building robust, efficient, and reproducible training pipelines, model architectures, and data loading.
+description: PyTorch deep learning patterns and best practices for building reliable, efficient, and reproducible training pipelines, model architectures, and data loading.
 origin: ECC
 ---
 
 # PyTorch Development Patterns
 
-Idiomatic PyTorch patterns and best practices for building robust, efficient, and reproducible deep learning applications.
+Idiomatic PyTorch patterns and best practices for building reliable, efficient, and reproducible deep learning applications.
 
 ## When to Activate
 

--- a/skills/rust-testing/SKILL.md
+++ b/skills/rust-testing/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Rust Testing Patterns
 
-Comprehensive Rust testing patterns for writing reliable, maintainable tests following TDD methodology.
+Rust testing patterns for writing reliable, maintainable tests following TDD methodology.
 
 ## When to Use
 

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -132,7 +132,7 @@ Need: Check markdown files for broken links
 Search: npm "markdown dead link checker"
 Found: textlint-rule-no-dead-link (score: 9/10)
 Action: ADOPT — npm install textlint-rule-no-dead-link
-Result: Zero custom code, battle-tested solution
+Result: Zero custom code, well-tested solution
 ```
 
 ### Example 2: "Add HTTP client wrapper"

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review
-description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
+description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides a detailed security checklist and patterns.
 origin: ECC
 ---
 

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # Test-Driven Development Workflow
 
-This skill ensures all code development follows TDD principles with comprehensive test coverage.
+This skill ensures all code development follows TDD principles with thorough test coverage.
 
 ## When to Activate
 
@@ -72,7 +72,7 @@ so that I can find relevant markets even without exact keywords.
 ```
 
 ### Step 2: Generate Test Cases
-For each user journey, create comprehensive test cases:
+For each user journey, create thorough test cases:
 
 ```typescript
 describe('Semantic Search', () => {

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: verification-loop
-description: "A comprehensive verification system for Claude Code sessions."
+description: "A multi-step verification system for Claude Code sessions."
 origin: ECC
 ---
 
 # Verification Loop Skill
 
-A comprehensive verification system for Claude Code sessions.
+A multi-step verification system for Claude Code sessions.
 
 ## When to Use
 
@@ -123,4 +123,4 @@ Run: /verify
 ## Integration with Hooks
 
 This skill complements PostToolUse hooks but provides deeper verification.
-Hooks catch issues immediately; this skill provides comprehensive review.
+Hooks catch issues immediately; this skill provides full review.


### PR DESCRIPTION
## Why
AI-generated filler words (comprehensive, robust, leverage, battle-tested, production-ready) reduce readability and add no technical value to skill descriptions.

## What
- Replaced 43 instances across 28 SKILL.md files
- comprehensive → thorough/detailed, robust → reliable, leverage → use, battle-tested → well-tested, production-ready → release-ready
- Preserved legitimate domain-specific uses

## How to Test
- `grep -r 'comprehensive\|robust\|leverage\|battle-tested\|production-ready' skills/*/SKILL.md` should return minimal results
- Verify replaced terms read naturally in context

## AI Usage
- AI Tool: Claude Code (Opus 4.6)
- Contribution: 95%
- Satisfaction: 5/5
- Model: claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes buzzword filler in `SKILL.md` files to improve clarity and consistency. Aligns with Linear ETA-553 by standardizing language without changing meaning.

- **Refactors**
  - Replaced 43 instances across 28 `SKILL.md` files
  - Mappings: comprehensive → thorough/detailed; robust → reliable; leverage → use; battle-tested → well-tested; production-ready → release-ready
  - Preserved domain-specific uses; docs-only change

<sup>Written for commit 57d50210c7ec70b2318c15331dab2bc23e4c1769. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined wording across 27 skill guides for improved consistency and clarity, replacing descriptors like "comprehensive" with more precise alternatives ("thorough," "detailed," "multi-step") and updating key phrases such as "robust" to "reliable" and "leverage" to "use."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->