### PR TITLE
fix: resolve markdownlint MD028 + ESLint eqeqeq lint failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Get up and running in under 2 minutes:
 ### Step 2: Install Rules (Required)
 
 > WARNING: **Important:** Claude Code plugins cannot distribute `rules` automatically. Install them manually:
-
+>
 > If your local Claude setup was wiped or reset, that does not mean you need to repurchase ECC. Start with `ecc list-installed`, then run `ecc doctor` and `ecc repair` before reinstalling anything. That usually restores ECC-managed files without rebuilding your setup. If the problem is account or marketplace access for ECC Tools, handle billing/account recovery separately.
 
 ```bash

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -55,7 +55,7 @@ function sanitizeParamValue(value, depth = 0) {
     return '[Truncated]';
   }
 
-  if (value == null) {
+  if (value === null || value === undefined) {
     return value;
   }
 
@@ -502,7 +502,7 @@ function summarizeInput(toolName, toolInput, filePaths) {
   if (toolInput && typeof toolInput === 'object') {
     const shallow = {};
     for (const [key, value] of Object.entries(toolInput)) {
-      if (value == null) {
+      if (value === null || value === undefined) {
         continue;
       }
       if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
@@ -517,7 +517,7 @@ function summarizeInput(toolName, toolInput, filePaths) {
 }
 
 function summarizeOutput(toolOutput) {
-  if (toolOutput == null) {
+  if (toolOutput === null || toolOutput === undefined) {
     return '';
   }
 


### PR DESCRIPTION
## Summary

Fixes two lint violations that cause `npm run lint` to exit non-zero, as reported in #1366.

- **README.md** — Replace bare blank line between consecutive blockquotes with `>` continuation line to satisfy markdownlint MD028 ("no blank line inside blockquote")
- **scripts/hooks/session-activity-tracker.js** — Replace three `== null` loose-equality checks with explicit `=== null || === undefined` to satisfy ESLint `eqeqeq` rule (lines 58, 505, 520)

Both fixes are behavior-preserving: `== null` already matched both `null` and `undefined`, and the blockquote content is unchanged.

## Verification

```
$ npm run lint     # ✅ exits 0 (was non-zero before)
$ npm test         # ✅ 1783/1783 passed
```

## Test plan

- [x] `npm run lint` passes clean (ESLint + markdownlint)
- [x] `npm test` — all 1783 tests pass
- [x] No behavioral change: `=== null || === undefined` is semantically identical to `== null`
- [x] Blockquote renders identically in GitHub markdown preview

Closes #1366

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdownlint MD028 and ESLint eqeqeq errors so `npm run lint` passes clean with no behavior changes. Closes #1366.

- **Bug Fixes**
  - `README.md`: Replace blank line between blockquote paragraphs with a `>` continuation (MD028).
  - `scripts/hooks/session-activity-tracker.js`: Replace three `== null` checks with `=== null || === undefined` (eqeqeq).

<sup>Written for commit 6a247d4c43f393bf4618b0fe228db9c7aecb003d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Markdown formatting consistency in installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->