### PR TITLE
docs: document CLV2_CONFIG env var and observer environment variables

### DIFF
--- a/docs/ja-JP/skills/continuous-learning-v2/SKILL.md
+++ b/docs/ja-JP/skills/continuous-learning-v2/SKILL.md
@@ -205,6 +205,44 @@ touch ~/.claude/homunculus/observations.jsonl
 }
 ```
 
+### 外部設定ファイル（プラグインインストール推奨）
+
+プラグインとしてインストールした場合、プラグインキャッシュ内の `config.json` は更新のたびに上書きされます。`CLV2_CONFIG` 環境変数をキャッシュ外の設定ファイルに向けることで、カスタム設定を保持できます：
+
+```bash
+# ~/.zshenv（または ~/.bashrc）に追加
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+設定ファイルを作成します：
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+`observe.sh` と `start-observer.sh` は `CLV2_CONFIG` をサポートします。設定すると、組み込みの `config.json` よりも優先されます。
+
+### 環境変数
+
+| 変数 | デフォルト | 説明 |
+|------|-----------|------|
+| `CLV2_CONFIG` | *（組み込み config.json）* | 外部設定ファイルのパス |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Haiku 分析の最大ツール呼び出し回数 |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | 分析プロセスのウォッチドッグタイムアウト |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | Haiku に送信する最大 observation 行数 |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | N 回の observation ごとに observer に通知 |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | 分析間の最小間隔（秒） |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | アイドルタイムアウト後に observer が自動終了 |
+
 ## ファイル構造
 
 ```

--- a/docs/ko-KR/skills/continuous-learning-v2/SKILL.md
+++ b/docs/ko-KR/skills/continuous-learning-v2/SKILL.md
@@ -239,6 +239,44 @@ mkdir -p ~/.claude/homunculus/{instincts/{personal,inherited},evolved/{agents,sk
 | `observer.run_interval_minutes` | `5` | 관찰자가 관찰 결과를 분석하는 빈도 |
 | `observer.min_observations_to_analyze` | `20` | 분석 실행 전 최소 관찰 횟수 |
 
+### 외부 설정 (플러그인 설치 시 권장)
+
+플러그인으로 설치한 경우, 플러그인 캐시 내의 `config.json`은 업데이트마다 덮어쓰기됩니다. `CLV2_CONFIG` 환경 변수를 캐시 외부의 설정 파일로 지정하면 사용자 정의 설정을 유지할 수 있습니다:
+
+```bash
+# ~/.zshenv (또는 ~/.bashrc)에 추가
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+설정 파일을 생성합니다:
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+`observe.sh`와 `start-observer.sh` 모두 `CLV2_CONFIG`를 지원합니다. 설정 시 내장 `config.json`보다 우선합니다.
+
+### 환경 변수
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `CLV2_CONFIG` | *(내장 config.json)* | 외부 설정 파일 경로 |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Haiku 분석의 최대 도구 호출 횟수 |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | 분석 프로세스의 워치독 타임아웃 |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | Haiku에 전송할 최대 observation 행 수 |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | N회 observation마다 observer에 알림 |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | 분석 간 최소 간격 (초) |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | 유휴 타임아웃 후 observer 자동 종료 |
+
 기타 동작 (관찰 캡처, 본능 임계값, 프로젝트 범위, 승격 기준)은 `instinct-cli.py`와 `observe.sh`의 코드 기본값으로 구성됩니다.
 
 ## 파일 구조

--- a/docs/tr/skills/continuous-learning-v2/SKILL.md
+++ b/docs/tr/skills/continuous-learning-v2/SKILL.md
@@ -239,6 +239,44 @@ Arka plan gözlemcisini kontrol etmek için `config.json` dosyasını düzenleyi
 | `observer.run_interval_minutes` | `5` | Gözlemcinin gözlemleri ne sıklıkla analiz ettiği |
 | `observer.min_observations_to_analyze` | `20` | Analiz çalışmadan önce minimum gözlem |
 
