### PR TITLE
ETA-554: Remove blockchain/Solana section from security-review

### DIFF
--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -335,60 +335,7 @@ catch (error) {
 - [ ] Detailed errors only in server logs
 - [ ] No stack traces exposed to users
 
-### 9. Blockchain Security (Solana)
-
-#### Wallet Verification
-```typescript
-import { verify } from '@solana/web3.js'
-
-async function verifyWalletOwnership(
-  publicKey: string,
-  signature: string,
-  message: string
-) {
-  try {
-    const isValid = verify(
-      Buffer.from(message),
-      Buffer.from(signature, 'base64'),
-      Buffer.from(publicKey, 'base64')
-    )
-    return isValid
-  } catch (error) {
-    return false
-  }
-}
-```
-
-#### Transaction Verification
-```typescript
-async function verifyTransaction(transaction: Transaction) {
-  // Verify recipient
-  if (transaction.to !== expectedRecipient) {
-    throw new Error('Invalid recipient')
-  }
-
-  // Verify amount
-  if (transaction.amount > maxAmount) {
-    throw new Error('Amount exceeds limit')
-  }
-
-  // Verify user has sufficient balance
-  const balance = await getBalance(transaction.from)
-  if (balance < transaction.amount) {
-    throw new Error('Insufficient balance')
-  }
-
-  return true
-}
-```
-
-#### Verification Steps
-- [ ] Wallet signatures verified
-- [ ] Transaction details validated
-- [ ] Balance checks before transactions
-- [ ] No blind transaction signing
-
-### 10. Dependency Security
+### 9. Dependency Security
 
 #### Regular Updates
 ```bash
@@ -481,7 +428,6 @@ Before ANY production deployment:
 - [ ] **Row Level Security**: Enabled in Supabase
 - [ ] **CORS**: Properly configured
 - [ ] **File Uploads**: Validated (size, type)
-- [ ] **Wallet Signatures**: Verified (if blockchain)
 
 ## Resources
 


### PR DESCRIPTION
## Why
The security-review skill contained a 54-line Blockchain/Solana audit section that is irrelevant to this project's scope, adding noise to the security review workflow.

## What
- Removed section 9 (Blockchain/Solana Security) from `skills/security-review/SKILL.md`
- Renumbered "Dependency Security" to section 9
- Net -55 lines

## How to Test
- Read `skills/security-review/SKILL.md` — no blockchain references
- Section numbering is sequential (1-9)

## AI Usage
- AI Tool: Claude Code (Opus 4.6)
- Contribution: 95%
- Satisfaction: 5/5
- Model: claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Blockchain/Solana section from `skills/security-review/SKILL.md` to keep the security review focused on our scope and reduce noise. Renumbered "Dependency Security" to section 9 and removed the wallet signatures checklist item, aligning with Linear ETA-554.

<sup>Written for commit b99bff6644d8517b29de6f2003225fb5704bab1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed "Blockchain Security (Solana)" section from security review guidance, including wallet verification examples and related checklist items.
  * Reorganized remaining sections with updated numbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->