### PR TITLE
ETA-555: Add error logging to bare catch blocks

### DIFF
--- a/scripts/hooks/auto-tmux-dev.js
+++ b/scripts/hooks/auto-tmux-dev.js
@@ -80,8 +80,9 @@ process.stdin.on('end', () => {
       }
     }
     process.stdout.write(JSON.stringify(input));
-  } catch {
+  } catch (err) {
     // Invalid input — pass through original data unchanged
+    console.error('[AutoTmuxDev]', err.message || err);
     process.stdout.write(data);
   }
   process.exit(0);

--- a/scripts/hooks/config-protection.js
+++ b/scripts/hooks/config-protection.js
@@ -65,7 +65,8 @@ function parseInput(inputOrRaw) {
   if (typeof inputOrRaw === 'string') {
     try {
       return inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {};
-    } catch {
+    } catch (err) {
+      console.error('[ConfigProtection]', err.message || err);
       return {};
     }
   }

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -70,8 +70,9 @@ process.stdin.on('end', () => {
     };
 
     appendFile(path.join(metricsDir, 'costs.jsonl'), `${JSON.stringify(row)}\n`);
-  } catch {
+  } catch (err) {
     // Keep hook non-blocking.
+    console.error('[CostTracker]', err.message || err);
   }
 
   process.stdout.write(raw);

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -28,7 +28,8 @@ let isWSL = false;
 if (process.platform === 'linux') {
   try {
     isWSL = require('fs').readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
-  } catch {
+  } catch (err) {
+    console.error('[DesktopNotify]', err.message || err);
     isWSL = false;
   }
 }
@@ -54,7 +55,8 @@ function findPowerShell() {
       if (result.status === 0) {
         return path;
       }
-    } catch {
+    } catch (err) {
+      console.error('[DesktopNotify]', err.message || err);
       // continue
     }
   }

--- a/scripts/hooks/doc-file-warning.js
+++ b/scripts/hooks/doc-file-warning.js
@@ -51,6 +51,7 @@ function run(inputOrRaw, _options = {}) {
       ? (inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {})
       : (inputOrRaw || {});
   } catch {
+    // Non-JSON input is expected (hooks receive varied payloads) — silent no-op.
     return { exitCode: 0 };
   }
   const filePath = String(input?.tool_input?.file_path || '');

--- a/scripts/hooks/evaluate-session.js
+++ b/scripts/hooks/evaluate-session.js
@@ -47,7 +47,8 @@ async function main() {
   try {
     const input = JSON.parse(stdinData);
     transcriptPath = input.transcript_path;
-  } catch {
+  } catch (err) {
+    console.error('[ContinuousLearning]', err.message || err);
     // Fallback: try env var for backwards compatibility
     transcriptPath = process.env.CLAUDE_TRANSCRIPT_PATH;
   }

--- a/scripts/hooks/governance-capture.js
+++ b/scripts/hooks/governance-capture.js
@@ -287,8 +287,9 @@ function run(rawInput, options = {}) {
         emitGovernanceEvent(event);
       }
     }
-  } catch {
-    // Silently ignore parse errors — never block the tool pipeline.
+  } catch (err) {
+    // Never block the tool pipeline.
+    console.error('[GovernanceCapture]', err.message || err);
   }
 
   return rawInput;

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -69,7 +69,8 @@ function configPaths() {
 function readJsonFile(filePath) {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
+  } catch (err) {
+    console.error('[MCPHealthCheck]', err.message || err);
     return null;
   }
 }
@@ -91,8 +92,9 @@ function saveState(filePath, state) {
   try {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, JSON.stringify(state, null, 2));
-  } catch {
+  } catch (err) {
     // Never block the hook on state persistence errors.
+    console.error('[MCPHealthCheck]', err.message || err);
   }
 }
 
