### PR TITLE
Add Community Projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,18 @@ These configs work for my workflow. You should:
 
 ---
 
+## Community Projects
+
+Projects built on or inspired by Everything Claude Code:
+
+| Project | Description |
+|---------|-------------|
+| [EVC](https://github.com/SaigonXIII/evc) | Marketing agent workspace — 42 commands for content operators, brand governance, and multi-channel publishing. [Visual overview](https://saigonxiii.github.io/evc). |
+
+*Built something with ECC? Open a PR to add it here.*
+
+---
+
 ## Sponsors
 
 This project is free and open source. Sponsors help keep it maintained and growing.


### PR DESCRIPTION
## Summary

Adds a **Community Projects** section between Customization and Sponsors to highlight projects built on or inspired by ECC.

- First entry: [EVC (Everything Vibe Code)](https://github.com/SaigonXIII/evc) — a marketing agent workspace that adapts ECC's hook/SOUL/session architecture for content operators. 42 commands, 12 hooks, 4 industry starters.
- Includes an open invite for others to PR their own projects — should encourage more community contributions.
- Placed before Sponsors so it's visible but doesn't displace anything important.

## Why

ECC has 140K+ stars and 21K+ forks — people are clearly building on it. A dedicated section for community projects gives those builders visibility and gives ECC users a way to discover domain-specific adaptations. More context in [Discussion #1284](https://github.com/affaan-m/everything-claude-code/discussions/1284).

## Changes

- `README.md` — 12 lines added (new section heading, table with 1 entry, invite line)
- Zero changes to code, config, or any other file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Community Projects section to `README.md` to showcase projects built on or inspired by ECC. Adds EVC as the first entry and invites others to open PRs; positioned before Sponsors.

<sup>Written for commit b7dab41e90ccb2aa61fbe0addba9001292355dbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new "Community Projects" section featuring a curated list of community-built and inspired projects with repository links and visual overviews to help users discover alternative solutions.
  * Added an invitation for users to contribute their own projects by opening a pull request for inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->