### PR TITLE
fix(continuous-learning-v2): reconfigure stdout to UTF-8 on Windows

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -28,6 +28,16 @@ from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 from typing import Optional
 
+# Force UTF-8 stdout/stderr on Windows so the confidence bar (█░) and any
+# non-ASCII instinct metadata don't crash `status` under cp1250/cp1252.
+# No-op on Linux/macOS, where stdout is already UTF-8 by default.
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 try:
     import fcntl
     _HAS_FCNTL = True


### PR DESCRIPTION
## Summary

Narrowed after rebasing onto latest \`main\`: #216 (`.md` glob) and #353 (file I/O UTF-8) already landed, so this PR now only contains the remaining, orthogonal Windows-console fix.

\`instinct-cli.py status\` renders a confidence bar using the box-drawing characters \`█\` / \`░\`. On Windows, \`sys.stdout\` inherits the console codec (cp1250 / cp1252 in non-UTF-8 locales), so the \`print\` call crashes with:

\`\`\`
UnicodeEncodeError: 'charmap' codec can't encode characters in position 4-13: character maps to <undefined>
\`\`\`

The two earlier UTF-8 fixes cover *reading* instinct files — this one covers *writing* to the console.

## Fix

Reconfigure \`sys.stdout\` / \`sys.stderr\` to UTF-8 at startup, guarded by \`sys.platform == \"win32\"\`. Wrapped in \`try/except\` because some captured streams (tests, certain wrappers) don't support \`reconfigure\`. No-op on Linux/macOS, where stdout is already UTF-8.

## Repro (before this PR, on top of current \`main\`)

\`\`\`
> python skills/continuous-learning-v2/scripts/instinct-cli.py status
============================================================
  INSTINCT STATUS - 155 total
============================================================
  Project:  everything-claude-code
  Project instincts: 0
  Global instincts:  155

## GLOBAL (apply to all projects)

  ### AI-ASSISTANT (7)

Traceback (most recent call last):
  ...
  File \"C:\Program Files\Python314\Lib\encodings\cp1250.py\", line 19, in encode
    return codecs.charmap_encode(input, self.errors, encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 4-13: character maps to <undefined>
\`\`\`

## After

\`\`\`
> python skills/continuous-learning-v2/scripts/instinct-cli.py status
============================================================
  INSTINCT STATUS - 155 total
============================================================
  Project:  everything-claude-code
  Global instincts:  155

## GLOBAL (apply to all projects)

  ### AI-ASSISTANT (7)

    █████████░  90%  ai-tool-description-must-list-return-data
...
\`\`\`

## Test plan

- [x] Windows 11 + Python 3.14, cp1250 console (\`chcp\` = 1250): \`status\` lists all 155 instincts without crashing.
- [x] Force \`chcp 65001\` beforehand: still works (reconfigure is a no-op when stdout is already UTF-8).
- [ ] Linux/macOS regression: the \`sys.platform == \"win32\"\` guard should make this a no-op, but worth a CI sanity check.

## Notes on bot reviews from the previous revision

The earlier revision of this PR duplicated changes that have since landed on \`main\` via #216 and #353. The reviewer comments about \`cmd_import\` / \`cmd_export\` / observations file encoding are **already fixed on \`main\`** — the new diff only touches stdout reconfigure.