### PR TITLE
feat(scripts): add gemini-adapt-agents utility for Gemini CLI compatibility

### DIFF
--- a/scripts/gemini-adapt-agents.js
+++ b/scripts/gemini-adapt-agents.js
@@ -5,6 +5,9 @@
  * Converts Claude Code agent files (.gemini/agents/*.md) to Gemini CLI format.
  * Run this after copying ECC agents into a project's .gemini/agents/ directory.
  *
+ * Only processes .md files directly inside agents-dir (non-recursive).
+ * Gemini CLI expects a flat .gemini/agents/ directory with no subdirectories.
+ *
  * Usage:
  *   node gemini-adapt-agents.js [agents-dir]
  *   # defaults to ./.gemini/agents
@@ -34,49 +37,59 @@ const TOOL_MAP = {
 // Note: 'model' is valid in Gemini CLI schema — do NOT strip it
 const UNSUPPORTED_KEYS = ['color'];
 
-function adaptFile(fp) {
-  const content = fs.readFileSync(fp, 'utf8');
+function adaptContent(content) {
   let result = content;
 
-  // Convert tools array (quoted or unquoted)
-  result = result.replace(/^tools:\s*\[([^\]]+)\]/m, (_, inner) => {
-    const tools = inner.split(',').map(t => {
-      let name = t.trim().replace(/^"|"$/g, '');
-      // Convert Claude Code MCP format (mcp__server__tool) to Gemini CLI (mcp_server_tool)
-      if (name.startsWith('mcp__')) {
-        name = 'mcp_' + name.slice(5).replace(/__/g, '_');
-      }
-      return '"' + (TOOL_MAP[name] || name) + '"';
-    });
-    return 'tools: [' + tools.join(', ') + ']';
-  });
+  // Rewrite only the frontmatter block (first --- ... --- section)
+  result = result.replace(/^---\r?\n([\s\S]*?\r?\n)---/m, (block) => {
+    let fm = block;
 
-  // Remove unsupported frontmatter keys
-  for (const key of UNSUPPORTED_KEYS) {
-    result = result.replace(new RegExp(`^${key}:.*\\n`, 'm'), '');
-  }
+    // Convert tools array (quoted or unquoted)
+    fm = fm.replace(/^tools:\s*\[([^\]]+)\]/m, (_, inner) => {
+      const tools = inner.split(',').map(t => {
+        let name = t.trim().replace(/^"|"$/g, '');
+        // Convert Claude Code MCP format (mcp__server__tool) to Gemini CLI (mcp_server_tool)
+        if (name.startsWith('mcp__')) {
+          name = 'mcp_' + name.slice(5).replace(/__/g, '_');
+        }
+        return '"' + (TOOL_MAP[name] || name) + '"';
+      });
+      return 'tools: [' + tools.join(', ') + ']';
+    });
+
+    // Remove unsupported frontmatter keys
+    for (const key of UNSUPPORTED_KEYS) {
+      fm = fm.replace(new RegExp(`^${key}:.*(?:\\r?\\n|$)`, 'm'), '');
+    }
+
+    return fm;
+  });
 
   return result;
 }
 
-const agentsDir = process.argv[2] || path.join(process.cwd(), '.gemini', 'agents');
+module.exports = { adaptContent };
 
-if (!fs.existsSync(agentsDir)) {
-  console.error('Directory not found:', agentsDir);
-  process.exit(1);
-}
+if (require.main === module) {
+  const agentsDir = process.argv[2] || path.join(process.cwd(), '.gemini', 'agents');
 
-const files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
-let changed = 0;
-
-for (const f of files) {
-  const fp = path.join(agentsDir, f);
-  const original = fs.readFileSync(fp, 'utf8');
-  const adapted = adaptFile(fp);
-  if (adapted !== original) {
-    fs.writeFileSync(fp, adapted);
-    changed++;
+  if (!fs.existsSync(agentsDir)) {
+    console.error('Directory not found:', agentsDir);
+    process.exit(1);
   }
-}
 
-console.log(`gemini-adapt-agents: fixed ${changed}/${files.length} files in ${agentsDir}`);
+  const files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+  let changed = 0;
+
+  for (const f of files) {
+    const fp = path.join(agentsDir, f);
+    const original = fs.readFileSync(fp, 'utf8');
+    const adapted = adaptContent(original);
+    if (adapted !== original) {
+      fs.writeFileSync(fp, adapted);
+      changed++;
+    }
+  }
+
+  console.log(`gemini-adapt-agents: fixed ${changed}/${files.length} files in ${agentsDir}`);
+}

--- a/scripts/gemini-adapt-agents.js
+++ b/scripts/gemini-adapt-agents.js
@@ -41,7 +41,7 @@ function adaptContent(content) {
   let result = content;
 
   // Rewrite only the frontmatter block (first --- ... --- section)
-  result = result.replace(/^---\r?\n([\s\S]*?\r?\n)---/m, (block) => {
+  result = result.replace(/^---\r?\n([\s\S]*?\r?\n)---/, (block) => {
     let fm = block;
 
     // Convert tools array (quoted or unquoted)

--- a/scripts/gemini-adapt-agents.js
+++ b/scripts/gemini-adapt-agents.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * gemini-adapt-agents.js
+ *
+ * Converts Claude Code agent files (.gemini/agents/*.md) to Gemini CLI format.
+ * Run this after copying ECC agents into a project's .gemini/agents/ directory.
+ *
+ * Usage:
+ *   node gemini-adapt-agents.js [agents-dir]
+ *   # defaults to ./.gemini/agents
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TOOL_MAP = {
+  Read: 'read_file',
+  read: 'read_file',
+  Write: 'write_file',
+  write: 'write_file',
+  Edit: 'replace',
+  edit: 'replace',
+  Bash: 'run_shell_command',
+  bash: 'run_shell_command',
+  Grep: 'grep_search',
+  grep: 'grep_search',
+  Glob: 'glob',
+  glob: 'glob',
+  WebSearch: 'google_web_search',
+  WebFetch: 'web_fetch',
+};
+
+// Gemini CLI does not support these frontmatter keys
+// Note: 'model' is valid in Gemini CLI schema — do NOT strip it
+const UNSUPPORTED_KEYS = ['color'];
+
+function adaptFile(fp) {
+  const content = fs.readFileSync(fp, 'utf8');
+  let result = content;
+
+  // Convert tools array (quoted or unquoted)
+  result = result.replace(/^tools:\s*\[([^\]]+)\]/m, (_, inner) => {
+    const tools = inner.split(',').map(t => {
+      let name = t.trim().replace(/^"|"$/g, '');
+      // Convert Claude Code MCP format (mcp__server__tool) to Gemini CLI (mcp_server_tool)
+      if (name.startsWith('mcp__')) {
+        name = 'mcp_' + name.slice(5).replace(/__/g, '_');
+      }
+      return '"' + (TOOL_MAP[name] || name) + '"';
+    });
+    return 'tools: [' + tools.join(', ') + ']';
+  });
+
+  // Remove unsupported frontmatter keys
+  for (const key of UNSUPPORTED_KEYS) {
+    result = result.replace(new RegExp(`^${key}:.*\\n`, 'm'), '');
+  }
+
+  return result;
+}
+
+const agentsDir = process.argv[2] || path.join(process.cwd(), '.gemini', 'agents');
+
+if (!fs.existsSync(agentsDir)) {
+  console.error('Directory not found:', agentsDir);
+  process.exit(1);
+}
+
+const files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+let changed = 0;
+
+for (const f of files) {
+  const fp = path.join(agentsDir, f);
+  const original = fs.readFileSync(fp, 'utf8');
+  const adapted = adaptFile(fp);
+  if (adapted !== original) {
+    fs.writeFileSync(fp, adapted);
+    changed++;
+  }
+}
+
+console.log(`gemini-adapt-agents: fixed ${changed}/${files.length} files in ${agentsDir}`);

--- a/tests/scripts/gemini-adapt-agents.test.js
+++ b/tests/scripts/gemini-adapt-agents.test.js
@@ -109,8 +109,8 @@ function runTests() {
     // No trailing newline — frontmatter regex won't match without closing ---,
     // but key removal inside matched block should handle EOF
     const result = adaptContent(input);
-    // If frontmatter is unclosed, no change expected — just verify no crash
-    assert.strictEqual(typeof result, 'string');
+    // If frontmatter is unclosed, no change expected — input returned as-is
+    assert.strictEqual(result, input);
   })) passed++; else failed++;
 
   if (test('is idempotent — already-adapted content unchanged', () => {

--- a/tests/scripts/gemini-adapt-agents.test.js
+++ b/tests/scripts/gemini-adapt-agents.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for scripts/gemini-adapt-agents.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'gemini-adapt-agents.js');
+const { adaptContent } = require(SCRIPT);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function run(args = []) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT, ...args], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      code: error.status || 1,
+      stdout: error.stdout || '',
+      stderr: error.stderr || '',
+    };
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing gemini-adapt-agents.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  // adaptContent unit tests
+
+  if (test('maps Read → read_file', () => {
+    const input = '---\ntools: [Read]\n---\n';
+    assert.ok(adaptContent(input).includes('"read_file"'));
+  })) passed++; else failed++;
+
+  if (test('maps Write → write_file', () => {
+    const input = '---\ntools: [Write]\n---\n';
+    assert.ok(adaptContent(input).includes('"write_file"'));
+  })) passed++; else failed++;
+
+  if (test('maps Edit → replace', () => {
+    const input = '---\ntools: [Edit]\n---\n';
+    assert.ok(adaptContent(input).includes('"replace"'));
+  })) passed++; else failed++;
+
+  if (test('maps Bash → run_shell_command', () => {
+    const input = '---\ntools: [Bash]\n---\n';
+    assert.ok(adaptContent(input).includes('"run_shell_command"'));
+  })) passed++; else failed++;
+
+  if (test('maps Grep → grep_search', () => {
+    const input = '---\ntools: [Grep]\n---\n';
+    assert.ok(adaptContent(input).includes('"grep_search"'));
+  })) passed++; else failed++;
+
+  if (test('maps WebSearch → google_web_search', () => {
+    const input = '---\ntools: [WebSearch]\n---\n';
+    assert.ok(adaptContent(input).includes('"google_web_search"'));
+  })) passed++; else failed++;
+
+  if (test('converts mcp__server__tool → mcp_server_tool', () => {
+    const input = '---\ntools: [mcp__context7__query-docs]\n---\n';
+    assert.ok(adaptContent(input).includes('"mcp_context7_query-docs"'));
+  })) passed++; else failed++;
+
+  if (test('converts double-underscore separators in MCP tool names', () => {
+    const input = '---\ntools: [mcp__my__server__tool]\n---\n';
+    assert.ok(adaptContent(input).includes('"mcp_my_server_tool"'));
+  })) passed++; else failed++;
+
+  if (test('removes color: key from frontmatter', () => {
+    const input = '---\nname: test\ncolor: purple\n---\n# body\n';
+    const result = adaptContent(input);
+    assert.ok(!result.includes('color:'), 'color key should be removed');
+    assert.ok(result.includes('name: test'), 'other keys preserved');
+    assert.ok(result.includes('# body'), 'body preserved');
+  })) passed++; else failed++;
+
+  if (test('does not remove color: outside frontmatter', () => {
+    const input = '---\nname: test\n---\n# body\ncolor: red is nice\n';
+    const result = adaptContent(input);
+    assert.ok(result.includes('color: red is nice'), 'body color line preserved');
+  })) passed++; else failed++;
+
+  if (test('removes color: at EOF without trailing newline', () => {
+    const input = '---\nname: test\ncolor: blue';
+    // No trailing newline — frontmatter regex won't match without closing ---,
+    // but key removal inside matched block should handle EOF
+    const result = adaptContent(input);
+    // If frontmatter is unclosed, no change expected — just verify no crash
+    assert.strictEqual(typeof result, 'string');
+  })) passed++; else failed++;
+
+  if (test('is idempotent — already-adapted content unchanged', () => {
+    const input = '---\nname: my-agent\ntools: ["read_file", "grep_search"]\n---\n# body\n';
+    assert.strictEqual(adaptContent(input), input);
+  })) passed++; else failed++;
+
+  if (test('preserves quoted tool names', () => {
+    const input = '---\ntools: ["Read", "Grep"]\n---\n';
+    const result = adaptContent(input);
+    assert.ok(result.includes('"read_file"'));
+    assert.ok(result.includes('"grep_search"'));
+  })) passed++; else failed++;
+
+  if (test('handles mixed quoted and unquoted tools', () => {
+    const input = '---\ntools: ["Read", Grep, Glob]\n---\n';
+    const result = adaptContent(input);
+    assert.ok(result.includes('"read_file"'));
+    assert.ok(result.includes('"grep_search"'));
+    assert.ok(result.includes('"glob"'));
+  })) passed++; else failed++;
+
+  if (test('does not alter model key', () => {
+    const input = '---\nmodel: claude-opus-4-5\n---\n';
+    assert.ok(adaptContent(input).includes('model: claude-opus-4-5'));
+  })) passed++; else failed++;
+
+  // CLI integration tests
+
+  if (test('CLI errors on missing directory', () => {
+    const result = run(['/nonexistent/path/agents']);
+    assert.strictEqual(result.code, 1);
+    assert.ok(result.stderr.includes('Directory not found'));
+  })) passed++; else failed++;
+
+  if (test('CLI writes adapted files and reports count', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gaa-test-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'agent.md'),
+        '---\nname: test\ncolor: red\ntools: [Read]\n---\nbody\n');
+      const result = run([tmpDir]);
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('fixed 1/1'));
+      const content = fs.readFileSync(path.join(tmpDir, 'agent.md'), 'utf8');
+      assert.ok(!content.includes('color:'));
+      assert.ok(content.includes('"read_file"'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('CLI reports 0 changed for already-adapted files', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gaa-noop-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'agent.md'),
+        '---\nname: test\ntools: ["read_file"]\n---\nbody\n');
+      const result = run([tmpDir]);
+      assert.strictEqual(result.code, 0);
+      assert.ok(result.stdout.includes('fixed 0/1'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/scripts/gemini-adapt-agents.test.js
+++ b/tests/scripts/gemini-adapt-agents.test.js
@@ -106,10 +106,8 @@ function runTests() {
 
   if (test('keeps color: at EOF when frontmatter is unclosed', () => {
     const input = '---\nname: test\ncolor: blue';
-    // No trailing newline — frontmatter regex won't match without closing ---,
-    // but key removal inside matched block should handle EOF
+    // Unclosed frontmatter: adaptContent should return input unchanged (no transform expected)
     const result = adaptContent(input);
-    // If frontmatter is unclosed, no change expected — input returned as-is
     assert.strictEqual(result, input);
   })) passed++; else failed++;
 

--- a/tests/scripts/gemini-adapt-agents.test.js
+++ b/tests/scripts/gemini-adapt-agents.test.js
@@ -104,7 +104,7 @@ function runTests() {
     assert.ok(result.includes('color: red is nice'), 'body color line preserved');
   })) passed++; else failed++;
 
-  if (test('removes color: at EOF without trailing newline', () => {
+  if (test('keeps color: at EOF when frontmatter is unclosed', () => {
     const input = '---\nname: test\ncolor: blue';
     // No trailing newline — frontmatter regex won't match without closing ---,
     // but key removal inside matched block should handle EOF

--- a/tests/scripts/gemini-adapt-agents.test.js
+++ b/tests/scripts/gemini-adapt-agents.test.js
@@ -141,7 +141,8 @@ function runTests() {
   // CLI integration tests
 
   if (test('CLI errors on missing directory', () => {
-    const result = run(['/nonexistent/path/agents']);
+    const missingDir = path.join(os.tmpdir(), 'gaa-nonexistent-' + Date.now());
+    const result = run([missingDir]);
     assert.strictEqual(result.code, 1);
     assert.ok(result.stderr.includes('Directory not found'));
   })) passed++; else failed++;


### PR DESCRIPTION
## What Changed

Added `scripts/gemini-adapt-agents.js` — a utility script that converts ECC agent frontmatter from Claude Code format to Gemini CLI format.

The script rewrites three things in every `.md` file under the target agents directory:

1. **Tool names** — maps Claude Code names to Gemini CLI equivalents:

   | Claude Code | Gemini CLI |
   |---|---|
   | `Read` | `read_file` |
   | `Write` | `write_file` |
   | `Edit` | `replace` |
   | `Bash` | `run_shell_command` |
   | `Grep` | `grep_search` |
   | `Glob` | `glob` |
   | `WebSearch` | `google_web_search` |
   | `WebFetch` | `web_fetch` |

2. **MCP tool name format** — converts double-underscore separators to single:
   `mcp__context7__query-docs` → `mcp_context7_query-docs`

3. **Unsupported frontmatter keys** — strips `color:`, which Gemini CLI's agent schema does not recognise. (`model:` is intentionally preserved — it is valid in Gemini CLI's schema.)

Handles both quoted (`["Read", "Grep"]`) and unquoted (`[Read, Grep]`) YAML array styles. Idempotent — only writes files that changed.

## Why This Change

Closes #1316.

ECC agents use Claude Code tool names in their `tools:` frontmatter field. Gemini CLI validates this field against its own built-in registry (`ALL_BUILTIN_TOOL_NAMES`) and rejects all unrecognised names. When users follow the documented workflow of copying `agents/*.md` into `.gemini/agents/`, **all 47 agents fail to load** at Gemini CLI startup:

```
✕ Agent loading error: Failed to load agent from
  .gemini/agents/architect.md: Validation failed: Agent Definition:
  tools.0: Invalid tool name
  tools.1: Invalid tool name
```

This script lets users fix all agents in one command after copying:

```bash
cp /path/to/everything-claude-code/agents/*.md .gemini/agents/
node /path/to/everything-claude-code/scripts/gemini-adapt-agents.js
# gemini-adapt-agents: fixed 47/47 files in ./.gemini/agents
```

## Testing Done

- [x] Manual testing completed — ran against all 47 ECC agents in a live Gemini CLI project; zero agent loading errors after conversion
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested:
  - Quoted arrays: `["Read", "Grep", "Glob"]`
  - Unquoted YAML arrays: `[Read, Grep, Glob]`
  - MCP tool names: `mcp__context7__resolve-library-id` → `mcp_context7_resolve-library-id`
  - Agents with `color:` key — stripped cleanly
  - Idempotency — running twice produces no further changes

## Type of Change

- [ ] `fix:` Bug fix
- [x] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable) — N/A, Node.js only
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Added comments for complex logic (MCP conversion logic, UNSUPPORTED_KEYS rationale)
- [ ] Updated relevant documentation
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/gemini-adapt-agents.js` to convert ECC agent frontmatter from Claude Code to Gemini CLI so copied agents load without validation errors. Addresses #1316.

- **New Features**
  - Maps tool names (Read/read→`read_file`, Write/write→`write_file`, Edit/edit→`replace`, Bash/bash→`run_shell_command`, Grep/grep→`grep_search`, Glob/glob→`glob`, WebSearch→`google_web_search`, WebFetch→`web_fetch`).
  - Normalizes MCP tool IDs (`mcp__server__tool` → `mcp_server_tool`) and removes unsupported `color` (keeps `model`).
  - Supports quoted/unquoted arrays, only rewrites the first frontmatter block, is idempotent, non-recursive (.md files only), defaults to `./.gemini/agents`, prints a fixed-files summary, and exits with a clear error if the agents dir is missing. Includes unit and CLI tests.

- **Migration**
  - Copy agents: `cp /path/to/everything-claude-code/agents/*.md .gemini/agents/`
  - Run: `node /path/to/everything-claude-code/scripts/gemini-adapt-agents.js [agents-dir]` (optional; defaults to `./.gemini/agents`)

<sup>Written for commit 029ac3f41eb26112bf886b8853f14d83530a5f00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CLI utility to batch-adapt agent Markdown files: normalizes tool names, rewrites certain agent identifiers, removes an unsupported frontmatter key, preserves other metadata, processes only top-level files, writes changes only when needed, and reports how many files were updated.
* **Tests**
  * Added automated tests covering adaptation logic, CLI behavior, idempotency, mappings, frontmatter edge cases, and success/failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->