### PR TITLE
fix: rename plugin id from ecc to everything-claude-code in manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "ecc",
+  "name": "everything-claude-code",
   "owner": {
     "name": "Affaan Mustafa",
     "email": "me@affaanmustafa.com"
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "ecc",
+      "name": "everything-claude-code",
       "source": "./",
       "description": "The most comprehensive Claude Code plugin — 38 agents, 156 skills, 72 legacy command shims, selective install profiles, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
       "version": "1.10.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "ecc",
+  "name": "everything-claude-code",
   "version": "1.10.0",
   "description": "Battle-tested Claude Code plugin for engineering teams — 38 agents, 156 skills, 72 legacy command shims, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {


### PR DESCRIPTION
## Problem

When Claude Code tries to resolve an installed plugin registered as `everything-claude-code@everything-claude-code`, it looks for a plugin named `everything-claude-code` inside the `everything-claude-code` marketplace. Both `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` declare the plugin `name` as `ecc`, causing the following error at install/update time:

```
Error: Plugin everything-claude-code not found in marketplace everything-claude-code
```

The marketplace is listed as `not updated` in the update summary because the update step can never succeed — it can't locate the plugin entry to compare versions.

## Fix

Rename the `name` field in both manifest files from `ecc` to `everything-claude-code` to match the external marketplace identifier:

- `.claude-plugin/marketplace.json` — top-level `name` and `plugins[0].name`
- `.claude-plugin/plugin.json` — top-level `name`

## Test plan

- [ ] After merge: `claude plugin marketplace update everything-claude-code` resolves without error
- [ ] `claude plugin list` shows `everything-claude-code@everything-claude-code` without an error annotation
- [ ] `claude plugin update everything-claude-code@everything-claude-code` succeeds (or correctly reports "already up to date")

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename plugin `name` from `ecc` to `everything-claude-code` in both manifests so the Claude Code CLI can find and update the plugin. This fixes install/update errors caused by a marketplace lookup miss.

- **Bug Fixes**
  - `.claude-plugin/marketplace.json`: set top-level `name` and `plugins[0].name` to `everything-claude-code`.
  - `.claude-plugin/plugin.json`: set top-level `name` to `everything-claude-code`.

<sup>Written for commit 92e5b4d415a0928d1f2d6b1126a5c982b107d895. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin identification from "ecc" to "everything-claude-code" across configuration manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->