@@ -120,7 +122,8 @@ function readRawStdin() {
 function safeParse(raw) {
   try {
     return raw.trim() ? JSON.parse(raw) : {};
-  } catch {
+  } catch (err) {
+    console.error('[MCPHealthCheck]', err.message || err);
     return {};
   }
 }
@@ -354,15 +357,15 @@ function probeCommandServer(serverName, config) {
     const timer = setTimeout(() => {
       try {
         child.kill('SIGTERM');
-      } catch {
-        // ignore
+      } catch (err) {
+        console.error('[MCPHealthCheck]', err.message || err);
       }
 
       setTimeout(() => {
         try {
           child.kill('SIGKILL');
-        } catch {
-          // ignore
+        } catch (err) {
+          console.error('[MCPHealthCheck]', err.message || err);
         }
       }, 200).unref?.();
 

--- a/scripts/hooks/post-bash-build-complete.js
+++ b/scripts/hooks/post-bash-build-complete.js
@@ -19,8 +19,8 @@ process.stdin.on('end', () => {
     if (/(npm run build|pnpm build|yarn build)/.test(cmd)) {
       console.error('[Hook] Build completed - async analysis running in background');
     }
-  } catch {
-    // ignore parse errors and pass through
+  } catch (err) {
+    console.error('[PostBashBuildComplete]', err.message || err);
   }
 
   process.stdout.write(raw);

--- a/scripts/hooks/post-bash-pr-created.js
+++ b/scripts/hooks/post-bash-pr-created.js
@@ -28,8 +28,8 @@ process.stdin.on('end', () => {
         console.error(`[Hook] To review: gh pr review ${prNum} --repo ${repo}`);
       }
     }
-  } catch {
-    // ignore parse errors and pass through
+  } catch (err) {
+    console.error('[PostBashPrCreated]', err.message || err);
   }
 
   process.stdout.write(raw);

--- a/scripts/hooks/post-edit-console-warn.js
+++ b/scripts/hooks/post-edit-console-warn.js
@@ -45,8 +45,9 @@ process.stdin.on('end', () => {
         console.error('[Hook] Remove console.log before committing');
       }
     }
-  } catch {
+  } catch (err) {
     // Invalid input — pass through
+    console.error('[PostEditConsoleWarn]', err.message || err);
   }
 
   process.stdout.write(data);

--- a/scripts/hooks/post-edit-format.js
+++ b/scripts/hooks/post-edit-format.js
@@ -76,12 +76,14 @@ function run(rawInput) {
             timeout: 15000
           });
         }
-      } catch {
+      } catch (err) {
         // Formatter not installed, file missing, or failed — non-blocking
+        console.error('[PostEditFormat]', err.message || err);
       }
     }
-  } catch {
+  } catch (err) {
     // Invalid input — pass through
+    console.error('[PostEditFormat]', err.message || err);
   }
 
   return rawInput;

--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -87,8 +87,9 @@ process.stdin.on("end", () => {
         }
       }
     }
-  } catch {
+  } catch (err) {
     // Invalid input — pass through
+    console.error('[PostEditTypecheck]', err.message || err);
   }
 
   process.stdout.write(data);

--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -125,8 +125,9 @@ function findFileIssues(filePath) {
         }
       }
     });
-  } catch {
+  } catch (err) {
     // File not readable, skip
+    console.error('[PreBashCommitQuality]', err.message || err);
   }
   
   return issues;
@@ -237,8 +238,9 @@ function runLinter(files) {
           output: result.stdout || result.stderr
         };
       }
-    } catch {
+    } catch (err) {
       // Pylint not available
+      console.error('[PreBashCommitQuality]', err.message || err);
     }
   }
   
@@ -258,8 +260,9 @@ function runLinter(files) {
           output: result.stdout
         };
       }
-    } catch {
+    } catch (err) {
       // golint not available
+      console.error('[PreBashCommitQuality]', err.message || err);
     }
   }
   

--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -179,8 +179,8 @@ process.stdin.on('end', () => {
         process.exit(2);
       }
     }
-  } catch {
-    // ignore parse errors and pass through
+  } catch (err) {
+    console.error('[PreBashDevServerBlock]', err.message || err);
   }
 
   process.stdout.write(raw);

--- a/scripts/hooks/pre-bash-git-push-reminder.js
+++ b/scripts/hooks/pre-bash-git-push-reminder.js
@@ -20,8 +20,8 @@ process.stdin.on('end', () => {
       console.error('[Hook] Review changes before push...');
       console.error('[Hook] Continuing with push (remove this hook to add interactive review)');
     }
-  } catch {
-    // ignore parse errors and pass through
+  } catch (err) {
+    console.error('[PreBashGitPushReminder]', err.message || err);
   }
 
   process.stdout.write(raw);

--- a/scripts/hooks/pre-bash-tmux-reminder.js
+++ b/scripts/hooks/pre-bash-tmux-reminder.js
@@ -25,8 +25,8 @@ process.stdin.on('end', () => {
       console.error('[Hook] Consider running in tmux for session persistence');
       console.error('[Hook] tmux new -s dev  |  tmux attach -t dev');
     }
-  } catch {
-    // ignore parse errors and pass through
+  } catch (err) {
+    console.error('[PreBashTmuxReminder]', err.message || err);
   }
 
   process.stdout.write(raw);

