### PR TITLE
docs(zh-TW): fix cross-strait terminology per MoE preferences

### DIFF
--- a/docs/zh-TW/CONTRIBUTING.md
+++ b/docs/zh-TW/CONTRIBUTING.md
@@ -23,19 +23,19 @@
 
 ### 指令（Commands）
 
-調用實用工作流程的斜線指令：
+呼叫實用工作流程的斜線指令：
 - 部署指令
 - 測試指令
 - 文件指令
 - 程式碼生成指令
 
-### 鉤子（Hooks）
+### 掛鉤（Hooks）
 
 實用的自動化：
-- Lint/格式化鉤子
+- Lint/格式化掛鉤
 - 安全檢查
-- 驗證鉤子
-- 通知鉤子
+- 驗證掛鉤
+- 通知掛鉤
 
 ### 規則（Rules）
 
@@ -77,7 +77,7 @@ git checkout -b add-python-reviewer
 - `skills/` 用於技能（可以是單一 .md 或目錄）
 - `commands/` 用於斜線指令
 - `rules/` 用於規則檔案
-- `hooks/` 用於鉤子設定
+- `hooks/` 用於掛鉤設定
 - `mcp-configs/` 用於 MCP 伺服器設定
 
 ### 4. 遵循格式
@@ -125,7 +125,7 @@ description: Brief description of command
 Detailed instructions...
 ```
 
-**鉤子**應包含描述：
+**掛鉤**應包含描述：
 
 ```json
 {

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -19,9 +19,9 @@
 
 ---
 
-**來自 Anthropic 黑客松冠軍的完整 Claude Code 設定集合。**
+**來自 Anthropic 駭客松冠軍的完整 Claude Code 設定集合。**
 
-經過 10 個月以上密集日常使用、打造真實產品所淬煉出的生產就緒代理程式、技能、鉤子、指令、規則和 MCP 設定。
+經過 10 個月以上密集日常使用、打造真實產品所淬煉出的生產就緒代理程式、技能、掛鉤、指令、規則和 MCP 設定。
 
 ---
 
@@ -51,10 +51,10 @@
 | 主題 | 學習內容 |
 |------|----------|
 | 權杖最佳化 | 模型選擇、系統提示精簡、背景程序 |
-| 記憶持久化 | 自動跨工作階段儲存/載入上下文的鉤子 |
+| 記憶持久化 | 自動跨工作階段儲存/載入上下文的掛鉤 |
 | 持續學習 | 從工作階段自動擷取模式並轉化為可重用技能 |
 | 驗證迴圈 | 檢查點 vs 持續評估、評分器類型、pass@k 指標 |
-| 平行處理 | Git worktrees、串聯方法、何時擴展實例 |
+| 平行處理 | Git worktrees、串聯方法、何時擴充實體 |
 | 子代理程式協調 | 上下文問題、漸進式檢索模式 |
 
 ---
@@ -104,7 +104,7 @@ cp -r everything-claude-code/rules/* ~/.claude/rules/
 
 ## 跨平台支援
 
-此外掛程式現已完整支援 **Windows、macOS 和 Linux**。所有鉤子和腳本已使用 Node.js 重寫以獲得最佳相容性。
+此外掛程式現已完整支援 **Windows、macOS 和 Linux**。所有掛鉤和指令碼已使用 Node.js 重寫以獲得最佳相容性。
 
 ### 套件管理器偵測
 
@@ -199,15 +199,15 @@ everything-claude-code/
 |   |-- performance.md      # 模型選擇、上下文管理
 |
 |-- hooks/            # 基於觸發器的自動化
-|   |-- hooks.json                # 所有鉤子設定（PreToolUse、PostToolUse、Stop 等）
-|   |-- memory-persistence/       # 工作階段生命週期鉤子（完整指南）
+|   |-- hooks.json                # 所有掛鉤設定（PreToolUse、PostToolUse、Stop 等）
+|   |-- memory-persistence/       # 工作階段生命週期掛鉤（完整指南）
 |   |-- strategic-compact/        # 壓縮建議（完整指南）
 |
-|-- scripts/          # 跨平台 Node.js 腳本（新增）
+|-- scripts/          # 跨平台 Node.js 指令碼（新增）
 |   |-- lib/                     # 共用工具
 |   |   |-- utils.js             # 跨平台檔案/路徑/系統工具
 |   |   |-- package-manager.js   # 套件管理器偵測與選擇
-|   |-- hooks/                   # 鉤子實作
+|   |-- hooks/                   # 掛鉤實作
 |   |   |-- session-start.js     # 工作階段開始時載入上下文
 |   |   |-- session-end.js       # 工作階段結束時儲存狀態
 |   |   |-- pre-compact.js       # 壓縮前狀態儲存
@@ -217,7 +217,7 @@ everything-claude-code/
 |
 |-- tests/            # 測試套件（新增）
 |   |-- lib/                     # 函式庫測試
-|   |-- hooks/                   # 鉤子測試
+|   |-- hooks/                   # 掛鉤測試
 |   |-- run-all.js               # 執行所有測試
 |
 |-- contexts/         # 動態系統提示注入上下文（完整指南）
@@ -291,7 +291,7 @@ everything-claude-code/
 }
 ```
 
-這會讓您立即存取所有指令、代理程式、技能和鉤子。
+這會讓您立即存取所有指令、代理程式、技能和掛鉤。
 
 ---
 
@@ -316,9 +316,9 @@ cp everything-claude-code/commands/*.md ~/.claude/commands/
 cp -r everything-claude-code/skills/* ~/.claude/skills/
 ```
 
-#### 將鉤子新增到 settings.json
+#### 將掛鉤新增到 settings.json
 
-將 `hooks/hooks.json` 中的鉤子複製到您的 `~/.claude/settings.json`。
+將 `hooks/hooks.json` 中的掛鉤複製到您的 `~/.claude/settings.json`。
 
 #### 設定 MCP
 
@@ -347,7 +347,7 @@ You are a senior code reviewer...
 
 ### 技能（Skills）
 
-技能是由指令或代理程式調用的工作流程定義：
+技能是由指令或代理程式呼叫的工作流程定義：
 
 ```markdown
 # TDD Workflow
@@ -359,9 +359,9 @@ You are a senior code reviewer...
 5. Verify 80%+ coverage
 ```
 
-### 鉤子（Hooks）
+### 掛鉤（Hooks）
 
-鉤子在工具事件時觸發。範例 - 警告 console.log：
+掛鉤在工具事件時觸發。範例 - 警告 console.log：
 
 ```json
 {
@@ -408,7 +408,7 @@ node tests/hooks/hooks.test.js
 
 本儲存庫旨在成為社群資源。如果您有：
 - 實用的代理程式或技能
-- 巧妙的鉤子
+- 巧妙的掛鉤
 - 更好的 MCP 設定
 - 改進的規則
 
@@ -426,7 +426,7 @@ node tests/hooks/hooks.test.js
 
 ## 背景
 
-我從實驗性推出就開始使用 Claude Code。2025 年 9 月與 [@DRodriguezFX](https://x.com/DRodriguezFX) 一起使用 Claude Code 打造 [zenith.chat](https://zenith.chat)，贏得了 Anthropic x Forum Ventures 黑客松。
+我從實驗性推出就開始使用 Claude Code。2025 年 9 月與 [@DRodriguezFX](https://x.com/DRodriguezFX) 一起使用 Claude Code 打造 [zenith.chat](https://zenith.chat)，贏得了 Anthropic x Forum Ventures 駭客松。
 
 這些設定已在多個生產應用程式中經過實戰測試。
 
@@ -451,7 +451,7 @@ node tests/hooks/hooks.test.js
 1. 從您認同的部分開始
 2. 根據您的技術堆疊修改
 3. 移除不需要的部分
-4. 添加您自己的模式
+4. 加入您自己的模式
 
 ---
 
@@ -467,7 +467,7 @@ node tests/hooks/hooks.test.js
 - **完整指南（進階）：** [Everything Claude Code 完整指南](https://x.com/affaanmustafa/status/2014040193557471352)
 - **追蹤：** [@affaanmustafa](https://x.com/affaanmustafa)
 - **zenith.chat：** [zenith.chat](https://zenith.chat)
-- **技能目錄：** awesome-agent-skills（社區維護的智能體技能目錄）
+- **技能目錄：** awesome-agent-skills（社群維護的智慧體技能目錄）
 
 ---
 

--- a/docs/zh-TW/agents/doc-updater.md
+++ b/docs/zh-TW/agents/doc-updater.md
@@ -27,7 +27,7 @@ model: opus
 
 ### 分析指令
 ```bash
-# 分析 TypeScript 專案結構（使用 ts-morph 函式庫執行自訂腳本）
+# 分析 TypeScript 專案結構（使用 ts-morph 函式庫執行自訂指令碼）
 npx tsx scripts/codemaps/generate.ts
 
 # 產生相依性圖表

--- a/docs/zh-TW/agents/security-reviewer.md
+++ b/docs/zh-TW/agents/security-reviewer.md
@@ -103,7 +103,7 @@ b) 審查高風險區域
    - 是否設定安全性標頭？
    - 生產環境是否停用除錯模式？
 
-7. 跨站腳本（XSS）
+7. 跨站指令碼（XSS）
    - 輸出是否跳脫/清理？
    - 是否設定 Content-Security-Policy？
    - 框架是否預設跳脫？
@@ -166,7 +166,7 @@ const dns = require('dns')
 dns.lookup(userInput, callback)
 ```
 
-### 4. 跨站腳本 XSS（高）
+### 4. 跨站指令碼 XSS（高）
 
 ```javascript
 // FAIL: 高：XSS 弱點

--- a/docs/zh-TW/skills/coding-standards/SKILL.md
+++ b/docs/zh-TW/skills/coding-standards/SKILL.md
@@ -17,7 +17,7 @@ description: Universal coding standards, best practices, and patterns for TypeSc
 
 ### 2. KISS（保持簡單）
 - 使用最簡單的解決方案
-- 避免過度工程
+- 避免過度設計
 - 不做過早優化
 - 易於理解 > 聰明的程式碼
 

--- a/docs/zh-TW/skills/continuous-learning-v2/SKILL.md
+++ b/docs/zh-TW/skills/continuous-learning-v2/SKILL.md
@@ -46,7 +46,7 @@ source: "session-observation"
 - **原子性** — 一個觸發器，一個動作
 - **信心加權** — 0.3 = 試探性，0.9 = 近乎確定
 - **領域標記** — code-style、testing、git、debugging、workflow 等
-- **證據支持** — 追蹤建立它的觀察
+- **證據支援** — 追蹤建立它的觀察
 
 ## 運作方式
 
@@ -249,7 +249,7 @@ v2 完全相容 v1：
 ## 相關
 
 - [Skill Creator](https://skill-creator.app) - 從倉庫歷史產生本能
-- Homunculus - 啟發 v2 架構的社區專案（原子觀察、信心評分、本能演化管線）
+- Homunculus - 啟發 v2 架構的社群專案（原子觀察、信心評分、本能演化管線）
 - [Longform Guide](https://x.com/affaanmustafa/status/2014040193557471352) - 持續學習章節
 
 ---

--- a/docs/zh-TW/skills/project-guidelines-example/SKILL.md
+++ b/docs/zh-TW/skills/project-guidelines-example/SKILL.md
@@ -82,7 +82,7 @@ project/
 │
 ├── deploy/                   # 部署設定
 ├── docs/                     # 文件
-└── scripts/                  # 工具腳本
+└── scripts/                  # 工具指令碼
 ```
 
 ---

--- a/docs/zh-TW/skills/strategic-compact/SKILL.md
+++ b/docs/zh-TW/skills/strategic-compact/SKILL.md
@@ -21,7 +21,7 @@ description: Suggests manual context compaction at logical intervals to preserve
 
 ## 運作方式
 
-`suggest-compact.sh` 腳本在 PreToolUse（Edit/Write）執行並：
+`suggest-compact.sh` 指令碼在 PreToolUse（Edit/Write）執行並：
 
 1. **追蹤工具呼叫** - 計算工作階段中的工具呼叫次數
 2. **門檻偵測** - 在可設定門檻建議（預設：50 次呼叫）


### PR DESCRIPTION
## Summary

Fix cross-strait terminology issues in `docs/zh-TW/` so the Traditional Chinese translation uses Taiwan-preferred vocabulary instead of mainland / simplified-Chinese conventions. 35 replacements across 8 files.

## Type

- [x] Translation fix (docs/zh-TW)

## How It Was Detected

All issues were surfaced using **[zhtw-mcp](https://github.com/search?q=zhtw-mcp)** — an MCP server that lints Traditional Chinese text against the MoE dictionary with cross-strait terminology rules. I ran it with `profile: strict` over every file under `docs/zh-TW/` and only applied the fixes that the tool flagged with unambiguous context. Remaining info-level items (e.g. `優化`, `擴展`, `回滾`) are tier2 gray-zone and are commonly accepted in Taiwanese tech writing, so they were left alone.

## Fixes Applied

| Before | After | English | Notes |
|---|---|---|---|
| 鉤子 | 掛鉤 | hook | 19 occurrences (README, CONTRIBUTING) |
| 黑客 | 駭客 | hackathon | `黑客松` → `駭客松` |
| 社區 | 社群 | community | tech community context |
| 腳本 | 指令碼 | script | programming script |
| 調用 | 呼叫 | call/invoke | programming verb |
| 添加 | 新增 / 加入 | add | UI verb |
| 支持 | 支援 | support | `證據支持` → `證據支援` |
| 擴展實例 | 擴充實體 | scalable instance | MoE: `實例` only means "example", `instance` → `實體` |
| 智能體 | 智慧體 | intelligent agent | |
| 過度工程 | 過度設計 | over-engineering | |

## Files Changed

```
docs/zh-TW/README.md
docs/zh-TW/CONTRIBUTING.md
docs/zh-TW/agents/doc-updater.md
docs/zh-TW/agents/security-reviewer.md
docs/zh-TW/skills/coding-standards/SKILL.md
docs/zh-TW/skills/continuous-learning-v2/SKILL.md
docs/zh-TW/skills/project-guidelines-example/SKILL.md
docs/zh-TW/skills/strategic-compact/SKILL.md
```

## Scope Note: Edits Inside Code Blocks

To keep terminology consistent between prose and the illustrative snippets, a small number of edits fall **inside** fenced code blocks. They only touch Chinese explanatory comments / tree-view labels — **no executable code, commands, identifiers, filenames, or flags were changed**:

- `docs/zh-TW/README.md` (directory-tree code block, no language tag) — 5 Chinese comments inside the `everything-claude-code/` tree, e.g. `# 所有鉤子設定` → `# 所有掛鉤設定`, `# 跨平台 Node.js 腳本` → `# 跨平台 Node.js 指令碼`.
- `docs/zh-TW/skills/project-guidelines-example/SKILL.md` (directory-tree code block) — 1 label: `└── scripts/  # 工具腳本` → `# 工具指令碼`.
- `docs/zh-TW/agents/doc-updater.md` (```bash` block) — 1 inline Chinese comment: `# 分析 TypeScript 專案結構（使用 ts-morph 函式庫執行自訂腳本）` → `自訂指令碼`. The `npx` commands below it are untouched.

Rationale: leaving these out would leave the README prose talking about `掛鉤/指令碼` while the directory tree right next to it still says `鉤子/腳本`, which defeats the purpose of a consistency pass. All three are pure documentation text.

## Testing

- Re-ran `zhtw-mcp` with `profile: strict` on edited sections after fixes — all warning-level issues are gone; only tier2-suppressed info items remain.
- English tool names, product names, filenames, and paths (e.g. `package.json`, `hooks.json`, `suggest-compact.sh`, `scripts/`) were preserved verbatim. No frontmatter changes.
- Scope limited to `docs/zh-TW/` only.

## Checklist

- [x] Follows format guidelines
- [x] Translation scope only — no behavior changes
- [x] No sensitive info (API keys, tokens, paths)
- [x] Clear descriptions
- [x] Verified with linting tool (`zhtw-mcp`, strict profile)
