### PR TITLE
docs(ja): add ECC guide set

### DIFF
--- a/docs/ja-JP/ECC-APPENDIX.md
+++ b/docs/ja-JP/ECC-APPENDIX.md
@@ -1,0 +1,188 @@
+# ECC 付録
+
+読むべき人: agents / MCP / rules / hooks / install profile の位置づけを知りたい人  
+読むタイミング: 最小構成を決めるとき、拡張を足す前  
+3行要約:
+- ECC の補助面は `agents` `MCP` `rules` `hooks` `profiles` で構成される。
+- 最初は全部有効にせず、運用コストの低いものから入れるのがよい。
+- 本付録は「何を足すと何が増えるか」を判断するための資料。
+
+## Agents 一覧
+
+36 agent のうち、初期運用でよく触るものを先頭に置いています。
+
+| Agent | 役割 | 使う場面 |
+|---|---|---|
+| `planner` | 実装計画作成 | 新機能、複雑な修正 |
+| `architect` | 設計判断と拡張性検討 | 大きい構造変更 |
+| `tdd-guide` | テスト先行の実装支援 | 機能追加、バグ修正 |
+| `code-reviewer` | 総合コードレビュー | 実装直後 |
+| `security-reviewer` | OWASP 系の security review | 認証、入力、秘密、API |
+| `build-error-resolver` | build / type error の最小差分修正 | とにかく build を通したい時 |
+| `doc-updater` | docs / codemap 更新 | 実装後の文書更新 |
+| `docs-lookup` | Context7 経由の最新 docs 参照 | API / setup 調査 |
+| `e2e-runner` | E2E 生成・実行 | 重要ユーザーフロー確認 |
+| `refactor-cleaner` | 死コード・重複の整理 | 負債返済 |
+| `harness-optimizer` | ハーネス設定の見直し | reliability / cost 改善 |
+| `loop-operator` | 自律 loop の管理 | loop 運用 |
+| `python-reviewer` | Python 専門レビュー | Python 変更 |
+| `go-reviewer` | Go 専門レビュー | Go 変更 |
+| `go-build-resolver` | Go build 修正 | Go build failure |
+| `java-reviewer` | Java / Spring レビュー | Java 変更 |
+| `java-build-resolver` | Java build 修正 | Maven / Gradle failure |
+| `kotlin-reviewer` | Kotlin / Android / KMP レビュー | Kotlin 変更 |
+| `kotlin-build-resolver` | Kotlin build 修正 | Kotlin compile failure |
+| `rust-reviewer` | Rust 専門レビュー | Rust 変更 |
+| `rust-build-resolver` | Rust build 修正 | cargo build failure |
+| `cpp-reviewer` | C++ 専門レビュー | C++ 変更 |
+| `cpp-build-resolver` | C++ build 修正 | CMake / linker failure |
+| `typescript-reviewer` | TS / JS レビュー | TypeScript / JavaScript 変更 |
+| `pytorch-build-resolver` | PyTorch / CUDA エラー修正 | training / inference crash |
+| `database-reviewer` | PostgreSQL / Supabase 観点の DB review | schema / migration / SQL |
+| `flutter-reviewer` | Flutter / Dart レビュー | Flutter 変更 |
+| `performance-optimizer` | 性能改善 | perf 問題がある時 |
+| `gan-planner` | GAN harness の設計側 | one-line prompt から仕様化 |
+| `gan-generator` | GAN harness の実装側 | evaluator feedback を受けて実装 |
+| `gan-evaluator` | GAN harness の評価側 | 実アプリを採点 |
+| `opensource-forker` | OSS 公開用 fork 作成 | private repo の公開準備 |
+| `opensource-sanitizer` | OSS 公開前 sanitization | secret / PII 検査 |
+| `opensource-packager` | OSS 公開 packaging | README / LICENSE / template 整備 |
+| `chief-of-staff` | コミュニケーション運用補助 | email / Slack / LINE / Messenger |
+| `healthcare-reviewer` | 医療ソフト安全性 review | healthcare アプリ変更 |
+
+## 既定 6 MCP
+
+ECC ルートの `.mcp.json` に最初から入っている構成です。
+
+| MCP | 何ができるか | 効果 | 前提 / 注意 |
+|---|---|---|---|
+| `github` | repo、issue、PR を読む / 操作する | GitHub 調査や PR ベースの作業が速い | token や認証設定が必要になることがある |
+| `context7` | ライブラリ / framework の最新 docs を引く | 古い記憶より最新 API に寄せられる | docs lookup が主用途 |
+| `exa` | Web を広く検索する | 公式 docs 外の比較調査に強い | 外部検索に依存 |
+| `memory` | セッション横断の記憶 | 継続作業の説明コストを下げる | 初期段階では必須ではない |
+| `playwright` | ブラウザ操作と検証 | E2E、UI 確認、録画ができる | ブラウザ環境依存 |
+| `sequential-thinking` | 段階的な推論補助 | 複雑タスクの分解がしやすい | 常時必須ではない |
+
+### 今回の導入方針
+
+- 採用はする
+- ただし常用するのは `github` `context7` `exa` が中心
+- `memory` `playwright` `sequential-thinking` は、必要になった時だけ前に出す
+
+## Rules
+
+`RULES.md` と `rules/` は、AI が常に守るべき行動原則の層です。
+
+### 中核の考え方
+
+- specialized agent を使う
+- テスト先行と重要経路の検証を守る
+- 入力検証と security を崩さない
+- mutation より immutable update を好む
+- 既存 repo パターンを優先する
+- 変更は小さくレビューしやすく保つ
+
+### 最小構成で入れる rules
+
+- `rules/common`
+- `rules/typescript`
+- `rules/python`
+
+### すぐに入れなくてよい rules
+
+- 使わない言語群
+- まだ触っていない framework / domain の rules
+
+## Hooks
+
+`hooks/hooks.json` には、Claude Code 向けの runtime automation が入っています。  
+代表的なものは次です。
+
+- `pre:bash:block-no-verify`: `--no-verify` の禁止
+- `pre:bash:auto-tmux-dev`: dev server を tmux 起動
+- `pre:bash:commit-quality`: commit 前品質確認
+- `pre:edit-write:suggest-compact`: compaction の提案
+- `pre:observe:continuous-learning`: continuous learning の観測
+- `pre:config-protection`: lint / format 設定の無効化を防ぐ
+- `pre:mcp-health-check`: MCP の健康確認
+- `session:start`: 前回文脈と package manager の読み込み
+- `post:quality-gate`: edit 後品質確認
+- `post:edit:accumulator`: 編集ファイル蓄積
+- `post:bash:command-log-audit`: bash command の監査ログ
+
+### なぜ初期導入で外しやすいか
+
+- 挙動の変化点が多い
+- 問題が出た時の切り分けが難しい
+- Claude Code 依存が強い
+
+### いつ足すか
+
+- daily workflow が固まってから
+- 自動品質保証の恩恵が大きいと判断した時
+- Claude Code を主環境にすると決めた時
+
+## Install Profiles
+
+`manifests/install-profiles.json` には、導入の束ね方が定義されています。
+
+| Profile | 向いている人 | 含まれるものの傾向 | 初期採用 |
+|---|---|---|---|
+| `core` | 最小構成で始めたい人 | rules、agents、commands、hooks runtime、platform config、quality workflow | 近い |
+| `developer` | 一般的な app 開発者 | core + framework/language + database + orchestration | 必要に応じて |
+| `security` | security 重視 | core + security module | 条件付き |
+| `research` | 調査や発信寄り | core + research + business/content + social | 目的次第 |
+| `full` | 全部ほしい人 | すべての module | 初期は非推奨 |
+
+### 今回の方針との関係
+
+今回のガイドは `core` を基準にしつつ、
+
+- `rules/typescript`
+- `rules/python`
+- 汎用 quality skill
+- 既定 6 MCP
+
+だけを明示的に採用する、という立て付けです。
+
+## 最小構成と full の比較
+
+| 観点 | 最小構成 | full |
+|---|---|---|
+| 導入速度 | 速い | 遅い |
+| 読む量 | 少ない | 多い |
+| スクラッチバッド圧迫 | 低い | 高い |
+| 自動化の多さ | 少ない | 多い |
+| 切り分けやすさ | 高い | 低い |
+| 向いている段階 | 初期導入 | 定着後 |
+
+## Codex と Claude の運用差
+
+### Codex
+
+- `skills` と `agents` が中心
+- `AGENTS.md` と plugin 定義を読み込ませる
+- slash command の知識は「対応 skill を探すための辞書」として使う
+
+### Claude Code
+
+- plugin + rules + settings + hooks を組み合わせやすい
+- slash command が入口として分かりやすい
+- hooks / session / instinct 系の自動化が生きやすい
+
+## おすすめの拡張順
+
+1. `github` `context7` `exa` を日常で使う
+2. `tdd-workflow` `verification-loop` `security-review` を回す
+3. 言語別 skill を追加する
+4. `memory` を入れてセッション跨ぎを楽にする
+5. `playwright` を E2E / demo 用に使う
+6. hooks を限定導入する
+7. orchestration / loops / research / business skill を足す
+
+## 参照先
+
+- 全体像: [ECC 詳細ガイド](./ECC-GUIDE.md)
+- 目的別索引: [ECC 参照インデックス](./ECC-REFERENCE-INDEX.md)
+- slash command 全件: [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+- skill 全件: [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md)

--- a/docs/ja-JP/ECC-COMMANDS-REFERENCE.md
+++ b/docs/ja-JP/ECC-COMMANDS-REFERENCE.md
@@ -1,0 +1,193 @@
+# ECC コマンドリファレンス
+
+読むべき人: slash command から ECC を使いたい人、Codex で対応 skill を知りたい人  
+読むタイミング: 日常運用を始める前、どの command を選ぶか迷うとき  
+3行要約:
+- `commands/` は ECC の互換入口で、現在の正規ワークフロー面は `skills/`。
+- Claude Code では slash command が使いやすく、Codex では対応する skill / agent に読み替える。
+- 本ファイルは 68 command をカテゴリ別に一覧し、目的と使う場面を短くまとめる。
+
+## 先に理解しておくこと
+
+- Claude Code では `/command-name` がそのまま入口になる
+- Codex では command より `skills` `agents` `AGENTS.md` が中心
+- `Legacy slash-entry shim` と書かれている command は、実体として対応 skill を呼ぶ薄い入口
+
+## 読み方
+
+各行は次を表します。
+
+- `Command`: slash command 名
+- `目的`: 何をさせるか
+- `使う場面`: いつ選ぶか
+- `例`: 最小の呼び方
+- `関連`: 背後の skill / agent / 機能
+- `差分`: Claude と Codex の考え方の違い
+
+## Core Workflow
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/plan` | 要件整理と実装計画 | 新機能、複雑な修正、着手前 | `/plan Add auth` | `planner` | Claude はそのまま。Codex は planner agent に読み替える。 |
+| `/tdd` | TDD ワークフロー開始 | 新機能、バグ修正、リファクタ | `/tdd Add API tests` | `tdd-workflow` | Codex では skill を直接使う。 |
+| `/code-review` | 変更差分の総合レビュー | 実装直後、PR 前 | `/code-review` | `code-reviewer` | Codex では reviewer agent を選ぶ。 |
+| `/build-fix` | 言語自動判別で build 修正 | まずビルドを緑にしたい | `/build-fix` | `build-error-resolver` | Codex では build resolver agent に直行。 |
+| `/verify` | build / lint / test / typecheck の検証 | マージ前、リリース前 | `/verify` | `verification-loop` | Codex では verification skill に読み替える。 |
+| `/quality-gate` | プロジェクト基準に照らした品質確認 | 完了宣言前、PR 前 | `/quality-gate` | quality hooks / workflow | Codex は手動でチェック観点を適用。 |
+
+## Testing
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/e2e` | Playwright E2E 生成と実行 | 重要 UX の検証 | `/e2e Checkout flow` | `e2e-testing`, `e2e-runner` | Codex では Playwright skill / MCP を使う。 |
+| `/test-coverage` | カバレッジ確認 | テスト不足を洗いたい | `/test-coverage` | testing workflow | Codex は verify/testing skill へ。 |
+| `/go-test` | Go 向け TDD | Go 機能追加 | `/go-test Add service tests` | `golang-testing` | Go skill 直利用で代替可。 |
+| `/kotlin-test` | Kotlin 向け TDD | Kotlin / Android / KMP | `/kotlin-test Add ViewModel tests` | `kotlin-testing` | Codex は Kotlin testing skill。 |
+| `/rust-test` | Rust 向け TDD | Rust の機能追加 | `/rust-test Add parser tests` | `rust-testing` | Codex は Rust testing skill。 |
+| `/cpp-test` | C++ 向け TDD | C++ の変更 | `/cpp-test Add edge cases` | `cpp-testing` | Codex は C++ testing skill。 |
+
+## Code Review
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/python-review` | Python 専門レビュー | Python 変更後 | `/python-review` | `python-reviewer` | Codex は Python reviewer agent。 |
+| `/go-review` | Go 専門レビュー | Go 変更後 | `/go-review` | `go-reviewer` | Codex は Go reviewer agent。 |
+| `/kotlin-review` | Kotlin 専門レビュー | Kotlin / Android / KMP | `/kotlin-review` | `kotlin-reviewer` | Codex は Kotlin reviewer agent。 |
+| `/rust-review` | Rust 専門レビュー | Rust 変更後 | `/rust-review` | `rust-reviewer` | Codex は Rust reviewer agent。 |
+| `/cpp-review` | C++ 専門レビュー | C++ 変更後 | `/cpp-review` | `cpp-reviewer` | Codex は C++ reviewer agent。 |
+
+## Build Fixers
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/go-build` | Go build / vet / lint 修正 | Go build が落ちた | `/go-build` | `go-build-resolver` | Codex は Go build resolver。 |
+| `/kotlin-build` | Kotlin / Gradle build 修正 | Kotlin compile error | `/kotlin-build` | `kotlin-build-resolver` | Codex は Kotlin build resolver。 |
+| `/rust-build` | Rust build / borrow checker 修正 | cargo build failure | `/rust-build` | `rust-build-resolver` | Codex は Rust build resolver。 |
+| `/cpp-build` | C++ / CMake / linker 修正 | C++ build failure | `/cpp-build` | `cpp-build-resolver` | Codex は C++ build resolver。 |
+| `/gradle-build` | Gradle 系エラー修正 | Android / KMP / Java build failure | `/gradle-build` | Gradle / Kotlin / Java | Codex では Java / Kotlin resolver を使い分ける。 |
+| `/gan-build` | GAN harness で生成側の実装推進 | GAN ワークフロー実行時 | `/gan-build` | `gan-generator` | Codex では GAN planner / generator へ寄せる。 |
+
+## Planning & Architecture
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/multi-plan` | 複数モデル協調の計画 | 複数観点で仕様を詰めたい | `/multi-plan Add billing` | multi workflow runtime | Codex では orchestration skill を直接使う。 |
+| `/multi-workflow` | 複数モデル協調の実行 | 複数トラック開発 | `/multi-workflow Build admin` | multi workflow runtime | 追加ランタイム前提。 |
+| `/multi-backend` | backend 特化 multi workflow | API / DB 中心の作業 | `/multi-backend Build API` | multi workflow runtime | 同上。 |
+| `/multi-frontend` | frontend 特化 multi workflow | UI / UX 中心の作業 | `/multi-frontend Build dashboard` | multi workflow runtime | 同上。 |
+| `/multi-execute` | 計画済み作業の協調実行 | multi-plan の後 | `/multi-execute` | multi workflow runtime | 同上。 |
+| `/orchestrate` | tmux / worktree 連携ガイド | 並列エージェント運用 | `/orchestrate` | `dmux-workflows`, `autonomous-agent-harness` | Codex でも概念は同じ。 |
+| `/devfleet` | DevFleet で並列 agent を回す | worktree 並列化 | `/devfleet` | `claude-devfleet` | Claude 寄りの入口だが考え方は共通。 |
+| `/gan-design` | GAN harness 用の仕様展開 | 1 行要求から設計したい | `/gan-design Landing page` | `gan-planner` | Codex は planner 的運用に読み替える。 |
+| `/prp-plan` | PRP 形式の詳細実装計画 | 大きい feature spec | `/prp-plan Add OAuth` | PRP workflow | Codex でも計画生成として使える。 |
+| `/prp-prd` | PRD を対話生成 | 仕様自体を詰めたい | `/prp-prd New onboarding` | product / planning workflow | Claude 入口が主。 |
+| `/prompt-optimize` | プロンプト改善 | 依頼文やシステム文を整えたい | `/prompt-optimize` | `prompt-optimizer` | Codex では skill を直接使う。 |
+| `/model-route` | タスクに合うモデル選定 | コスト / 品質を調整したい | `/model-route Review PR` | model routing | Codex は手動判断の補助として読む。 |
+
+## Session Management
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/save-session` | セッション状態保存 | 作業を中断する前 | `/save-session` | session store | Codex ではメモリ / ノート運用と組み合わせる。 |
+| `/resume-session` | 最新セッション再開 | 翌日再開時 | `/resume-session` | session store | Codex は memory / notes で代替することが多い。 |
+| `/sessions` | セッション履歴管理 | どの作業を再開するか選びたい | `/sessions` | session store | Claude 入口が主。 |
+| `/checkpoint` | セッションの節目を打つ | 大きい変更の前後 | `/checkpoint` | session / learning | Codex でも checkpoint 運用に使える概念。 |
+| `/aside` | 本筋を崩さず横道質問 | ちょい質問を挟みたい | `/aside Explain this error` | session context | Codex では会話運用で代替。 |
+| `/context-budget` | コンテキスト使用量の監査 | 重くなってきたとき | `/context-budget` | `context-budget` | Codex でも有用な考え方。 |
+
+## Learning & Improvement
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/learn` | セッションから再利用パターン抽出 | 作業後の知識化 | `/learn` | `continuous-learning` | Codex でも skill 化の種として使える。 |
+| `/learn-eval` | 抽出内容を自己評価つきで保存 | 学習の質も見たい | `/learn-eval` | `continuous-learning`, eval | Claude 側で運用しやすい。 |
+| `/evolve` | instincts を skill / command 化へ進める | 学習結果を整理したい | `/evolve` | learning v2 | Codex は手動 skill 化へ。 |
+| `/promote` | project-scoped instinct を global 化 | 汎用化できた時 | `/promote` | instinct system | Claude の学習面が主。 |
+| `/instinct-status` | instincts 一覧を見る | 何を学習済みか知りたい | `/instinct-status` | instinct system | Claude 寄り。 |
+| `/instinct-export` | instinct を書き出す | バックアップ / 移行 | `/instinct-export` | instinct system | Claude 寄り。 |
+| `/instinct-import` | instinct を取り込む | 他環境から移行 | `/instinct-import` | instinct system | Claude 寄り。 |
+| `/skill-create` | git 履歴から skill 作成 | チーム知見を skill 化したい | `/skill-create` | skill creator workflow | Codex でも有用。 |
+| `/skill-health` | skill 群の品質監査 | 既存 skill の棚卸し | `/skill-health` | skill analytics | 保守寄り。 |
+| `/rules-distill` | skill から rules を蒸留 | 横断原則を整理したい | `/rules-distill` | `rules-distill` | Codex では skill 直接利用。 |
+| `/prune` | 古い未昇格 instinct を削除 | 学習データの整理 | `/prune` | instinct hygiene | Claude 寄り。 |
+
+## Refactoring & Cleanup
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/refactor-clean` | 死んだコードや重複の整理 | 保守、負債返済 | `/refactor-clean` | `refactor-cleaner` | Codex では cleaner agent。 |
+| `/quality-gate` | 変更後の品質確認 | PR 前 | `/quality-gate` | workflow quality | Core Workflow にも登場。 |
+| `/santa-loop` | 二重レビューの収束ループ | 厳格な出荷前確認 | `/santa-loop` | `santa-method` | 高コストなので限定利用。 |
+
+## Docs & Research
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/docs` | Context7 経由の最新 docs 参照 | API / setup / syntax 調査 | `/docs react useEffect` | `documentation-lookup` | Codex では skill と Context7 を直接使う。 |
+| `/update-docs` | プロジェクト docs 更新 | 実装後の文書更新 | `/update-docs` | `doc-updater` | Codex でも docs 更新 agent 的に使える。 |
+| `/update-codemaps` | codemap 再生成 | コードベース索引更新 | `/update-codemaps` | `doc-updater` | 解析用 docs 面。 |
+| `/eval` | eval harness 実行 | 回帰検証、評価駆動開発 | `/eval` | `eval-harness` | Codex でも評価フレームとして読める。 |
+
+## Loops & Automation
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/loop-start` | 繰り返し loop 開始 | 巡回監視や定期タスク | `/loop-start every 15m` | `loop-operator`, loop system | Claude 側運用が主。 |
+| `/loop-status` | loop 状態確認 | 進捗や停止確認 | `/loop-status` | `loop-operator` | Claude 側運用が主。 |
+| `/claw` | NanoClaw REPL 起動 | 永続 REPL、モデル切替、分岐 | `/claw` | `nanoclaw-repl` | Claude 色が強い。 |
+| `/pm2` | PM2 初期化 | 長時間プロセス管理 | `/pm2` | PM2 workflow | ローカル運用向け。 |
+
+## Project & Infrastructure
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/projects` | 既知プロジェクト一覧と統計 | 複数 repo の運用 | `/projects` | project memory | Claude 寄り。 |
+| `/harness-audit` | ハーネス設定の監査 | 信頼性 / コストの見直し | `/harness-audit` | `harness-optimizer` | Codex でも価値が高い。 |
+| `/setup-pm` | package manager 設定 | npm / pnpm / yarn / bun の固定 | `/setup-pm pnpm` | setup-package-manager | どのハーネスでも有用。 |
+
+## PRP / Delivery
+
+| Command | 目的 | 使う場面 | 例 | 関連 | 差分 |
+|---|---|---|---|---|---|
+| `/prp-implement` | 計画を実装へ落とす | `prp-plan` 後の遂行 | `/prp-implement` | PRP workflow | Claude 側の強い入口。 |
+| `/prp-commit` | 自然文でコミット対象指定 | コミット整理 | `/prp-commit only docs files` | PRP workflow | Git 支援コマンド。 |
+| `/prp-pr` | PR 作成 | 変更をまとめて提出 | `/prp-pr` | GitHub / PR workflow | GitHub CLI 前提になりやすい。 |
+
+## コマンド選びの最短ガイド
+
+### 新機能
+
+- 最初に `/plan`
+- そのまま `/tdd`
+- 書き終えたら `/code-review`
+- 最後に `/verify`
+
+### 既存コードの修正
+
+- build が壊れているなら `/build-fix`
+- 原因調査なら `/docs` と `search-first`
+- 仕上げに `/quality-gate`
+
+### 調査や資料化
+
+- 最新 docs なら `/docs`
+- codemap 更新なら `/update-codemaps`
+- ドキュメント更新なら `/update-docs`
+
+## Codex での読み替え早見表
+
+| Claude command | Codex での主な読み替え |
+|---|---|
+| `/plan` | `planner` agent |
+| `/tdd` | `tdd-workflow` skill |
+| `/code-review` | `code-reviewer` または言語別 reviewer |
+| `/build-fix` | 言語別 build resolver agent |
+| `/verify` | `verification-loop` skill |
+| `/docs` | `documentation-lookup` + Context7 |
+| `/refactor-clean` | `refactor-cleaner` agent |
+| `/harness-audit` | `harness-optimizer` agent |
+
+## 補足
+
+- `commands/` は現在も重要ですが、長期的には `skills-first` が前提です。
+- Codex を主環境にするなら、このファイルを「Claude 入口一覧」として見て、詳細は [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md) を主に読む方が運用しやすいです。

--- a/docs/ja-JP/ECC-GUIDE.md
+++ b/docs/ja-JP/ECC-GUIDE.md
@@ -1,0 +1,256 @@
+# ECC 詳細ガイド
+
+読むべき人: ECC をこれから入れる人、`full` を避けて必要なものだけ使いたい人  
+読むタイミング: 初回導入前、既存 README だけでは全体像が掴みにくいとき  
+3行要約:
+- ECC は「Claude Code / Codex などの AI コーディング環境を強化するハーネス一式」で、単体アプリではない。
+- 中核は `skills`、補助面は `agents` `rules` `commands` `hooks` `MCP`。
+- 最初は全部入れず、最小構成から始める方がコンテキスト効率と運用負荷の両方で有利。
+
+## まず読む順番
+
+1. このファイル
+2. [ECC 参照インデックス](./ECC-REFERENCE-INDEX.md)
+3. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+4. [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md)
+5. [ECC 付録](./ECC-APPENDIX.md)
+
+## ECC は何か
+
+ECC は、AI エージェントに対して次の面をまとめて提供するリポジトリです。
+
+- `skills`: 実務ワークフローや専門知識を与える Markdown ベースの再利用単位
+- `agents`: 計画、レビュー、ビルド修正、セキュリティ確認などを役割分担する専門エージェント
+- `commands`: 既存の slash-command 文化に合わせた入口。現在は `skills` が正規のワークフロー面
+- `rules`: 常に守らせたい原則、言語別ガイドライン、品質ルール
+- `hooks`: セッション開始、編集後、Bash 実行前後などに走る自動補助
+- `MCP`: GitHub、Context7、Exa、Playwright など外部能力の接続
+- `platform-configs`: Claude / Codex / Cursor / OpenCode などハーネスごとの設定
+
+## 何ができるか
+
+ECC が強いのは「コードを書く」ことそのものより、AI コーディングの運用を安定させることです。
+
+- 新機能や大きい修正を始める前に、計画を明文化できる
+- TDD と検証ループを標準化できる
+- 言語別・領域別のレビュー基準を再利用できる
+- build error resolver 系 agent で壊れたビルドを最小差分で直せる
+- Context7 / Exa / GitHub を使った調査をルーチン化できる
+- 継続学習、セッション再開、コンテキスト節約の仕組みを持ち込める
+- multi-agent orchestration や loops まで段階的に広げられる
+
+## Codex と Claude Code の違い
+
+ECC の思想は共通ですが、入口が違います。
+
+- Claude Code
+  - `commands/` の slash command を直接使いやすい
+  - hooks や `settings.json` を使った自動化が中心
+  - plugin と rules の組み合わせで機能を足す
+- Codex
+  - `AGENTS.md`、plugin、skills、MCP を中心に使う
+  - slash command 面はそのままでは主戦場ではない
+  - Claude 的な command は「対応する skill / agent / 運用パターン」に読み替える
+
+実務上の理解としては次の通りです。
+
+- Claude では `commands` が入口、`skills` が本体
+- Codex では最初から `skills` と `agents` を読む
+
+## 低コンテキスト圧迫の考え方
+
+ECC は強力ですが、全部を有効にすると読み物としても運用としても重くなります。  
+このガイド群は次の設計で圧迫を抑えます。
+
+- 1 本の巨大 README にしない
+- 概要と索引を先に読むだけで判断できるようにする
+- 全件一覧は別ファイルへ逃がす
+- `full` を前提にせず、`今入れるもの` と `後で足すもの` を分ける
+- Codex / Claude の差分は各章の末尾に短く書く
+
+## 最小構成
+
+このガイドの前提として採用している最小構成は次の通りです。
+
+- `rules/common`
+- `rules/typescript`
+- `rules/python`
+- 汎用 skill 群
+  - TDD
+  - コードレビュー
+  - セキュリティレビュー
+  - 調査 / docs lookup
+- 既定 6 MCP
+  - `github`
+  - `context7`
+  - `exa`
+  - `memory`
+  - `playwright`
+  - `sequential-thinking`
+
+この構成の狙いは、「毎日使うものだけ最初に入れる」ことです。
+
+## 何を入れて、何を後回しにするか
+
+### 最初に入れる
+
+- `rules/common`
+- 使う言語の rules
+- `tdd-workflow`、`verification-loop`、`security-review`
+- docs / research 系の skill
+- GitHub / Context7 / Exa のような日常調査系 MCP
+
+### 初期導入で様子を見る
+
+- `memory`
+- `playwright`
+- `sequential-thinking`
+- 学習系 skill
+- orchestration 系 skill
+
+### すぐには入れない
+
+- 使わない言語の rules
+- 業種特化 skill 群
+- hooks の全面有効化
+- `multi-*` コマンドの前提になる追加ランタイム
+- `full` プロファイル
+
+## 最小導入手順
+
+### 1. リポジトリを取得する
+
+```bash
+git clone https://github.com/affaan-m/everything-claude-code.git
+cd everything-claude-code
+```
+
+### 2. 依存を入れる
+
+Windows PowerShell では `npm.ps1` が Execution Policy に引っかかることがあるため、`cmd /c` を使うと安全です。
+
+```powershell
+cmd /c npm install
+```
+
+macOS / Linux:
+
+```bash
+npm install
+```
+
+### 3. 最小ルールだけ入れる
+
+Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 typescript python
+```
+
+macOS / Linux:
+
+```bash
+./install.sh typescript python
+```
+
+### 4. Claude Code の場合
+
+- plugin を追加する
+- `rules` は手動または installer で入れる
+- 必要なら `hooks/hooks.json` を `settings.json` に移植する
+- MCP は `.mcp.json` または `settings.json` に反映する
+
+### 5. Codex の場合
+
+- `AGENTS.md`
+- `.codex-plugin/plugin.json`
+- `.mcp.json`
+- `skills/`
+
+この 4 面を基準に使う。Codex では `skills` と `agents` が主面です。
+
+## 日常ワークフロー
+
+### 新機能を作る
+
+1. まず計画する
+2. TDD で書く
+3. レビューする
+4. 必要なら build-fix / verify を回す
+5. ドキュメントと codemap を更新する
+
+Claude Code なら:
+
+```text
+/plan
+/tdd
+/code-review
+/verify
+```
+
+Codex なら:
+
+- `planner` agent
+- `tdd-workflow` skill
+- `code-reviewer` / 言語別 reviewer
+- `verification-loop` skill
+
+### 壊れたビルドを直す
+
+- 言語が分からないなら `/build-fix`
+- 分かっているなら言語別 build command / build resolver agent
+- 直した後は `verify` 系で閉じる
+
+### 調査から始める
+
+- ライブラリの API を知りたいなら `documentation-lookup`
+- Web を広く見たいなら `exa-search` または Exa MCP
+- GitHub 上の PR / issue / repo を見たいなら GitHub MCP
+- 大きい調査は `search-first` や `deep-research`
+
+### セッションを切り上げる
+
+- `save-session`
+- `learn-eval`
+- `sessions`
+- `resume-session`
+
+## full を急がない理由
+
+`full` が悪いのではなく、次の 3 点で初期コストが高いからです。
+
+- 読む量が増える
+- AI が参照しうる面が増え、ワークフローが散る
+- hooks / automation / specialized skills まで一度に抱えると運用の失敗原因が切り分けづらい
+
+まずは最小構成で、
+
+- 毎週使う skill は何か
+- 実際に不足した review / docs / test 支援は何か
+- どの MCP が本当に必要か
+
+を確認してから足す方が安定します。
+
+## どのファイルを見ればよいか
+
+- 導入と全体像: [ECC 参照インデックス](./ECC-REFERENCE-INDEX.md)
+- slash command 全件: [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+- skill 全件: [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md)
+- agents / MCP / rules / hooks / profiles: [ECC 付録](./ECC-APPENDIX.md)
+
+## 既存ファイルとの関係
+
+このガイドは次を再整理したものです。
+
+- `README.md`
+- `COMMANDS-QUICK-REF.md`
+- `AGENTS.md`
+- `RULES.md`
+- `TROUBLESHOOTING.md`
+- `commands/`
+- `skills/`
+- `agents/`
+- `.mcp.json`
+- `manifests/*`
+
+既存 README はリポジトリの入口、こちらは「実際に使い始めるための運用ガイド」と捉えるとズレにくいです。

--- a/docs/ja-JP/ECC-REFERENCE-INDEX.md
+++ b/docs/ja-JP/ECC-REFERENCE-INDEX.md
@@ -1,0 +1,93 @@
+# ECC 参照インデックス
+
+読むべき人: 必要なファイルだけ素早く開きたい人  
+読むタイミング: 全体像を掴んだあと、具体的な目的別に辿りたいとき  
+3行要約:
+- このファイルは ECC 日本語ガイド群の入口。
+- 「何をしたいか」から読むべきファイルへ飛べる。
+- 詳細を全部読む前に、必要な面だけ絞るための索引。
+
+## 主要ドキュメント
+
+- [ECC 詳細ガイド](./ECC-GUIDE.md)
+  - ECC の全体像
+  - 最小導入手順
+  - Codex / Claude 差分
+  - 最初に何を入れるべきか
+- [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+  - slash command 全件
+  - 目的、使う場面、例、対応 skill / agent
+- [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md)
+  - skill 全件
+  - カテゴリ別の整理
+  - どういう依頼で起動すべきか
+- [ECC 付録](./ECC-APPENDIX.md)
+  - agents 一覧
+  - 既定 6 MCP
+  - rules / hooks / install profiles
+  - 最小構成と full の切り分け
+
+## 目的別の読み方
+
+### ECC が何者かを知りたい
+
+1. [ECC 詳細ガイド](./ECC-GUIDE.md)
+2. [ECC 付録](./ECC-APPENDIX.md)
+
+### 最初に何を入れるべきかを知りたい
+
+1. [ECC 詳細ガイド](./ECC-GUIDE.md)
+2. [ECC 付録](./ECC-APPENDIX.md)
+
+### slash command の使い方だけ知りたい
+
+1. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+
+### Codex では何に読み替えればよいか知りたい
+
+1. [ECC 詳細ガイド](./ECC-GUIDE.md)
+2. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+
+### どんな skill があるかを一覧したい
+
+1. [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md)
+
+### どの agent が何を担当するか知りたい
+
+1. [ECC 付録](./ECC-APPENDIX.md)
+
+### MCP が何をするか知りたい
+
+1. [ECC 付録](./ECC-APPENDIX.md)
+
+## すぐ使う場合の最短ルート
+
+### 新機能を始める
+
+1. [ECC 詳細ガイド](./ECC-GUIDE.md)
+2. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md) の `plan` `tdd` `code-review` `verify`
+3. [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md) の `tdd-workflow` `verification-loop` `security-review`
+
+### 壊れたビルドを直す
+
+1. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md) の build 系
+2. [ECC 付録](./ECC-APPENDIX.md) の build resolver agents
+
+### ドキュメントや API を調べる
+
+1. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md) の `docs`
+2. [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md) の `documentation-lookup` `search-first` `deep-research`
+3. [ECC 付録](./ECC-APPENDIX.md) の MCP 章
+
+### セッションをまたいで使う
+
+1. [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md) の session / learning 系
+2. [ECC 付録](./ECC-APPENDIX.md) の hooks / memory / profile 章
+
+## このガイド群の設計方針
+
+- 概要を先に、全件一覧は後に置く
+- Codex / Claude の差分は都度短く書く
+- `full` 前提ではなく、最小構成から始める
+- skill / command は全件載せるが、1 項目あたりは短く保つ
+- スクラッチバッドを圧迫しないよう、索引ファイルを独立させる