--- a/scripts/hooks/quality-gate.js
+++ b/scripts/hooks/quality-gate.js
@@ -142,8 +142,8 @@ function run(rawInput) {
     const input = JSON.parse(rawInput);
     const filePath = String(input.tool_input?.file_path || '');
     maybeRunQualityGate(filePath);
-  } catch {
-    // Ignore parse errors.
+  } catch (err) {
+    console.error('[QualityGate]', err.message || err);
   }
   return rawInput;
 }

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -90,7 +90,8 @@ function extractSessionSummary(transcriptPath) {
           }
         }
       }
-    } catch {
+    } catch (err) {
+      console.error('[SessionEnd]', err.message || err);
       parseErrors++;
     }
   }
@@ -183,7 +184,8 @@ async function main() {
   try {
     const input = JSON.parse(stdinData);
     transcriptPath = input.transcript_path;
-  } catch {
+  } catch (err) {
+    console.error('[SessionEnd]', err.message || err);
     // Fallback: try env var for backwards compatibility
     transcriptPath = process.env.CLAUDE_TRANSCRIPT_PATH;
   }

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -56,8 +56,9 @@ async function main() {
     } finally {
       fs.closeSync(fd);
     }
-  } catch {
+  } catch (err) {
     // Fallback: just use writeFile if fd operations fail
+    console.error('[SuggestCompact]', err.message || err);
     writeFile(counterFile, String(count));
   }
 

--- a/scripts/lib/agent-compress.js
+++ b/scripts/lib/agent-compress.js
@@ -25,8 +25,9 @@ function parseFrontmatter(content) {
     if (value.startsWith('[') && value.endsWith(']')) {
       try {
         value = JSON.parse(value);
-      } catch {
+      } catch (err) {
         // keep as string
+        console.error('[AgentCompress]', err.message || err);
       }
     }
 

--- a/scripts/lib/package-manager.js
+++ b/scripts/lib/package-manager.js
@@ -71,7 +71,8 @@ function loadConfig() {
   if (content) {
     try {
       return JSON.parse(content);
-    } catch {
+    } catch (err) {
+      console.error('[PackageManager]', err.message || err);
       return null;
     }
   }
@@ -118,8 +119,9 @@ function detectFromPackageJson(projectDir = process.cwd()) {
           return pmName;
         }
       }
-    } catch {
+    } catch (err) {
       // Invalid package.json
+      console.error('[PackageManager]', err.message || err);
     }
   }
   return null;
@@ -186,8 +188,9 @@ function getPackageManager(options = {}) {
           source: 'project-config'
         };
       }
-    } catch {
+    } catch (err) {
       // Invalid config
+      console.error('[PackageManager]', err.message || err);
     }
   }
 

--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -131,7 +131,8 @@ const FRAMEWORK_RULES = [
 function fileExists(projectDir, filePath) {
   try {
     return fs.existsSync(path.join(projectDir, filePath));
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return false;
   }
 }
@@ -150,7 +151,8 @@ function hasFileWithExtension(projectDir, extensions) {
       const ext = path.extname(entry.name);
       return extensions.includes(ext);
     });
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return false;
   }
 }
@@ -166,7 +168,8 @@ function getPackageJsonDeps(projectDir) {
     if (!fs.existsSync(pkgPath)) return [];
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
     return [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.devDependencies || {})];
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return [];
   }
 }
@@ -195,8 +198,8 @@ function getPythonDeps(projectDir) {
         }
       });
     }
-  } catch {
-    /* ignore */
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
   }
 
   // pyproject.toml — simple extraction of dependency names
@@ -217,8 +220,8 @@ function getPythonDeps(projectDir) {
         });
       }
     }
-  } catch {
-    /* ignore */
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
   }
 
   return deps;
@@ -246,7 +249,8 @@ function getGoDeps(projectDir) {
       });
     }
     return deps;
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return [];
   }
 }
@@ -275,7 +279,8 @@ function getRustDeps(projectDir) {
       });
     }
     return deps;
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return [];
   }
 }