+### Harici Yapılandırma (Plugin Kurulumları İçin Önerilir)
+
+Plugin olarak kurulduğunda, plugin önbelleğindeki `config.json` her güncellemede üzerine yazılır. `CLV2_CONFIG` ortam değişkenini önbellek dışındaki bir dosyaya yönlendirerek özel ayarlarınızı koruyabilirsiniz:
+
+```bash
+# ~/.zshenv (veya ~/.bashrc) dosyasına ekleyin
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+Yapılandırma dosyasını oluşturun:
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+`observe.sh` ve `start-observer.sh` `CLV2_CONFIG`'i destekler. Ayarlandığında, yerleşik `config.json`'dan önceliklidir.
+
+### Ortam Değişkenleri
+
+| Değişken | Varsayılan | Açıklama |
+|----------|-----------|----------|
+| `CLV2_CONFIG` | *(yerleşik config.json)* | Harici yapılandırma dosyası yolu |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Haiku analizi için maksimum araç çağrısı |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | Analiz süreci için watchdog zaman aşımı |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | Haiku'ya gönderilen maksimum observation satırı |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | Her N observation'da observer'a sinyal gönder |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | Analizler arası minimum süre (saniye) |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | Boşta kalma zaman aşımı sonrası observer otomatik çıkış |
+
 Diğer davranışlar (gözlem yakalama, instinct eşikleri, proje kapsamı, yükseltme kriterleri) `instinct-cli.py` ve `observe.sh` içindeki kod varsayılanları aracılığıyla yapılandırılır.
 
 ## Dosya Yapısı

--- a/docs/zh-CN/skills/continuous-learning-v2/SKILL.md
+++ b/docs/zh-CN/skills/continuous-learning-v2/SKILL.md
@@ -242,6 +242,44 @@ mkdir -p ~/.claude/homunculus/{instincts/{personal,inherited},evolved/{agents,sk
 | `observer.run_interval_minutes` | `5` | 观察器分析观察结果的频率 |
 | `observer.min_observations_to_analyze` | `20` | 运行分析所需的最小观察次数 |
 
+### 外部配置（推荐 Plugin 安装使用）
+
+以 Plugin 安装时，plugin cache 中的 `config.json` 会在每次更新时被覆盖。设置 `CLV2_CONFIG` 环境变量指向 cache 外的配置文件，即可保留自定义设置：
+
+```bash
+# 添加到 ~/.zshenv（或 ~/.bashrc）
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+创建配置文件：
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+`observe.sh` 和 `start-observer.sh` 都支持 `CLV2_CONFIG`，设置后优先于内置的 `config.json`。
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `CLV2_CONFIG` | *（内置 config.json）* | 外部配置文件路径 |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Haiku 分析的最大工具调用次数 |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | 分析进程的 watchdog 超时 |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | 发送给 Haiku 的最大 observation 行数 |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | 每 N 次 observation 才通知 observer |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | 两次分析之间的最小间隔（秒） |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | 空闲超时后 observer 自动退出 |
+
 其他行为 (观察捕获、本能阈值、项目作用域、提升标准) 通过 `instinct-cli.py` 和 `observe.sh` 中的代码默认值进行配置。
 
 ## 文件结构

