### PR TITLE
docs: document CLV2_CONFIG env var and observer environment variables

### DIFF
--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -240,6 +240,44 @@ Edit `config.json` to control the background observer:
 | `observer.run_interval_minutes` | `5` | How often the observer analyzes observations |
 | `observer.min_observations_to_analyze` | `20` | Minimum observations before analysis runs |
 
+### External Config (Recommended for Plugin Installs)
+
+When installed as a plugin, the `config.json` inside the plugin cache is overwritten on every plugin update. To persist your configuration, set the `CLV2_CONFIG` environment variable to point to a file outside the cache:
+
+```bash
+# Add to ~/.zshenv (or ~/.bashrc)
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+Then create the config file:
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+Both `observe.sh` and `start-observer.sh` respect `CLV2_CONFIG`. When set, it takes precedence over the built-in `config.json`.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLV2_CONFIG` | *(built-in config.json)* | Path to external config file |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Max tool-use turns for Haiku analysis |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | Watchdog timeout for analysis process |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | Max observation lines sent to Haiku |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | Signal observer every N observations |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | Minimum seconds between analyses |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | Idle timeout before observer exits |
+
 Other behavior (observation capture, instinct thresholds, project scoping, promotion criteria) is configured via code defaults in `instinct-cli.py` and `observe.sh`.
 
 ## File Structure


### PR DESCRIPTION
## Summary

- Document the `CLV2_CONFIG` environment variable for external config override
- Add environment variables table for observer tuning (`ECC_OBSERVER_MAX_TURNS`, etc.)

## Problem

When installed as a plugin, the `config.json` inside the plugin cache (`~/.claude/plugins/cache/ecc/ecc/<version>/`) is overwritten on every plugin update. Users who enable the observer via `config.json` lose their settings after updating.

The `CLV2_CONFIG` environment variable already exists in `observe.sh` (line 317) and `observer-loop.sh`, but is not documented in the SKILL.md. Several other useful environment variables (`ECC_OBSERVER_MAX_TURNS`, `ECC_OBSERVER_TIMEOUT_SECONDS`, etc.) are also undocumented.

## Changes

- Added "External Config (Recommended for Plugin Installs)" section with `CLV2_CONFIG` usage
- Added "Environment Variables" table documenting all observer-related env vars
- No code changes — documentation only

## References

- `observe.sh` lines 316-318: `CLV2_CONFIG` override logic
- `observer-loop.sh` line 185: `ECC_OBSERVER_MAX_TURNS`
- `observer-loop.sh` line 116: `ECC_OBSERVER_MAX_ANALYSIS_LINES`
- `research/ecc2-codebase-analysis.md` section 3.4: lists "no env var overrides" as a gap (already solved in v1 but undocumented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for external configuration file support via environment variable settings.
  * Documented configuration options for observer behavior (max turns, timeout, analysis limits, signal cadence).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `CLV2_CONFIG` environment variable for persistent external config and adds an observer env vars table in `SKILL.md`. Confirms both `observe.sh` and `start-observer.sh` honor `CLV2_CONFIG` for plugin installs.

- **Migration**
  - Set `CLV2_CONFIG` to a path outside the plugin cache to persist `config.json`.
  - Use `ECC_OBSERVER_MAX_TURNS`, `ECC_OBSERVER_TIMEOUT_SECONDS`, `ECC_OBSERVER_MAX_ANALYSIS_LINES`, `ECC_OBSERVER_SIGNAL_EVERY_N`, `ECC_OBSERVER_ANALYSIS_COOLDOWN`, and `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` to tune the observer.

<sup>Written for commit 5fe0a64fb2ecb2fff4b5d5b4058c57f92f1194cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

