### PR TITLE
fix: correct Codex section inaccuracies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,8 +1047,8 @@ Codex macOS app:
 |-----------|-------|---------|
 | Config | 1 | `.codex/config.toml` — top-level approvals/sandbox/web_search, MCP servers, notifications, profiles |
 | AGENTS.md | 2 | Root (universal) + `.codex/AGENTS.md` (Codex-specific supplement) |
-| Skills | 16 | `.agents/skills/` — SKILL.md + agents/openai.yaml per skill |
-| MCP Servers | 6 | Supabase, Playwright, Context7, GitHub, Memory, Sequential Thinking (auto-merged via add-only sync) |
+| Skills | 30 | `.agents/skills/` — SKILL.md + agents/openai.yaml per skill |
+| MCP Servers | 6 | GitHub, Context7, Exa, Memory, Playwright, Sequential Thinking (7 with Supabase via `--update-mcp` sync) |
 | Profiles | 2 | `strict` (read-only sandbox) and `yolo` (full auto-approve) |
 | Agent Roles | 3 | `.codex/agents/` — explorer, reviewer, docs-researcher |
 
@@ -1058,22 +1058,36 @@ Skills at `.agents/skills/` are auto-loaded by Codex:
 
 | Skill | Description |
 |-------|-------------|
-| tdd-workflow | Test-driven development with 80%+ coverage |
-| security-review | Comprehensive security checklist |
-| coding-standards | Universal coding standards |
-| frontend-patterns | React/Next.js patterns |
-| frontend-slides | HTML presentations, PPTX conversion, visual style exploration |
+| api-design | REST API design patterns |
 | article-writing | Long-form writing from notes and voice references |
-| content-engine | Platform-native social content and repurposing |
-| market-research | Source-attributed market and competitor research |
-| investor-materials | Decks, memos, models, and one-pagers |
-| investor-outreach | Personalized outreach, follow-ups, and intro blurbs |
 | backend-patterns | API design, database, caching |
+| brand-voice | Source-derived writing style profiles from real content |
+| bun-runtime | Bun as runtime, package manager, bundler, and test runner |
+| claude-api | Anthropic Claude API patterns for Python and TypeScript |
+| coding-standards | Universal coding standards |
+| content-engine | Platform-native social content and repurposing |
+| crosspost | Multi-platform content distribution across X, LinkedIn, Threads |
+| deep-research | Multi-source research with synthesis and source attribution |
+| dmux-workflows | Multi-agent orchestration using tmux pane manager |
+| documentation-lookup | Up-to-date library and framework docs via Context7 MCP |
 | e2e-testing | Playwright E2E tests |
 | eval-harness | Eval-driven development |
+| everything-claude-code | Development conventions and patterns for the project |
+| exa-search | Neural search via Exa MCP for web, code, company research |
+| fal-ai-media | Unified media generation for images, video, and audio |
+| frontend-patterns | React/Next.js patterns |
+| frontend-slides | HTML presentations, PPTX conversion, visual style exploration |
+| investor-materials | Decks, memos, models, and one-pagers |
+| investor-outreach | Personalized outreach, follow-ups, and intro blurbs |
+| market-research | Source-attributed market and competitor research |
+| mcp-server-patterns | Build MCP servers with Node/TypeScript SDK |
+| nextjs-turbopack | Next.js 16+ and Turbopack incremental bundling |
+| security-review | Comprehensive security checklist |
 | strategic-compact | Context management |
-| api-design | REST API design patterns |
+| tdd-workflow | Test-driven development with 80%+ coverage |
 | verification-loop | Build, test, lint, typecheck, security |
+| video-editing | AI-assisted video editing workflows with FFmpeg and Remotion |
+| x-api | X/Twitter API integration for posting and analytics |
 
 ### Key Limitation
 
@@ -1081,7 +1095,7 @@ Codex does **not yet provide Claude-style hook execution parity**. ECC enforceme
 
 ### Multi-Agent Support
 
-Current Codex builds support experimental multi-agent workflows.
+Current Codex builds support stable multi-agent workflows.
 
 - Enable `features.multi_agent = true` in `.codex/config.toml`
 - Define roles under `[agents.<name>]`


### PR DESCRIPTION
## Summary
- **MCP servers**: Replace Supabase (commented out in `.codex/config.toml`) with Exa (active); note Supabase available via `--update-mcp` sync
- **Skills count**: 16 → 30 to match actual `.agents/skills/` directory; add 14 missing skills to table, alphabetize
- **Multi-agent**: "experimental" → "stable" to align with `.codex/config.toml` comment ("stable and on by default")

## Test plan
- [ ] Verify skill count matches `ls .agents/skills/ | wc -l`
- [ ] Verify MCP server list matches active (uncommented) entries in `.codex/config.toml`
- [ ] Verify multi-agent wording is consistent with `config.toml` comments

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex README inaccuracies to match the current setup: MCP servers, skills list/count, and multi-agent status are now accurate. Aligns docs with `.codex/config.toml` and the actual `.agents/skills/` directory.

- **Bug Fixes**
  - Updated MCP servers: list now reflects active servers (includes Exa); note that Supabase is available via `--update-mcp`.
  - Increased skills count from 16 to 30; added missing skills and alphabetized the table.
  - Marked multi-agent support as stable (was labeled experimental).

<sup>Written for commit e5e05bda3ee5003c40ad904eb5ba35c511b264cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded built-in skills library from 16 to 30 capabilities for enhanced automation workflows.
  * Multi-Agent Support upgraded to stable.

* **Updates**
  * Updated default integration configuration with new server options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->