### PR TITLE
fix(observer): read prompt_content before cd to fix Windows path mismatch (#1296)

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -183,6 +183,11 @@ PROMPT
     max_turns=20
   fi
 
+  # Read prompt content before cd to avoid Windows path mismatch (#1296).
+    # On Windows (Git Bash/MSYS2), mktemp returns a path that may differ from the MSYS-style
+      # path used by other tools after cd. Read content now, before cd, to avoid the mismatch.
+        prompt_content="$(cat "$prompt_file")"
+          rm -f "$prompt_file"
   # Ensure CWD is PROJECT_DIR so the relative analysis_relpath resolves correctly
   # on all platforms, not just when the observer happens to be launched from the project root.
   cd "$PROJECT_DIR" || { echo "[$(date)] Failed to cd to PROJECT_DIR ($PROJECT_DIR), skipping analysis" >> "$LOG_FILE"; rm -f "$prompt_file" "$analysis_file"; return; }
@@ -191,11 +196,9 @@ PROMPT
   # Pass prompt via -p flag instead of stdin redirect for Windows compatibility (#842).
   ECC_SKIP_OBSERVE=1 ECC_HOOK_PROFILE=minimal claude --model haiku --max-turns "$max_turns" --print \
     --allowedTools "Read,Write" \
-    -p "$(cat "$prompt_file")" >> "$LOG_FILE" 2>&1 &
+    -p "$prompt_content" >> "$LOG_FILE" 2>&1 &
   claude_pid=$!
-  # prompt_file content was already expanded by the shell; remove early to avoid
-  # leaving stale temp files during the (potentially long) analysis window.
-  rm -f "$prompt_file"
+    # prompt_file was already removed above (before cd) for cross-platform safety (#1296).
 
   (
     sleep "$timeout_seconds"


### PR DESCRIPTION
…atch (#1296)

On Windows (Git Bash/MSYS2), mktemp returns a Windows-style path (C:/Users/...) while detect-project.sh returns an MSYS-style path (/c/Users/...). When prompt_file is read via $(cat "$prompt_file") after cd "$PROJECT_DIR", the path mismatch causes "No such file or directory".

Fix: read the prompt file content into prompt_content immediately after writing it (before any cd), then remove the temp file. Pass $prompt_content directly to claude -p instead of re-reading the file later. This is the same approach used for analysis_relpath in PR #972.

Fixes #1296. Related: #295, #842.

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows path mismatch in the observer by reading the prompt file before changing directories and passing it to `claude` via `-p`. Prevents "No such file or directory" errors on Git Bash/MSYS2. Fixes #1296.

- **Bug Fixes**
  - Read prompt into `prompt_content` before `cd` and remove the temp file.
  - Use `-p "$prompt_content"` instead of `$(cat "$prompt_file")` when invoking `claude`.

<sup>Written for commit 9f726f3a5460c56dc32525ab8e097f463605afd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the prompt handling flow in the observer loop by improving file operation sequencing and variable management for enhanced efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->