--- a/docs/zh-TW/skills/continuous-learning-v2/SKILL.md
+++ b/docs/zh-TW/skills/continuous-learning-v2/SKILL.md
@@ -178,6 +178,44 @@ touch ~/.claude/homunculus/observations.jsonl
 }
 ```
 
+### 外部設定檔（建議 Plugin 安裝使用）
+
+以 Plugin 安裝時，plugin cache 中的 `config.json` 會在每次更新時被覆蓋。設定 `CLV2_CONFIG` 環境變數指向 cache 外的設定檔，即可保留自訂設定：
+
+```bash
+# 加入 ~/.zshenv（或 ~/.bashrc）
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+建立設定檔：
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+`observe.sh` 和 `start-observer.sh` 都支援 `CLV2_CONFIG`，設定後優先於內建的 `config.json`。
+
+### 環境變數
+
+| 變數 | 預設值 | 說明 |
+|------|--------|------|
+| `CLV2_CONFIG` | *（內建 config.json）* | 外部設定檔路徑 |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Haiku 分析的最大工具呼叫次數 |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | 分析程序的 watchdog 超時 |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | 傳送給 Haiku 的最大 observation 行數 |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | 每 N 次 observation 才通知 observer |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | 兩次分析之間的最小間隔（秒） |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | 閒置超時後 observer 自動退出 |
+
 ## 檔案結構
 
 ```

--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -240,6 +240,44 @@ Edit `config.json` to control the background observer:
 | `observer.run_interval_minutes` | `5` | How often the observer analyzes observations |
 | `observer.min_observations_to_analyze` | `20` | Minimum observations before analysis runs |
 
+### External Config (Recommended for Plugin Installs)
+
+When installed as a plugin, the `config.json` inside the plugin cache is overwritten on every plugin update. To persist your configuration, set the `CLV2_CONFIG` environment variable to point to a file outside the cache:
+
+```bash
+# Add to ~/.zshenv (or ~/.bashrc)
+export CLV2_CONFIG="$HOME/.claude/homunculus/config.json"
+```
+
+Then create the config file:
+
+```bash
+cat > ~/.claude/homunculus/config.json << 'EOF'
+{
+  "version": "2.1",
+  "observer": {
+    "enabled": true,
+    "run_interval_minutes": 5,
+    "min_observations_to_analyze": 20
+  }
+}
+EOF
+```
+
+Both `observe.sh` and `start-observer.sh` respect `CLV2_CONFIG`. When set, it takes precedence over the built-in `config.json`.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLV2_CONFIG` | *(built-in config.json)* | Path to external config file |
+| `ECC_OBSERVER_MAX_TURNS` | `20` | Max tool-use turns for Haiku analysis |
+| `ECC_OBSERVER_TIMEOUT_SECONDS` | `120` | Watchdog timeout for analysis process |
+| `ECC_OBSERVER_MAX_ANALYSIS_LINES` | `500` | Max observation lines sent to Haiku |
+| `ECC_OBSERVER_SIGNAL_EVERY_N` | `20` | Signal observer every N observations |
+| `ECC_OBSERVER_ANALYSIS_COOLDOWN` | `60` | Minimum seconds between analyses |
+| `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS` | `1800` | Idle timeout before observer exits |
+
 Other behavior (observation capture, instinct thresholds, project scoping, promotion criteria) is configured via code defaults in `instinct-cli.py` and `observe.sh`.
 
 ## File Structure


### PR DESCRIPTION
## Summary

Document the `CLV2_CONFIG` environment variable and observer-related environment variables in continuous-learning-v2 SKILL.md and all translations.

Closes #1349

## Type

- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Documentation

## Changes

- Added "External Config (Recommended for Plugin Installs)" section with `CLV2_CONFIG` usage
- Added "Environment Variables" table documenting 7 observer-related env vars
- Updated all 5 translations: zh-TW, zh-CN, ja-JP, ko-KR, tr
- No code changes — documentation only

## Testing

- `npm test` — 1783 tests passed, 0 failed
- Verified all 7 env vars against source code:
  - `CLV2_CONFIG`: `observe.sh:317`, `start-observer.sh:39`
  - `ECC_OBSERVER_MAX_TURNS`: `observer-loop.sh:185`
  - `ECC_OBSERVER_TIMEOUT_SECONDS`: `observer-loop.sh`
  - `ECC_OBSERVER_MAX_ANALYSIS_LINES`: `observer-loop.sh:116`
  - `ECC_OBSERVER_SIGNAL_EVERY_N`: `observe.sh:387`
  - `ECC_OBSERVER_ANALYSIS_COOLDOWN`: `observer-loop.sh:16`
  - `ECC_OBSERVER_IDLE_TIMEOUT_SECONDS`: `observer-loop.sh:17`

## Checklist

- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
- [x] Updated translation files (zh-TW, zh-CN, ja-JP, ko-KR, tr)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `CLV2_CONFIG` env var and observer env vars so plugin installs can persist config and users can tune observer behavior.

- **Documentation**
  - Added “External Config” section with `CLV2_CONFIG` setup and example path; `observe.sh` and `start-observer.sh` honor it over built-in `config.json`.
  - Added environment variables table for observer controls (turns, timeouts, analysis lines, signal interval, cooldown, idle timeout).
  - Updated SKILL.md in English and translations: zh-TW, zh-CN, ja-JP, ko-KR, tr.

<sup>Written for commit b955f4615bc5e773de45bb60d65dfa4acba4deb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented external configuration via CLV2_CONFIG to point to a custom config.json outside the plugin cache, ensuring custom settings persist across plugin updates and take precedence over built-in config.
  * Added a comprehensive environment variables table for observer behavior (ECC_OBSERVER_*: turn limits, timeouts, analysis limits, signal frequency, cooldowns, idle timeout) with defaults.
  * Updated multiple language versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->