### PR TITLE
feat: add continuous-improvement to Ecosystem Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,16 +559,16 @@ Use `/security-scan` in Claude Code to run it, or add to CI with the [GitHub Act
 
 ### Continuous Improvement — Learning & Discipline Loop
 
-Structured self-improvement system with instinct-based learning (Mulahazah), MCP server, and GitHub Action for agent discipline scoring.
+Third-party structured self-improvement system with instinct-based learning (Mulahazah), MCP server, and GitHub Action for agent discipline scoring. Complements the built-in Continuous Learning v2 system with discipline metrics and GitHub Action integration.
 
 ```bash
-npm install continuous-improvement
+npm install -g continuous-improvement
 
-# Beginner mode: status, instincts, reflection
-claude-code --add-plugin continuous-improvement --mode beginner
+# Add to Claude Code:
+claude mcp add continuous-improvement
 
-# Expert mode: full learning system with dashboard, packs, linting
-claude-code --add-plugin continuous-improvement --mode expert --pack react
+# Or run directly with a starter pack (React, Python, or Go):
+continuous-improvement --mode beginner --pack react
 ```
 
 **What it does:**


### PR DESCRIPTION
## Summary

Add **continuous-improvement** (v3.1.0) to the Ecosystem Tools section in the README.

### What is it?

continuous-improvement is an MCP server that implements the **Mulahazah** learning system — capturing observations from every tool use and distilling them into instincts (behavioral heuristics). It includes:

- **Discipline Score**: GitHub Action that lints agent transcripts against 7 Laws of Effective Engineering
- **Instinct Packs**: Pre-built collections for React, Python, and Go
- **Zero dependencies**: Ships as a single executable
- **Beginner/Expert modes**: Different tool sets for different user levels

### Features

- **ci_status**: See what the system has learned
- **ci_instincts**: List behaviors with confidence levels
- **ci_reflect**: Session reflection templates
- **ci_dashboard**: Real-time instinct analytics (expert mode)
- **ci_create_instinct**: Teach new behaviors (expert mode)
- **ci_export/ci_import**: Share learning across teams

### Installation

Beginner mode (3 tools, no config):
```bash
npm install -g continuous-improvement
# Then add to claude-desktop.json or claude-code harness
```

With starter pack (React, Python, or Go):
```bash
continuous-improvement --mode beginner --pack react
```

### Usage in GitHub Actions

Lint every transcript against discipline rules:
```yaml
- uses: naimkatiman/continuous-improvement@v3.1.0
  with:
    transcript: ${{ runner.temp }}/agent-transcript.jsonl
```

### Links

- GitHub: https://github.com/naimkatiman/continuous-improvement
- npm: https://www.npmjs.com/package/continuous-improvement
- Mulahazah: The learning system behind the tool

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `continuous-improvement` (v3.1.0) to the Ecosystem Tools README with install steps, `claude mcp add continuous-improvement`, starter packs, MCP tools, and a CI example. Clarifies how it complements Continuous Learning v2.

- **Bug Fixes**
  - Corrected Claude Code CLI syntax in examples.
  - Updated GitHub Action example to use `naimkatiman/continuous-improvement@v3.1.0` with `transcript-path` and `strict: true`.

<sup>Written for commit 0e7f806b2d5de4dd3463fb1692ec5a1531a4e210. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Continuous Improvement — Learning & Discipline Loop" README subsection with installation and registration steps, sample CLI usage for beginner and pack modes, and an overview of capabilities: observation learning with confidence scoring, GitHub Action–based discipline scoring, real-time dashboard, starter packs (React/Python/Go), zero-network execution, and MCP tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->