### PR TITLE
ci: gate release workflows on OpenCode pack payload verification (#1287)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify OpenCode package payload
+        run: node tests/scripts/build-opencode.test.js
+
       - name: Validate version tag
         run: |
           if ! [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -27,6 +27,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify OpenCode package payload
+        run: node tests/scripts/build-opencode.test.js
+
       - name: Validate version tag
         env:
           INPUT_TAG: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary
Issue #1287 showed that v1.10.0 could be released with a broken npm artifact missing compiled OpenCode output under .opencode/dist. Main already contains the packaging fix and a tarball regression test, but the tag-triggered release path did not explicitly enforce that guard before creating a release.

This PR adds that missing enforcement in the release workflows.

## Changes
1. Updated .github/workflows/release.yml to run:
- Setup Node 20
- npm ci
- node tests/scripts/build-opencode.test.js

2. Updated .github/workflows/reusable-release.yml with the same gate.

## Why this closes the remaining gap
The OpenCode regression test validates the packed artifact contract using npm pack --dry-run --json and asserts these paths are present:
- .opencode/dist/index.js
- .opencode/dist/plugins/index.js
- .opencode/dist/tools/index.js

By running that test inside the release workflows, tag-based releases now fail fast if the npm payload is incomplete.

## Scope
Workflow-only change.
No packaging logic, source code, or release-note generation behavior changed.

## Verification
1. Commit touches only:
- .github/workflows/release.yml
- .github/workflows/reusable-release.yml

2. Guard command is wired in both release paths:
- node tests/scripts/build-opencode.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a guard in tag-triggered release workflows to verify the OpenCode `npm pack` payload before creating a release. Releases now fail fast if `.opencode/dist` artifacts are missing.

- **Bug Fixes**
  - Enforce payload check via `node tests/scripts/build-opencode.test.js` in both `.github/workflows/release.yml` and `.github/workflows/reusable-release.yml`.
  - Setup Node 20 and run `npm ci` to support the check.

<sup>Written for commit 3264367755281aee6cd6cdfc1aaa13ae227c98ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation of OpenCode package payload during release workflows to ensure package integrity before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->