@@ -291,7 +296,8 @@ function getComposerDeps(projectDir) {
     if (!fs.existsSync(composerPath)) return [];
     const composer = JSON.parse(fs.readFileSync(composerPath, 'utf8'));
     return [...Object.keys(composer.require || {}), ...Object.keys(composer['require-dev'] || {})];
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return [];
   }
 }
@@ -312,7 +318,8 @@ function getElixirDeps(projectDir) {
       matches.forEach(m => deps.push(m.replace('{:', '')));
     }
     return deps;
-  } catch {
+  } catch (err) {
+    console.error('[ProjectDetect]', err.message || err);
     return [];
   }
 }

--- a/scripts/lib/resolve-ecc-root.js
+++ b/scripts/lib/resolve-ecc-root.js
@@ -66,7 +66,8 @@ function resolveEccRoot(options = {}) {
       let versionDirs;
       try {
         versionDirs = fs.readdirSync(orgPath, { withFileTypes: true });
-      } catch {
+      } catch (err) {
+        console.error('[ResolveEccRoot]', err.message || err);
         continue;
       }
 
@@ -78,8 +79,9 @@ function resolveEccRoot(options = {}) {
         }
       }
     }
-  } catch {
+  } catch (err) {
     // Plugin cache doesn't exist or isn't readable — continue to fallback
+    console.error('[ResolveEccRoot]', err.message || err);
   }
 
   return claudeDir;

--- a/scripts/lib/resolve-formatter.js
+++ b/scripts/lib/resolve-formatter.js
@@ -100,8 +100,9 @@ function detectFormatter(projectRoot) {
         return 'prettier';
       }
     }
-  } catch {
+  } catch (err) {
     // Malformed package.json — continue to file-based detection
+    console.error('[ResolveFormatter]', err.message || err);
   }
 
   for (const cfg of PRETTIER_CONFIGS) {

--- a/scripts/lib/session-adapters/canonical-session.js
+++ b/scripts/lib/session-adapters/canonical-session.js
@@ -285,7 +285,8 @@ function readExistingRecording(filePath) {
 
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
+  } catch (err) {
+    console.error('[CanonicalSession]', err.message || err);
     return null;
   }
 }

--- a/scripts/lib/session-aliases.js
+++ b/scripts/lib/session-aliases.js
@@ -142,8 +142,9 @@ function saveAliases(aliases) {
       if (fs.existsSync(tempPath)) {
         fs.unlinkSync(tempPath);
       }
-    } catch {
+    } catch (err) {
       // Non-critical: temp file will be overwritten on next save
+      console.error('[SessionAliases]', err.message || err);
     }
 
     return false;

