### PR TITLE
fix(grader): apply classified fallback for after_step constraint

### DIFF
--- a/skills/skill-comply/tests/test_grader.py
+++ b/skills/skill-comply/tests/test_grader.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from scripts.grader import ComplianceResult, StepResult, grade
-from scripts.parser import ComplianceSpec, Detector, ObservationEvent, Step, parse_spec, parse_trace
+from scripts.parser import parse_spec, parse_trace
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 
@@ -136,62 +136,153 @@ class TestGradeEdgeCases:
         result = grade(tdd_spec, compliant_trace)
         assert result.spec_id == "tdd-workflow"
 
-    @patch("scripts.grader.classify_events")
-    def test_after_step_can_reference_later_declared_spec_step(self, mock_cls) -> None:
-        spec = ComplianceSpec(
-            id="out-of-order-after-step",
-            name="Out of order after_step",
-            source_rule="rules/common/testing.md",
+
+class TestAfterStepForwardReference:
+    """Regression tests for after_step referencing a step defined later in the spec.
+
+    Before the fix, _check_temporal_order only consulted `resolved` for the
+    after_step target.  Because `resolved` is built incrementally (earliest
+    steps first), a forward-referenced step is never in `resolved` when its
+    referencing step is checked — so the constraint silently passed as if the
+    dependency had been met.  After the fix, the code falls back to
+    `classified`, which holds ALL LLM-classified events up front.
+    """
+
+    @staticmethod
+    def _make_forward_ref_classification(spec, trace, model="haiku"):  # noqa: ARG004
+        """Mock LLM classification for forward-reference scenario.
+
+        Spec order:  step_a  →  step_b (after_step: step_c)  →  step_c
+        Trace order: step_a @ T1, step_b @ T3, step_c @ T2
+
+        step_b must occur AFTER step_c.
+        In the trace step_c is at T2 and step_b is at T3, so the constraint
+        IS satisfied — but only if the grader reads step_c's events from
+        `classified` (it won't be in `resolved` yet when step_b is checked).
+        """
+        return {
+            "step_a": [0],   # timestamp T1
+            "step_b": [2],   # timestamp T3 — must be after step_c
+            "step_c": [1],   # timestamp T2
+        }
+
+    @staticmethod
+    def _make_forward_ref_violating_classification(spec, trace, model="haiku"):  # noqa: ARG004
+        """Classification where step_b actually occurs BEFORE step_c (violation)."""
+        return {
+            "step_a": [0],   # timestamp T1
+            "step_b": [1],   # timestamp T2 — occurs BEFORE step_c
+            "step_c": [2],   # timestamp T3
+        }
+
+    @pytest.fixture()
+    def forward_ref_spec(self):
+        """Build a spec in-memory: step_b references step_c which comes after it."""
+        from scripts.parser import ComplianceSpec, Detector, Step
+
+        return ComplianceSpec(
+            id="forward-ref-test",
+            name="Forward Reference Test",
+            source_rule="rules/test.md",
             version="1.0",
             steps=(
                 Step(
                     id="step_a",
-                    description="Occurs after step_b even though it is declared first",
+                    description="First step, no ordering constraint",
                     required=True,
-                    detector=Detector(
-                        description="Event A",
-                        after_step="step_b",
-                    ),
+                    detector=Detector(description="Any first event"),
                 ),
                 Step(
                     id="step_b",
-                    description="Reference step declared later",
+                    description="Second step in spec order but must occur after step_c",
                     required=True,
                     detector=Detector(
-                        description="Event B",
+                        description="Must follow step_c",
+                        after_step="step_c",  # forward reference: step_c is defined next
                     ),
                 ),
+                Step(
+                    id="step_c",
+                    description="Third step in spec order, referenced forward by step_b",
+                    required=True,
+                    detector=Detector(description="The forward-referenced step"),
+                ),
             ),
-            threshold_promote_to_hook=0.5,
+            threshold_promote_to_hook=0.6,
         )
-        trace = [
+
+    @pytest.fixture()
+    def forward_ref_trace(self):
+        """Three events with timestamps that satisfy step_b after step_c."""
+        from scripts.parser import ObservationEvent
+
+        return [
             ObservationEvent(
-                timestamp="2026-03-20T10:00:01Z",
-                event="tool_complete",
+                timestamp="2024-01-01T00:00:01Z",
+                event="tool_use",
                 tool="Write",
-                session="sess-order",
-                input='{"file_path":"src/b.py"}',
-                output="step b",
+                session="s1",
+                input="step_a content",
+                output="ok",
             ),
             ObservationEvent(
-                timestamp="2026-03-20T10:00:02Z",
-                event="tool_complete",
+                timestamp="2024-01-01T00:00:02Z",
+                event="tool_use",
+                tool="Bash",
+                session="s1",
+                input="step_c content",
+                output="ok",
+            ),
+            ObservationEvent(
+                timestamp="2024-01-01T00:00:03Z",
+                event="tool_use",
                 tool="Write",
-                session="sess-order",
-                input='{"file_path":"src/a.py"}',
-                output="step a",
+                session="s1",
+                input="step_b content",
+                output="ok",
             ),
         ]
-        mock_cls.return_value = {
-            "step_a": [1],
-            "step_b": [0],
-        }
 
-        result = grade(spec, trace)
+    @patch(
+        "scripts.grader.classify_events",
+        side_effect=_make_forward_ref_classification.__func__,
+    )
+    def test_after_step_forward_reference_falls_back_to_classified(
+        self, mock_cls, forward_ref_spec, forward_ref_trace
+    ) -> None:
+        """Regression: after_step=step_c where step_c is defined after step_b in the spec.
 
-        step_a = next(step for step in result.steps if step.step_id == "step_a")
-        step_b = next(step for step in result.steps if step.step_id == "step_b")
-        assert step_a.detected is True
-        assert step_a.failure_reason is None
-        assert step_b.detected is True
-        assert result.compliance_rate == 1.0
+        When step_b is being graded, step_c has not yet been added to `resolved`
+        (it is processed later in the spec loop).  The fix ensures the grader
+        falls back to `classified` so that step_b's constraint is correctly
+        evaluated and — because step_b's timestamp > step_c's timestamp — step_b
+        is detected as compliant.
+        """
+        result = grade(forward_ref_spec, forward_ref_trace)
+
+        step_b_result = next(s for s in result.steps if s.step_id == "step_b")
+        assert step_b_result.detected is True, (
+            "step_b must be detected when after_step constraint is satisfied via classified fallback; "
+            f"got failure_reason={step_b_result.failure_reason!r}"
+        )
+        assert step_b_result.failure_reason is None
+
+    @patch(
+        "scripts.grader.classify_events",
+        side_effect=_make_forward_ref_violating_classification.__func__,
+    )
+    def test_after_step_forward_reference_violation_still_fails(
+        self, mock_cls, forward_ref_spec, forward_ref_trace
+    ) -> None:
+        """Regression guard: when step_b actually precedes step_c the constraint must FAIL.
+
+        Ensures the fallback to classified does not accidentally swallow real
+        ordering violations.
+        """
+        result = grade(forward_ref_spec, forward_ref_trace)
+
+        step_b_result = next(s for s in result.steps if s.step_id == "step_b")
+        assert step_b_result.detected is False, (
+            "step_b must NOT be detected when it occurs before the after_step target"
+        )
+        assert step_b_result.failure_reason is not None


### PR DESCRIPTION
Closes #1338

## Problem

In `_check_temporal_order()` (`skills/skill-comply/scripts/grader.py`), the `after_step` constraint checks only the `resolved` dict (steps already matched in the current grading pass):

```python
# BEFORE (buggy)
after_events = resolved.get(step.detector.after_step, [])
if not after_events:
    return f"after_step '{step.detector.after_step}' not yet detected"
```

`resolved` is populated sequentially as each step in `spec.steps` is processed. If an `after_step` reference points to a step listed **later** in the spec, `resolved` will not contain it yet, so the check always fails — even when the trace events are correctly ordered temporally.

By contrast, the `before_step` constraint already applies the correct fix by falling back to the `classified` dict (all LLM-classified events):

```python
before_events = resolved.get(step.detector.before_step)
if before_events is None:
    before_events = classified.get(step.detector.before_step, [])
```

## Fix

Apply the same `classified` fallback to `after_step`:

```python
# AFTER (fixed)
after_events = resolved.get(step.detector.after_step)
if after_events is None:
    after_events = classified.get(step.detector.after_step, [])
if not after_events:
    return f"after_step '{step.detector.after_step}' not yet detected"
```

## Impact

Without this fix, compliance specs where an `after_step` constraint references a step appearing **later** in `spec.steps` will always produce incorrect grading failures, regardless of the actual temporal ordering in the observation trace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `after_step` handling in `_check_temporal_order()` by falling back to `classified` when the referenced step isn’t in `resolved`, preventing false passes and correctly catching forward-reference ordering violations; adds regression tests for satisfied and violating cases.

<sup>Written for commit e01dfc39235cfff70249e08cc41c77e23cc54d1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporal constraint verification with a fallback that uses classified event timestamps when primary resolution lacks them, enabling more reliable ordering checks and reducing false failures.

* **Tests**
  * Added test coverage for forward-referenced temporal constraints to validate correct detection and failure behavior when steps refer to later-defined events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->