### PR TITLE
Add skill: chatgpt-plus-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1399,6 +1399,7 @@ Projects built on or inspired by Everything Claude Code:
 | Project | Description |
 |---------|-------------|
 | [EVC](https://github.com/SaigonXIII/evc) | Marketing agent workspace — 42 commands for content operators, brand governance, and multi-channel publishing. [Visual overview](https://saigonxiii.github.io/evc). |
+| [ChatGPT Plus Guide](https://github.com/xyzm6/chatgpt-plus-guide) | Practical guide for ChatGPT Plus/Pro subscribers — regional pricing, payment methods for blocked regions, account safety checklist. |
 
 Built something with ECC? Open a PR to add it here.
 


### PR DESCRIPTION
Adds [chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide) — a practical guide for ChatGPT Plus/Pro subscribers covering regional pricing, payment methods for blocked regions, and account safety checklist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ChatGPT Plus Guide to the Community Projects table in README. It links to a practical resource covering regional pricing, payment methods for blocked regions, and an account safety checklist for ChatGPT Plus/Pro.

<sup>Written for commit 2d16cf530faaca64c86dc8304ddeae6d95c3dcf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community project entry for "ChatGPT Plus Guide" featuring practical guidance for ChatGPT Plus/Pro subscribers, including regional pricing information, payment methods, and account safety tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->