### PR TITLE
fix(scripts): harness-audit findPluginInstall — support cache/<marketplace>/<plugin>/<version>/ layout and installed_plugins.json

### DIFF
--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -186,6 +186,27 @@ function detectTargetMode(rootDir) {
   return 'consumer';
 }
 
+// Plugin manifest keys that identify an ECC install across the current and
+// legacy marketplace names. Hoisted out of findPluginInstall so the tier
+// helpers below can share a single authoritative list.
+const ECC_PLUGIN_KEY_PATTERNS = [
+  /^ecc@/i,
+  /^everything-claude-code@/i,
+];
+
+// Legacy flat-layout plugin directory names, tried in priority order.
+const ECC_LEGACY_PLUGIN_DIRS = [
+  'ecc',
+  'ecc@ecc',
+  'everything-claude-code',
+  'everything-claude-code@everything-claude-code',
+];
+
+// Marketplace and plugin names used by `claude plugin install
+// ecc@everything-claude-code` on v1.9.0+.
+const ECC_MARKETPLACES = ['everything-claude-code', 'ecc'];
+const ECC_PLUGIN_NAMES = ['ecc', 'everything-claude-code'];
+
 // Descending numeric-component version comparator. Compares "1.10.0" and
 // "1.8.0" by their numeric components so 1.10.0 sorts before 1.8.0, unlike
 // the lexicographic default. Non-numeric tokens (e.g. "1.0.0-beta") compare
@@ -203,33 +224,28 @@ function compareVersionDesc(a, b) {
   return 0;
 }
 
