### PR TITLE
ETA-560: Extract shared readJson() utility

### DIFF
--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { readJson } = require('./json-utils');
 const { planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
@@ -63,14 +64,6 @@ const LEGACY_LANGUAGE_EXTRA_MODULE_IDS = Object.freeze({
   swift: [],
   typescript: ['framework-language'],
 });
-
-function readJson(filePath, label) {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch (error) {
-    throw new Error(`Failed to read ${label}: ${error.message}`);
-  }
-}
 
 function dedupeStrings(values) {
   return [...new Set((Array.isArray(values) ? values : []).map(value => String(value).trim()).filter(Boolean))];

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { readJson } = require('./json-utils');
 
 let Ajv = null;
 try {
@@ -21,14 +22,6 @@ function cloneJsonValue(value) {
   }
 
   return JSON.parse(JSON.stringify(value));
-}
-
-function readJson(filePath, label) {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch (error) {
-    throw new Error(`Failed to read ${label}: ${error.message}`);
-  }
 }
 
 function getValidator() {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -3,22 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { readJsonObject } = require('../json-utils');
 const { writeInstallState } = require('../install-state');
-
-function readJsonObject(filePath, label) {
-  let parsed;
-  try {
-    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch (error) {
-    throw new Error(`Failed to parse ${label} at ${filePath}: ${error.message}`);
-  }
-
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`Invalid ${label} at ${filePath}: expected a JSON object`);
-  }
-
-  return parsed;
-}
 
 function mergeHookEntries(existingEntries, incomingEntries) {
   const mergedEntries = [];

--- a/scripts/lib/install/config.js
+++ b/scripts/lib/install/config.js
@@ -3,19 +3,12 @@
 const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
+const { readJson } = require('../json-utils');
 
 const DEFAULT_INSTALL_CONFIG = 'ecc-install.json';
 const CONFIG_SCHEMA_PATH = path.join(__dirname, '..', '..', '..', 'schemas', 'ecc-install-config.schema.json');
 
 let cachedValidator = null;
-
-function readJson(filePath, label) {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch (error) {
-    throw new Error(`Invalid JSON in ${label}: ${error.message}`);
-  }
-}
 
 function getValidator() {
   if (cachedValidator) {

--- a/scripts/lib/json-utils.js
+++ b/scripts/lib/json-utils.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Read and parse a JSON file synchronously.
+ * @param {string} filePath - Absolute path to the JSON file.
+ * @param {string} label - Human-readable label used in error messages.
+ * @returns {*} The parsed JSON value.
+ */
+function readJson(filePath, label) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Failed to read ${label}: ${error.message}`);
+  }
+}
+
+/**
+ * Read and parse a JSON file, asserting the result is a plain object.
+ * @param {string} filePath - Absolute path to the JSON file.
+ * @param {string} label - Human-readable label used in error messages.
+ * @returns {Object} The parsed JSON object.
+ */
+function readJsonObject(filePath, label) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Failed to parse ${label} at ${filePath}: ${error.message}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Invalid ${label} at ${filePath}: expected a JSON object`);
+  }
+
+  return parsed;
+}
+
+module.exports = {
+  readJson,
+  readJsonObject,
+};


### PR DESCRIPTION
## Why
Four modules (install-manifests.js, install-state.js, install/apply.js, install/config.js) each had their own copy of a try/catch JSON file reader, creating duplication and inconsistent error handling.

## What
- Created `scripts/lib/json-utils.js` with shared `readJson()` and `readJsonObject()`
- Updated 4 consumers to use the shared utility
- Net +8 lines (43 new utility, -35 removed duplicates)

## How to Test
- `node tests/run-all.js`
- `node -e "const {readJson} = require('./scripts/lib/json-utils'); console.log(typeof readJson)"` → function

## AI Usage
- AI Tool: Claude Code (Opus 4.6)
- Contribution: 90%
- Satisfaction: 4/5
- Model: claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared JSON read helpers to remove duplicated parsing and unify error handling across install scripts. Implements ETA-560 by centralizing `readJson()`/`readJsonObject()` and simplifying four modules.

- **Refactors**
  - Added `scripts/lib/json-utils.js` with `readJson()` and `readJsonObject()`.
  - Replaced local readers in `scripts/lib/install-manifests.js`, `scripts/lib/install-state.js`, `scripts/lib/install/apply.js`, and `scripts/lib/install/config.js`.
  - Standardized error messages and object validation.

<sup>Written for commit 578cdd1ecb2b7dbdb48c2e2fba294e95ef57b6fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal JSON parsing utilities into a shared module to reduce code duplication and improve maintainability across installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->