--- a/scripts/lib/session-manager.js
+++ b/scripts/lib/session-manager.js
@@ -443,7 +443,8 @@ function getSessionSize(sessionPath) {
   let stats;
   try {
     stats = fs.statSync(sessionPath);
-  } catch {
+  } catch (err) {
+    console.error('[SessionManager]', err.message || err);
     return '0 B';
   }
   const size = stats.size;
@@ -511,7 +512,8 @@ function deleteSession(sessionPath) {
 function sessionExists(sessionPath) {
   try {
     return fs.statSync(sessionPath).isFile();
-  } catch {
+  } catch (err) {
+    console.error('[SessionManager]', err.message || err);
     return false;
   }
 }

--- a/scripts/lib/skill-evolution/tracker.js
+++ b/scripts/lib/skill-evolution/tracker.js
@@ -95,8 +95,9 @@ function readJsonl(filePath) {
     .reduce((rows, line) => {
       try {
         rows.push(JSON.parse(line));
-      } catch {
+      } catch (err) {
         // Ignore malformed rows so analytics remain best-effort.
+        console.error('[SkillTracker]', err.message || err);
       }
       return rows;
     }, []);
@@ -113,8 +114,9 @@ function recordSkillExecution(input, options = {}) {
         record,
         result,
       };
-    } catch {
+    } catch (err) {
       // Fall back to JSONL until the formal state-store exists on this branch.
+      console.error('[SkillTracker]', err.message || err);
     }
   }
 

--- a/scripts/lib/skill-evolution/versioning.js
+++ b/scripts/lib/skill-evolution/versioning.js
@@ -144,8 +144,9 @@ function readJsonl(filePath) {
     .reduce((rows, line) => {
       try {
         rows.push(JSON.parse(line));
-      } catch {
+      } catch (err) {
         // Ignore malformed rows so the log remains append-only and resilient.
+        console.error('[SkillVersioning]', err.message || err);
       }
       return rows;
     }, []);

--- a/scripts/lib/skill-improvement/observations.js
+++ b/scripts/lib/skill-improvement/observations.js
@@ -90,7 +90,8 @@ function readSkillObservations(options = {}) {
     .map(line => {
       try {
         return JSON.parse(line);
-      } catch {
+      } catch (err) {
+        console.error('[SkillObservations]', err.message || err);
         return null;
       }
     })

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -227,7 +227,8 @@ function findFiles(dir, pattern, options = {}) {
           let stats;
           try {
             stats = fs.statSync(fullPath);
-          } catch {
+          } catch (err) {
+            console.error('[Utils]', err.message || err);
             continue; // File deleted between readdir and stat
           }
 
@@ -281,7 +282,8 @@ async function readStdinJson(options = {}) {
         // Resolve with whatever we have so far rather than hanging
         try {
           resolve(data.trim() ? JSON.parse(data) : {});
-        } catch {
+        } catch (err) {
+          console.error('[Utils]', err.message || err);
           resolve({});
         }
       }
@@ -300,9 +302,10 @@ async function readStdinJson(options = {}) {
       clearTimeout(timer);
       try {
         resolve(data.trim() ? JSON.parse(data) : {});
-      } catch {
+      } catch (err) {
         // Consistent with timeout path: resolve with empty object
         // so hooks don't crash on malformed input
+        console.error('[Utils]', err.message || err);
         resolve({});
       }
     });
@@ -341,7 +344,8 @@ function output(data) {
 function readFile(filePath) {
   try {
     return fs.readFileSync(filePath, 'utf8');
-  } catch {
+  } catch (err) {
+    console.error('[Utils]', err.message || err);
     return null;
   }
 }
@@ -381,7 +385,8 @@ function commandExists(cmd) {
       const result = spawnSync('which', [cmd], { stdio: 'pipe' });
       return result.status === 0;
     }
-  } catch {
+  } catch (err) {
+    console.error('[Utils]', err.message || err);
     return false;
   }
 }
@@ -451,8 +456,9 @@ function getGitModifiedFiles(patterns = []) {
       if (typeof pattern !== 'string' || pattern.length === 0) continue;
       try {
         compiled.push(new RegExp(pattern));
-      } catch {
+      } catch (err) {
         // Skip invalid regex patterns
+        console.error('[Utils]', err.message || err);
       }
     }
     if (compiled.length > 0) {
@@ -515,7 +521,8 @@ function countInFile(filePath, pattern) {
     } else {
       return 0;
     }
-  } catch {
+  } catch (err) {
+    console.error('[Utils]', err.message || err);
     return 0; // Invalid regex pattern
   }
   const matches = content.match(regex);
@@ -558,7 +565,8 @@ function grepFile(filePath, pattern) {
     } else {
       regex = new RegExp(pattern);
     }
-  } catch {
+  } catch (err) {
+    console.error('[Utils]', err.message || err);
     return []; // Invalid regex pattern
   }
   const lines = content.split('\n');


### PR DESCRIPTION
## Why
56 bare catch blocks across hook and lib scripts silently swallowed errors, making debugging impossible when hooks failed.

## What
- Added `console.error('[ModuleName]', err.message || err)` to 56 bare catch blocks
- 32 files modified across `scripts/hooks/` and `scripts/lib/`
- Each log includes the module name prefix for easy grep-based debugging

## How to Test
- `node tests/run-all.js` — all tests pass
- `grep -rn "catch" scripts/ | grep -v "console.error\|err\|error"` should show minimal unlogged catches

## AI Usage
- AI Tool: Claude Code (Opus 4.6)
- Contribution: 90%
- Satisfaction: 4/5
- Model: claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add error logging to previously bare catch blocks across hooks and libs to surface hidden failures and improve debugging. Meets Linear ETA-555 by stopping silent error swallowing without changing non-blocking behavior.

- **Bug Fixes**
  - Added `console.error` in 56 catch blocks across 32 files under `scripts/hooks/` and `scripts/lib/`.
  - Prefixed logs with module tags (e.g., `[MCPHealthCheck]`) for easy grep and tracing.
  - Hooks still pass input through and remain non-blocking on non-critical errors.

<sup>Written for commit 021d78a0697dec546caa0436e27d145668dc505d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error reporting across processing hooks and utilities—errors occurring during data parsing, file operations, and command execution are now logged with contextual details instead of being silently ignored, improving troubleshooting and system diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->