### PR TITLE
ci: add codex-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -32,4 +32,3 @@ jobs:
 
       - name: Run scanner
         uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
-        with:


### PR DESCRIPTION
Adds a CI workflow that runs the [codex-plugin-scanner](https://github.com/hashgraph-online/codex-plugin-scanner) on changes to plugin manifests, skills, and MCP config.

Ran the scanner locally against your repo (score: 71/100, Grade C).

**Note:** 65 high-severity findings (mostly hardcoded patterns in docs/references) were excluded from this summary. Run the scanner locally with `codex-plugin-scanner scan .` for the full report.

- **MEDIUM** (2): Risky approval or sandbox default detected, Skill frontmatter is invalid
- **INFO** (6): Interface asset or URL "privacyPolicyURL" is invalid, Interface asset or URL "termsOfServiceURL" is invalid, Interface asset or URL "composerIcon" is invalid, Interface asset or URL "logo" is invalid,

The workflow uses pinned action SHAs and runs with minimal `contents: read` permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that runs the Codex plugin scanner on changes to plugin manifests, skills, and `.mcp.json` to catch unsafe configs early. Uses least-privilege permissions and per-ref concurrency.

- **New Features**
  - Triggers on push/PR to `main` for `.codex-plugin/**`, `skills/**`, and `.mcp.json`.
  - Uses pinned `actions/checkout` and `hashgraph-online/hol-codex-plugin-scanner-action` SHAs.
  - 10-minute timeout; `contents: read` only; per-ref concurrency with cancel-in-progress.

- **Bug Fixes**
  - Switched to `hashgraph-online/hol-codex-plugin-scanner-action` and removed custom args and an empty `with` block to use action defaults.

<sup>Written for commit ddad048edddc60b3d87a91603f29e99b404bd55a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow ("Codex Plugin Scanner CI") that automatically scans and validates plugin-related changes on pushes and pull requests to main. It runs selectively for plugin-related edits, enforces single-run concurrency with cancellation for duplicate refs, and sets a short job timeout to provide faster feedback and earlier detection of plugin issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->