### PR TITLE
fix: route block-no-verify hook through run-with-flags.js

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/run-with-flags.js\" \"pre:bash:block-no-verify\" \"scripts/hooks/block-no-verify.js\" \"standard,strict\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/run-with-flags.js\" \"pre:bash:block-no-verify\" \"scripts/hooks/block-no-verify.js\" \"minimal,standard,strict\""
           }
         ],
         "description": "Block git hook-bypass flag to protect pre-commit, commit-msg, and pre-push hooks from being skipped",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx block-no-verify@1.1.2"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/run-with-flags.js\" \"pre:bash:block-no-verify\" \"scripts/hooks/block-no-verify.js\" \"standard,strict\""
           }
         ],
         "description": "Block git hook-bypass flag to protect pre-commit, commit-msg, and pre-push hooks from being skipped",

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -76,6 +76,8 @@ function findGit(input, start) {
 
 /**
  * Detect which git subcommand (commit, push, etc.) is being invoked.
+ * Returns { command, offset } where offset is the position right after the
+ * subcommand keyword, so callers can scope flag checks to only that portion.
  */
 function detectGitCommand(input) {
   let start = 0;
@@ -88,18 +90,58 @@ function detectGitCommand(input) {
       continue;
     }
 
+    // Find the first matching subcommand token after "git".
+    // We pick the one closest to "git" so that argument values like
+    // "git push origin commit" don't misclassify "commit" as the subcommand.
+    let bestCmd = null;
+    let bestIdx = Infinity;
+
     for (const cmd of GIT_COMMANDS_WITH_NO_VERIFY) {
-      const cmdIdx = input.indexOf(cmd, git.idx + git.len);
-      if (cmdIdx === -1) continue;
+      let searchPos = git.idx + git.len;
+      while (searchPos < input.length) {
+        const cmdIdx = input.indexOf(cmd, searchPos);
+        if (cmdIdx === -1) break;
 
-      const before = cmdIdx > 0 ? input[cmdIdx - 1] : ' ';
-      const after = input[cmdIdx + cmd.length] || ' ';
-      if (!/\s/.test(before)) continue;
-      if (!/[\s;&#|>)\]}"']/.test(after) && after !== '') continue;
-      if (/[;|]/.test(input.slice(git.idx + git.len, cmdIdx))) continue;
-      if (isInComment(input, cmdIdx)) continue;
+        const before = cmdIdx > 0 ? input[cmdIdx - 1] : ' ';
+        const after = input[cmdIdx + cmd.length] || ' ';
+        if (!/\s/.test(before)) { searchPos = cmdIdx + 1; continue; }
+        if (!/[\s;&#|>)\]}"']/.test(after) && after !== '') { searchPos = cmdIdx + 1; continue; }
+        if (/[;|]/.test(input.slice(git.idx + git.len, cmdIdx))) break;
+        if (isInComment(input, cmdIdx)) { searchPos = cmdIdx + 1; continue; }
 
-      return cmd;
+        // Verify this token is the first non-flag word after "git" — i.e. the
+        // actual subcommand, not an argument value to a different subcommand.
+        const gap = input.slice(git.idx + git.len, cmdIdx);
+        const tokens = gap.trim().split(/\s+/).filter(Boolean);
+        // Every token before the candidate must be a flag or a flag argument.
+        // Git global flags like -c take a value argument (e.g. -c key=value).
+        let onlyFlagsAndArgs = true;
+        let expectFlagArg = false;
+        for (const t of tokens) {
+          if (expectFlagArg) { expectFlagArg = false; continue; }
+          if (t.startsWith('-')) {
+            // -c is a git global flag that takes the next token as its argument
+            if (t === '-c' || t === '-C' || t === '--work-tree' || t === '--git-dir' ||
+                t === '--namespace' || t === '--super-prefix') {
+              expectFlagArg = true;
+            }
+            continue;
+          }
+          onlyFlagsAndArgs = false;
+          break;
+        }
+        if (!onlyFlagsAndArgs) { searchPos = cmdIdx + 1; continue; }
+
+        if (cmdIdx < bestIdx) {
+          bestIdx = cmdIdx;
+          bestCmd = cmd;
+        }
+        break;
+      }
+    }
+
+    if (bestCmd) {
+      return { command: bestCmd, offset: bestIdx + bestCmd.length };
     }
 
     start = git.idx + git.len;
@@ -109,13 +151,17 @@ function detectGitCommand(input) {
 
 /**
  * Check if the input contains a --no-verify flag for a specific git command.
+ * Only inspects the portion of the input starting at `offset` (the position
+ * right after the detected subcommand keyword) so that flags belonging to
+ * earlier commands in a chain are not falsely matched.
  */
-function hasNoVerifyFlag(input, command) {
-  if (/--no-verify\b/.test(input)) return true;
+function hasNoVerifyFlag(input, command, offset) {
+  const region = input.slice(offset);
+  if (/--no-verify\b/.test(region)) return true;
 
   // For commit, -n is shorthand for --no-verify
   if (command === 'commit') {
-    if (/\s-n(?:\s|$)/.test(input) || /\s-n[a-zA-Z]/.test(input)) return true;
+    if (/\s-n(?:\s|$)/.test(region) || /\s-n[a-zA-Z]/.test(region)) return true;
   }
 
   return false;
@@ -132,10 +178,12 @@ function hasHooksPathOverride(input) {
  * Check a command string for git hook bypass attempts.
  */
 function checkCommand(input) {
-  const gitCommand = detectGitCommand(input);
-  if (!gitCommand) return { blocked: false };
+  const detected = detectGitCommand(input);
+  if (!detected) return { blocked: false };
 
-  if (hasNoVerifyFlag(input, gitCommand)) {
+  const { command: gitCommand, offset } = detected;
+
+  if (hasNoVerifyFlag(input, gitCommand, offset)) {
     return {
       blocked: true,
       reason: `BLOCKED: --no-verify flag is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
@@ -197,23 +245,25 @@ function run(rawInput) {
 
 module.exports = { run };
 
-// Stdin fallback for spawnSync execution
-process.stdin.setEncoding('utf8');
-process.stdin.on('data', chunk => {
-  if (raw.length < MAX_STDIN) {
-    const remaining = MAX_STDIN - raw.length;
-    raw += chunk.substring(0, remaining);
-  }
-});
+// Stdin fallback for spawnSync execution — only when invoked directly, not via require()
+if (require.main === module) {
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      const remaining = MAX_STDIN - raw.length;
+      raw += chunk.substring(0, remaining);
+    }
+  });
 
-process.stdin.on('end', () => {
-  const command = extractCommand(raw);
-  const result = checkCommand(command);
+  process.stdin.on('end', () => {
+    const command = extractCommand(raw);
+    const result = checkCommand(command);
 
-  if (result.blocked) {
-    process.stderr.write(result.reason + '\n');
-    process.exit(2);
-  }
+    if (result.blocked) {
+      process.stderr.write(result.reason + '\n');
+      process.exit(2);
+    }
 
-  process.stdout.write(raw);
-});
+    process.stdout.write(raw);
+  });
+}

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Hook: Block --no-verify flag
+ *
+ * Blocks git hook-bypass flags (--no-verify, -c core.hooksPath=) to protect
+ * pre-commit, commit-msg, and pre-push hooks from being skipped by AI agents.
+ *
+ * Replaces the previous npx-based invocation that failed in pnpm-only projects
+ * (EBADDEVENGINES) and could not be disabled via ECC_DISABLED_HOOKS.
+ *
+ * Exit codes:
+ *   0 = allow (not a git command or no bypass flags)
+ *   2 = block (bypass flag detected)
+ */
+
+'use strict';
+
+const MAX_STDIN = 1024 * 1024;
+let raw = '';
+
+/**
+ * Git commands that support the --no-verify flag.
+ */
+const GIT_COMMANDS_WITH_NO_VERIFY = [
+  'commit',
+  'push',
+  'merge',
+  'cherry-pick',
+  'rebase',
+  'am',
+];
+
+/**
+ * Characters that can appear immediately before 'git' in a command string.
+ */
+const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
+
+/**
+ * Check if a position in the input is inside a shell comment.
+ */
+function isInComment(input, idx) {
+  const lineStart = input.lastIndexOf('\n', idx - 1) + 1;
+  const before = input.slice(lineStart, idx);
+  for (let i = 0; i < before.length; i++) {
+    if (before.charAt(i) === '#') {
+      const prev = i > 0 ? before.charAt(i - 1) : '';
+      if (prev !== '$' && prev !== '\\') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Find the next 'git' token in the input starting from a position.
+ */
+function findGit(input, start) {
+  let pos = start;
+  while (pos < input.length) {
+    const idx = input.indexOf('git', pos);
+    if (idx === -1) return null;
+
+    const isExe = input.slice(idx + 3, idx + 7).toLowerCase() === '.exe';
+    const len = isExe ? 7 : 3;
+    const after = input[idx + len] || ' ';
+    if (!/[\s"']/.test(after)) {
+      pos = idx + 1;
+      continue;
+    }
+
+    const before = idx > 0 ? input[idx - 1] : ' ';
+    if (VALID_BEFORE_GIT.includes(before)) return { idx, len };
+    pos = idx + 1;
+  }
+  return null;
+}
+
+/**
+ * Detect which git subcommand (commit, push, etc.) is being invoked.
+ */
+function detectGitCommand(input) {
+  let start = 0;
+  while (start < input.length) {
+    const git = findGit(input, start);
+    if (!git) return null;
+
+    if (isInComment(input, git.idx)) {
+      start = git.idx + git.len;
+      continue;
+    }
+
+    for (const cmd of GIT_COMMANDS_WITH_NO_VERIFY) {
+      const cmdIdx = input.indexOf(cmd, git.idx + git.len);
+      if (cmdIdx === -1) continue;
+
+      const before = cmdIdx > 0 ? input[cmdIdx - 1] : ' ';
+      const after = input[cmdIdx + cmd.length] || ' ';
+      if (!/\s/.test(before)) continue;
+      if (!/[\s;&#|>)\]}"']/.test(after) && after !== '') continue;
+      if (/[;|]/.test(input.slice(git.idx + git.len, cmdIdx))) continue;
+      if (isInComment(input, cmdIdx)) continue;
+
+      return cmd;
+    }
+
+    start = git.idx + git.len;
+  }
+  return null;
+}
+
+/**
+ * Check if the input contains a --no-verify flag for a specific git command.
+ */
+function hasNoVerifyFlag(input, command) {
+  if (/--no-verify\b/.test(input)) return true;
+
+  // For commit, -n is shorthand for --no-verify
+  if (command === 'commit') {
+    if (/\s-n(?:\s|$)/.test(input) || /\s-n[a-zA-Z]/.test(input)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check if the input contains a -c core.hooksPath= override.
+ */
+function hasHooksPathOverride(input) {
+  return /-c\s+["']?core\.hooksPath\s*=/.test(input);
+}
+
+/**
+ * Check a command string for git hook bypass attempts.
+ */
+function checkCommand(input) {
+  const gitCommand = detectGitCommand(input);
+  if (!gitCommand) return { blocked: false };
+
+  if (hasNoVerifyFlag(input, gitCommand)) {
+    return {
+      blocked: true,
+      reason: `BLOCKED: --no-verify flag is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
+    };
+  }
+
+  if (hasHooksPathOverride(input)) {
+    return {
+      blocked: true,
+      reason: `BLOCKED: Overriding core.hooksPath is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
+    };
+  }
+
+  return { blocked: false };
+}
+
+/**
+ * Extract the command string from hook input (JSON or plain text).
+ */
+function extractCommand(rawInput) {
+  const trimmed = rawInput.trim();
+  if (!trimmed.startsWith('{')) return trimmed;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== 'object' || parsed === null) return trimmed;
+
+    // Claude Code format: { tool_input: { command: "..." } }
+    const cmd = parsed.tool_input?.command;
+    if (typeof cmd === 'string') return cmd;
+
+    // Generic JSON formats
+    for (const key of ['command', 'cmd', 'input', 'shell', 'script']) {
+      if (typeof parsed[key] === 'string') return parsed[key];
+    }
+
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Exportable run() for in-process execution via run-with-flags.js.
+ */
+function run(rawInput) {
+  const command = extractCommand(rawInput);
+  const result = checkCommand(command);
+
+  if (result.blocked) {
+    return {
+      exitCode: 2,
+      stderr: result.reason,
+    };
+  }
+
+  return { exitCode: 0 };
+}
+
+module.exports = { run };
+
+// Stdin fallback for spawnSync execution
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => {
+  if (raw.length < MAX_STDIN) {
+    const remaining = MAX_STDIN - raw.length;
+    raw += chunk.substring(0, remaining);
+  }
+});
+
+process.stdin.on('end', () => {
+  const command = extractCommand(raw);
+  const result = checkCommand(command);
+
+  if (result.blocked) {
+    process.stderr.write(result.reason + '\n');
+    process.exit(2);
+  }
+
+  process.stdout.write(raw);
+});

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -1,0 +1,132 @@
+/**
+ * Tests for scripts/hooks/block-no-verify.js via run-with-flags.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runHook(input, env = {}) {
+  const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
+  const result = spawnSync('node', [runner, 'pre:bash:block-no-verify', 'scripts/hooks/block-no-verify.js', 'minimal,standard,strict'], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+let passed = 0;
+let failed = 0;
+
+console.log('\nblock-no-verify hook tests');
+console.log('─'.repeat(50));
+
+// --- Basic allow/block ---
+
+if (test('allows plain git commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "hello"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify on git commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(r.stderr.includes('BLOCKED'), `stderr should contain BLOCKED: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks -n shorthand on git commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit -n -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(r.stderr.includes('BLOCKED'), `stderr should contain BLOCKED: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks core.hooksPath override', () => {
+  const r = runHook({ tool_input: { command: 'git -c core.hooksPath=/dev/null commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(r.stderr.includes('core.hooksPath'), `stderr should mention core.hooksPath: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Chained command false positive prevention (Comment 2) ---
+
+if (test('does not false-positive on -n belonging to git log in a chain', () => {
+  const r = runHook({ tool_input: { command: 'git log -n 10 && git commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('does not false-positive on --no-verify in a prior non-git command', () => {
+  const r = runHook({ tool_input: { command: 'echo --no-verify && git commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still blocks --no-verify on the git commit part of a chain', () => {
+  const r = runHook({ tool_input: { command: 'git log -n 5 && git commit --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+// --- Subcommand detection (Comment 4) ---
+
+if (test('does not misclassify "commit" as subcommand when it is an argument to push', () => {
+  // "git push origin commit" — "commit" is a refspec arg, not the subcommand
+  const r = runHook({ tool_input: { command: 'git push origin commit' } });
+  // This should detect "push" as the subcommand, not "commit"
+  // Either way it should not block since there's no --no-verify
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Blocks on push --no-verify ---
+
+if (test('blocks --no-verify on git push', () => {
+  const r = runHook({ tool_input: { command: 'git push --no-verify' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(r.stderr.includes('git push'), `stderr should mention git push: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Non-git commands pass through ---
+
+if (test('allows non-git commands', () => {
+  const r = runHook({ tool_input: { command: 'npm test' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Plain text input (not JSON) ---
+
+if (test('handles plain text input', () => {
+  const r = runHook('git commit -m "hello"');
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks plain text input with --no-verify', () => {
+  const r = runHook('git commit --no-verify -m "msg"');
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+console.log('─'.repeat(50));
+console.log(`Passed: ${passed}  Failed: ${failed}`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Replace inline `npx block-no-verify@1.1.2` in `hooks.json` with a standalone `scripts/hooks/block-no-verify.js` routed through `run-with-flags.js`
- Fixes EBADDEVENGINES crash in pnpm-only projects where `devEngines.packageManager.onFail=error` causes npm/npx to abort before the hook runs
- Fixes `ECC_DISABLED_HOOKS=pre:bash:block-no-verify` having no effect because the hook bypassed `run-with-flags.js` and never called `isHookEnabled()`

The new script replicates the full `block-no-verify@1.1.2` detection logic (`--no-verify`, `-n` shorthand for commit, `core.hooksPath` override) with zero external dependencies, pure Node.js.

Closes #1378

## Changes

- `hooks/hooks.json` — 1 line changed: `npx block-no-verify@1.1.2` → `node run-with-flags.js` dispatch, matching all other hooks
- `scripts/hooks/block-no-verify.js` — new standalone hook script with `module.exports.run()` for in-process execution

## Test plan

- [x] `npm test` passes (1783/1783 tests, including `validate-hooks.js`)
- [ ] Manual: set `ECC_DISABLED_HOOKS=pre:bash:block-no-verify` and verify the hook is skipped
- [ ] Manual: run `git commit --no-verify` in a pnpm project — hook should block without EBADDEVENGINES

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routed the block-no-verify hook through `run-with-flags.js` and replaced `npx block-no-verify@1.1.2` with a Node script to reliably block bypass flags and honor disabled hooks. Added the `minimal` profile and improved subcommand-scoped detection to prevent false positives.

- **Bug Fixes**
  - Removed `npx` usage to avoid `EBADDEVENGINES` in `pnpm`-only projects with `devEngines.packageManager.onFail=error`.
  - Hook now runs via `run-with-flags.js`, so `ECC_DISABLED_HOOKS=pre:bash:block-no-verify` is honored; scoped `-n`/`--no-verify` to the detected subcommand and improved parsing to avoid chained-command false positives and arg misclassification; gated stdin with `require.main === module`.

- **Refactors**
  - Added `scripts/hooks/block-no-verify.js` with detection for `--no-verify`, `-n` (commit), and `-c core.hooksPath=`; no external deps.
  - Updated `hooks/hooks.json` to dispatch via `node` through `run-with-flags.js` with profiles `minimal,standard,strict`; added integration tests for chains, hooksPath, and plain-text input.

<sup>Written for commit 809e0fa0a91879f06ec66d383cfe327a2d03705e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and blocks attempts to bypass git hooks (e.g., --no-verify, hooksPath overrides).

* **Chores**
  * Switched hook execution to the internal runner with consistent flag handling.

* **Tests**
  * Added tests validating blocking behavior across command forms, chained commands, JSON/plain inputs, and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->