### PR TITLE
fix: correct agent names in opencode commands

### DIFF
--- a/.opencode/commands/build-fix.md
+++ b/.opencode/commands/build-fix.md
@@ -1,6 +1,6 @@
 ---
 description: Fix build and TypeScript errors with minimal changes
-agent: everything-claude-code:build-error-resolver
+agent: build-error-resolver
 subtask: true
 ---
 

--- a/.opencode/commands/checkpoint.md
+++ b/.opencode/commands/checkpoint.md
@@ -1,6 +1,6 @@
 ---
 description: Save verification state and progress checkpoint
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Checkpoint Command

--- a/.opencode/commands/code-review.md
+++ b/.opencode/commands/code-review.md
@@ -1,6 +1,6 @@
 ---
 description: Review code for quality, security, and maintainability
-agent: everything-claude-code:code-reviewer
+agent: code-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/e2e.md
+++ b/.opencode/commands/e2e.md
@@ -1,6 +1,6 @@
 ---
 description: Generate and run E2E tests with Playwright
-agent: everything-claude-code:e2e-runner
+agent: e2e-runner
 subtask: true
 ---
 

--- a/.opencode/commands/eval.md
+++ b/.opencode/commands/eval.md
@@ -1,6 +1,6 @@
 ---
 description: Run evaluation against acceptance criteria
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Eval Command

--- a/.opencode/commands/evolve.md
+++ b/.opencode/commands/evolve.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze instincts and suggest or generate evolved structures
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Evolve Command

--- a/.opencode/commands/go-build.md
+++ b/.opencode/commands/go-build.md
@@ -1,6 +1,6 @@
 ---
 description: Fix Go build and vet errors
-agent: everything-claude-code:go-build-resolver
+agent: go-build-resolver
 subtask: true
 ---
 

--- a/.opencode/commands/go-review.md
+++ b/.opencode/commands/go-review.md
@@ -1,6 +1,6 @@
 ---
 description: Go code review for idiomatic patterns
-agent: everything-claude-code:go-reviewer
+agent: go-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/go-test.md
+++ b/.opencode/commands/go-test.md
@@ -1,6 +1,6 @@
 ---
 description: Go TDD workflow with table-driven tests
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/instinct-export.md
+++ b/.opencode/commands/instinct-export.md
@@ -1,6 +1,6 @@
 ---
 description: Export instincts for sharing
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Instinct Export Command

--- a/.opencode/commands/instinct-import.md
+++ b/.opencode/commands/instinct-import.md
@@ -1,6 +1,6 @@
 ---
 description: Import instincts from external sources
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Instinct Import Command

--- a/.opencode/commands/instinct-status.md
+++ b/.opencode/commands/instinct-status.md
@@ -1,6 +1,6 @@
 ---
 description: Show learned instincts (project + global) with confidence
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Instinct Status Command

--- a/.opencode/commands/learn.md
+++ b/.opencode/commands/learn.md
@@ -1,6 +1,6 @@
 ---
 description: Extract patterns and learnings from current session
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Learn Command

--- a/.opencode/commands/orchestrate.md
+++ b/.opencode/commands/orchestrate.md
@@ -1,6 +1,6 @@
 ---
 description: Orchestrate multiple agents for complex tasks
-agent: everything-claude-code:planner
+agent: planner
 subtask: true
 ---
 

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -1,6 +1,6 @@
 ---
 description: Create implementation plan with risk assessment
-agent: everything-claude-code:planner
+agent: planner
 subtask: true
 ---
 

--- a/.opencode/commands/projects.md
+++ b/.opencode/commands/projects.md
@@ -1,6 +1,6 @@
 ---
 description: List registered projects and instinct counts
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Projects Command

--- a/.opencode/commands/promote.md
+++ b/.opencode/commands/promote.md
@@ -1,6 +1,6 @@
 ---
 description: Promote project instincts to global scope
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Promote Command