--- a/docs/ja-JP/ECC-SKILLS-CATALOG.md
+++ b/docs/ja-JP/ECC-SKILLS-CATALOG.md
@@ -1,0 +1,319 @@
+# ECC スキルカタログ
+
+読むべき人: ECC の本体である `skills/` を主に使いたい人、Codex で ECC を使う人  
+読むタイミング: command ではなく skill 単位で運用設計したいとき  
+3行要約:
+- ECC の正規ワークフロー面は `skills`。
+- 本ファイルは 151 skill をカテゴリ別に整理し、全件を短い実務用メモとして並べる。
+- まずカテゴリ要約を読み、必要な skill だけ深掘りするのが最も軽い。
+
+## 使い方
+
+### Claude Code
+
+- command から入っても、実体が skill のことが多い
+- 実際の運用は「この task ならどの skill を効かせるか」で考える
+
+### Codex
+
+- 最初から skill を主面として読む
+- slash command 名より、skill の役割で覚える
+
+## 最初に見るべき skill
+
+最小構成なら次を先に押さえるだけで十分に価値が出ます。
+
+- `tdd-workflow`
+- `verification-loop`
+- `security-review`
+- `documentation-lookup`
+- `search-first`
+- `context-budget`
+- `configure-ecc`
+
+## カテゴリ概要
+
+### 1. ハーネス・運用基盤
+
+AI コーディング環境そのものを設計・評価・改善する skill 群。  
+ECC を「ただのプロンプト集」ではなく、運用システムとして使うときの核です。
+
+### 2. 計画・仕様・アーキテクチャ
+
+実装前の仕様化、設計判断、ADR、blueprint、分割計画を扱います。
+
+### 3. 品質・検証・レビュー・安全
+
+TDD、検証ループ、セキュリティ、回帰検知、レビュー観点の standard skill 群です。
+
+### 4. 言語・フレームワーク別実装
+
+TypeScript / Python / Go / Java / Kotlin / Rust / C++ / Laravel / Swift など、言語別ベストプラクティスをまとめています。
+
+### 5. データ・研究・MCP・外部知識
+
+database、deep research、MCP server 実装、外部 docs 参照、Web 調査に関する skill 群です。
+
+### 6. ブラウザ・デザイン・動画・メディア
+
+Playwright、デザインシステム、UI デモ、スライド、画像/動画ワークフローをまとめています。
+
+### 7. ビジネス・コンテンツ・営業・業務オペ
+
+市場調査、投資家向け資料、アウトリーチ、Google Workspace、顧客対応など、コード以外の仕事に寄った skill 群です。
+
+### 8. 業種特化
+
+Healthcare、物流、通関、エネルギーなど、特定ドメイン向けの深い運用知識です。
+
+## 全 skill 一覧
+
+各項目は `用途 / どう依頼すると起動しやすいか / 似た skill との差分` の順に短く書いています。
+
+## ハーネス・運用基盤
+
+- `agent-eval`: 複数 coding agent の比較評価。`Claude と Codex を比較して` のように依頼。`eval-harness` は単一ワークフロー評価、こちらは agent 比較。
+- `agent-harness-construction`: action space や tool 定義の設計。`agent harness を設計して` と依頼。`harness-audit` より構築寄り。
+- `agent-payment-x402`: agent に支払い機能を持たせる。`AI agent が API に支払えるようにしたい` と依頼。決済統合専用。
+- `agentic-engineering`: eval-first、分解、コスト意識を持つ agentic 開発。`agentic に進めて` と依頼。全体運用の作法。
+- `ai-first-engineering`: AI を前提にしたチーム開発モデル。`AI-first な開発体制にしたい` と依頼。個別実装より組織運用向け。
+- `autonomous-agent-harness`: 永続メモリと scheduled operations を持つ自律 agent 構築。`継続稼働する agent にしたい` と依頼。自律運用基盤。
+- `autonomous-loops`: 自律ループ設計パターン。`loop を安全に回したい` と依頼。`continuous-agent-loop` より概念寄り。
+- `ck`: プロジェクトごとの永続メモリ。`この repo の記憶を持たせたい` と依頼。Claude Code ネイティブ運用寄り。
+- `claude-api`: Anthropic API 実装パターン。`Claude API を使ってアプリを作りたい` と依頼。Anthropic 固有。
+- `claude-devfleet`: DevFleet による並列 agent 制御。`複数エージェントで並列実行したい` と依頼。worktree 運用に強い。
+- `configure-ecc`: ECC の対話式インストーラ。`ECC を必要最小限で設定したい` と依頼。初回導入の入口。
+- `context-budget`: コンテキスト消費の監査。`今の構成が重いか診断して` と依頼。スクラッチバッド節約に直結。
+- `continuous-agent-loop`: quality gate 付き継続ループ設計。`止まりにくい継続 loop を作りたい` と依頼。`autonomous-loops` より実装指向。
+- `continuous-learning`: セッションからパターン抽出。`この作業から reusable な知見を抽出して` と依頼。学習の初代系。
+- `continuous-learning-v2`: instinct と confidence scoring を持つ学習系。`project-scoped に学習させたい` と依頼。v2 は project 汚染対策込み。
+- `cost-aware-llm-pipeline`: LLM API のコスト最適化。`モデル選定と予算管理を組み込みたい` と依頼。token / retry / routing の実装面。
+- `dmux-workflows`: tmux ベースの multi-agent orchestration。`tmux で並列運用したい` と依頼。`claude-devfleet` より手動制御寄り。
+- `enterprise-agent-ops`: 長寿命 agent workload の運用。`agent 運用の observability を整えたい` と依頼。企業運用向け。
+- `eval-harness`: eval-driven development の評価枠組み。`この変更を eval 駆動で検証して` と依頼。回帰テストの基盤。
+- `mcp-server-patterns`: Node/TS で MCP server を作る。`MCP server を実装したい` と依頼。ECC 利用より provider 側実装向け。
+- `nanoclaw-repl`: NanoClaw v2 REPL を運用・拡張する。`NanoClaw を使いたい` と依頼。対話 REPL 専用。
+- `search-first`: 実装前に調査を挟む。`まず既存のライブラリや実装例を調べて` と依頼。最初に常用したい skill。
+- `strategic-compact`: 論理的な区切りで手動 compaction を促す。`コンテキストを崩さず圧縮したい` と依頼。`context-budget` は監査、こちらは運用。
+- `team-builder`: 並列 agent チームの編成。`この task に必要な agent チームを組んで` と依頼。役割割当向け。
+- `token-budget-advisor`: token 消費を見積もる。`この運用の token コストを見て` と依頼。`context-budget` より予算観点。
+- `workspace-surface-audit`: repo、MCP、plugins、env の棚卸し。`この環境で何が使えるか監査して` と依頼。導入直後に有用。
+
+## 計画・仕様・アーキテクチャ
+
+- `api-design`: REST API 設計。`API を設計して` と依頼。resource / error / pagination の標準化。
+- `architecture-decision-records`: ADR を残す。`この設計判断を ADR にして` と依頼。設計ログ専用。
+- `blueprint`: multi-session / multi-PR の construction plan。`大きい移行計画を blueprint 化して` と依頼。`plan` より長期分割向け。
+- `codebase-onboarding`: 新しい repo の onboarding guide 生成。`この repo の onboarding doc を作って` と依頼。初見解析向け。
+- `hexagonal-architecture`: Ports & Adapters 設計。`hexagonal に整理したい` と依頼。境界分離向け。
+- `iterative-retrieval`: subagent context 問題への段階的 retrieval。`必要な文脈だけ徐々に渡したい` と依頼。大規模 repo で有効。
+- `product-lens`: build 前に product 問題を検証。`何を作るべきか整理して` と依頼。実装より前の why を扱う。
+- `project-guidelines-example`: project 固有 skill の雛形。`この repo 専用 skill を作りたい` と依頼。テンプレート用途。
+- `ralphinho-rfc-pipeline`: RFC 駆動の DAG 実行。`RFC ベースで multi-agent 実行したい` と依頼。運用が重い分、大規模案件向け。
+
+## 品質・検証・レビュー・安全
+
+- `ai-regression-testing`: AI 実装の blind spot を拾う回帰戦略。`AI が書いた変更を回帰観点で見て` と依頼。`eval-harness` より QA 観点。
+- `benchmark`: before/after 性能測定。`この PR の性能差を計測して` と依頼。回帰検知向け。
+- `browser-qa`: browser automation による visual / interaction QA。`デプロイ後に UI を点検して` と依頼。E2E より QA 寄り。
+- `canary-watch`: デプロイ後の回帰監視。`本番 URL を見張って` と依頼。継続監視向け。
+- `click-path-audit`: ボタンから状態変化全体を追跡。`このボタンがなぜ効かないか経路で洗って` と依頼。UI デバッグ専用。
+- `design-system`: design system 生成や監査。`デザインシステムを整理して` と依頼。`frontend-patterns` より design 観点。
+- `documentation-lookup`: Context7 による最新 docs 参照。`React 19 の最新 API を調べて` と依頼。日常で最重要。
+- `e2e-testing`: Playwright E2E 設計と運用。`E2E を整備して` と依頼。`browser-qa` は点検、こちらは test 本体。
+- `plankton-code-quality`: edit 後の format / lint / AI 修正。`書くたびに品質を自動維持したい` と依頼。hooks 強め。
+- `prompt-optimizer`: draft prompt を ECC 流に最適化。`この依頼文を改善して` と依頼。meta skill。
+- `repo-scan`: ソース資産監査と third-party 埋め込み検出。`この repo を資産監査して` と依頼。棚卸し向け。
+- `rules-distill`: skill 群から共通ルール抽出。`この skill セットから rules を作って` と依頼。横断原則化。
+- `safety-guard`: 破壊的操作の防止。`本番や破壊的操作なので慎重に進めて` と依頼。prod safety 専用。
+- `santa-method`: 2 reviewer 合意の adversarial review。`厳格に二重レビューして` と依頼。高コスト品質保証。
+- `security-review`: 認証、入力、秘密、決済などの security review。`この API をセキュリティ観点で見て` と依頼。最初に入れるべき skill。
+- `security-scan`: Claude Code 設定の脆弱性検査。`.claude 設定を scan して` と依頼。AgentShield 寄り。
+- `skill-comply`: skills / rules / agents が本当に守られているか評価。`この skill が守られているか検証して` と依頼。品質監査向け。
+- `skill-stocktake`: skill / command の棚卸し。`ECC skill 群の品質棚卸しをして` と依頼。メンテナ向け。
+- `tdd-workflow`: 新機能・修正・リファクタの TDD。`テスト先行で進めて` と依頼。日常最重要。
+- `verification-loop`: build / lint / tests / review の包括検証。`最後に verification を回して` と依頼。出荷前の締め。
+
+## Web / JS / TS / Frontend / Backend
+
+- `backend-patterns`: Node / Express / Next API の backend 実装指針。`Node backend を設計して` と依頼。Web backend 向け。
+- `bun-runtime`: Bun の runtime / package manager 運用。`Bun を採用すべきか見て` と依頼。Node 代替の比較軸。
+- `coding-standards`: TypeScript / JavaScript / React / Node の標準。`TS/JS の標準に沿って書いて` と依頼。最汎用。
+- `content-hash-cache-pattern`: SHA-256 ベースの高コスト処理キャッシュ。`ファイル処理を content hash でキャッシュしたい` と依頼。局所パターン。
+- `deployment-patterns`: CI/CD、Docker、health check、rollback。`本番デプロイの流れを設計して` と依頼。運用まで含む。
+- `docker-patterns`: Docker / Compose 設計。`Docker 構成を整えて` と依頼。container 近辺に限定。
+- `frontend-patterns`: React / Next / state / performance。`React フロントを改善して` と依頼。最重要 frontend skill。
+- `frontend-slides`: HTML スライド作成。`プレゼン資料を Web スライドで作って` と依頼。ドキュメントではなく presentation 専用。
+- `git-workflow`: branch / commit / rebase / conflict 解決。`このチーム向け git workflow を整理して` と依頼。チーム運用寄り。
+- `nextjs-turbopack`: Next.js 16+ と Turbopack。`Turbopack に寄せたい` と依頼。Next 固有。
+- `nuxt4-patterns`: Nuxt 4 の hydration / SSR / perf。`Nuxt 4 アプリを設計して` と依頼。Vue / Nuxt 固有。
+
+## Python / Django
+
+- `python-patterns`: Python の idiom と型と PEP 8。`Python らしく書き直して` と依頼。Python 基本。
+- `python-testing`: pytest / fixtures / coverage。`pytest でテストを整備して` と依頼。Python TDD 面。
+- `django-patterns`: Django / DRF / ORM / middleware。`Django API を作って` と依頼。Django 基本。
+- `django-security`: Django の auth / CSRF / XSS / secure deploy。`Django のセキュリティを見て` と依頼。Django security 専用。
+- `django-tdd`: pytest-django / factory_boy での TDD。`Django をテスト先行で進めて` と依頼。Django testing 特化。
+- `django-verification`: migrations / lint / tests / security scan を回す。`Django の release readiness を見て` と依頼。verification 専用。
+
+## Go
+
+- `golang-patterns`: idiomatic Go 実装。`Go らしく整理して` と依頼。Go 基本。
+- `golang-testing`: table-driven tests / fuzzing / coverage。`Go テストを増やして` と依頼。Go testing 特化。
+
+## Java / Kotlin / Android / Spring
+
+- `android-clean-architecture`: Android / KMP の clean architecture。`Android アプリを clean architecture にしたい` と依頼。モジュール構造向け。
+- `compose-multiplatform-patterns`: Compose Multiplatform の UI 設計。`KMP UI を Compose で組みたい` と依頼。UI 層特化。
+- `java-coding-standards`: Spring Boot 系 Java の標準。`Java サービスの標準に沿って直して` と依頼。Java 基本。
+- `jpa-patterns`: JPA / Hibernate の entity、transaction、query 最適化。`JPA 設計を見直して` と依頼。ORM 特化。
+- `kotlin-coroutines-flows`: coroutines / Flow / structured concurrency。`Flow と coroutine の設計を見て` と依頼。非同期専用。
+- `kotlin-exposed-patterns`: JetBrains Exposed ORM。`Exposed で DB 層を作って` と依頼。Exposed 限定。
+- `kotlin-ktor-patterns`: Ktor server 設計。`Ktor API を作って` と依頼。Ktor 固有。
+- `kotlin-patterns`: Kotlin idiom 全般。`Kotlin らしく整理して` と依頼。Kotlin 基本。
+- `kotlin-testing`: Kotest / MockK / Kover。`Kotlin テストを整えて` と依頼。Kotlin testing 特化。
+- `springboot-patterns`: Spring Boot layered backend。`Spring Boot API を設計して` と依頼。Java backend 基本。
+- `springboot-security`: Spring Security の auth / headers / validation。`Spring のセキュリティを見て` と依頼。security 専用。
+- `springboot-tdd`: JUnit 5 / Mockito / MockMvc / Testcontainers。`Spring を TDD で進めて` と依頼。testing 特化。
+- `springboot-verification`: build / static analysis / tests / scan。`Spring Boot の release readiness を見て` と依頼。verification 特化。
+
+## Laravel / PHP
+
+- `laravel-patterns`: Laravel の routing / service layer / queue / API resource。`Laravel の構成を整えて` と依頼。Laravel 基本。
+- `laravel-plugin-discovery`: LaraPlugins.io で package 探索。`Laravel package を探して` と依頼。選定専用。
+- `laravel-security`: Laravel の auth / validation / uploads / secrets。`Laravel の脆弱性を見て` と依頼。security 専用。
+- `laravel-tdd`: PHPUnit / Pest / factories。`Laravel をテスト先行で` と依頼。testing 特化。
+- `laravel-verification`: env / static analysis / tests / security。`Laravel の検証を回して` と依頼。verification 特化。
+
+## Rust / C++ / Perl
+
+- `cpp-coding-standards`: C++ Core Guidelines ベースの標準。`C++ を modern に直して` と依頼。C++ 基本。
+- `cpp-testing`: GoogleTest / CTest / sanitizers。`C++ テストを整備して` と依頼。testing 特化。
+- `perl-patterns`: Modern Perl 5.36+ の idiom。`Perl を modern に書き直して` と依頼。Perl 基本。
+- `perl-security`: taint mode、DBI、web security。`Perl の security を確認して` と依頼。security 専用。
+- `perl-testing`: Test2 / prove / coverage。`Perl テストを整えて` と依頼。testing 特化。
+- `rust-patterns`: ownership / traits / concurrency。`Rust らしく設計して` と依頼。Rust 基本。
+- `rust-testing`: unit / integration / async / property-based tests。`Rust テストを増やして` と依頼。testing 特化。
+
+## Swift / Apple
+
+- `foundation-models-on-device`: Apple FoundationModels の on-device LLM。`iOS で on-device LLM を使いたい` と依頼。Apple 独自面。
+- `liquid-glass-design`: iOS 26 Liquid Glass design system。`Liquid Glass 風 UI にしたい` と依頼。デザイン専用。
+- `swift-actor-persistence`: actor ベースの安全な永続化。`Swift で race-free persistence を組みたい` と依頼。局所設計。
+- `swift-concurrency-6-2`: Swift 6.2 concurrency。`Swift 6.2 concurrency を前提に整理して` と依頼。言語進化寄り。
+- `swift-protocol-di-testing`: protocol ベース DI とテスト。`Swift を testable にしたい` と依頼。DI / testing 専用。
+- `swiftui-patterns`: SwiftUI の state / navigation / perf。`SwiftUI で実装して` と依頼。Apple UI 基本。
+
+## データ・研究・外部知識
+
+- `clickhouse-io`: ClickHouse の query / analytics パターン。`ClickHouse クエリを最適化して` と依頼。分析 DB 特化。
+- `database-migrations`: schema change、data migration、rollback。`安全な migration plan を作って` と依頼。DB 移行の標準。
+- `data-scraper-agent`: 公開情報を継続収集する agent。`価格や求人を定期収集したい` と依頼。自動収集向け。
+- `deep-research`: firecrawl / exa を使う深掘り調査。`根拠付きで徹底調査して` と依頼。`search-first` より重い。
+- `exa-search`: Exa MCP ベースの Web / code / company research。`Exa で調査して` と依頼。検索面の主力。
+- `postgres-patterns`: PostgreSQL の query / schema / indexing / security。`Postgres を最適化して` と依頼。DB 基本。
+- `pytorch-patterns`: PyTorch training / model / data pipeline。`PyTorch training pipeline を整えて` と依頼。ML 専用。
+- `regex-vs-llm-structured-text`: regex と LLM の使い分け。`この構造化テキストは regex で行けるか判断して` と依頼。設計判断用。
+- `workspace-surface-audit`: repo と外部接続面の監査。`MCP や plugin を含めて現状把握したい` と依頼。導入診断にも有効。
+
+## ブラウザ・デザイン・メディア
+
+- `fal-ai-media`: fal.ai による image / video / audio 生成。`fal.ai で画像や動画を作って` と依頼。生成メディア全般。
+- `manim-video`: Manim で技術説明動画。`技術概念をアニメ動画で説明したい` と依頼。図解アニメ専用。
+- `remotion-video-creation`: React / Remotion で動画制作。`Remotion で動画を作って` と依頼。React ベース。
+- `ui-demo`: Playwright で polished UI demo を録画。`このアプリのデモ動画を撮って` と依頼。完成デモ向け。
+- `videodb`: 動画 / 音声の ingest、検索、編集、アラート。`動画を理解して編集したい` と依頼。media ops 全般。
+- `video-editing`: 実写ベースの AI-assisted video 編集。`動画素材をカットして仕上げたい` と依頼。制作ワークフロー寄り。
+- `visa-doc-translate`: ビザ申請書類の英訳 PDF 化。`この書類画像を英訳して` と依頼。用途限定。
+
+## OSS・リポジトリ公開
+
+- `opensource-pipeline`: private repo を公開可能にする 3 agent pipeline。`この repo を open source 化したい` と依頼。パイプライン全体。
+- `opensource-forker`: 公開用 fork 作成と secret 除去。`公開向け fork を作って` と依頼。第1段階。
+- `opensource-sanitizer`: secret / PII / internal refs の最終検査。`公開前に sanitization を確認して` と依頼。第2段階。
+- `opensource-packager`: README、LICENSE、template など公開 packaging。`OSS 公開向けパッケージを整えて` と依頼。第3段階。
+
+## ビジネス・コンテンツ・営業・コミュニケーション
+
+- `article-writing`: 長文記事やガイド執筆。`この内容で記事を書いて` と依頼。長文専用。
+- `brand-voice`: 実例から文体プロファイルを作る。`この人の文体で書いて` と依頼。voice 再現専用。
+- `connections-optimizer`: X / LinkedIn の関係網を最適化。`フォロー関係を整理したい` と依頼。network cleanup。
+- `content-engine`: 複数媒体向けの content system 構築。`SNS と newsletter を横断するコンテンツ戦略を作って` と依頼。記事単発より運用向け。
+- `crosspost`: X / LinkedIn / Threads / Bluesky へ再配布。`この投稿を各 SNS 向けに展開して` と依頼。platform adaptation 専用。
+- `customer-billing-ops`: subscription / refund / churn 対応。`この顧客の請求状況を見て` と依頼。Stripe など billing 運用。
+- `google-workspace-ops`: Drive / Docs / Sheets / Slides を横断運用。`Google Docs と Sheets を整理して` と依頼。Workspace 専用。
+- `investor-materials`: pitch deck、one-pager、memo、financial model。`投資家向け資料を作って` と依頼。fundraising 材料向け。
+- `investor-outreach`: investor 向け outreach 文面。`VC への初回メールを書いて` と依頼。資金調達コミュニケーション。
+- `lead-intelligence`: AI-native lead intelligence と outreach pipeline。`狙うべき見込み顧客を絞って` と依頼。営業 pipeline 全体。
+- `market-research`: 市場、競合、投資家 DD の調査。`市場調査をして` と依頼。意思決定材料向け。
+- `project-flow-ops`: GitHub と Linear の execution flow 管理。`issue と PR の流れを整理して` と依頼。チケット運用専用。
+- `social-graph-ranker`: warm intro 発見の ranking engine。`人脈から warm intro 候補を順位付けして` と依頼。network scoring 専用。
+- `x-api`: X/Twitter API 連携。`X API で投稿や分析をしたい` と依頼。X 専用。
+
+## ドメイン特化: Healthcare
+
+- `healthcare-cdss-patterns`: CDSS の開発パターン。`臨床意思決定支援を実装したい` と依頼。診療支援専用。
+- `healthcare-emr-patterns`: EMR/EHR の workflow 設計。`EMR 画面や処方フローを設計したい` と依頼。医療 UI / workflow 向け。
+- `healthcare-eval-harness`: patient safety 評価。`医療アプリの安全性 eval を回して` と依頼。医療 release gate。
+- `healthcare-phi-compliance`: PHI / PII の保護。`この医療データ設計が compliant か見て` と依頼。規制順守専用。
+
+## ドメイン特化: 物流・調達・通関・製造
+
+- `carrier-relationship-management`: carrier portfolio、rate negotiation、scorecards。`運送会社との交渉や評価を整理して` と依頼。物流調達寄り。
+- `customs-trade-compliance`: HS code、duty、restricted party screening。`輸出入の通関・関税を見て` と依頼。通関専用。
+- `energy-procurement`: energy sourcing と契約最適化。`電力調達の比較をして` と依頼。調達専用。
+- `inventory-demand-planning`: demand planning と在庫配分。`需要予測と在庫計画を整理して` と依頼。SCM 計画向け。
+- `logistics-exception-management`: 物流例外対応。`配送遅延や欠品の例外対応を整理して` と依頼。運用トラブル向け。
+- `production-scheduling`: 生産計画とスケジューリング。`工場の生産順序を最適化したい` と依頼。製造計画向け。
+- `quality-nonconformance`: 品質不適合の記録と是正。`品質不良の是正フローを整理して` と依頼。品質業務向け。
+- `returns-reverse-logistics`: 返品と reverse logistics。`返品オペレーションを設計して` と依頼。逆物流専用。
+
+## そのほかの specialized skill
+
+- `browser-qa`: deploy 後の visual QA。`リリース後の UI を確認して` と依頼。E2E より軽い確認向け。
+- `canary-watch`: canary URL の監視。`デプロイ直後の回帰を監視して` と依頼。継続監視向け。
+- `carrier-relationship-management`: 物流 carrier 管理。`運送会社ポートフォリオを見直して` と依頼。SCM 実務向け。
+- `clickhouse-io`: analytics DB としての ClickHouse。`分析クエリを最適化して` と依頼。分析基盤特化。
+- `connections-optimizer`: ソーシャル graph の整理。`X / LinkedIn の接続を整理したい` と依頼。営業より network hygiene。
+- `flutter-dart-code-review`: Flutter / Dart の library-agnostic code review。`Flutter の PR をレビューして` と依頼。state management 非依存の review 用。
+- `foundation-models-on-device`: iOS の on-device LLM。`Apple の on-device AI を使いたい` と依頼。Apple / ML 交差点。
+- `gan-style-harness`: generator / evaluator 分離の GAN 風 harness。`GAN 風ループで作りたい` と依頼。研究的ワークフロー。
+- `openclaw-persona-forge`: OpenClaw persona / character / identity 生成。`OpenClaw の persona を作りたい` と依頼。OpenClaw 特化。
+- `plankton-code-quality`: write-time quality automation。`編集直後に format/lint を強制したい` と依頼。hook 前提。
+- `nutrient-document-processing`: PDF / DOCX / XLSX / PPTX / 画像の処理。`OCR、変換、抽出、redaction をしたい` と依頼。文書処理 API 専用。
+- `ui-demo`: polished screen recording。`使い方動画を収録して` と依頼。browser-qa と違い成果物が動画。
+
+## 選定のコツ
+
+### 最初に入れると価値が高い
+
+- `tdd-workflow`
+- `verification-loop`
+- `security-review`
+- `documentation-lookup`
+- `search-first`
+- `context-budget`
+- `configure-ecc`
+
+### 実際に必要になったら足す
+
+- 言語 / framework 特化 skill
+- `continuous-learning-v2`
+- `deep-research`
+- `claude-devfleet`
+- `browser-qa`
+- `ui-demo`
+
+### 最後に考える
+
+- 業種特化 skill
+- media generation skill
+- multi-agent / autonomous loop skill
+- open source pipeline skill
+
+## 補足
+
+- 151 skill を毎回全部読む必要はありません。
+- 「今やっている task に対して 1 つか 2 つだけ選ぶ」のが基本です。
+- Codex ではこのファイルを主に参照し、Claude Code では [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md) を入口として読むのが実務上扱いやすいです。

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -1,3 +1,11 @@
+## 日本語詳細ガイド
+
+- [ECC 詳細ガイド](./ECC-GUIDE.md)
+- [ECC 参照インデックス](./ECC-REFERENCE-INDEX.md)
+- [ECC コマンドリファレンス](./ECC-COMMANDS-REFERENCE.md)
+- [ECC スキルカタログ](./ECC-SKILLS-CATALOG.md)
+- [ECC 付録](./ECC-APPENDIX.md)
+
 **言語:** English | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](README.md) | [한국어](../ko-KR/README.md)
 
 # Everything Claude Code