-function findPluginInstall(rootDir) {
-  // Three-tier lookup to match how Claude Code actually lays out plugin installs
-  // across legacy and marketplace installs.
-  //
-  // 1) Authoritative source: installed_plugins.json (project or user scope).
-  //    Claude Code writes this manifest when a plugin is installed and it is
-  //    the most reliable way to locate the active install path.
-  // 2) Legacy flat layout: ~/.claude/plugins/<pluginDir>/plugin.json. This is
-  //    the layout that existed before the marketplace was introduced and is
-  //    still produced by some manual installs.
-  // 3) Marketplace cache layout: ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/.
-  //    This is the layout produced by `claude plugin install ecc@everything-claude-code`
-  //    on v1.9.0+. Without this branch, consumer projects that installed ECC
-  //    via the marketplace always report consumer-plugin-install: pass=false.
-  const homeDir = process.env.HOME || require('os').homedir() || '';
+// Returns the first existing plugin.json under `installRoot`, checking both
+// `.claude-plugin/plugin.json` and a bare `plugin.json` fallback, or null if
+// neither exists. Centralising this avoids repeating the two-path check in
+// every tier helper below.
+function findPluginJsonUnder(installRoot) {
+  const pluginJson = path.join(installRoot, '.claude-plugin', 'plugin.json');
+  if (fs.existsSync(pluginJson)) return pluginJson;
+  const fallback = path.join(installRoot, 'plugin.json');
+  if (fs.existsSync(fallback)) return fallback;
+  return null;
+}
 
-  const pluginKeyPatterns = [
-    /^ecc@/i,
-    /^everything-claude-code@/i,
-  ];
-
-  // 1) installed_plugins.json (project first, then user).
-  const installedPluginsPaths = [
-    path.join(rootDir, '.claude', 'plugins', 'installed_plugins.json'),
-    homeDir && path.join(homeDir, '.claude', 'plugins', 'installed_plugins.json'),
-  ].filter(Boolean);
-
+// Tier 1 — authoritative: installed_plugins.json manifest (project scope
+// first, then user scope). Matches ECC plugin keys, validates that each
+// entry's installPath is a non-empty string, resolves relative paths against
+// the manifest's own directory, and returns the first plugin.json found.
+//
+// The type check is deliberate — `installed_plugins.json` is external data
+// that can be edited or corrupted by other tools. An unchecked installPath
+// (null, number, object, ...) would throw out of path.join and abort the
+// whole audit run.
+function findPluginInstallFromManifest(installedPluginsPaths) {
   for (const installedPath of installedPluginsPaths) {
     if (!fs.existsSync(installedPath)) continue;
     const manifest = safeParseJson(
@@ -237,46 +253,47 @@ function findPluginInstall(rootDir) {
     );
     if (!manifest || !manifest.plugins) continue;
     for (const key of Object.keys(manifest.plugins)) {
-      if (!pluginKeyPatterns.some((re) => re.test(key))) continue;
+      if (!ECC_PLUGIN_KEY_PATTERNS.some((re) => re.test(key))) continue;
       const entries = Array.isArray(manifest.plugins[key]) ? manifest.plugins[key] : [];
       for (const entry of entries) {
-        if (!entry || !entry.installPath) continue;
-        const pluginJson = path.join(entry.installPath, '.claude-plugin', 'plugin.json');
-        if (fs.existsSync(pluginJson)) return pluginJson;
-        const fallback = path.join(entry.installPath, 'plugin.json');
-        if (fs.existsSync(fallback)) return fallback;
+        if (!entry || typeof entry.installPath !== 'string' || !entry.installPath.trim()) {
+          continue;
+        }
+        // Anchor relative installPaths at the manifest's own directory so
+        // they behave the same regardless of the audit's current working
+        // directory.
+        const installRoot = path.isAbsolute(entry.installPath)
+          ? entry.installPath
+          : path.resolve(path.dirname(installedPath), entry.installPath);
+        const hit = findPluginJsonUnder(installRoot);
+        if (hit) return hit;
       }
     }
   }
+  return null;
+}
 
-  const candidateRoots = [
-    path.join(rootDir, '.claude', 'plugins'),
-    homeDir && path.join(homeDir, '.claude', 'plugins'),
-  ].filter(Boolean);
-
-  // 2) Legacy flat layout: ~/.claude/plugins/<pluginDir>/plugin.json
-  const pluginDirs = [
-    'ecc',
-    'ecc@ecc',
-    'everything-claude-code',
-    'everything-claude-code@everything-claude-code',
-  ];
-  const flatCandidates = candidateRoots.flatMap((pluginsDir) =>
-    pluginDirs.flatMap((pluginDir) => [
-      path.join(pluginsDir, pluginDir, '.claude-plugin', 'plugin.json'),
-      path.join(pluginsDir, pluginDir, 'plugin.json'),
-    ])
-  );
-  const flatHit = flatCandidates.find((candidate) => fs.existsSync(candidate));
-  if (flatHit) return flatHit;
-
-  // 3) Marketplace cache layout:
-  //    ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/
-  const marketplaces = ['everything-claude-code', 'ecc'];
-  const pluginNames = ['ecc', 'everything-claude-code'];
+// Tier 2 — legacy flat layout: ~/.claude/plugins/<pluginDir>/plugin.json.
+// Preserved for manual/dev installs and backwards compatibility with
+// pre-marketplace install scripts.
+function findPluginInstallFlatLayout(candidateRoots) {
   for (const pluginsDir of candidateRoots) {
-    for (const marketplace of marketplaces) {
-      for (const pluginName of pluginNames) {
+    for (const pluginDir of ECC_LEGACY_PLUGIN_DIRS) {
+      const hit = findPluginJsonUnder(path.join(pluginsDir, pluginDir));
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+// Tier 3 — marketplace cache layout:
+// ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/. Produced by
+// `claude plugin install ecc@everything-claude-code` on v1.9.0+. Picks the
+// newest install when multiple versions coexist on disk.
+function findPluginInstallMarketplaceCache(candidateRoots) {
+  for (const pluginsDir of candidateRoots) {
+    for (const marketplace of ECC_MARKETPLACES) {
+      for (const pluginName of ECC_PLUGIN_NAMES) {
         const pluginRoot = path.join(pluginsDir, 'cache', marketplace, pluginName);
         if (!fs.existsSync(pluginRoot)) continue;
         let versions = [];
@@ -286,20 +303,45 @@ function findPluginInstall(rootDir) {
             .filter((d) => d.isDirectory())
             .map((d) => d.name)
             .sort(compareVersionDesc);
-        } catch (_error) {
+        } catch (error) {
+          // Surface the failure rather than hiding a potentially actionable
+          // cause of a missed install (typically: permission denied on the
+          // user's ~/.claude/plugins/cache). We still continue so a single
+          // unreadable plugin root does not abort the whole audit.
+          console.error(
+            `harness-audit: cannot read plugin cache directory ${pluginRoot}: ${error.message}`
+          );
           continue;
         }
         for (const version of versions) {
-          const pluginJson = path.join(pluginRoot, version, '.claude-plugin', 'plugin.json');
-          if (fs.existsSync(pluginJson)) return pluginJson;
-          const fallback = path.join(pluginRoot, version, 'plugin.json');
-          if (fs.existsSync(fallback)) return fallback;
+          const hit = findPluginJsonUnder(path.join(pluginRoot, version));
+          if (hit) return hit;
         }
       }
     }
   }
-
   return null;
+}
+
+// Three-tier lookup to match how Claude Code actually lays out plugin
+// installs across legacy and marketplace installs. See the tier helpers
+// above for per-tier details and rationale.
+function findPluginInstall(rootDir) {
+  const homeDir = process.env.HOME || require('os').homedir() || '';
+  const installedPluginsPaths = [
+    path.join(rootDir, '.claude', 'plugins', 'installed_plugins.json'),
+    homeDir && path.join(homeDir, '.claude', 'plugins', 'installed_plugins.json'),
+  ].filter(Boolean);
+  const candidateRoots = [
+    path.join(rootDir, '.claude', 'plugins'),
+    homeDir && path.join(homeDir, '.claude', 'plugins'),
+  ].filter(Boolean);
+
+  return (
+    findPluginInstallFromManifest(installedPluginsPaths)
+    || findPluginInstallFlatLayout(candidateRoots)
+    || findPluginInstallMarketplaceCache(candidateRoots)
+  );
 }
 
 function getRepoChecks(rootDir) {

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -187,25 +187,103 @@ function detectTargetMode(rootDir) {
 }
 
 function findPluginInstall(rootDir) {
-  const homeDir = process.env.HOME || '';
+  // Three-tier lookup to match how Claude Code actually lays out plugin installs
+  // across legacy and marketplace installs.
+  //
+  // 1) Authoritative source: installed_plugins.json (project or user scope).
+  //    Claude Code writes this manifest when a plugin is installed and it is
+  //    the most reliable way to locate the active install path.
+  // 2) Legacy flat layout: ~/.claude/plugins/<pluginDir>/plugin.json. This is
+  //    the layout that existed before the marketplace was introduced and is
+  //    still produced by some manual installs.
+  // 3) Marketplace cache layout: ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/.
+  //    This is the layout produced by `claude plugin install ecc@everything-claude-code`
+  //    on v1.9.0+. Without this branch, consumer projects that installed ECC
+  //    via the marketplace always report consumer-plugin-install: pass=false.
+  const homeDir = process.env.HOME || require('os').homedir() || '';
+
+  const pluginKeyPatterns = [
+    /^ecc@/i,
+    /^everything-claude-code@/i,
+  ];
+
+  // 1) installed_plugins.json (project first, then user).
+  const installedPluginsPaths = [
+    path.join(rootDir, '.claude', 'plugins', 'installed_plugins.json'),
+    homeDir && path.join(homeDir, '.claude', 'plugins', 'installed_plugins.json'),
+  ].filter(Boolean);
+
+  for (const installedPath of installedPluginsPaths) {
+    if (!fs.existsSync(installedPath)) continue;
+    const manifest = safeParseJson(
+      safeRead(path.dirname(installedPath), path.basename(installedPath))
+    );
+    if (!manifest || !manifest.plugins) continue;
+    for (const key of Object.keys(manifest.plugins)) {
+      if (!pluginKeyPatterns.some((re) => re.test(key))) continue;
+      const entries = Array.isArray(manifest.plugins[key]) ? manifest.plugins[key] : [];
+      for (const entry of entries) {
+        if (!entry || !entry.installPath) continue;
+        const pluginJson = path.join(entry.installPath, '.claude-plugin', 'plugin.json');
+        if (fs.existsSync(pluginJson)) return pluginJson;
+        const fallback = path.join(entry.installPath, 'plugin.json');
+        if (fs.existsSync(fallback)) return fallback;
+      }
+    }
+  }
+
+  const candidateRoots = [
+    path.join(rootDir, '.claude', 'plugins'),
+    homeDir && path.join(homeDir, '.claude', 'plugins'),
+  ].filter(Boolean);
+
+  // 2) Legacy flat layout: ~/.claude/plugins/<pluginDir>/plugin.json
   const pluginDirs = [
     'ecc',
     'ecc@ecc',
     'everything-claude-code',
     'everything-claude-code@everything-claude-code',
   ];
-  const candidateRoots = [
-    path.join(rootDir, '.claude', 'plugins'),
-    homeDir && path.join(homeDir, '.claude', 'plugins'),
-  ].filter(Boolean);
-  const candidates = candidateRoots.flatMap((pluginsDir) =>
+  const flatCandidates = candidateRoots.flatMap((pluginsDir) =>
     pluginDirs.flatMap((pluginDir) => [
       path.join(pluginsDir, pluginDir, '.claude-plugin', 'plugin.json'),
       path.join(pluginsDir, pluginDir, 'plugin.json'),
     ])
   );
+  const flatHit = flatCandidates.find((candidate) => fs.existsSync(candidate));
+  if (flatHit) return flatHit;
 
-  return candidates.find(candidate => fs.existsSync(candidate)) || null;
+  // 3) Marketplace cache layout:
+  //    ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/
+  const marketplaces = ['everything-claude-code', 'ecc'];
+  const pluginNames = ['ecc', 'everything-claude-code'];
+  for (const pluginsDir of candidateRoots) {
+    for (const marketplace of marketplaces) {
+      for (const pluginName of pluginNames) {
+        const pluginRoot = path.join(pluginsDir, 'cache', marketplace, pluginName);
+        if (!fs.existsSync(pluginRoot)) continue;
+        let versions = [];
+        try {
+          versions = fs
+            .readdirSync(pluginRoot, { withFileTypes: true })
+            .filter((d) => d.isDirectory())
+            .map((d) => d.name)
+            .sort()
+            .reverse();
+        } catch (_error) {
+          continue;
+        }
+        for (const version of versions) {
+          const pluginJson = path.join(pluginRoot, version, '.claude-plugin', 'plugin.json');
+          if (fs.existsSync(pluginJson)) return pluginJson;
+          const fallback = path.join(pluginRoot, version, 'plugin.json');
+          if (fs.existsSync(fallback)) return fallback;
+        }
+      }
+    }
+  }
+
+  return null;
 }
 
 function getRepoChecks(rootDir) {

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -186,6 +186,23 @@ function detectTargetMode(rootDir) {
   return 'consumer';
 }
 
+// Descending numeric-component version comparator. Compares "1.10.0" and
+// "1.8.0" by their numeric components so 1.10.0 sorts before 1.8.0, unlike
+// the lexicographic default. Non-numeric tokens (e.g. "1.0.0-beta") compare
+// as 0 for that position, which is good enough for picking the newest real
+// install directory without pulling in a semver dependency.
+function compareVersionDesc(a, b) {
+  const pa = String(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i += 1) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na !== nb) return nb - na;
+  }
+  return 0;
+}
+
 function findPluginInstall(rootDir) {
   // Three-tier lookup to match how Claude Code actually lays out plugin installs
   // across legacy and marketplace installs.
@@ -268,8 +285,7 @@ function findPluginInstall(rootDir) {
             .readdirSync(pluginRoot, { withFileTypes: true })
             .filter((d) => d.isDirectory())
             .map((d) => d.name)
-            .sort()
-            .reverse();
+            .sort(compareVersionDesc);
         } catch (_error) {
           continue;
         }
@@ -810,4 +826,6 @@ if (require.main === module) {
 module.exports = {
   buildReport,
   parseArgs,
+  findPluginInstall,
+  compareVersionDesc,
 };

--- a/tests/scripts/harness-audit.test.js
+++ b/tests/scripts/harness-audit.test.js
@@ -318,6 +318,143 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // --- Tier 1 (installed_plugins.json) robustness ---
+  //
+  // These tests protect the manifest-driven lookup against malformed external
+  // data and relative-path installPaths, per the defensive-programming
+  // coding guideline ("Never trust external data").
+
+  if (test('findPluginInstall does not crash on malformed installPath types', () => {
+    const homeDir = createTempDir('harness-audit-home-');
+    const projectRoot = createTempDir('harness-audit-project-');
+    const installRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'everything-claude-code', 'ecc', '1.10.0');
+
+    try {
+      // A real, valid install alongside a manifest that contains several
+      // malformed entries. The lookup should skip the bad entries without
+      // throwing and fall back to the cache-layout tier or the valid entry.
+      fs.mkdirSync(path.join(installRoot, '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(
+        path.join(installRoot, '.claude-plugin', 'plugin.json'),
+        JSON.stringify({ name: 'ecc', version: '1.10.0' }, null, 2)
+      );
+
+      fs.writeFileSync(
+        path.join(homeDir, '.claude', 'plugins', 'installed_plugins.json'),
+        JSON.stringify(
+          {
+            plugins: {
+              'ecc@everything-claude-code': [
+                // Malformed entries that previously would have thrown out of
+                // path.join when the function only checked for truthiness.
+                null,
+                { installPath: null },
+                { installPath: 42 },
+                { installPath: { nested: 'object' } },
+                { installPath: '   ' },
+                { installPath: '' },
+                // Finally, one valid absolute entry.
+                { installPath: installRoot },
+              ],
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      // Direct call so we can assert no throw.
+      let found;
+      const originalHome = process.env.HOME;
+      process.env.HOME = homeDir;
+      try {
+        assert.doesNotThrow(() => {
+          found = findPluginInstall(projectRoot);
+        });
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
+
+      assert.ok(found, 'lookup should still find the valid entry after skipping malformed ones');
+      assert.ok(
+        found.includes(`${path.sep}1.10.0${path.sep}`),
+        `lookup should return the valid 1.10.0 install, got: ${found}`
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('findPluginInstall resolves relative installPath against the manifest directory', () => {
+    const homeDir = createTempDir('harness-audit-home-');
+    const projectRoot = createTempDir('harness-audit-project-');
+
+    try {
+      // Place the install directory next to installed_plugins.json and
+      // reference it with a relative path. Before the fix, `path.join` would
+      // interpret "./ecc-local/1.10.0" as CWD-relative rather than
+      // manifest-relative, and the lookup would silently miss it.
+      const pluginsDir = path.join(homeDir, '.claude', 'plugins');
+      fs.mkdirSync(pluginsDir, { recursive: true });
+
+      const relativeInstallRoot = path.join(pluginsDir, 'ecc-local', '1.10.0');
+      fs.mkdirSync(path.join(relativeInstallRoot, '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(
+        path.join(relativeInstallRoot, '.claude-plugin', 'plugin.json'),
+        JSON.stringify({ name: 'ecc', version: '1.10.0' }, null, 2)
+      );
+
+      fs.writeFileSync(
+        path.join(pluginsDir, 'installed_plugins.json'),
+        JSON.stringify(
+          {
+            plugins: {
+              'ecc@everything-claude-code': [
+                { installPath: path.join('ecc-local', '1.10.0') },
+              ],
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      // Intentionally run from a CWD that cannot resolve the relative path
+      // correctly on its own — projectRoot has nothing named "ecc-local".
+      // If the lookup resolved against CWD, it would fail; resolving against
+      // the manifest's directory is the only way to succeed.
+      const originalHome = process.env.HOME;
+      const originalCwd = process.cwd();
+      process.env.HOME = homeDir;
+      process.chdir(projectRoot);
+      let found;
+      try {
+        found = findPluginInstall(projectRoot);
+      } finally {
+        process.chdir(originalCwd);
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
+
+      assert.ok(found, 'relative installPath should resolve against the manifest directory');
+      assert.ok(
+        found.includes(`ecc-local${path.sep}1.10.0`),
+        `lookup should land inside the manifest-relative install, got: ${found}`
+      );
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/harness-audit.test.js
+++ b/tests/scripts/harness-audit.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'harness-audit.js');
+const { findPluginInstall, compareVersionDesc } = require(SCRIPT);
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -227,29 +228,73 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('compareVersionDesc orders numeric version components correctly', () => {
+    // Lexicographic sort would put 1.8.0 before 1.10.0; the semver-aware
+    // comparator must put 1.10.0 first.
+    assert.ok(compareVersionDesc('1.10.0', '1.8.0') < 0, '1.10.0 should sort before 1.8.0');
+    assert.ok(compareVersionDesc('1.8.0', '1.10.0') > 0, '1.8.0 should sort after 1.10.0');
+    assert.strictEqual(compareVersionDesc('1.10.0', '1.10.0'), 0);
+
+    const ordered = ['1.8.0', '1.10.0', '1.9.0', '2.0.0'].sort(compareVersionDesc);
+    assert.deepStrictEqual(ordered, ['2.0.0', '1.10.0', '1.9.0', '1.8.0']);
+
+    // Non-numeric / missing components collapse to 0 at that position and the
+    // comparator must not throw.
+    assert.doesNotThrow(() => compareVersionDesc('1.0.0-beta', '1.0.0'));
+    assert.doesNotThrow(() => compareVersionDesc('1', '1.0.0'));
+  })) passed++; else failed++;
+
   if (test('findPluginInstall prefers the newest version in the cache layout', () => {
     const homeDir = createTempDir('harness-audit-home-');
-    const projectRoot = createTempDir('harness-audit-project-');
 
     try {
       const pluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'everything-claude-code', 'ecc');
-      // Only the newer version has a plugin.json — the older dir is empty and
-      // must not shadow it. This guards the version sort order in the lookup.
-      fs.mkdirSync(path.join(pluginRoot, '1.8.0'), { recursive: true });
+      // Put a valid plugin.json in BOTH versioned directories. This is the
+      // only setup that can actually detect a reversed or lexicographic sort
+      // order — if iteration picks the wrong directory, the returned path
+      // will contain "1.8.0" instead of "1.10.0".
+      fs.mkdirSync(path.join(pluginRoot, '1.8.0', '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, '1.8.0', '.claude-plugin', 'plugin.json'),
+        JSON.stringify({ name: 'ecc', version: '1.8.0' }, null, 2)
+      );
       fs.mkdirSync(path.join(pluginRoot, '1.10.0', '.claude-plugin'), { recursive: true });
       fs.writeFileSync(
         path.join(pluginRoot, '1.10.0', '.claude-plugin', 'plugin.json'),
         JSON.stringify({ name: 'ecc', version: '1.10.0' }, null, 2)
       );
 
-      writeConsumerProject(projectRoot);
-      const parsed = JSON.parse(run(['repo', '--format', 'json'], { cwd: projectRoot, homeDir }));
+      // Call findPluginInstall directly so we can assert which path it
+      // returns. We point rootDir at a throwaway project directory that does
+      // NOT have its own .claude/plugins, so the lookup is forced to fall
+      // through to the user-scope HOME. process.env.HOME is temporarily
+      // redirected at the function call to make the lookup hermetic.
+      const projectRoot = createTempDir('harness-audit-project-');
+      const originalHome = process.env.HOME;
+      process.env.HOME = homeDir;
+      let found;
+      try {
+        found = findPluginInstall(projectRoot);
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+        cleanup(projectRoot);
+      }
 
-      const check = findCheck(parsed, 'consumer-plugin-install');
-      assert.strictEqual(check.pass, true, 'consumer-plugin-install should still pass when an older sibling version has no plugin.json');
+      assert.ok(found, 'findPluginInstall should return a path when either version is valid');
+      assert.ok(
+        found.includes(`${path.sep}1.10.0${path.sep}`),
+        `findPluginInstall should prefer 1.10.0 over 1.8.0, got: ${found}`
+      );
+      assert.ok(
+        !found.includes(`${path.sep}1.8.0${path.sep}`),
+        `findPluginInstall should not return the older 1.8.0 path, got: ${found}`
+      );
     } finally {
       cleanup(homeDir);
-      cleanup(projectRoot);
     }
   })) passed++; else failed++;
 

--- a/tests/scripts/harness-audit.test.js
+++ b/tests/scripts/harness-audit.test.js
@@ -132,6 +132,147 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  // --- findPluginInstall lookup paths ---
+  //
+  // These tests fix a gap where consumer-plugin-install only passed when the
+  // plugin lived at the legacy flat path ~/.claude/plugins/<pluginDir>/. The
+  // lookup now also supports the authoritative installed_plugins.json manifest
+  // and the marketplace cache layout (cache/<marketplace>/<plugin>/<version>/)
+  // produced by `claude plugin install ecc@everything-claude-code` on v1.9.0+.
+
+  // Minimal consumer-project scaffold reused by the plugin-install tests. We
+  // only need it to satisfy enough consumer checks for the audit to run and
+  // surface the consumer-plugin-install check result.
+  function writeConsumerProject(projectRoot) {
+    fs.mkdirSync(path.join(projectRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'AGENTS.md'), '# Project instructions\n');
+    fs.writeFileSync(path.join(projectRoot, '.gitignore'), '.env\n');
+    fs.writeFileSync(
+      path.join(projectRoot, '.claude', 'settings.json'),
+      JSON.stringify({ hooks: ['PreToolUse'] }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(projectRoot, 'package.json'),
+      JSON.stringify({ name: 'consumer-project' }, null, 2)
+    );
+  }
+
+  function findCheck(parsed, id) {
+    return parsed.checks.find((check) => check.id === id);
+  }
+
+  if (test('findPluginInstall passes when installed_plugins.json points to the install', () => {
+    const homeDir = createTempDir('harness-audit-home-');
+    const projectRoot = createTempDir('harness-audit-project-');
+    const installRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'everything-claude-code', 'ecc', '1.10.0');
+
+    try {
+      // Real plugin install on disk, with a non-flat layout.
+      fs.mkdirSync(path.join(installRoot, '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(
+        path.join(installRoot, '.claude-plugin', 'plugin.json'),
+        JSON.stringify({ name: 'ecc', version: '1.10.0' }, null, 2)
+      );
+
+      // installed_plugins.json manifest that points at the install.
+      fs.writeFileSync(
+        path.join(homeDir, '.claude', 'plugins', 'installed_plugins.json'),
+        JSON.stringify(
+          {
+            plugins: {
+              'ecc@everything-claude-code': [
+                { version: '1.10.0', installPath: installRoot },
+              ],
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      writeConsumerProject(projectRoot);
+      const parsed = JSON.parse(run(['repo', '--format', 'json'], { cwd: projectRoot, homeDir }));
+
+      const check = findCheck(parsed, 'consumer-plugin-install');
+      assert.ok(check, 'consumer-plugin-install check should exist');
+      assert.strictEqual(check.pass, true, 'consumer-plugin-install should pass when installed_plugins.json references the install');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('findPluginInstall passes via the marketplace cache layout', () => {
+    const homeDir = createTempDir('harness-audit-home-');
+    const projectRoot = createTempDir('harness-audit-project-');
+
+    try {
+      // Marketplace install path without an installed_plugins.json manifest.
+      const installRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'everything-claude-code', 'ecc', '1.10.0');
+      fs.mkdirSync(path.join(installRoot, '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(
+        path.join(installRoot, '.claude-plugin', 'plugin.json'),
+        JSON.stringify({ name: 'ecc', version: '1.10.0' }, null, 2)
+      );
+
+      writeConsumerProject(projectRoot);
+      const parsed = JSON.parse(run(['repo', '--format', 'json'], { cwd: projectRoot, homeDir }));
+
+      const check = findCheck(parsed, 'consumer-plugin-install');
+      assert.ok(check, 'consumer-plugin-install check should exist');
+      assert.strictEqual(check.pass, true, 'consumer-plugin-install should pass with cache/<marketplace>/<plugin>/<version>/ layout');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('findPluginInstall prefers the newest version in the cache layout', () => {
+    const homeDir = createTempDir('harness-audit-home-');
+    const projectRoot = createTempDir('harness-audit-project-');
+
+    try {
+      const pluginRoot = path.join(homeDir, '.claude', 'plugins', 'cache', 'everything-claude-code', 'ecc');
+      // Only the newer version has a plugin.json — the older dir is empty and
+      // must not shadow it. This guards the version sort order in the lookup.
+      fs.mkdirSync(path.join(pluginRoot, '1.8.0'), { recursive: true });
+      fs.mkdirSync(path.join(pluginRoot, '1.10.0', '.claude-plugin'), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, '1.10.0', '.claude-plugin', 'plugin.json'),
+        JSON.stringify({ name: 'ecc', version: '1.10.0' }, null, 2)
+      );
+
+      writeConsumerProject(projectRoot);
+      const parsed = JSON.parse(run(['repo', '--format', 'json'], { cwd: projectRoot, homeDir }));
+
+      const check = findCheck(parsed, 'consumer-plugin-install');
+      assert.strictEqual(check.pass, true, 'consumer-plugin-install should still pass when an older sibling version has no plugin.json');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('findPluginInstall fails cleanly when no install is present', () => {
+    const homeDir = createTempDir('harness-audit-home-');
+    const projectRoot = createTempDir('harness-audit-project-');
+
+    try {
+      // HOME has .claude/plugins but no plugin install anywhere.
+      fs.mkdirSync(path.join(homeDir, '.claude', 'plugins'), { recursive: true });
+
+      writeConsumerProject(projectRoot);
+      const parsed = JSON.parse(run(['repo', '--format', 'json'], { cwd: projectRoot, homeDir }));
+
+      const check = findCheck(parsed, 'consumer-plugin-install');
+      assert.ok(check, 'consumer-plugin-install check should exist');
+      assert.strictEqual(check.pass, false, 'consumer-plugin-install should fail when no install is reachable');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary

`findPluginInstall` in `scripts/harness-audit.js` only walks the legacy flat layout `~/.claude/plugins/<pluginDir>/plugin.json`. That layout is no longer produced by `claude plugin install ecc@everything-claude-code` on v1.9.0+, which writes to `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` instead.

As a result, every consumer project audited via `harness-audit` reports `consumer-plugin-install: pass=false` even when ECC is clearly installed and active. On my own consumer projects this silently cost 4 points of the Tool Coverage rubric (the full weight of `consumer-plugin-install`).

This PR rewrites `findPluginInstall` as a three-tier lookup:

1. **Authoritative** — `.claude/plugins/installed_plugins.json` (project scope first, then user scope). Matches keys with `^ecc@` or `^everything-claude-code@`, reads each entry's `installPath`, and returns the first `plugin.json` found.
2. **Legacy** — the original flat `~/.claude/plugins/<pluginDir>/plugin.json` layout (unchanged; preserved for manual/dev installs and backwards compatibility).
3. **Marketplace cache** — `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, sorting versions in reverse so the newest install wins when multiple versions are on disk.

Both `.claude-plugin/plugin.json` and `plugin.json` variants are accepted at every tier for parity with the existing flat-layout code path.

## Type

- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] **Bug fix in `scripts/harness-audit.js`**

## Testing

Four new regression tests under `tests/scripts/harness-audit.test.js` using temp `HOME` fixtures so they are hermetic and don't touch the real user install:

- `findPluginInstall passes when installed_plugins.json points to the install`
- `findPluginInstall passes via the marketplace cache layout`
- `findPluginInstall prefers the newest version in the cache layout`
- `findPluginInstall fails cleanly when no install is present`

Full results:

| Command | Before | After |
|---|---|---|
| `node tests/scripts/harness-audit.test.js` | 5/5 passing | **9/9 passing** |
| `node tests/run-all.js` | 1730/1735 passing (5 Windows env failures unchanged) | **1734/1739 passing** (same 5 Windows env failures, 4 new tests added) |
| `node scripts/ci/check-unicode-safety.js` | pass | pass |
| `node scripts/ci/validate-no-personal-paths.js` | pass | pass |
| `npx eslint scripts/harness-audit.js tests/scripts/harness-audit.test.js` | clean | clean |

The 5 pre-existing Windows failures are all broken-symlink and `npm pack` environmental issues that exist on `main` with or without this patch.

## Checklist

- [x] Follows format guidelines
- [x] Tested with Claude Code (validated against my live consumer projects that previously reported `consumer-plugin-install: pass=false` — they now report `pass=true` after applying this patch locally)
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
- [x] No changes to `.claude-plugin/plugin.json`, agents, skills, commands, hooks, or the rubric itself — only the lookup function
- [x] Backwards compatible with the existing flat layout (Tier 2)

## Additional context

Related to PR #1014 (`fix: audit consumer projects from cwd`, merged 2026-03-30) which introduced `findPluginInstall` in its current form. This PR is a direct follow-up that covers the v1.9.0+ marketplace install layout that #1014 did not anticipate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin detection in `harness-audit` by hardening `findPluginInstall` and adding support for the v1.9.0+ marketplace cache and the `installed_plugins.json` manifest with semver-aware version selection. Prevents false `consumer-plugin-install: pass=false` when ECC is installed via `claude plugin install ecc@everything-claude-code`.

- **Bug Fixes**
  - Manifest handling: validate entry types; resolve relative `installPath` against the manifest directory; skip malformed entries safely.
  - Three-tier lookup: manifest (project then user; keys `^ecc@`/`^everything-claude-code@`), legacy flat layout, and marketplace cache `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`; newest preferred via `compareVersionDesc`; accepts `.claude-plugin/plugin.json` and `plugin.json`.
  - Surface cache read errors to stderr.
  - Tests: added cases for malformed manifest and manifest-relative paths; results — `tests/scripts/harness-audit.test.js` 12/12; `tests/run-all.js` 1737/1742 (same 5 pre-existing Windows env failures).

- **Refactors**
  - Split `findPluginInstall` into tiered helper functions; export `findPluginInstall` and `compareVersionDesc` for tests.

<sup>Written for commit 942dd83ec2669652e8af47eabb3d10d3d07016b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved plugin discovery: checks project/user installed lists, falls back to legacy layouts, and scans marketplace cache; resolves relative install paths, prefers newest version using numeric-aware version ordering, and uses system home as a fallback.

* **Tests**
  * Added tests covering discovery across installed lists, legacy and cache layouts, version-sorting and newest-version selection, relative-path resolution, and failure cases for unreachable installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->