### PR TITLE
fix: include .opencode/dist/ in npm package for OpenCode plugin support

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     ".codex/",
     ".cursor/",
     ".opencode/commands/",
+    ".opencode/dist/",
     ".opencode/instructions/",
     ".opencode/plugins/",
     ".opencode/prompts/",
@@ -103,6 +104,8 @@
   },
   "scripts": {
     "postinstall": "echo '\\n  ecc-universal installed!\\n  Run: npx ecc typescript\\n  Compat: npx ecc-install typescript\\n  Docs: https://github.com/affaan-m/everything-claude-code\\n'",
+    "build:opencode": "cd .opencode && npm install --ignore-scripts && npx tsc",
+    "prepublishOnly": "npm run build:opencode",
     "catalog:check": "node scripts/ci/catalog.js --text",
     "catalog:sync": "node scripts/ci/catalog.js --write --text",
     "lint": "eslint . && markdownlint '**/*.md' --ignore node_modules",


### PR DESCRIPTION
## Summary

- Fix OpenCode plugin failing to load because compiled `.opencode/dist/` was missing from the npm package
- Add `build:opencode` script and `prepublishOnly` hook to auto-compile TypeScript before publish

## Problem

The `.opencode/` directory contains TypeScript source files (`index.ts`, `plugins/ecc-hooks.ts`, `tools/*.ts`) with a `tsconfig.json` that outputs to `.opencode/dist/`. However:

1. **`.opencode/dist/` is not listed in the `files` array** in `package.json`, so npm excludes it from the published package
2. **No build script exists** to compile the `.opencode/` TypeScript before publishing
3. The `.opencode/package.json` correctly references `dist/` in its `main` and `exports` fields, but the compiled output simply doesn't exist in the package

This causes `"plugin": ["ecc-universal"]` in `opencode.json` to fail with a module-not-found error because the JavaScript entry points are missing.

### Note

The Cursor IDE equivalent (`.cursor/`) works because its compiled dist already exists in the repository at `.cursor/.opencode/dist/` (likely committed directly). The `.opencode/` directory follows the correct pattern of compiling from source but was missing the packaging steps.

## Changes

**`package.json`** (3 lines added):

1. Added `".opencode/dist/"` to the `files` array — ensures compiled output is included in npm package
2. Added `"build:opencode"` script — `cd .opencode && npm install --ignore-scripts && npx tsc`
3. Added `"prepublishOnly"` script — automatically runs `build:opencode` before `npm publish`

## Verification

- ✅ `npm run build:opencode` compiles successfully, generating `.opencode/dist/` with correct JS + type declarations
- ✅ All 1745 existing tests pass (`npm test`)
- ✅ No changes to any other files — lock file churn from dev testing intentionally excluded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include compiled `.opencode/dist/` in the npm package and auto-build it before publish so the OpenCode plugin loads correctly. Fixes module-not-found errors when using `plugin: ["ecc-universal"]` in `opencode.json`.

- **Bug Fixes**
  - Add `.opencode/dist/` to the `files` array in `package.json`.
  - Add `build:opencode` script to compile the `.opencode/` TypeScript.
  - Add `prepublishOnly` to run `build:opencode` on publish.

<sup>Written for commit 13e7e7c051d63aacfa29bc214f0f038520433e06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration to include compiled output in releases and enhanced automated build steps before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->