### PR TITLE
docs: document CLV2_CONFIG env var and observer environment variables

### DIFF
--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -240,6 +240,44 @@ Edit `config.json` to control the background observer:
 | `observer.run_interval_minutes` | `5` | How often the observer analyzes observations |
 | `observer.min_observations_to_analyze` | `20` | Minimum observations before analysis runs |
 
+### External Config (Recommended for Plugin Installs)
+
+When installed as a plugin, the `config.json` inside the plugin cache is overwritten on every plugin update. To persist your configuration, set the `CLV2_CONFIG` environment variable to point to a file outside the cache:
+
+```bash
+# Add to ~/.zshenv (or ~/.bashrc)
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+Then create the config file:
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+Both `observe.sh` and `start-observer.sh` respect `CLV2_CONFIG`. When set, it takes precedence over the built-in `config.json`.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLV2_CONFIG` | *(built-in config.json)* | Path to external config file |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Max tool-use turns for Haiku analysis |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | Watchdog timeout for analysis process |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | Max observation lines sent to Haiku |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | Signal observer every N observations |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | Minimum seconds between analyses |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | Idle timeout before observer exits |
+
 Other behavior (observation capture, instinct thresholds, project scoping, promotion criteria) is configured via code defaults in `instinct-cli.py` and `observe.sh`.
 
 ## File Structure


### PR DESCRIPTION
## Summary

Document the `CLV2_CONFIG` environment variable and other observer-related environment variables in the continuous-learning-v2 SKILL.md.

When installed as a plugin, the `config.json` inside the plugin cache is overwritten on every plugin update. `CLV2_CONFIG` already exists in `observe.sh` (line 317) and `start-observer.sh` (line 39) but was not documented.

## Type

- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Documentation

## Changes

- Added "External Config (Recommended for Plugin Installs)" section with `CLV2_CONFIG` usage
- Added "Environment Variables" table documenting 7 observer-related env vars

## Testing

- `npm test` — 1783 tests passed, 0 failed
- Verified all 7 env vars against source code (`observe.sh`, `start-observer.sh`, `observer-loop.sh`)
- No code changes — documentation only

## Checklist

- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions

## References

- `observe.sh` lines 316-318: `CLV2_CONFIG` override logic
- `start-observer.sh` lines 39-40: `CLV2_CONFIG` override logic
- `observer-loop.sh` lines 16-17, 116, 185: env var defaults
- `observe.sh` line 387: `ECC_OBSERVER_SIGNAL_EVERY_N`