### PR TITLE
fix(clv2): add POSIX mkdir fallback for observer lazy-start on macOS

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -352,7 +352,7 @@ if [ "$OBSERVER_ENABLED" = "true" ]; then
         fi
       ) 9>"$LAZY_START_LOCK"
     else
-      # macOS fallback: use lockfile if available, otherwise skip
+      # macOS fallback: use lockfile if available, otherwise mkdir-based lock
       if command -v lockfile >/dev/null 2>&1; then
         # Use subshell to isolate exit and add trap for cleanup
         (
@@ -364,6 +364,17 @@ if [ "$OBSERVER_ENABLED" = "true" ]; then
             nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
           fi
           rm -f "$LAZY_START_LOCK" 2>/dev/null || true
+        )
+      else
+        # POSIX fallback: mkdir is atomic -- fails if dir already exists
+        (
+          trap 'rmdir "${LAZY_START_LOCK}.d" 2>/dev/null || true' EXIT
+          mkdir "${LAZY_START_LOCK}.d" 2>/dev/null || exit 0
+          _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
+          _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
+          if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+            nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
+          fi
         )
       fi
     fi


### PR DESCRIPTION
## Summary

- On a fresh macOS install, neither `flock` (Linux) nor `lockfile` (procmail) is available
- The observer lazy-start in `observe.sh` silently skips, leaving observations unanalyzed and **no instincts generated**
- Adds a `mkdir`-based atomic lock as the final POSIX fallback — `mkdir` fails atomically if the directory already exists, providing the same race-condition safety

## Problem

```bash
# observe.sh line 343-369 (before this fix)
if command -v flock; then       # Linux → OK
elif command -v lockfile; then  # macOS + procmail → OK
else
  # macOS default → silently skips observer start ← BUG
fi
```

This was first noted in PR #890 but never addressed as a separate fix.

## Solution

```bash
else
  # POSIX fallback: mkdir is atomic -- fails if dir already exists
  (
    trap 'rmdir "${LAZY_START_LOCK}.d" 2>/dev/null || true' EXIT
    mkdir "${LAZY_START_LOCK}.d" 2>/dev/null || exit 0
    # ... double-check PID files, then start observer
  )
fi
```

- Uses `mkdir` which is POSIX-standard and available on all platforms
- Lock directory is cleaned up via `trap EXIT`
- No new dependencies required

## Test plan

- [ ] Verify on macOS without `flock`/`lockfile`: observer starts automatically after observations accumulate
- [ ] Verify on Linux with `flock`: existing behavior unchanged
- [ ] Verify concurrent `observe.sh` calls: only one observer instance starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes observer lazy-start on macOS by adding a POSIX `mkdir`-based atomic lock when neither `flock` nor `lockfile` is available. Prevents silent skips, ensures only one observer starts, and keeps Linux behavior unchanged with no new dependencies.

<sup>Written for commit 1e0f7739b9150d29d775d991f93a24105f5fabf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS system stability by enhancing the observer process initialization with a more robust fallback locking mechanism, ensuring reliable operation when standard utilities are unavailable and preventing duplicate background processes from launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->