### PR TITLE
fix(hooks): treat HTTP 400 MCP probes as reachable

### DIFF
--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -24,7 +24,7 @@ const DEFAULT_TTL_MS = 2 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_BACKOFF_MS = 30 * 1000;
 const MAX_BACKOFF_MS = 10 * 60 * 1000;
-const HEALTHY_HTTP_CODES = new Set([200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 405]);
+const HEALTHY_HTTP_CODES = new Set([200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 400, 405]);
 const RECONNECT_STATUS_CODES = new Set([401, 403, 429, 503]);
 const FAILURE_PATTERNS = [
   { code: 401, pattern: /\b401\b|unauthori[sz]ed|auth(?:entication)?\s+(?:failed|expired|invalid)/i },

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -6,9 +6,10 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const http = require('http');
 const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 const script = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'mcp-health-check.js');
 
@@ -97,6 +98,17 @@ function runRawHook(rawInput, env = {}) {
     stdout: result.stdout || '',
     stderr: result.stderr || ''
   };
+}
+
+function waitForFile(filePath, timeoutMs = 5000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath, 'utf8');
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
 }
 async function runTests() {
   console.log('\n=== Testing mcp-health-check.js ===\n');
@@ -190,6 +202,64 @@ async function runTests() {
       assert.strictEqual(state.servers.flaky.status, 'unhealthy', 'Expected flaky server to be marked unhealthy');
       assert.ok(state.servers.flaky.nextRetryAt > state.servers.flaky.checkedAt, 'Expected retry backoff to be recorded');
     } finally {
+      cleanupTempDir(tempDir);
+    }
+  })) passed++; else failed++;
+
+  if (await asyncTest('treats HTTP 400 probe responses as healthy reachable servers', async () => {
+    const tempDir = createTempDir();
+    const configPath = path.join(tempDir, 'claude.json');
+    const statePath = path.join(tempDir, 'mcp-health.json');
+    const serverScript = path.join(tempDir, 'http-400-server.js');
+    const portFile = path.join(tempDir, 'server-port.txt');
+    const serverProcess = spawn(process.execPath, [serverScript, portFile], {
+      stdio: 'ignore'
+    });
+
+    try {
+      fs.writeFileSync(
+        serverScript,
+        [
+          "const fs = require('fs');",
+          "const http = require('http');",
+          "const portFile = process.argv[2];",
+          "const server = http.createServer((_req, res) => {",
+          "  res.writeHead(400, { 'Content-Type': 'application/json' });",
+          "  res.end(JSON.stringify({ error: 'invalid MCP request' }));",
+          "});",
+          "server.listen(0, '127.0.0.1', () => {",
+          "  fs.writeFileSync(portFile, String(server.address().port));",
+          "});",
+          "setInterval(() => {}, 1000);"
+        ].join('\n')
+      );
+
+      const port = waitForFile(portFile).trim();
+
+      writeConfig(configPath, {
+        mcpServers: {
+          github: {
+            type: 'http',
+            url: `http://127.0.0.1:${port}/mcp`
+          }
+        }
+      });
+
+      const input = { tool_name: 'mcp__github__search_repositories', tool_input: {} };
+      const result = runHook(input, {
+        CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
+        ECC_MCP_CONFIG_PATH: configPath,
+        ECC_MCP_HEALTH_STATE_PATH: statePath,
+        ECC_MCP_HEALTH_TIMEOUT_MS: '500'
+      });
+
+      assert.strictEqual(result.code, 0, `Expected HTTP 400 probe to be treated as healthy, got ${result.code}`);
+      assert.strictEqual(result.stdout.trim(), JSON.stringify(input), 'Expected original JSON on stdout');
+
+      const state = readState(statePath);
+      assert.strictEqual(state.servers.github.status, 'healthy', 'Expected HTTP MCP server to be marked healthy');
+    } finally {
+      serverProcess.kill('SIGTERM');
       cleanupTempDir(tempDir);
     }
   })) passed++; else failed++;


### PR DESCRIPTION
## Summary
- treat HTTP 400 probe responses as reachable MCP HTTP servers instead of marking them unhealthy
- add a regression test that boots a local HTTP server returning 400 and verifies the health state stays healthy

## Validation
- `node tests/hooks/mcp-health-check.test.js`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat HTTP 400 MCP HTTP probe responses as reachable so HTTP-based MCP servers aren’t incorrectly marked unhealthy or put on backoff. Adds a regression test that spins up a local server returning 400 to verify the server stays healthy.

<sup>Written for commit 08126370aa55d55e8c97badad41ebddd0ced92ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP 400 responses are now correctly treated as healthy for server health probes, affecting health assessment in preflight checks and post-failure recovery.

* **Tests**
  * Added test coverage for HTTP-based server health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->