### PR TITLE
docs: update catalog counts in README to match actual surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This repo is the raw code only. The guides explain everything.
 
 ### v1.10.0 — Surface Refresh, Operator Workflows, and ECC 2.0 Alpha (Apr 2026)
 
-- **Public surface synced to the live repo** — metadata, catalog counts, plugin manifests, and install-facing docs now match the actual OSS surface: 38 agents, 156 skills, and 72 legacy command shims.
+- **Public surface synced to the live repo** — metadata, catalog counts, plugin manifests, and install-facing docs now match the actual OSS surface: 47 agents, 181 skills, and 79 legacy command shims.
 - **Operator and outbound workflow expansion** — `brand-voice`, `social-graph-ranker`, `connections-optimizer`, `customer-billing-ops`, `ecc-tools-cost-audit`, `google-workspace-ops`, `project-flow-ops`, and `workspace-surface-audit` round out the operator lane.
 - **Media and launch tooling** — `manim-video`, `remotion-video-creation`, and upgraded social publishing surfaces make technical explainers and launch content part of the same system.
 - **Framework and product surface growth** — `nestjs-patterns`, richer Codex/OpenCode install surfaces, and expanded cross-harness packaging keep the repo usable beyond Claude Code alone.


### PR DESCRIPTION
Updated the catalog counts in `README.md` line 87 (v1.10.0 release notes) from `38 agents, 156 skills, and 72 legacy
  command shims` to `47 agents, 181 skills, and 79 legacy command shims`.

  ## Why This Change
  Since the v1.10.0 release notes were written, new agents, skills, and commands have been added to the repo. The
  documented counts no longer match the actual contents, which is misleading for users reading the changelog.

  ## Testing Done
  - [x] Manual testing completed
  - [ ] Automated tests pass locally (`node tests/run-all.js`)
  - [ ] Edge cases considered and tested

  Verified counts:
  - `ls agents/*.md | wc -l` → 47
  - `ls skills/ | wc -l` → 181
  - `ls commands/*.md | wc -l` → 79

  ## Type of Change
  - [ ] `fix:` Bug fix
  - [ ] `feat:` New feature
  - [ ] `refactor:` Code refactoring
  - [x] `docs:` Documentation
  - [ ] `test:` Tests
  - [ ] `chore:` Maintenance/tooling
  - [ ] `ci:` CI/CD changes

  ## Security & Quality Checklist
  - [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
  - [x] JSON files validate cleanly
  - [x] Shell scripts pass shellcheck (if applicable)
  - [x] Pre-commit hooks pass locally (if configured)
  - [x] No sensitive data exposed in logs or output
  - [x] Follows conventional commits format

  ## Documentation
  - [x] Updated relevant documentation
  - [x] Added comments for complex logic
  - [x] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the v1.10.0 release notes in `README.md` to reflect current catalog counts: 47 agents, 181 skills, and 79 legacy command shims. This keeps the changelog aligned with the actual OSS surface.

<sup>Written for commit 1a159adcaa83f6c0bec897e7b57dc415e98c96e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v1.10.0 release notes with corrected counts for available agents, skills, and legacy command shims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->