### PR TITLE
Fix/tests and lint cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,16 @@ ecc2/target/
 .opencode/package-lock.json
 .opencode/node_modules/
 assets/images/security/badrudi-exploit.mp4
+
+# Local environment dotfiles (leaked from home directory)
+.bash_profile
+.bashrc
+.zshrc
+.zprofile
+.profile
+.gitconfig
+.ripgreprc
+.gitmodules
+
+# Plugin state
+.omc/

--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ assets/images/security/badrudi-exploit.mp4
 .profile
 .gitconfig
 .ripgreprc
-.gitmodules
 
-# Plugin state
+# Plugin/worktree state
 .omc/
+.dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Everything Claude Code (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 28 specialized agents, 125 skills, 60 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 28 specialized agents, 127 skills, 60 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 
@@ -142,7 +142,7 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 
 ```
 agents/          — 28 specialized subagents
-skills/          — 125 workflow skills and domain knowledge
+skills/          — 127 workflow skills and domain knowledge
 commands/        — 60 slash commands
 hooks/           — Trigger-based automations
 rules/           — Always-follow guidelines (common + per-language)

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ For manual install instructions see the README in the `rules/` folder. When copy
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-✨ **That's it!** You now have access to 28 agents, 125 skills, and 60 commands.
+✨ **That's it!** You now have access to 28 agents, 127 skills, and 60 commands.
 
 ### Multi-model commands require additional setup
 
@@ -1113,7 +1113,7 @@ The configuration is automatically detected from `.opencode/opencode.json`.
 |---------|-------------|----------|--------|
 | Agents | ✅ 28 agents | ✅ 12 agents | **Claude Code leads** |
 | Commands | ✅ 60 commands | ✅ 31 commands | **Claude Code leads** |
-| Skills | ✅ 125 skills | ✅ 37 skills | **Claude Code leads** |
+| Skills | ✅ 127 skills | ✅ 37 skills | **Claude Code leads** |
 | Hooks | ✅ 8 event types | ✅ 11 events | **OpenCode has more!** |
 | Rules | ✅ 29 rules | ✅ 13 instructions | **Claude Code leads** |
 | MCP Servers | ✅ 14 servers | ✅ Full | **Full parity** |

--- a/scripts/lib/skill-improvement/observations.js
+++ b/scripts/lib/skill-improvement/observations.js
@@ -37,8 +37,8 @@ function createSkillObservation(input) {
     ? input.skill.path.trim()
     : null;
   const success = Boolean(input.success);
-  const error = input.error == null ? null : String(input.error);
-  const feedback = input.feedback == null ? null : String(input.feedback);
+  const error = input.error === null || input.error === undefined ? null : String(input.error);
+  const feedback = input.feedback === null || input.feedback === undefined ? null : String(input.feedback);
   const variant = typeof input.variant === 'string' && input.variant.trim().length > 0
     ? input.variant.trim()
     : 'baseline';

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -707,9 +707,18 @@ async function runTests() {
 
   if (
     await asyncTest('creates compaction log', async () => {
-      await runScript(path.join(scriptsDir, 'pre-compact.js'));
-      const logFile = path.join(getCanonicalSessionsDir(os.homedir()), 'compaction-log.txt');
-      assert.ok(fs.existsSync(logFile), 'Compaction log should exist');
+      const isoHome = path.join(os.tmpdir(), `ecc-compact-log-${Date.now()}`);
+      fs.mkdirSync(isoHome, { recursive: true });
+      try {
+        await runScript(path.join(scriptsDir, 'pre-compact.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome
+        });
+        const logFile = path.join(getCanonicalSessionsDir(isoHome), 'compaction-log.txt');
+        assert.ok(fs.existsSync(logFile), 'Compaction log should exist');
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
     })
   )
     passed++;

--- a/tests/lib/package-manager.test.js
+++ b/tests/lib/package-manager.test.js
@@ -727,28 +727,27 @@ function runTests() {
   console.log('\nsetPreferredPackageManager (success):');
 
   if (test('successfully saves preferred package manager', () => {
-    // This writes to ~/.claude/package-manager.json — read original to restore
-    const utils = require('../../scripts/lib/utils');
-    const configPath = path.join(utils.getClaudeDir(), 'package-manager.json');
-    const original = utils.readFile(configPath);
+    // Use isolated temp HOME to avoid sandbox EROFS on ~/.claude
+    const isoHome = path.join(os.tmpdir(), `pm-save-test-${Date.now()}`);
+    const isoClaudeDir = path.join(isoHome, '.claude');
+    fs.mkdirSync(isoClaudeDir, { recursive: true });
+    const origHome = process.env.HOME;
+    const origUserProfile = process.env.USERPROFILE;
     try {
+      process.env.HOME = isoHome;
+      process.env.USERPROFILE = isoHome;
+      // Re-require to pick up new HOME (utils caches nothing)
       const config = pm.setPreferredPackageManager('bun');
       assert.strictEqual(config.packageManager, 'bun');
       assert.ok(config.setAt, 'Should have setAt timestamp');
       // Verify it was persisted
+      const configPath = path.join(isoClaudeDir, 'package-manager.json');
       const saved = JSON.parse(fs.readFileSync(configPath, 'utf8'));
       assert.strictEqual(saved.packageManager, 'bun');
     } finally {
-      // Restore original config
-      if (original) {
-        fs.writeFileSync(configPath, original, 'utf8');
-      } else {
-        try {
-          fs.unlinkSync(configPath);
-        } catch (_err) {
-          // ignore
-        }
-      }
+      process.env.HOME = origHome;
+      process.env.USERPROFILE = origUserProfile;
+      fs.rmSync(isoHome, { recursive: true, force: true });
     }
   })) passed++;
   else failed++;


### PR DESCRIPTION
 What Changed

  - Test isolation: tests/hooks/hooks.test.js and tests/lib/package-manager.test.js now run compaction-log and preferred-package-manager
  tests in a temporary HOME directory instead of writing to ~/.claude/
  - Skill count sync: README.md and AGENTS.md updated from 125 → 127 skills (4 occurrences across 2 files)
  - ESLint fix: scripts/lib/skill-improvement/observations.js — replaced loose == null with === null || === undefined (2 occurrences)
  - Gitignore: Added .omc/, .gitmodules, and common home-directory dotfiles (.bashrc, .zshrc, .profile, etc.) that leak into the repo root
  when using worktrees

  Why This Change

  Two tests wrote directly to ~/.claude/ which fails with EROFS (read-only filesystem) in sandboxed environments like NixOS. Adjacent tests
  in the same files already use isolated temp directories — these two were the outliers. The skill count drift was caught by
  ci/validators.test.js which compares documented counts against actual directory contents.

  Testing Done

  - Manual testing completed
  - Automated tests pass locally (node tests/run-all.js)
  - Edge cases considered and tested

  Type of Change

  - fix: Bug fix
  - feat: New feature
    - refactor: Code refactoring
  - docs: Documentation
  - test: Tests
  - chore: Maintenance/tooling
  - ci: CI/CD changes

  Security & Quality Checklist

  - No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
  - JSON files validate cleanly
  - Shell scripts pass shellcheck (if applicable)
  - Pre-commit hooks pass locally (if configured)
  - No sensitive data exposed in logs or output
  - Follows conventional commits format

  Documentation

  - Updated relevant documentation
  - Added comments for complex logic
  - README updated (if needed)

  Summary by cubic
  
  Stabilizes tests by running compaction-log and preferred package manager cases in a temp HOME, avoiding writes to real home directories
  and read-only filesystem errors. Also fixes ESLint eqeqeq in observations.js, updates docs to 127 skills, and expands .gitignore to ignore
   common local dotfiles and .omc/ plugin state.

  Written for commit 3635230. Summary will update on new commits.

  Summary by CodeRabbit

  Documentation
  - Updated documentation to reflect 127 workflow skills (previously listed as 125).

  Bug Fixes
  - Improved handling of null and undefined values in skill observation feedback processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 2 new workflow skills to the catalog (127 total available)

* **Bug Fixes**
  * Fixed error and feedback field validation to properly handle null and undefined values in skill observations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->