--- a/.opencode/commands/refactor-clean.md
+++ b/.opencode/commands/refactor-clean.md
@@ -1,6 +1,6 @@
 ---
 description: Remove dead code and consolidate duplicates
-agent: everything-claude-code:refactor-cleaner
+agent: refactor-cleaner
 subtask: true
 ---
 

--- a/.opencode/commands/rust-build.md
+++ b/.opencode/commands/rust-build.md
@@ -1,6 +1,6 @@
 ---
 description: Fix Rust build errors and borrow checker issues
-agent: everything-claude-code:rust-build-resolver
+agent: rust-build-resolver
 subtask: true
 ---
 

--- a/.opencode/commands/rust-review.md
+++ b/.opencode/commands/rust-review.md
@@ -1,6 +1,6 @@
 ---
 description: Rust code review for ownership, safety, and idiomatic patterns
-agent: everything-claude-code:rust-reviewer
+agent: rust-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/rust-test.md
+++ b/.opencode/commands/rust-test.md
@@ -1,6 +1,6 @@
 ---
 description: Rust TDD workflow with unit and property tests
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/security.md
+++ b/.opencode/commands/security.md
@@ -1,6 +1,6 @@
 ---
 description: Run comprehensive security review
-agent: everything-claude-code:security-reviewer
+agent: security-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/setup-pm.md
+++ b/.opencode/commands/setup-pm.md
@@ -1,6 +1,6 @@
 ---
 description: Configure package manager preference
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Setup Package Manager Command

--- a/.opencode/commands/skill-create.md
+++ b/.opencode/commands/skill-create.md
@@ -1,6 +1,6 @@
 ---
 description: Generate skills from git history analysis
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Skill Create Command

--- a/.opencode/commands/tdd.md
+++ b/.opencode/commands/tdd.md
@@ -1,6 +1,6 @@
 ---
 description: Enforce TDD workflow with 80%+ coverage
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/test-coverage.md
+++ b/.opencode/commands/test-coverage.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze and improve test coverage
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/update-codemaps.md
+++ b/.opencode/commands/update-codemaps.md
@@ -1,6 +1,6 @@
 ---
 description: Update codemaps for codebase navigation
-agent: everything-claude-code:doc-updater
+agent: doc-updater
 subtask: true
 ---
 

--- a/.opencode/commands/update-docs.md
+++ b/.opencode/commands/update-docs.md
@@ -1,6 +1,6 @@
 ---
 description: Update documentation for recent changes
-agent: everything-claude-code:doc-updater
+agent: doc-updater
 subtask: true
 ---
 

--- a/.opencode/commands/verify.md
+++ b/.opencode/commands/verify.md
@@ -1,6 +1,6 @@
 ---
 description: Run verification loop to validate implementation
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Verify Command


### PR DESCRIPTION
## Summary
Fix incorrect agent references in opencode command files by removing the `everything-claude-code:` namespace prefix.

## Changes
- Updated 29 command files in `.opencode/commands/`
- Changed from: `agent: everything-claude-code:tdd-guide`
- Changed to: `agent: tdd-guide`

## Affected Commands
- tdd, code-review, build-fix, e2e, security, verify
- go-build, go-review, go-test
- rust-build, rust-review, rust-test
- plan, orchestrate, evolve, learn
- checkpoint, eval, projects, promote
- refactor-clean, setup-pm, skill-create
- test-coverage, update-codemaps, update-docs
- instinct-export, instinct-import, instinct-status

## Testing
- Verified agent references are now correct
- Commands should load and invoke agents properly

## Related
- This is a minimal fix that corrects the agent name format
- No functional changes to command logic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect agent namespaces across 29 `.opencode/commands/*` files by removing the `everything-claude-code:` prefix so each command uses the correct local agent.

- **Bug Fixes**
  - Updated `agent:` fields to local names (e.g., `tdd-guide`, `build`, `planner`, `code-reviewer`, `e2e-runner`) so commands load the right agents.

<sup>Written for commit 287ed205a2ef837728205628ffb11c7f8e79beb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration references across command documentation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->