### PR TITLE
ci: add codex-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
 
       - name: Run scanner
-        uses: hashgraph-online/codex-plugin-scanner@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@40d95e49abdd8aeb34b534461a9fa4f96cdd4d7c # v1
         with:
           args: scan --fail-on critical


### PR DESCRIPTION
Adds a CI workflow that runs the [codex-plugin-scanner](https://github.com/hashgraph-online/codex-plugin-scanner) on changes to plugin manifests, skills, and MCP config.

Ran the scanner locally against your repo (score: 71/100, Grade C).

**Note:** 65 high-severity findings (mostly hardcoded patterns in docs/references) were excluded from this summary. Run the scanner locally with `codex-plugin-scanner scan .` for the full report.

- **MEDIUM** (2): Risky approval or sandbox default detected, Skill frontmatter is invalid
- **INFO** (6): Interface asset or URL "privacyPolicyURL" is invalid, Interface asset or URL "termsOfServiceURL" is invalid, Interface asset or URL "composerIcon" is invalid, Interface asset or URL "logo" is invalid,

The workflow uses pinned action SHAs and runs with minimal `contents: read` permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI workflow to scan plugin manifests, skills, and MCP config for security and policy issues. The check fails on critical findings to prevent unsafe changes from merging.

- **New Features**
  - Runs `codex-plugin-scanner` on `push` and `pull_request` to `main` when `.codex-plugin/**`, `skills/**`, or `.mcp.json` change.
  - Uses pinned `actions/checkout` and `hashgraph-online/hol-codex-plugin-scanner-action` SHAs.
  - Minimal permissions (`contents: read`), 10-minute timeout, and concurrency to cancel in-progress runs per ref.
  - Executes `scan --fail-on critical` to block merges on critical issues.

<sup>Written for commit 3e3dfed4501e8f0dddeb6ad5dd2902a740a35ae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated scanning workflow for code submissions to detect critical issues in plugin-related changes during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->