### PR TITLE
feat(community): add trading-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1396,6 +1396,7 @@ Projects built on or inspired by Everything Claude Code:
 | Project | Description |
 |---------|-------------|
 | [EVC](https://github.com/SaigonXIII/evc) | Marketing agent workspace — 42 commands for content operators, brand governance, and multi-channel publishing. [Visual overview](https://saigonxiii.github.io/evc). |
+| [trading-skills](https://github.com/VictorVVedtion/trading-skills) | 68 trading legends as Claude Code skills — Warren Buffett reviews your trades, Jim Simons asks if you backtested. Pre-trade risk gate with ghost warnings from SBF, Do Kwon, 3AC. |
 
 Built something with ECC? Open a PR to add it here.
 


### PR DESCRIPTION
## Summary

- Adds [trading-skills](https://github.com/VictorVVedtion/trading-skills) to Community Projects
- 8 legendary master trading advisors as Claude Code skills (Buffett, Soros, Livermore, Simons, Sun Tzu, Graham, Satoshi, von Neumann)
- Pre-trade risk gate (9 checks + 10 ghost warnings from history's greatest blowups)
- Tilt detector (revenge trading, FOMO, panic selling prevention)
- One-liner installer, MIT licensed

## Type

Community Skill

## Testing

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/VictorVVedtion/trading-skills/main/install.sh | bash
\`\`\`

Then open Claude Code and discuss any trade — installed master advisors activate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `trading-skills` to the Community Projects list in README. Links to 68 Claude Code trading advisor skills with a pre-trade risk gate and tilt detection.

<sup>Written for commit 398177aa5067e816cb773c74ec465447ed9a9652. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "trading-skills" entry to the Community Projects section, featuring 68 trading legends as Claude Code skills with information on trade review and pre-trade risk gate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->