### PR DESCRIPTION
## Summary
- add a Japanese ECC guide set split into overview, index, commands, skills, and appendix docs
- document the minimum Codex + Claude-friendly setup and the default 6 MCP servers
- add links from the Japanese README to the new guide pages

## Testing
- verified all command entries are covered in the commands reference
- verified all skill directories are covered in the skills catalog
- did not run code tests (docs-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Japanese ECC guide set (overview, index, commands reference, skills catalog, appendix) to support a minimal, Claude/Codex‑friendly setup. Updates the Japanese README to link the new pages.

- **New Features**
  - Added five docs under `docs/ja-JP`: `ECC-GUIDE.md`, `ECC-REFERENCE-INDEX.md`, `ECC-COMMANDS-REFERENCE.md`, `ECC-SKILLS-CATALOG.md`, `ECC-APPENDIX.md`.
  - Guide covers minimal setup, Codex vs Claude usage, and recommended first steps; index enables purpose-based navigation.
  - Commands reference lists 68 commands with purposes and Codex mappings; skills catalog lists 151 skills; entries cross-checked against repo.
  - Appendix documents agents, default 6 MCP (`github`, `context7`, `exa`, `memory`, `playwright`, `sequential-thinking`), and rules/hooks/install profiles; `docs/ja-JP/README.md` now links to all new pages.

<sup>Written for commit 5438b24b298674ddde583ca092222e4510bdcf36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

