### PR TITLE
docs: add manual adaptation guide for non-native harnesses

### DIFF
--- a/docs/MANUAL-ADAPTATION-GUIDE.md
+++ b/docs/MANUAL-ADAPTATION-GUIDE.md
@@ -1,0 +1,202 @@
+# Manual Adaptation Guide for Non-Native Harnesses
+
+This guide documents how to adapt **everything-claude-code (ECC)** to AI harnesses that don't support the native ECC folder layouts (like Grok, Claude Desktop, etc.).
+
+## Table of Contents
+
+- [When to Use This Guide](#when-to-use-this-guide)
+- [Quick Start](#quick-start)
+- [Minimal Skill Selection](#minimal-skill-selection)
+- [Context Compression](#context-compression)
+- [Command/Hook Reproduction](#commandhook-reproduction)
+- [Harness Comparison](#harness-comparison)
+- [Limitations](#limitations)
+
+---
+
+## When to Use This Guide
+
+Use this guide if your target harness:
+
+- ❌ Doesn't support `.claude/` or `.cursorrules` auto-loading
+- ❌ Doesn't support custom commands (`/command`)
+- ❌ Doesn't support hooks (prePrompt, onDiskWrite, etc.)
+- ❌ Has limited or no filesystem access
+
+**First-class targets** (native support): Claude Code, Cursor, Codex, Opencode, CodeBuddy
+
+**Second-class targets** (this guide): Grok, Claude Desktop, other LLM interfaces
+
+---
+
+## Quick Start
+
+```bash
+# 1. Install repomix for context packing
+npm install -g repomix
+
+# 2. Pack only the skills you need
+repomix --include "skills/python-patterns,skills/tdd-workflow" --output packed.md
+
+# 3. Feed packed.md at session start
+# Your AI harness will now have the skill context loaded
+```
+
+---
+
+## Minimal Skill Selection
+
+### By Task Type
+
+| Task Type | Minimal Skills |
+|----------|----------------|
+| General coding | `python-patterns` or `javascript-patterns` |
+| Debugging | `debugging`, `error-analysis` |
+| API work | `api-design`, `rest-api-patterns` |
+| Testing | `tdd-workflow`, `testing` |
+| Security | `security-review` |
+
+### Priority Order
+
+1. **Language patterns** - Your primary language idiom
+2. **Framework patterns** - Your specific framework
+3. **Workflow skill** - TDD, refactoring, etc.
+4. **Domain knowledge** - Security, API design, etc.
+
+---
+
+## Context Compression
+
+### Using Repomix
+
+```bash
+# Pack specific skills
+repomix --include "skills/tdd-workflow,skills/python-patterns" --output tdd-context.md
+
+# Pack only agents
+repomix --include "agents/planner,agents/reviewer" --output agents.md
+
+# Pack rules
+repomix --include "rules/global.md" --output rules.md
+```
+
+### Manual Compression Tips
+
+1. **Keep skill headers** - The activation triggers (`## When to Activate`) are critical
+2. **Extract code examples** - Copy actual code blocks, skip verbose explanations
+3. **Use XML tags** - Some harnesses respond better to:
+   ```xml
+   <skill name="tdd-workflow">
+   <trigger>When test-driven development is needed</trigger>
+   <steps>
+   1. Write failing test
+   2. Make pass
+   3. Refactor
+   </steps>
+   </skill>
+   ```
+
+---
+
+## Command/Hook Reproduction
+
+### Commands
+
+Define a **Command Registry** in your system instructions:
+
+```
+# Command Registry
+- /plan: Execute [planner] agent logic
+- /tdd: Apply the [tdd-workflow] skill
+- /review: Run [code-reviewer] agent
+- /test: Run test suite with coverage
+```
+
+### Hooks (Reproduced via System Prompt)
+
+**onDiskWrite hook:**
+```
+# onDiskWrite Hook
+Before writing to disk, run these checks:
+1. Validate syntax (language-appropriate linter)
+2. Check for secrets/keys in the content
+3. Ensure proper file permissions (644 for code, 600 for secrets)
+```
+
+**prePrompt hook:**
+```
+# prePrompt Hook
+Before responding, verify:
+1. Did you answer the user's actual question?
+2. Are there any security concerns with the code?
+3. Should any hooks have triggered?
+```
+
+---
+
+## Harness Comparison
+
+| Feature | Claude Code | Grok | Claude Desktop |
+|---------|-------------|------|----------------|
+| Native ECC | ✅ | ❌ | ❌ |
+| Custom Commands | ✅ | ❌ | Limited |
+| Hooks | ✅ | ❌ | Limited |
+| Context Packing | ✅ | ✅ (manual) | ✅ (manual) |
+| Agent Files | ✅ | ❌ (manual) | ❌ |
+| Auto-activation | ✅ | ❌ | ❌ |
+
+---
+
+## Limitations
+
+When using manual adaptation, you lose:
+
+1. **Auto-activation** - Skills won't auto-load based on context
+2. **Native commands** - Must define command registry manually
+3. **Hook automation** - Must manually add hook logic to prompts
+4. **Agent orchestration** - Must manually invoke agents
+
+### Mitigation Strategies
+
+| Lost Feature | Workaround |
+|--------------|------------|
+| Auto-activation | Include `<skill name="...">` triggers in every prompt |
+| Commands | Define Command Registry in system instructions |
+| Hooks | Add hook logic to your base prompt |
+| Agents | Copy agent logic directly into prompts |
+
+---
+
+## Example: Grok Setup
+
+1. **Pack your context:**
+   ```bash
+   repomix --include "skills/tdd-workflow,skills/python-patterns,rules/" --output grok-context.md
+   ```
+
+2. **Add to Custom Instructions:**
+   ```
+   # ECC Context (load at session start)
+   [ paste grok-context.md here ]
+   
+   # Command Registry
+   - /plan: Use planner agent logic from context
+   - /tdd: Use tdd-workflow skill
+   - /review: Use code-reviewer agent
+   
+   # Hooks
+   - onDiskWrite: Run lint check and secret scan before writing
+   ```
+
+3. **Test:**
+   ```bash
+   /tdd
+   # Should trigger TDD workflow from your packed context
+   ```
+
+---
+
+## Related Issues
+
+- [#1077](https://github.com/affaan-m/everything-claude-code/discussions/1077) - Grok discussion
+- [#1070](https://github.com/affaan-m/everything-claude-code/issues/1070) - Non-harness compatibility


### PR DESCRIPTION
## Summary

Adds comprehensive guide for adapting ECC to harnesses like Grok that don't support native folder layouts.

## Changes

- New document: `docs/MANUAL-ADAPTATION-GUIDE.md`
- Covers repomix, minimal skill selection, context compression
- Includes command/hook reproduction workarounds
- Harness comparison table (Claude Code vs Grok vs Claude Desktop)
- Grok setup example

## Related Issue

Fixes #1186

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual adaptation guide for using ECC with harnesses that don’t support the native folder layout or custom commands (e.g., Grok, Claude Desktop). Provides `repomix`-based context packing and step-by-step workarounds. Fixes #1186.

- **New Features**
  - New doc: `docs/MANUAL-ADAPTATION-GUIDE.md`
  - Quick start using `repomix` to pack targeted skills
  - Minimal skill selection by task type and priority
  - Context compression tips, including XML-tag formatting
  - Command and hook reproduction via system prompts/registry
  - Harness comparison table and a Grok setup example

<sup>Written for commit 76d86fdfd68d046cc3c1fa076b0ee6c7038b5b4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added comprehensive manual adaptation guide for configuring everything-claude-code with AI harnesses lacking native auto-loading and custom command capabilities. Includes step-by-step setup examples, feature comparison tables, context compression techniques, and strategies for reproducing command and hook behaviors in system prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->