### PR TITLE
feat: add X Layer support to agent-payment-x402 skill via OKX Payment SDK and onchainos cli

### DIFF
--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -107,10 +107,10 @@ To build a seller (server that accepts x402 payments), fetch the complete refere
 
 - **TypeScript** (Express, Hono, Fastify, Next.js) — `@okxweb3/x402-express` etc.
   `https://raw.githubusercontent.com/okx/payments/main/typescript/SELLER.md`
-- **Go** (Gin, Echo, net/http) — `github.com/okx/payments/go`
-  `https://raw.githubusercontent.com/okx/payments/main/go/SELLER.md`
-- **Rust** (Axum) — `github.com/okx/payments/rust`
-  `https://raw.githubusercontent.com/okx/payments/main/rust/SELLER.md`
+- **Go** (Gin, Echo, net/http) — `github.com/okx/payments/go/x402`
+  `https://raw.githubusercontent.com/okx/payments/main/go/x402/SELLER.md`
+- **Rust** (Axum) — `github.com/okx/payments/rust/x402`
+  `https://raw.githubusercontent.com/okx/payments/main/rust/x402/SELLER.md`
 
 Supported seller languages: TypeScript, Go, Rust. Python and Java are not yet available — check [okx/payments](https://github.com/okx/payments) for updates.
 

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -41,7 +41,6 @@ Base, Arbitrum, Optimism, Polygon, Ethereum, Avalanche, Unichain, Linea, Sonic, 
 
 ### OKX Payments x402 SDK
 
-
 | Network | Chain ID | Token |
 |---------|----------|-------|
 | X Layer | eip155:196 | USDT0 |
@@ -91,25 +90,16 @@ The payment layer exposes standard MCP tools that slot into any Claude Code or a
 
 > **Note**: Spending policy is set by the **orchestrator** before delegating to the agent — not by the agent itself. This prevents agents from escalating their own spending limits. Configure policy via `set_policy` in your orchestration layer or pre-task hook, never as an agent-callable tool.
 
-## Option B: OKX Payments x402 SDK (X Layer)
+### Option B: OKX Payments x402 SDK (X Layer)
 
-### Buyer Integration
+#### Buyer Integration
 
 To pay for x402-gated resources, use the [OnchainOS CLI](https://github.com/okx/onchainos-skills) with the `okx-x402-payment` skill. The CLI provides a TEE wallet where private keys never leave the server-side secure enclave — no local key management needed.
 
-Install the [OnchainOS CLI](https://github.com/okx/onchainos-skills#installation) and plugin:
-```bash
-# macOS/Linux
-curl -sSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh
+For installation instructions, fetch the official guide using WebFetch:
+`https://raw.githubusercontent.com/okx/onchainos-skills/main/README.md#installation`
 
-# Windows
-irm https://raw.githubusercontent.com/okx/onchainos-skills/main/install.ps1 | iex
-
-# Add skills plugin
-npx skills add okx/onchainos-skills
-```
-
-### Seller Integration
+#### Seller Integration
 
 To build a seller (server that accepts x402 payments), fetch the complete reference doc for your language using WebFetch:
 
@@ -242,9 +232,9 @@ main().catch((err) => {
 
 ## Production Reference
 
-- **npm**: `[agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk)` — multi-chain MCP provider
-- **npm**: `[@okxweb3/x402-core](https://www.npmjs.com/package/@okxweb3/x402-core)`, `[@okxweb3/x402-evm](https://www.npmjs.com/package/@okxweb3/x402-evm)`, `[@okxweb3/x402-express](https://www.npmjs.com/package/@okxweb3/x402-express)`, `[@okxweb3/x402-hono](https://www.npmjs.com/package/@okxweb3/x402-hono)`, `[@okxweb3/x402-fastify](https://www.npmjs.com/package/@okxweb3/x402-fastify)`, `[@okxweb3/x402-next](https://www.npmjs.com/package/@okxweb3/x402-next)` — OKX Payments x402 TypeScript SDK
-- **GitHub**: `[okx/payments](https://github.com/okx/payments)` — OKX Payments x402 SDK (Go, Rust)
+- **npm**: [agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk) — multi-chain MCP provider
+- **npm**: [@okxweb3/x402-core](https://www.npmjs.com/package/@okxweb3/x402-core), [@okxweb3/x402-evm](https://www.npmjs.com/package/@okxweb3/x402-evm), [@okxweb3/x402-express](https://www.npmjs.com/package/@okxweb3/x402-express), [@okxweb3/x402-hono](https://www.npmjs.com/package/@okxweb3/x402-hono), [@okxweb3/x402-fastify](https://www.npmjs.com/package/@okxweb3/x402-fastify), [@okxweb3/x402-next](https://www.npmjs.com/package/@okxweb3/x402-next) — OKX Payments x402 TypeScript SDK
+- **GitHub**: [okx/payments](https://github.com/okx/payments) — OKX Payments x402 SDK (Go, Rust)
 - **Merged into NVIDIA NeMo Agent Toolkit**: [PR #17](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) — x402 payment tool for NVIDIA's agent examples
 - **Protocol spec**: [x402.org](https://x402.org)
 - **OKX Payments x402 docs**: [web3.okx.com — x402 Introduction](https://web3.okx.com/zh-hans/onchainos/dev-docs/payments/x402-introduction)

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-payment-x402
-description: Add x402 payment execution to AI agents — per-task budgets, spending controls, and non-custodial wallets via MCP tools. Use when agents need to pay for APIs, services, or other agents.
+description: Add x402 payment execution to AI agents — per-task budgets, spending controls, and non-custodial wallets via MCP tools. Supports Base (agentwallet-sdk) and X Layer (OKX Payments x402 SDK). Use when agents need to pay for APIs, services, or other agents.
 origin: community
 ---
 
@@ -11,6 +11,40 @@ Enable AI agents to make autonomous payments with built-in spending controls. Us
 ## When to Use
 
 Use when: your agent needs to pay for an API call, purchase a service, settle with another agent, enforce per-task spending limits, or manage a non-custodial wallet. Pairs naturally with cost-aware-llm-pipeline and security-review skills.
+
+## Decision Tree
+
+```
+Are you paying for a resource, or charging for one?
+│
+├─ BUYER (paying for 402-gated APIs)
+│  │
+│  ├─ Want TEE wallet (no local keys)?
+│  │  └─ Option B → OnchainOS CLI + okx-x402-payment skill
+│  │
+│  └─ Want local wallet with spending controls?
+│     └─ Option A → agentwallet-sdk (Base, multi-chain)
+│
+└─ SELLER (charging for your API)
+   │
+   ├─ TypeScript? → WebFetch typescript/SELLER.md (Express, Hono, Fastify, Next.js)
+   ├─ Go?         → WebFetch go/SELLER.md (Gin, Echo, net/http)
+   ├─ Rust?       → WebFetch rust/SELLER.md (Axum)
+   └─ Python/Java? → Not yet supported, check okx/payments for updates
+```
+
+## Supported Networks
+
+### agentwallet-sdk
+
+Base, Arbitrum, Optimism, Polygon, Ethereum, Avalanche, Unichain, Linea, Sonic, Worldchain, Base Sepolia (testnet), Solana.
+
+### OKX Payments x402 SDK
+
+
+| Network | Chain ID | Token |
+|---------|----------|-------|
+| X Layer | eip155:196 | USDT0 |
 
 ## How It Works
 
@@ -33,6 +67,8 @@ The payment layer exposes standard MCP tools that slot into any Claude Code or a
 
 > **Security note**: Always pin the package version. This tool manages private keys — unpinned `npx` installs introduce supply-chain risk.
 
+### Option A: agentwallet-sdk (Base)
+
 ```json
 {
   "mcpServers": {
@@ -54,6 +90,39 @@ The payment layer exposes standard MCP tools that slot into any Claude Code or a
 | `list_transactions` | Audit trail of all payments |
 
 > **Note**: Spending policy is set by the **orchestrator** before delegating to the agent — not by the agent itself. This prevents agents from escalating their own spending limits. Configure policy via `set_policy` in your orchestration layer or pre-task hook, never as an agent-callable tool.
+
+## Option B: OKX Payments x402 SDK (X Layer)
+
+### Buyer Integration
+
+To pay for x402-gated resources, use the [OnchainOS CLI](https://github.com/okx/onchainos-skills) with the `okx-x402-payment` skill. The CLI provides a TEE wallet where private keys never leave the server-side secure enclave — no local key management needed.
+
+Install the [OnchainOS CLI](https://github.com/okx/onchainos-skills#installation) and plugin:
+```bash
+# macOS/Linux
+curl -sSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh
+
+# Windows
+irm https://raw.githubusercontent.com/okx/onchainos-skills/main/install.ps1 | iex
+
+# Add skills plugin
+npx skills add okx/onchainos-skills
+```
+
+### Seller Integration
+
+To build a seller (server that accepts x402 payments), fetch the complete reference doc for your language using WebFetch:
+
+- **TypeScript** (Express, Hono, Fastify, Next.js) — `@okxweb3/x402-express` etc.
+  `https://raw.githubusercontent.com/okx/payments/main/typescript/SELLER.md`
+- **Go** (Gin, Echo, net/http) — `github.com/okx/payments/go`
+  `https://raw.githubusercontent.com/okx/payments/main/go/SELLER.md`
+- **Rust** (Axum) — `github.com/okx/payments/rust`
+  `https://raw.githubusercontent.com/okx/payments/main/rust/SELLER.md`
+
+Supported seller languages: TypeScript, Go, Rust. Python and Java are not yet available — check [okx/payments](https://github.com/okx/payments) for updates.
+
+These docs are designed for AI agents — each contains complete setup patterns, framework-specific examples, decision trees, and common mistakes. Use them as the authoritative reference for generating seller code.
 
 ## Examples
 
@@ -173,6 +242,10 @@ main().catch((err) => {
 
 ## Production Reference
 
-- **npm**: [`agentwallet-sdk`](https://www.npmjs.com/package/agentwallet-sdk)
+- **npm**: `[agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk)` — multi-chain MCP provider
+- **npm**: `[@okxweb3/x402-core](https://www.npmjs.com/package/@okxweb3/x402-core)`, `[@okxweb3/x402-evm](https://www.npmjs.com/package/@okxweb3/x402-evm)`, `[@okxweb3/x402-express](https://www.npmjs.com/package/@okxweb3/x402-express)`, `[@okxweb3/x402-hono](https://www.npmjs.com/package/@okxweb3/x402-hono)`, `[@okxweb3/x402-fastify](https://www.npmjs.com/package/@okxweb3/x402-fastify)`, `[@okxweb3/x402-next](https://www.npmjs.com/package/@okxweb3/x402-next)` — OKX Payments x402 TypeScript SDK
+- **GitHub**: `[okx/payments](https://github.com/okx/payments)` — OKX Payments x402 SDK (Go, Rust)
 - **Merged into NVIDIA NeMo Agent Toolkit**: [PR #17](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) — x402 payment tool for NVIDIA's agent examples
 - **Protocol spec**: [x402.org](https://x402.org)
+- **OKX Payments x402 docs**: [web3.okx.com — x402 Introduction](https://web3.okx.com/zh-hans/onchainos/dev-docs/payments/x402-introduction)
+

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -28,8 +28,8 @@ Are you paying for a resource, or charging for one?
 └─ SELLER (charging for your API)
    │
    ├─ TypeScript? → WebFetch typescript/SELLER.md (Express, Hono, Fastify, Next.js)
-   ├─ Go?         → WebFetch go/SELLER.md (Gin, Echo, net/http)
-   ├─ Rust?       → WebFetch rust/SELLER.md (Axum)
+   ├─ Go?         → WebFetch go/x402/SELLER.md (Gin, Echo, net/http)
+   ├─ Rust?       → WebFetch rust/x402/SELLER.md (Axum)
    └─ Python/Java? → Not yet supported, check okx/payments for updates
 ```
 
@@ -97,7 +97,7 @@ The payment layer exposes standard MCP tools that slot into any Claude Code or a
 To pay for x402-gated resources, use the [OnchainOS CLI](https://github.com/okx/onchainos-skills) with the `okx-x402-payment` skill. The CLI provides a TEE wallet where private keys never leave the server-side secure enclave — no local key management needed.
 
 For installation instructions, fetch the official guide using WebFetch:
-`https://raw.githubusercontent.com/okx/onchainos-skills/main/README.md#installation`
+`https://raw.githubusercontent.com/okx/onchainos-skills/main/README.md`
 
 > **Note**: These external URLs point to `main` and may change over time. This is intentional — installation and SDK docs should stay in sync with the latest release. Do not cache or pin these references.
 

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -99,6 +99,8 @@ To pay for x402-gated resources, use the [OnchainOS CLI](https://github.com/okx/
 For installation instructions, fetch the official guide using WebFetch:
 `https://raw.githubusercontent.com/okx/onchainos-skills/main/README.md#installation`
 
+> **Note**: These external URLs point to `main` and may change over time. This is intentional — installation and SDK docs should stay in sync with the latest release. Do not cache or pin these references.
+
 #### Seller Integration
 
 To build a seller (server that accepts x402 payments), fetch the complete reference doc for your language using WebFetch:

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -235,9 +235,15 @@ main().catch((err) => {
 ## Production Reference
 
 - **npm**: [agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk) — multi-chain MCP provider
-- **npm**: [@okxweb3/x402-core](https://www.npmjs.com/package/@okxweb3/x402-core), [@okxweb3/x402-evm](https://www.npmjs.com/package/@okxweb3/x402-evm), [@okxweb3/x402-express](https://www.npmjs.com/package/@okxweb3/x402-express), [@okxweb3/x402-hono](https://www.npmjs.com/package/@okxweb3/x402-hono), [@okxweb3/x402-fastify](https://www.npmjs.com/package/@okxweb3/x402-fastify), [@okxweb3/x402-next](https://www.npmjs.com/package/@okxweb3/x402-next) — OKX Payments x402 TypeScript SDK
+- **npm**: OKX Payments x402 TypeScript SDK
+  - [@okxweb3/x402-core](https://www.npmjs.com/package/@okxweb3/x402-core)
+  - [@okxweb3/x402-evm](https://www.npmjs.com/package/@okxweb3/x402-evm)
+  - [@okxweb3/x402-express](https://www.npmjs.com/package/@okxweb3/x402-express)
+  - [@okxweb3/x402-hono](https://www.npmjs.com/package/@okxweb3/x402-hono)
+  - [@okxweb3/x402-fastify](https://www.npmjs.com/package/@okxweb3/x402-fastify)
+  - [@okxweb3/x402-next](https://www.npmjs.com/package/@okxweb3/x402-next)
 - **GitHub**: [okx/payments](https://github.com/okx/payments) — OKX Payments x402 SDK (Go, Rust)
 - **Merged into NVIDIA NeMo Agent Toolkit**: [PR #17](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) — x402 payment tool for NVIDIA's agent examples
 - **Protocol spec**: [x402.org](https://x402.org)
-- **OKX Payments x402 docs**: [web3.okx.com — x402 Introduction](https://web3.okx.com/zh-hans/onchainos/dev-docs/payments/x402-introduction)
+- **OKX Payments x402 docs**: [web3.okx.com — Payments Overview](https://web3.okx.com/onchainos/dev-docs/payments/overview)
 

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -27,9 +27,9 @@ Are you paying for a resource, or charging for one?
 │
 └─ SELLER (charging for your API)
    │
-   ├─ TypeScript? → WebFetch typescript/SELLER.md (Express, Hono, Fastify, Next.js)
-   ├─ Go?         → WebFetch go/x402/SELLER.md (Gin, Echo, net/http)
-   ├─ Rust?       → WebFetch rust/x402/SELLER.md (Axum)
+   ├─ TypeScript? → WebFetch https://raw.githubusercontent.com/okx/payments/main/typescript/SELLER.md  (Express, Hono, Fastify, Next.js)
+   ├─ Go?         → WebFetch https://raw.githubusercontent.com/okx/payments/main/go/x402/SELLER.md     (Gin, Echo, net/http)
+   ├─ Rust?       → WebFetch https://raw.githubusercontent.com/okx/payments/main/rust/x402/SELLER.md   (Axum)
    └─ Python/Java? → Not yet supported, check okx/payments for updates
 ```
 


### PR DESCRIPTION
## What Changed

- Extended `skills/agent-payment-x402/SKILL.md` to add **X Layer** support via OKX Payments x402 SDK
- Added a **Decision Tree** section to help users choose between buyer/seller roles and SDK options (agentwallet-sdk vs OKX Payments)
- Added **Supported Networks** table covering both agentwallet-sdk (Base, Arbitrum, etc.) and OKX Payments (X Layer)
- Added **Option B: OKX Payments x402 SDK** section with buyer integration (OnchainOS CLI + TEE wallet) and seller integration (TypeScript, Go, Rust framework references)
- Updated **Production Reference** links with OKX Payments npm packages and documentation

## Why This Change

The x402 payment skill previously only supported Base chain via agentwallet-sdk. OKX has released a x402-compatible payments SDK supporting X Layer (chain ID eip155:196, USDT0 token). This PR adds X Layer as a second network option, giving agents access to OKX's ecosystem including TEE wallets where private keys never leave the server-side secure enclave.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [x] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds X Layer support to the `agent-payment-x402` skill via OKX Payments x402 SDK alongside `agentwallet-sdk`. Enables x402 payments on X Layer (eip155:196, USDT0) with clear buyer (TEE wallet via OnchainOS CLI) and seller paths.

- **New Features**
  - Decision tree for buyer/seller and SDK choice.
  - Supported networks updated; X Layer added for OKX Payments.
  - Option B via OKX Payments x402:
    - Buyer: OnchainOS CLI with `okx-x402-payment` (TEE wallet).
    - Seller: WebFetch refs for TS/Go/Rust with `@okxweb3/x402-*` and `okx/payments`.

- **Bug Fixes**
  - Replaced pipe-to-shell installs with a WebFetch install guide link.
  - Fixed links/paths: Go/Rust `SELLER.md` under `x402/`; decision tree now uses full raw URLs; prod refs; replaced dead intro link with Payments Overview.
  - Normalized headings and cleaned markdown.
  - Added note that external WebFetch URLs point to `main` to track latest SDK docs.

<sup>Written for commit f5b89dcea25536a42bd0543d900cac796b4ac521. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded payment agent docs to cover two payment backends (Base via agent wallet and OKX x402) and added a decision tree for buyer vs seller flows and buyer wallet types (TEE vs local).
  * Specified supported networks and the single-chain/token example for OKX x402.
  * Added step-by-step buyer/seller integration guidance and language-specific seller references; noted TS/Go/Rust support, Python/Java pending.
  * Added production reference links to SDKs and repo resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->