### PR TITLE
feat: add framecraft and code-tour skills

### DIFF
--- a/skills/code-tour/SKILL.md
+++ b/skills/code-tour/SKILL.md
@@ -1,0 +1,647 @@
+---
+name: code-tour
+origin: community
+description: >
+  Use this skill to create CodeTour .tour files — persona-targeted, step-by-step walkthroughs
+  that link to real files and line numbers. Trigger for: "create a tour", "make a code tour",
+  "generate a tour", "onboarding tour", "tour for this PR", "tour for this bug", "RCA tour",
+  "architecture tour", "explain how X works", "vibe check", "PR review tour",
+  "contributor guide", "help someone ramp up", or any request for a structured walkthrough
+  through code. Supports 20 developer personas (new joiner, bug fixer, architect, PR reviewer,
+  vibecoder, security reviewer, and more), all CodeTour step types (file/line, selection,
+  pattern, uri, commands, view), and tour-level fields (ref, isPrimary, nextTour).
+  Works with any repository in any language.
+---
+
+# Code Tour Skill
+
+You are creating a **CodeTour** — a persona-targeted, step-by-step walkthrough of a codebase
+that links directly to files and line numbers. CodeTour files live in `.tours/` and work with
+the [VS Code CodeTour extension](https://github.com/microsoft/codetour).
+
+Two scripts are bundled in `scripts/`:
+
+- **`scripts/validate_tour.py`** — run after writing any tour. Checks JSON validity, file/directory existence, line numbers within bounds, pattern matches, nextTour cross-references, and narrative arc. Run it: `python ~/.agents/skills/code-tour/scripts/validate_tour.py .tours/<name>.tour --repo-root .`
+- **`scripts/generate_from_docs.py`** — when the user asks to generate from README/docs, run this first to extract a skeleton, then fill it in. Run it: `python ~/.agents/skills/code-tour/scripts/generate_from_docs.py --persona new-joiner --output .tours/skeleton.tour`
+
+Two reference files are bundled:
+
+- **`references/codetour-schema.json`** — the authoritative JSON schema. Read it to verify any field name or type. Every field you use must conform to it.
+- **`references/examples.md`** — 8 real-world CodeTour tours from production repos with annotated techniques. Read it when you want to see how a specific feature (`commands`, `selection`, `view`, `pattern`, `isPrimary`, multi-tour series) is used in practice.
+
+### Real-world `.tour` files on GitHub
+
+These are confirmed production `.tour` files. Fetch one when you need a working example of a specific step type, tour-level field, or narrative structure — don't write from memory when the real thing is one fetch away.
+
+Find more with the GitHub code search: https://github.com/search?q=path%3A**%2F*.tour+&type=code
+
+#### By step type / technique demonstrated
+
+| What to study | File URL |
+|---|---|
+| `directory` + `file+line` (contributor onboarding) | https://github.com/coder/code-server/blob/main/.tours/contributing.tour |
+| `selection` + `file+line` + intro content step (accessibility project) | https://github.com/a11yproject/a11yproject.com/blob/main/.tours/code-tour.tour |
+| Minimal tutorial — tight `file+line` narration for interactive learning | https://github.com/lostintangent/rock-paper-scissors/blob/master/main.tour |
+| Multi-tour repo with `nextTour` chaining (cloud native OCI walkthroughs) | https://github.com/lucasjellema/cloudnative-on-oci-2021/blob/main/.tours/introduction.tour |
+| `isPrimary: true` (marks the onboarding entry point) | https://github.com/nickvdyck/webbundlr/blob/main/.tours/getting-started.tour |
+| `pattern` instead of `line` (regex-anchored steps) | https://github.com/nickvdyck/webbundlr/blob/main/.tours/architecture.tour |
+
+#### Notes on each
+
+**`coder/code-server` — Contributing**
+Opens with a `directory` step on `src/` that orients with a single sentence, then drives straight into `src/node/entry.ts` line 157. Clean external-contributor structure: orientation → entry point → key subsystems → links to FAQ docs via URI steps. Good model for any contributor tour.
+
+**`a11yproject/a11yproject.com` — Code Tour**
+Uses `selection` to highlight a block within `package.json` (start line 1, end varies) alongside a `line` for the same file. Shows how to vary step type on the same file. Note: the intro step in this tour is content-only — in some VS Code versions this renders blank. Prefer anchoring the first step to a file or directory and putting the welcome text in its description.
+
+**`lostintangent/rock-paper-scissors` — main.tour**
+Only 4–5 steps. Shows how a minimal tour can be complete: every step tells the reader something actionable, links to a specific line, and ends with a clear call to action ("try changing this and watch it take effect"). Good reference when writing a vibecoder or quick-explainer tour.
+
+**`lucasjellema/cloudnative-on-oci-2021` — multi-tour series**
+Multiple `.tour` files in the same repo, each scoped to a different cloud service. Browse the `.tours/` directory to see how a series is organized — separate files, clear scoped titles, and `nextTour` linking between them. Good model for a complex domain with a tour-series strategy.
+
+**Raw content tip:** If GitHub rate-limits the HTML view, prefix `raw.githubusercontent.com` and drop `/blob/`:
+```
+https://raw.githubusercontent.com/coder/code-server/main/.tours/contributing.tour
+https://raw.githubusercontent.com/a11yproject/a11yproject.com/main/.tours/code-tour.tour
+https://raw.githubusercontent.com/lostintangent/rock-paper-scissors/master/main.tour
+```
+
+A great tour is not just annotated files. It is a **narrative** — a story told to a specific
+person about what matters, why it matters, and what to do next. Your goal is to write the tour
+that the right person would wish existed when they first opened this repo.
+
+**CRITICAL: Only create `.tour` JSON files. Never create, modify, or scaffold any other files.**
+
+---
+
+## Step 1: Discover the repo
+
+Before asking the user anything, explore the codebase:
+
+- List the root directory, read the README, and check key config files
+  (package.json, pyproject.toml, go.mod, Cargo.toml, composer.json, etc.)
+- Identify the language(s), framework(s), and what the project does
+- Map the folder structure 1–2 levels deep
+- Find entry points: main files, index files, app bootstrapping
+- **Note which files actually exist** — every path you write in the tour must be real
+
+If the repo is sparse or empty, say so and work with what exists.
+
+**If the user says "generate from README" or "use the docs":** run the skeleton generator first, then fill in every `[TODO: ...]` by reading the actual files:
+
+```bash
+python skills/code-tour/scripts/generate_from_docs.py \
+  --persona new-joiner \
+  --output .tours/skeleton.tour
+```
+
+### Entry points by language/framework
+
+Don't read everything — start here, then follow imports.
+
+| Stack | Entry points to read first |
+|-------|---------------------------|
+| **Node.js / TS** | `index.js/ts`, `server.js`, `app.js`, `src/main.ts`, `package.json` (scripts) |
+| **Python** | `main.py`, `app.py`, `__main__.py`, `manage.py` (Django), `app/__init__.py` (Flask/FastAPI) |
+| **Go** | `main.go`, `cmd/<name>/main.go`, `internal/` |
+| **Rust** | `src/main.rs`, `src/lib.rs`, `Cargo.toml` |
+| **Java / Kotlin** | `*Application.java`, `src/main/java/.../Main.java`, `build.gradle` |
+| **Ruby** | `config/application.rb`, `config/routes.rb`, `app/controllers/application_controller.rb` |
+| **PHP** | `index.php`, `public/index.php`, `bootstrap/app.php` (Laravel) |
+
+### Repo type variants — adjust focus accordingly
+
+The same persona asks for different things depending on what kind of repo this is:
+
+| Repo type | What to emphasize | Typical anchor files |
+|-----------|-------------------|----------------------|
+| **Service / API** | Request lifecycle, auth, error contracts | router, middleware, handler, schema |
+| **Library / SDK** | Public API surface, extension points, versioning | index/exports, types, changelog |
+| **CLI tool** | Command parsing, config loading, output formatting | main, commands/, config |
+| **Monorepo** | Package boundaries, shared contracts, build graph | root package.json/pnpm-workspace, shared/, packages/ |
+| **Framework** | Plugin system, lifecycle hooks, escape hatches | core/, plugins/, lifecycle |
+| **Data pipeline** | Source → transform → sink, schema ownership | ingest/, transform/, schema/, dbt models |
+| **Frontend app** | Component hierarchy, state management, routing | pages/, store/, router, api/ |
+
+For **monorepos**: identify the 2–3 packages most relevant to the persona's goal. Don't try to tour everything — open the tour with a step that explains how to navigate the workspace, then stay focused.
+
+### Large repo strategy
+
+For repos with 100+ files: don't try to read everything.
+
+1. Read entry points and the README first
+2. Build a mental model of the top 5–7 modules
+3. For the requested persona, identify the **2–3 modules that matter most** and read those deeply
+4. For modules you're not covering, mention them in the intro step as "out of scope for this tour"
+5. Use `directory` steps for areas you mapped but didn't read — they orient without requiring full knowledge
+
+A focused 10-step tour of the right files beats a scattered 25-step tour of everything.
+
+---
+
+## Step 2: Read the intent — infer everything you can, ask only what you can't
+
+**One message from the user should be enough.** Read their request and infer persona,
+depth, and focus before asking anything.
+
+### Intent map
+
+| User says | → Persona | → Depth | → Action |
+|-----------|-----------|---------|----------|
+| "tour for this PR" / "PR review" / "#123" | pr-reviewer | standard | Add `uri` step for the PR; use `ref` for the branch |
+| "why did X break" / "RCA" / "incident" | rca-investigator | standard | Trace the failure causality chain |
+| "debug X" / "bug tour" / "find the bug" | bug-fixer | standard | Entry → fault points → tests |
+| "onboarding" / "new joiner" / "ramp up" | new-joiner | standard | Directories, setup, business context |
+| "quick tour" / "vibe check" / "just the gist" | vibecoder | quick | 5–8 steps, fast path only |
+| "explain how X works" / "feature tour" | feature-explainer | standard | UI → API → backend → storage |
+| "architecture" / "tech lead" / "system design" | architect | deep | Boundaries, decisions, tradeoffs |
+| "security" / "auth review" / "trust boundaries" | security-reviewer | standard | Auth flow, validation, sensitive sinks |
+| "refactor" / "safe to extract?" | refactorer | standard | Seams, hidden deps, extraction order |
+| "performance" / "bottlenecks" / "slow path" | performance-optimizer | standard | Hot path, N+1, I/O, caches |
+| "contributor" / "open source onboarding" | external-contributor | quick | Safe areas, conventions, landmines |
+| "concept" / "explain pattern X" | concept-learner | standard | Concept → implementation → rationale |
+| "test coverage" / "where to add tests" | test-writer | standard | Contracts, seams, coverage gaps |
+| "how do I call the API" | api-consumer | standard | Public surface, auth, error semantics |
+
+**Infer silently:** persona, depth, focus area, whether to add `uri`/`ref`, `isPrimary`.
+
+**Ask only if you genuinely can't infer:**
+- "bug tour" but no bug described → ask for the bug description
+- "feature tour" but no feature named → ask which feature
+- "specific files" explicitly requested → honor them as required stops
+
+Never ask about `nextTour`, `commands`, `when`, or `stepMarker` unless the user mentioned them.
+
+### PR tour recipe
+
+When the user says "tour for this PR" or pastes a GitHub PR URL:
+
+1. Set `"ref"` to the PR's branch name
+2. Open with a `uri` step pointing to the PR itself — this gives the reviewer the full diff context
+3. Add a `uri` step for any related issue or RFC if linked in the PR description
+4. Cover **changed files first** — what changed and why
+5. Then add steps for **files not in the diff** that reviewers must understand to evaluate the change correctly (call sites, dependency files, tests)
+6. Flag invariants the change must preserve
+7. Close with a reviewer checklist: what to verify, what tests to run, what to watch out for
+
+```json
+[
+  { "uri": "https://github.com/org/repo/pull/456",
+    "title": "The PR", "description": "This PR refactors auth to use refresh tokens. Key concern: session invalidation during migration." },
+  { "file": "src/auth/tokenService.ts", "line": 12, "title": "What Changed: Token Issuing", "description": "..." },
+  { "file": "src/auth/middleware.ts", "line": 38, "title": "Unchanged But Critical", "description": "This file wasn't touched but depends on the token shape. Verify line 38 still matches." },
+  { "title": "Reviewer Checklist", "description": "- [ ] Session invalidation tested?\n- [ ] Old tokens still rejected after migration?\n- [ ] Refresh token rotation tested?" }
+]
+```
+
+### User-provided customization — always honor these
+
+| User says | What to do |
+|-----------|-----------|
+| "cover `src/auth.ts` and `config/db.yml`" | Those files are required stops |
+| "pin to the `v2.3.0` tag" / "this commit: abc123" | Set `"ref": "v2.3.0"` |
+| "link to PR #456" / pastes a URL | Add a `uri` step at the right narrative moment |
+| "lead into the security tour when done" | Set `"nextTour": "Security Review"` |
+| "make this the main onboarding tour" | Set `"isPrimary": true` |
+| "open a terminal at this step" | Add `"commands": ["workbench.action.terminal.focus"]` |
+| "deep" / "thorough" / "5 steps" / "quick" | Override depth accordingly |
+
+---
+
+## Step 3: Read the actual files — no exceptions
+
+**Every file path and line number in the tour must be verified by reading the file.**
+A tour pointing to the wrong file or a non-existent line is worse than no tour.
+
+For every planned step:
+1. Read the file
+2. Find the exact line of the code you want to highlight
+3. Understand it well enough to explain it to the target persona
+
+If a user-requested file doesn't exist, say so — don't silently substitute another.
+
+---
+
+## Step 4: Write the tour
+
+Save to `.tours/<persona>-<focus>.tour`. Read `references/codetour-schema.json` for the
+authoritative field list. Every field you use must appear in that schema.
+
+### Tour root
+
+```json
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Descriptive Title — Persona / Goal",
+  "description": "One sentence: who this is for and what they'll understand after.",
+  "ref": "main",
+  "isPrimary": false,
+  "nextTour": "Title of follow-up tour",
+  "steps": []
+}
+```
+
+Omit any field that doesn't apply to this tour.
+
+**`when`** — conditional display. A JavaScript expression evaluated at runtime. Only show this tour
+if the condition is true. Useful for persona-specific auto-launching, or hiding advanced tours
+until a simpler one is complete.
+```json
+{ "when": "workspaceFolders[0].name === 'api'" }
+```
+
+**`stepMarker`** — embed step anchors directly in source code comments. When set, CodeTour
+looks for `// <stepMarker>` comments in files and uses them as step positions instead of
+(or alongside) line numbers. Useful for tours on actively changing code where line numbers
+shift constantly. Example: set `"stepMarker": "CT"` and put `// CT` in the source file.
+Don't suggest this unless the user asks — it requires editing source files, which is unusual.
+
+---
+
+### Step types — the full toolkit
+
+**Content step** — narrative only, no file. Use for intro and closing. Max 2 per tour.
+```json
+{ "title": "Welcome", "description": "markdown..." }
+```
+
+**Directory step** — orient to a module. "What lives here."
+```json
+{ "directory": "src/services", "title": "Service Layer", "description": "..." }
+```
+
+**File + line step** — the workhorse. One specific meaningful line.
+```json
+{ "file": "src/auth/middleware.ts", "line": 42, "title": "Auth Gate", "description": "..." }
+```
+
+> **Path rule — always relative to repo root.** `"file"` and `"directory"` values must be relative to the repository root (the directory that contains `.tours/`). Never use an absolute path (`/Users/...`) and never use a leading `./`. If the repo root is `/projects/myapp` and the file is at `/projects/myapp/src/auth.ts`, write `"src/auth.ts"` — not `./src/auth.ts`, not `/projects/myapp/src/auth.ts`, not `auth.ts` (unless it's actually at the root).
+
+**Selection step** — a block of logic. Use when one line isn't enough (a function body, a config block, a type definition).
+```json
+{
+  "file": "src/core/pipeline.py",
+  "selection": { "start": { "line": 15, "character": 0 }, "end": { "line": 34, "character": 0 } },
+  "title": "The Request Pipeline",
+  "description": "..."
+}
+```
+
+**Pattern step** — match by regex instead of line number. Use when line numbers shift frequently (actively changing files, generated code).
+```json
+{ "file": "src/app.ts", "pattern": "export default class Application", "title": "...", "description": "..." }
+```
+
+**URI step** — link to an external resource: a PR, issue, RFC, ADR, architecture diagram, Notion doc. Use to bring in context that lives outside the codebase.
+```json
+{
+  "uri": "https://github.com/org/repo/pull/456",
+  "title": "The PR That Introduced This Pattern",
+  "description": "This design was debated in PR #456. The key tradeoff was..."
+}
+```
+
+**View step** — auto-focus a VS Code panel at this step (terminal, problems, scm, explorer).
+```json
+{ "file": "src/server.ts", "line": 1, "view": "terminal", "title": "...", "description": "..." }
+```
+
+**Commands step** — execute VS Code commands when the reader arrives. Add to any file step.
+```json
+{
+  "file": "src/server.ts", "line": 1,
+  "title": "Run It",
+  "description": "Hit the play button — you'll see the server boot sequence here.",
+  "commands": ["workbench.action.terminal.focus"]
+}
+```
+
+Useful commands:
+| Command | What it does |
+|---------|-------------|
+| `editor.action.goToDeclaration` | Jump to definition |
+| `editor.action.showHover` | Show type hover |
+| `references-view.findReferences` | Show all references |
+| `workbench.action.terminal.focus` | Open terminal |
+| `workbench.action.tasks.runTask` | Run a task |
+| `workbench.view.scm` | Open source control panel |
+| `workbench.view.explorer` | Open file explorer |
+
+---
+
+### When to use each step type
+
+| Situation | Step type |
+|-----------|-----------|
+| Tour intro or closing | content |
+| "Here's what lives in this folder" | directory |
+| One line tells the whole story | file + line |
+| A function/class body is the point | selection |
+| Line numbers shift, file is volatile | pattern |
+| PR / issue / doc gives the "why" | uri |
+| Reader should open terminal or explorer | view or commands |
+
+---
+
+### Step count calibration
+
+Match steps to depth and persona. These are targets, not hard limits.
+
+| Depth | Total steps | Core path steps | Notes |
+|-------|-------------|-----------------|-------|
+| Quick | 5–8 | 3–5 | Vibecoder, fast explorer — cut ruthlessly |
+| Standard | 9–13 | 6–9 | Most personas — breadth + enough detail |
+| Deep | 14–18 | 10–13 | Architect, RCA — every tradeoff surfaced |
+
+Scale with repo size too. A 3-file CLI doesn't get 15 steps. A 200-file monolith shouldn't be squeezed into 5.
+
+| Repo size | Recommended standard depth |
+|-----------|---------------------------|
+| Tiny (< 20 files) | 5–8 steps |
+| Small (20–80 files) | 8–11 steps |
+| Medium (80–300 files) | 10–13 steps |
+| Large (300+ files) | 12–15 steps (scoped to relevant subsystem) |
+
+---
+
+### Writing excellent descriptions — the SMIG formula
+
+Every description should answer four questions in order. You don't need four paragraphs — but every description needs all four elements, even briefly.
+
+**S — Situation**: What is the reader looking at? One sentence grounding them in context.
+**M — Mechanism**: How does this code work? What pattern, rule, or design is in play?
+**I — Implication**: Why does this matter for *this persona's goal specifically*?
+**G — Gotcha**: What would a smart person get wrong here? What's non-obvious, fragile, or surprising?
+
+**Bad description** (generic — could apply to any codebase):
+> "This is the authentication middleware. It checks if the user is authenticated before allowing access to protected routes."
+
+**Good description** (SMIG applied):
+> **S:** Every HTTP request passes through this file before reaching any controller — it's the sole auth checkpoint.
+>
+> **M:** Notice the **dual-check pattern** on line 42: it validates the JWT signature *and* does a Redis lookup for the session. Both must pass. A valid JWT alone isn't enough if the session was revoked (logout, password reset, force-expire).
+>
+> **I:** For a bug fixer: if a user reports being logged out unexpectedly, this is your first stop. Redis miss → 401 → silent logout is the most common failure path.
+>
+> **G:** If Redis is down, line 53 propagates the error as a 401 — meaning a Redis outage silently logs everyone out. There's no circuit breaker here. This is tracked in ISSUE-4421, and the workaround is in `config/redis.ts` line 18.
+
+The good description tells the reader something they couldn't learn by reading the file themselves. It names the pattern, explains the design decision, flags the failure mode, and cross-references related context.
+
+**Persona vocabulary cheat sheet** — speak their language, not generic developer-speak:
+
+| Persona | Their vocabulary | Avoid |
+|---------|-----------------|-------|
+| New joiner | "this means", "you'll need to", "the team calls this" | acronyms, assumed context |
+| Bug fixer | "failure path", "where this breaks", "repro steps" | architecture history |
+| Security reviewer | "trust boundary", "untrusted input", "privilege escalation" | vague "be careful" |
+| PR reviewer | "invariant", "this must stay true", "the change story" | unrelated context |
+| Architect | "seam", "coupling", "extension point", "decision" | step-by-step walkthroughs |
+| Vibecoder | "the main loop", "ignore for now", "start here" | deep explanations |
+
+---
+
+## Narrative arc — every tour, every persona
+
+1. **Orientation** — **must be a `file` or `directory` step, never content-only.**
+   Use `"file": "README.md", "line": 1` or `"directory": "src"` and put your welcome text in the description.
+   A content-only first step (no `file`, `directory`, or `uri`) renders as a blank page in VS Code CodeTour — this is a known VS Code extension behaviour, not configurable.
+
+2. **High-level map** (1–3 directory or uri steps) — major modules and how they relate.
+   Not every folder — just what this persona needs to know.
+
+3. **Core path** (file/line, selection, pattern, uri steps) — the specific code that matters.
+   This is the heart of the tour. Read and narrate. Don't skim.
+
+4. **Closing** (content) — what the reader now understands, what they can do next,
+   2–3 suggested follow-up tours. If `nextTour` is set, reference it by name here.
+
+### What makes a closing step excellent
+
+The closing is frequently the weakest step. Don't summarize — the reader just read it.
+Instead:
+
+❌ Bad closing (recap):
+> "In this tour we covered the entry point, the middleware stack, and the database layer."
+
+✅ Good closing (action + next):
+> "You now know enough to safely add a new route without breaking auth or session handling.
+> The danger zones to stay away from are `src/auth/tokenService.ts` (don't change the token shape without a migration plan) and `src/db/pool.ts` (connection limits are load-tested at current values).
+>
+> **What's next:**
+> - If you're fixing a bug → jump to the **Bug Fixer: Payment Flow** tour for the specific path
+> - If you're adding a feature → the **Feature Explainer: Notifications** tour shows the full pattern
+> - If something's on fire → the **RCA: Incident Guide** tour maps the observability anchors"
+
+The good closing tells the reader what they're now capable of, what to avoid, and gives them a map of where to go next.
+
+---
+
+## The 20 personas
+
+| Persona | Goal | Must cover | Avoid |
+|---------|------|------------|-------|
+| **Vibecoder** | Get the vibe fast | Entry point, request flow, main modules. "Start here / Core loop / Ignore for now." Max 8 steps. | Deep dives, history, edge cases |
+| **New joiner** | Structured ramp-up | Directories, setup/run instructions, business context, service boundaries, team terms defined. | Advanced internals before basics |
+| **Reboarding engineer** | Catch up on what changed | What's new vs. what they remember. "This used to be X, now it's Y." | Re-explaining things they knew |
+| **Bug fixer** | Root cause fast | User action → trigger → fault points. Validation, branching, error handling. Repro hints + test locations. | Architecture tours, business context |
+| **RCA / incident investigator** | Why did it fail | Causality chain. State transitions, side effects, race conditions. Observability anchors. | Happy path |
+| **Feature explainer** | One feature end-to-end | UI → API → backend → storage. Feature flags, auth, edge cases, scope. | Unrelated features |
+| **Concept learner** | Understand a pattern | Concept intro → implementation → why this design → tradeoffs → common misunderstanding. | Code without conceptual framing |
+| **PR reviewer** | Review the change correctly | The change story, not just changed files. Invariants. Risky areas. Reviewer checklist. URI step for the PR. | Unrelated context |
+| **Maintainer** | Long-term health | Architectural intent. Extension points. "Do not bypass this layer." Long-lived invariants. | One-time setup concerns |
+| **Refactorer** | Safe restructuring | Seams, hidden deps, implicit contracts, coupling hotspots, safe extraction order. | Feature explanations |
+| **Performance optimizer** | Find bottlenecks | Hot paths, N+1, I/O, serialization. Caches, batching. Existing benchmarks. | Cold paths, setup code |
+| **Security reviewer** | Trust boundaries + abuse paths | Auth flow. Input validation. Secret handling. Sensitive sinks. Safe failure modes. | Unrelated business logic |
+| **Test writer** | Add good tests | Behavior contracts. Existing patterns. Mocking seams. Coverage gaps. High-value scenarios. | Implementation detail |
+| **API consumer** | Call the system correctly | Public surface, request/response shapes, auth, error semantics, stable vs. internal. | Internal implementation |
+| **Platform / infra engineer** | Operational understanding | Boot sequence, config loading, infra deps, background jobs, graceful shutdown. | Business logic |
+| **Data engineer** | Data lineage + schemas | Event emission, schema definitions, source-to-sink path, data quality, backfill. | UI / request flow |
+| **AI agent operator** | Deterministic navigation | Stable anchors, allowed edit zones, required validation steps. "Do not infer — read this file first." | Ambiguous or implied structure |
+| **Product-minded engineer** | Business rules in code | Domain language, business rules, feature toggles, "why does this weird code exist?" | Pure infrastructure |
+| **External contributor** | Contribute without breaking | Contribution-safe areas, code style, architecture landmines, typical first-timer mistakes. | Deep internals |
+| **Tech lead / architect** | Shape and rationale | Module boundaries, design tradeoffs, risk hotspots, future evolution. | Line-by-line walkthroughs |
+
+---
+
+## Designing a tour series
+
+When a codebase is complex enough that one tour can't cover it well, design a series.
+The `nextTour` field chains them: when the reader finishes one tour, VS Code offers to
+launch the next automatically.
+
+**Plan the series before writing any tour.** A good series has:
+- A clear escalation path (broad → narrow, orientation → deep-dive)
+- No duplicate steps between tours
+- Each tour standalone enough to be useful on its own
+
+**Common series patterns:**
+
+*Onboarding series (new joiner):*
+1. "Orientation" → repo structure, how to run it (isPrimary: true)
+2. "Core Request Flow" → entry to response, middleware chain
+3. "Data Layer" → models, migrations, query patterns
+4. "Testing Patterns" → how to write and run tests
+
+*Incident / debug series (bug fixer + RCA):*
+1. "Happy Path" → normal flow from trigger to response
+2. "Failure Modes" → where it can break and why
+3. "Observability Map" → logs, metrics, traces to look at
+
+*Architecture series (tech lead):*
+1. "Module Boundaries" → what lives where and why
+2. "Extension Points" → where to add new features
+3. "Danger Zones" → what must never be changed carelessly
+
+**When writing a series:** set `nextTour` in each tour to the `title` of the next one.
+The value must match exactly. Tell the reader in the closing step which tour comes next
+and why they should read it.
+
+### Hot files — anchor the series
+
+Some files deserve a step in almost every tour because they're where the system's core rules live. Identify 2–3 of these early and treat them as anchors:
+
+- The **main entry point** — every persona needs to see this
+- The **central router or dispatcher** — where requests branch
+- The **primary config loader** — where behavior is controlled
+- The **auth boundary** — the single place permissions are checked
+
+When the same file appears in multiple tours, give it a *different* framing each time — new joiners get "this is where the server starts", security reviewers get "this is the only place secrets are loaded".
+
+---
+
+## What CodeTour cannot do
+
+If asked for any of these, say clearly that it's not supported — do not suggest a workaround that doesn't exist:
+
+| Request | Reality |
+|---|---|
+| **Auto-advance to next step after X seconds** | Not supported. Navigation is always manual — the reader clicks Next. There is no timer, delay, or autoplay step mechanic in CodeTour. |
+| **Embed a video or GIF in a step** | Not supported. Descriptions are Markdown text only. |
+| **Run arbitrary shell commands** | Not supported. `commands` only executes VS Code commands (e.g. `workbench.action.terminal.focus`), not shell commands. |
+| **Branch / conditional next step** | Not supported. Tours are linear. `when` controls whether a tour is shown, not which step follows which. |
+| **Show a step without opening a file** | Partially — content-only steps work, but step 1 must have a `file` or `directory` anchor or VS Code shows a blank page. |
+
+---
+
+## Anti-patterns — what ruins a tour
+
+Avoid these. They are the most common failures.
+
+| Anti-pattern | What it looks like | The fix |
+|---|---|---|
+| **File listing** | Visiting `models.py`, `routes.py`, `utils.py` in sequence with descriptions like "this file contains the models" | Tell a story — each step should depend on having seen the previous one. Ask: "why does this step come after the last one?" |
+| **Generic descriptions** | "This is the main entry point of the application." | If your description would make sense for any repo, rewrite it. Name the specific pattern, decision, or gotcha that's unique to *this* codebase. |
+| **Line number guessing** | Writing `"line": 42` without reading the file | Never write a line number you didn't verify. Off-by-one lands the cursor on the wrong code and breaks trust instantly. |
+| **Ignoring the persona** | Security reviewer getting a folder structure tour | Step selection must reflect what this specific person is trying to accomplish. Cut every step that doesn't serve their goal. |
+| **Too many steps** | A 20-step "vibecoder" tour | Respecting depth means *actually cutting steps* — not just labeling it "quick." |
+| **Hallucinated files** | Steps pointing to files that don't exist | If a file doesn't exist in the repo, skip the step. Never use a placeholder. |
+| **Recap closing** | "In this tour we covered X, Y, and Z." | The closing should tell the reader what they can now *do*, what to watch out for, and where to go next. |
+| **Persona vocabulary mismatch** | Explaining JWTs to a security reviewer | Meet each persona where they are. Security reviewers know what a JWT is — tell them what's *wrong* with this implementation. |
+| **Broken `nextTour`** | `"nextTour"` value doesn't exactly match any tour title | Always copy the title string verbatim. A typo silently breaks the chain. |
+
+---
+
+## Quality checklist — verify before writing the file
+
+- [ ] Every `file` path is **relative to the repo root** (no leading `/` or `./`)
+- [ ] Every `file` path read and confirmed to exist
+- [ ] Every `line` number verified by reading the file (not guessed)
+- [ ] Every `directory` is **relative to the repo root** and confirmed to exist
+- [ ] Every `pattern` regex would match a real line in the file
+- [ ] Every `uri` is a complete, real URL (https://...)
+- [ ] `ref` is a real branch/tag/commit if set
+- [ ] `nextTour` exactly matches the `title` of another `.tour` file if set
+- [ ] Only `.tour` JSON files created — no source code touched
+- [ ] First step has a `file` or `directory` anchor (content-only first step = blank page in VS Code)
+- [ ] Tour ends with a closing content step that tells the reader what they can *do* next
+- [ ] Every description answers SMIG — Situation, Mechanism, Implication, Gotcha
+- [ ] Persona's priorities drive step selection (cut everything that doesn't serve their goal)
+- [ ] Step count matches requested depth and repo size (see calibration table)
+- [ ] At most 2 content-only steps (intro + closing)
+- [ ] All fields conform to `references/codetour-schema.json`
+
+---
+
+## Step 5: Validate the tour
+
+**Always run the validator immediately after writing the tour file. Do not skip this step.**
+
+```bash
+python ~/.agents/skills/code-tour/scripts/validate_tour.py .tours/<name>.tour --repo-root .
+```
+
+The validator checks:
+- JSON validity
+- Every `file` path exists and every `line` is within file bounds
+- Every `directory` exists
+- Every `pattern` regex compiles and matches at least one line in the file
+- Every `uri` starts with `https://`
+- `nextTour` matches an existing tour title in `.tours/`
+- Content-only step count (warns if > 2)
+- Narrative arc (warns if no orientation or closing step)
+
+**Fix every error before proceeding.** Re-run until the validator reports ✓ or only warnings. Warnings are advisory — use your judgment. Do not show the user the tour until validation passes.
+
+**What actually breaks VS Code CodeTour** (the real causes of blank/broken steps):
+- **Content-only first step** — step 1 has no `file`, `directory`, or `uri`. VS Code opens to a blank page. Fix: anchor step 1 to a file or directory and put the intro text in its description.
+- **File path not relative to repo root** — absolute paths or `./`-prefixed paths silently fail to open. Fix: always use paths relative to where `.tours/` lives (e.g. `src/auth.ts`, not `./src/auth.ts`).
+- **Line number out of bounds** — VS Code opens the file but scrolls nowhere. The validator catches this.
+
+These are the only structural issues that cause VS Code rendering failures. Description length, markdown formatting, and use of `\n` in JSON strings do NOT affect rendering.
+
+If you can't run scripts, do the equivalent check manually:
+1. Confirm step 1 has a `file` or `directory` field
+2. Confirm every `file` path exists by reading it (relative to repo root, no leading `./`)
+3. Confirm every `line` is within the file's line count
+4. Confirm every `directory` exists
+5. Read the step titles in sequence — do they tell a coherent story?
+6. Confirm `nextTour` matches another tour's `title` exactly
+
+**Autoplay on repo open** — `isPrimary: true` makes CodeTour show a "Start Tour?" prompt when the repo opens in VS Code. To make this reliable for everyone who clones the repo, also write `.vscode/settings.json`:
+
+```json
+{ "codetour.promptForPrimaryTour": true }
+```
+
+Without this file, the prompt depends on each user's global VS Code config. Committed to the repo, it fires for everyone automatically. Create this file whenever you set `isPrimary: true`.
+
+**`ref` and autoplay:** if the tour has `"ref": "main"`, CodeTour only prompts when the user is on that exact branch or tag. For tours that should appear on any branch, omit `ref`.
+
+**Share via vscode.dev** — the fastest way for someone to use the tour without
+cloning the repo. For any public GitHub repo with tours committed to `.tours/`,
+they can open it directly in the browser:
+
+```
+https://vscode.dev/github.com/<owner>/<repo>
+```
+
+VS Code Web will detect the `.tours/` directory and offer to start the tour.
+No install needed. Tell the user this URL in your summary when the repo is public.
+
+---
+
+## Step 6: Summarize
+
+After writing the tour, tell the user:
+- File path (`.tours/<name>.tour`)
+- One-paragraph summary of what the tour covers and who it's for
+- The `vscode.dev` URL if the repo is public (so they can share it immediately)
+- 2–3 suggested follow-up tours (or the next tour in the series if one was planned)
+- Any user-requested files that didn't exist (be explicit — don't quietly substitute)
+
+---
+
+## File naming
+
+`<persona>-<focus>.tour` — kebab-case, communicates both:
+```
+onboarding-new-joiner.tour
+bug-fixer-payment-flow.tour
+architect-overview.tour
+vibecoder-quickstart.tour
+pr-review-auth-refactor.tour
+security-auth-boundaries.tour
+concept-dependency-injection.tour
+rca-login-outage.tour
+```

--- a/skills/framecraft/SKILL.md
+++ b/skills/framecraft/SKILL.md
@@ -1,0 +1,425 @@
+---
+name: framecraft
+description: Create polished demo videos from screenshots and scene descriptions. Think like a video producer — story arc, pacing, emotion, visual hierarchy. Orchestrates playwright, ffmpeg, and edge-tts MCPs or falls back to an atomic pipeline.
+origin: community
+trigger: |
+  When the user asks to create a demo video, product walkthrough, feature showcase,
+  animated presentation, marketing video, product teaser, GIF, launch video,
+  onboarding video, or any visual content from screenshots, UI captures, or descriptions.
+  Phrases: "make a video", "create a demo", "product video", "demo video",
+  "animated walkthrough", "feature showcase", "record a demo", "make a GIF",
+  "launch video", "product teaser", "show how it works", "promo video".
+---
+
+# framecraft
+
+You are a video producer. Not a slideshow maker. Every frame has a job. Every second earns the next.
+
+## Your Mindset
+
+Before touching any tool, think like this:
+
+1. **What's the one thing the viewer should feel?** "Wow, I need this" — not "huh, interesting features."
+2. **What's the story?** Every good demo is: problem → magic moment → proof → invite.
+3. **What's the pace?** Fast enough to keep attention. Slow enough to land each point. Never boring.
+
+You are NOT making a documentation video. You are making something someone watches and immediately shares.
+
+---
+
+## The Toolbox
+
+Check which MCPs are available. Use what's there.
+
+| MCP | Tools | Purpose |
+|-----|-------|---------|
+| **playwright** | `browser_navigate`, `browser_screenshot` | Render HTML scenes to PNG frames |
+| **ffmpeg** | `ffmpeg_convert`, `ffmpeg_merge`, `ffmpeg_extract_frames` | Composite, transitions, audio mix |
+| **edge-tts** | TTS tools | Neural voiceover (free, no API key) |
+| **framecraft** | `render_video`, `preview_scene`, `generate_tts` | Atomic pipeline fallback |
+
+### Three ways to render
+
+**Mode A — MCP Orchestration** (most control):
+Write HTML → playwright screenshots → edge-tts audio → ffmpeg composite
+
+**Mode B — Pipeline** (most reliable):
+`framecraft.render_video(scenes_json, auto_duration=true)` — one call, everything
+
+**Mode C — CLI** (always works):
+```bash
+uv run python framecraft.py scenes.json --auto-duration
+uv run python framecraft.py scenes.json --scene 2       # iterate on one scene
+uv run python framecraft.py --validate output.mp4        # quality check
+```
+
+---
+
+## Story Structures
+
+Pick the structure that fits. Don't default to "feature list."
+
+### The Classic Demo (30-60s)
+```
+1. HOOK         — 3s  — One provocative line or visual. Grab attention.
+2. PROBLEM      — 5s  — Show the pain. Make it visceral.
+3. MAGIC MOMENT — 5s  — The product in action. The "holy shit" moment.
+4. PROOF        — 15s — 2-3 features, each with visual evidence.
+5. SOCIAL PROOF — 4s  — Numbers, logos, quotes (optional).
+6. INVITE       — 4s  — CTA. URL. "Try it now."
+```
+
+### The Problem-Solution (20-40s)
+```
+1. BEFORE  — 6s  — Show the world without your product. Ugly, painful.
+2. AFTER   — 6s  — Same world, with your product. Beautiful, effortless.
+3. HOW     — 10s — Quick feature highlights.
+4. GET IT  — 4s  — CTA.
+```
+
+### The Feature Deep-Dive (45-90s)
+```
+1. CONTEXT   — 4s  — What the product is (one sentence).
+2. FEATURE 1 — 8s  — Screenshot + zoom + callout + narration.
+3. FEATURE 2 — 8s  — Different visual approach (browser mockup? animation?).
+4. FEATURE 3 — 8s  — Third visual style for variety.
+5. FEATURE 4 — 8s  — The "one more thing" — most impressive feature last.
+6. SUMMARY   — 4s  — Recap badges.
+7. CTA       — 4s  — URL + invite.
+```
+
+### The 15-Second Teaser
+```
+1. HOOK    — 2s  — Bold text, no narration.
+2. DEMO    — 8s  — Fast cuts showing the product. Music-driven.
+3. LOGO    — 3s  — Product name + URL.
+4. TAGLINE — 2s  — One line that sticks.
+```
+
+---
+
+## Scene Design System
+
+### Visual Hierarchy Per Scene
+
+Every scene has exactly ONE primary focus. If you can't point at it, it's wrong.
+
+```
+Title scenes:    Focus = the product name
+Problem scenes:  Focus = the pain (red, chaotic, cramped)
+Solution scenes: Focus = the result (green, spacious, organized)
+Feature scenes:  Focus = the screenshot region being highlighted
+End scenes:      Focus = the URL / CTA button
+```
+
+### Color Language
+
+Colors are not decoration. They communicate.
+
+| Color | Meaning | Use for |
+|-------|---------|---------|
+| `#c5d5ff` | Trust, product identity | Titles, logo |
+| `#7c6af5` | Premium, accent | Subtitles, badges, links |
+| `#4ade80` | Success, positive | "After" states, checkmarks, good metrics |
+| `#f28b82` | Problem, danger, attention | "Before" states, error counts, warnings |
+| `#fbbf24` | Energy, highlight | Callouts, important numbers |
+| `#7a8099` | Neutral, secondary | Body text, descriptions |
+| `#0d0e12` | Background | Always. Dark mode only. |
+
+### Animation Timing Science
+
+The human eye needs **300ms** to register a new element. Faster = subliminal. Slower = boring.
+
+```
+Element entrance:     0.5-0.8s  (cubic-bezier(0.16, 1, 0.3, 1) for spring feel)
+Between elements:     0.2-0.4s  gap (stagger)
+Screenshot appear:    0.8-1.0s  (slightly slower — it's the hero)
+Zoom into region:     1.0-1.5s  (smooth, never jarring)
+Scene transition:     0.3-0.5s  crossfade
+Hold after last anim: 1.0-2.0s  (let it breathe before next scene)
+```
+
+**The rhythm**: enter → breathe → enter → breathe → transition. Never enter → enter → enter.
+
+### Typography Rules
+
+```
+Title:     48-72px, weight 800, gradient or white
+Subtitle:  24-32px, weight 400, muted color
+Bullets:   18-22px, weight 600, accent color, pill-shaped background
+Callouts:  14-16px, weight 600, colored border + dot
+Body:      Never. If you need body text, you're doing it wrong.
+```
+
+**Font**: Inter. Always. Load from Google Fonts in every HTML scene.
+
+---
+
+## Writing Narration Like a Pro
+
+### The Rules
+
+1. **One idea per scene.** If you need "and" you need two scenes.
+2. **Lead with the verb.** "Organize your tabs" not "Tab organization is provided."
+3. **Cut every word you can.** Read it aloud. If you pause, add a comma. If you rush, cut words.
+4. **No jargon.** "Your tabs organize themselves" not "AI-powered ML-based tab categorization."
+5. **Use contrast.** "24 tabs. One click. 5 groups." Numbers land harder than adjectives.
+6. **End scenes with a period, not a question.** Statements are confident. Questions are weak.
+
+### Narration Patterns That Work
+
+| Pattern | Example | When to use |
+|---------|---------|-------------|
+| **Contrast** | "24 tabs. Zero organization." | Problem scenes |
+| **Magic** | "One click, and your tabs organize themselves." | Solution reveal |
+| **Proof** | "Corrections count triple. Rejections remembered 30 days." | Feature scenes |
+| **Numbers** | "8 providers. 3 completely free." | Credibility scenes |
+| **Invitation** | "Open source. Free. Try it now." | End card |
+| **Rhetorical** | "Sound familiar?" | After problem (use sparingly) |
+
+### Pacing Guide
+
+| Scene duration | Max narration words | Narration fills |
+|---------------|--------------------|-|
+| 3-4s | 8-12 words | ~70% of scene (leave breathing room) |
+| 5-6s | 15-22 words | ~75% |
+| 7-8s | 22-30 words | ~80% |
+| 9-10s | 28-35 words | ~80% (never fill 100%) |
+
+### Voice Direction
+
+| Voice | Personality | Best for |
+|-------|------------|----------|
+| `andrew` | Warm, confident, conversational | Product demos, launches |
+| `jenny` | Clear, upbeat, approachable | Tutorials, onboarding |
+| `davis` | Deep, authoritative, serious | Enterprise, security products |
+| `brian` | Professional, measured | B2B, technical demos |
+| `emma` | Friendly, enthusiastic | Consumer products, social |
+| `ryan` | British, polished | Premium/luxury positioning |
+
+**Switch voices between scenes** for variety in longer videos. Use one voice for narration and another for "quotes" or feature callouts.
+
+---
+
+## HTML Scene Craft
+
+### The Golden Layout
+
+Every scene follows this structure:
+
+```html
+<body>                          <!-- Full 1920x1080 canvas -->
+  <h1 class="title">...</h1>   <!-- Top 15% — headline -->
+  <div class="hero">...</div>  <!-- Middle 65% — screenshot/mockup/animation -->
+  <div class="footer">...</div> <!-- Bottom 20% — bullets/badges/callouts -->
+</body>
+```
+
+**Never center everything vertically.** The eye enters top-left, scans in an F-pattern. Title up top, hero in the middle, proof at the bottom.
+
+### Background Recipe
+
+Always use this. Never flat black.
+
+```css
+background: #0d0e12;
+background-image:
+  radial-gradient(ellipse at 20% 30%, rgba(124,106,245,0.15) 0%, transparent 50%),
+  radial-gradient(ellipse at 80% 70%, rgba(79,139,255,0.10) 0%, transparent 50%);
+```
+
+Subtle purple-blue glow. Feels premium without being distracting.
+
+### Screenshot Presentation
+
+Never show a raw screenshot. Always:
+
+```css
+.screenshot {
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.08);
+}
+```
+
+The shadow sells "this is floating on a surface." The 1px border prevents edge bleed.
+
+### The Spring Easing
+
+Use this for every entrance animation. It feels alive.
+
+```css
+cubic-bezier(0.16, 1, 0.3, 1)
+```
+
+**Never use `ease` or `linear`.** They feel robotic. The spring curve overshoots slightly then settles — it's what Apple uses.
+
+---
+
+## Browser Mockup Scenes
+
+For product demos that show a web UI in action. See `templates/browser-mockup.html` and `templates/browser-groups.html`.
+
+### Building a Convincing Browser
+
+```
+Traffic lights:  12px dots, colors #ff5f57 #ffbd2e #28c940
+Title bar:       #202124, 40px height
+Tab bar:         #292b2f, flex layout
+URL bar:         #35363a, rounded 20px, with lock icon
+Content area:    #1a1a2e or embed a real screenshot
+```
+
+### Tab Group Animation Pattern
+
+Groups appear one-by-one with staggered timing:
+
+```css
+.group:nth-child(1) { animation: group-in 0.6s cubic-bezier(0.16,1,0.3,1) 0.5s forwards; }
+.group:nth-child(2) { animation: group-in 0.6s cubic-bezier(0.16,1,0.3,1) 0.9s forwards; }
+.group:nth-child(3) { animation: group-in 0.6s cubic-bezier(0.16,1,0.3,1) 1.3s forwards; }
+```
+
+Each group needs:
+- A **solid-colored label chip** (the group name)
+- A **colored bottom bar** (3px, spans the group width)
+- **Tinted background** on the tab area
+- **Favicons** as small colored squares (14px) — brand colors sell realism
+
+### "Before vs After" Technique
+
+Scene N: Messy tabs (all grey, cramped, chaotic, red "24" counter)
+Scene N+1: Same browser, but tabs now grouped with colors (green checkmark, group badges)
+
+The contrast is the whole point. Make the "before" genuinely ugly.
+
+---
+
+## Callout & Zoom Technique
+
+### Callouts
+
+Position annotation labels that point at specific UI elements:
+
+```json
+"callouts": [
+  {"text": "Correction Tracking", "x": 35, "y": 42, "color": "#4ade80", "delay": 1.5},
+  {"text": "30-day memory", "x": 35, "y": 55, "color": "#f28b82", "delay": 2.0}
+]
+```
+
+Rules:
+- Max 3 callouts per scene (more = noise)
+- Stagger by 0.5s each
+- Use different colors per callout
+- Position so they don't overlap the content they're pointing at
+
+### Zoom
+
+Start with the full screenshot, then smoothly zoom into the interesting part:
+
+```json
+"zoom": {"x": 35, "y": 45, "scale": 2.0, "delay": 1.5, "duration": 1.2}
+```
+
+Rules:
+- Only zoom AFTER the viewer has seen the full context (1.5s delay minimum)
+- Scale 1.5-2.0x (more = disorienting)
+- Duration 1.0-1.5s (faster = jarring, slower = boring)
+- The zoom target should be the thing the narration is talking about
+
+---
+
+## Scene Config Reference
+
+```json
+{
+  "scenes": [
+    {
+      "title": "Heading text",
+      "subtitle": "Secondary text",
+      "narration": "Voiceover text",
+      "voice": "andrew",
+      "screenshot": "/absolute/path/to/image.png",
+      "bullets": ["Point 1", "Point 2"],
+      "callouts": [{"text": "Label", "x": 40, "y": 55, "color": "#4ade80", "delay": 1.5}],
+      "zoom": {"x": 40, "y": 55, "scale": 1.8, "delay": 2.0, "duration": 1.0},
+      "duration": 0,
+      "animation": "fade | slide-up | scale | none",
+      "screenshot_animation": "scale | fade | slide-up | none",
+      "custom_html": "/path/to/custom.html",
+      "bg_color": "#0d0e12",
+      "title_color": "#c5d5ff",
+      "accent_color": "#7c6af5",
+      "title_size": 48
+    }
+  ],
+  "output": "/path/to/output.mp4",
+  "width": 1920,
+  "height": 1080,
+  "fps": 24,
+  "voice": "andrew",
+  "transition": "crossfade | cut",
+  "transition_duration": 0.4,
+  "background_music": "/path/to/music.mp3",
+  "music_volume": 0.15,
+  "subtitle_format": "srt | vtt | "
+}
+```
+
+`duration: 0` = auto-detect from TTS length + 1.5s buffer. Always prefer this.
+
+---
+
+## Quality Checklist
+
+Before delivering, verify:
+
+### Technical
+- [ ] Video has audio stream (`ffprobe` shows both v and a)
+- [ ] Audio duration matches video duration (within 1s)
+- [ ] Resolution is 1920x1080 (or what was configured)
+- [ ] No black frames between scenes
+- [ ] File size: 1-5MB for 30s, 3-10MB for 60s
+
+### Creative
+- [ ] First 3 seconds grab attention (no slow fade from black)
+- [ ] Every scene has exactly one focus point
+- [ ] Narration matches what's on screen (no talking about Feature B while showing Feature A)
+- [ ] Color-coding is consistent (same feature = same color throughout)
+- [ ] End card has a clear URL and CTA
+- [ ] Total duration feels right (30s for teaser, 45-60s for demo, 90s max for deep dive)
+
+### The "Would I Share This?" Test
+Watch the video. If you wouldn't share it, it's not done. Common failures:
+- Too slow (fix: cut scene durations by 20%)
+- Too much text on screen (fix: move info to narration, simplify visuals)
+- Narration is generic (fix: rewrite with specific numbers and concrete verbs)
+- Looks like a slideshow (fix: add custom_html scenes with animations)
+
+---
+
+## Platform-Specific Exports
+
+| Platform | Format | Resolution | Duration | Notes |
+|----------|--------|-----------|----------|-------|
+| GitHub README | GIF | 640x360 | 15-30s | Loop, no audio, keep under 5MB |
+| Twitter/X | MP4 | 1920x1080 | 15-60s | First 3s must hook |
+| LinkedIn | MP4 | 1920x1080 | 30-90s | Subtitles required (autoplay is muted) |
+| Product Hunt | MP4 | 1920x1080 | 30-60s | Show the product working, not talking heads |
+| Chrome Web Store | MP4 | 1280x800 | 30-45s | Must show the extension in action |
+| Landing page | GIF or MP4 | 1280x720 | 10-20s | Auto-loop, no audio, hero section |
+
+Generate GIF from MP4:
+```bash
+ffmpeg -i demo.mp4 -vf "fps=12,scale=640:360:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" demo.gif
+```
+
+---
+
+## Reference
+
+**Example project**: [gTabs v0.4 demo](https://github.com/vaddisrinivas/gtabs/blob/main/store-assets/demo-v04.gif) — built entirely with framecraft.
+
+**Templates**: See `templates/` directory for real HTML scenes you can copy and customize.
+
+**Learnings**: See `LEARNINGS.md` for what we discovered building the gTabs demo — browser mockup patterns, animation timing, TTS voice quality, rendering performance.


### PR DESCRIPTION
## Summary

- **framecraft** ([repo](https://github.com/vaddisrinivas/framecraft)): Skill for creating polished demo videos from a prompt. Orchestrates Playwright for HTML scene rendering, edge-tts for narration, and ffmpeg for video assembly. Supports story structure, pacing, and visual hierarchy.
- **code-tour** ([repo](https://github.com/vaddisrinivas/code-tour)): Skill for creating AI-generated CodeTour walkthroughs. Produces persona-targeted `.tour` files (VS Code CodeTour compatible) with file/line links, validation scripts, and support for 20+ developer personas.

## Changes

- Added `skills/framecraft/SKILL.md` (424 lines)
- Added `skills/code-tour/SKILL.md` (645 lines)
- Both use `origin: community` in frontmatter

## Test plan

- [ ] Copy `skills/framecraft/` to `~/.claude/skills/` and verify skill triggers on "make a demo video"
- [ ] Copy `skills/code-tour/` to `~/.claude/skills/` and verify skill triggers on "create a code tour"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two community skills to create demo videos and CodeTour walkthroughs from prompts. Expands our content creation and onboarding tooling with `framecraft` and `code-tour`.

- **New Features**
  - `framecraft`: Produces polished demo videos from scene descriptions/screenshots. Orchestrates `Playwright` for HTML scene renders, `edge-tts` for narration, and `ffmpeg` for assembly (or a fallback pipeline). Includes story structures, pacing, and a design system. Triggers on phrases like “make a demo video.”
  - `code-tour`: Generates VS Code CodeTour `.tour` files that link to real files/lines. Supports 20+ personas, all step types, and fields like `ref`, `isPrimary`, `nextTour`. References a validator and a docs-based skeleton generator. Triggers on “create a code tour.”
  - Files added: `skills/framecraft/SKILL.md`, `skills/code-tour/SKILL.md` (both `origin: community`).

<sup>Written for commit 73058ae1f9884d72b7a0403c065b1441330f932b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CodeTour skill for creating interactive VS Code guided code tours with step-by-step repository exploration
  * Added Framecraft skill for generating polished demo and marketing videos from screenshots and scene descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->