### PR TITLE
Add chatgpt-plus-guide to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1399,6 +1399,7 @@ Projects built on or inspired by Everything Claude Code:
 | Project | Description |
 |---------|-------------|
 | [EVC](https://github.com/SaigonXIII/evc) | Marketing agent workspace — 42 commands for content operators, brand governance, and multi-channel publishing. [Visual overview](https://saigonxiii.github.io/evc). |
+| [ChatGPT Plus Guide](https://github.com/xyzm6/chatgpt-plus-guide) | Practical guide for ChatGPT Plus/Pro subscribers — regional pricing, payment methods for blocked regions, account safety checklist. |
 
 Built something with ECC? Open a PR to add it here.
 


### PR DESCRIPTION
## Summary

- Adds [chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide) to the **Community Projects** table in README.md
- Practical guide for ChatGPT Plus/Pro subscribers — covers regional pricing, payment methods for blocked regions, and account safety checklist

## Context

This is a community resource that helps ChatGPT users navigate subscription logistics, especially in regions where payment is restricted. Adding it to the Community Projects section alongside other community-built resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ChatGPT Plus Guide to the Community Projects table in README to help ChatGPT Plus/Pro subscribers with regional pricing, payment methods in blocked regions, and account safety.

<sup>Written for commit e748d686a322783baefa6a91177873af3767ccaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a new ChatGPT Plus Guide entry to the "Community Projects" section in README.md, providing practical guidance for Plus and Pro subscribers, including detailed information on regional pricing, payment options and workarounds, plus an account safety checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->