### PR TITLE
fix: detach ecc2 background session runners

### DIFF
--- a/ecc2/src/session/manager.rs
+++ b/ecc2/src/session/manager.rs
@@ -4,6 +4,7 @@ use cron::Schedule as CronSchedule;
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str::FromStr;
@@ -2983,6 +2984,26 @@ async fn spawn_session_runner_for_program(
     working_dir: &Path,
     current_exe: &Path,
 ) -> Result<()> {
+    let stderr_log_path = background_runner_stderr_log_path(working_dir, session_id);
+    if let Some(parent) = stderr_log_path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create ECC runner log directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    let stderr_log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log_path)
+        .with_context(|| {
+            format!(
+                "Failed to open ECC runner stderr log {}",
+                stderr_log_path.display()
+            )
+        })?;
+
     let mut command = Command::new(current_exe);
     command
         .arg("run-session")
@@ -2996,7 +3017,7 @@ async fn spawn_session_runner_for_program(
         .arg(working_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::from(stderr_log));
     configure_background_runner_command(&mut command);
 
     let child = command
@@ -3007,6 +3028,21 @@ async fn spawn_session_runner_for_program(
         .id()
         .ok_or_else(|| anyhow::anyhow!("ECC runner did not expose a process id"))?;
     Ok(())
+}
+
+fn background_runner_stderr_log_path(working_dir: &Path, session_id: &str) -> PathBuf {
+    working_dir
+        .join(".claude")
+        .join("ecc2")
+        .join("logs")
+        .join(format!("{session_id}.runner-stderr.log"))
+}
+
+#[cfg(windows)]
+fn detached_creation_flags() -> u32 {
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+    DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
 }
 
 fn configure_background_runner_command(command: &mut Command) {
@@ -3030,11 +3066,7 @@ fn configure_background_runner_command(command: &mut Command) {
     {
         use std::os::windows::process::CommandExt;
 
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
-        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-        command
-            .as_std_mut()
-            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+        command.as_std_mut().creation_flags(detached_creation_flags());
     }
 }
 
@@ -5135,6 +5167,22 @@ mod tests {
         let _ = child.kill().await;
         let _ = child.wait().await;
         Ok(())
+    }
+
+    #[test]
+    fn background_runner_stderr_log_path_is_session_scoped() {
+        let path =
+            background_runner_stderr_log_path(Path::new("/tmp/ecc-repo"), "session-123");
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/ecc-repo/.claude/ecc2/logs/session-123.runner-stderr.log")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn detached_creation_flags_include_detach_and_process_group() {
+        assert_eq!(detached_creation_flags(), 0x0000_0008 | 0x0000_0200);
     }
 
     fn write_package_manager_project_files(

--- a/ecc2/src/session/manager.rs
+++ b/ecc2/src/session/manager.rs
@@ -2983,7 +2983,8 @@ async fn spawn_session_runner_for_program(
     working_dir: &Path,
     current_exe: &Path,
 ) -> Result<()> {
-    let child = Command::new(current_exe)
+    let mut command = Command::new(current_exe);
+    command
         .arg("run-session")
         .arg("--session-id")
         .arg(session_id)
@@ -2995,7 +2996,10 @@ async fn spawn_session_runner_for_program(
         .arg(working_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    configure_background_runner_command(&mut command);
+
+    let child = command
         .spawn()
         .with_context(|| format!("Failed to spawn ECC runner from {}", current_exe.display()))?;
 
@@ -3003,6 +3007,35 @@ async fn spawn_session_runner_for_program(
         .id()
         .ok_or_else(|| anyhow::anyhow!("ECC runner did not expose a process id"))?;
     Ok(())
+}
+
+fn configure_background_runner_command(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+
+        // Detach the runner from the caller's shell/session so it keeps
+        // processing a live harness session after `ecc-tui start` returns.
+        unsafe {
+            command.as_std_mut().pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        command
+            .as_std_mut()
+            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
 }
 
 fn build_agent_command(
@@ -5032,6 +5065,22 @@ mod tests {
         anyhow::bail!("timed out waiting for {}", path.display());
     }
 
+    fn wait_for_text(path: &Path, needle: &str) -> Result<String> {
+        for _ in 0..200 {
+            if path.exists() {
+                let content = fs::read_to_string(path)
+                    .with_context(|| format!("failed to read {}", path.display()))?;
+                if content.contains(needle) {
+                    return Ok(content);
+                }
+            }
+
+            thread::sleep(StdDuration::from_millis(20));
+        }
+
+        anyhow::bail!("timed out waiting for {}", path.display());
+    }
+
     fn command_env_map(command: &Command) -> BTreeMap<String, String> {
         command
             .as_std()
@@ -5045,6 +5094,47 @@ mod tests {
                 })
             })
             .collect()
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn background_runner_command_starts_new_session() -> Result<()> {
+        let tempdir = TestDir::new("manager-detached-runner")?;
+        let script_path = tempdir.path().join("detached-runner.py");
+        let log_path = tempdir.path().join("detached-runner.log");
+        let script = format!(
+            "#!/usr/bin/env python3\nimport os\nimport pathlib\nimport time\n\npath = pathlib.Path(r\"{}\")\npath.write_text(f\"pid={{os.getpid()}} sid={{os.getsid(0)}}\", encoding=\"utf-8\")\ntime.sleep(30)\n",
+            log_path.display()
+        );
+        fs::write(&script_path, script)?;
+        let mut permissions = fs::metadata(&script_path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions)?;
+
+        let mut command = Command::new(&script_path);
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        configure_background_runner_command(&mut command);
+
+        let mut child = command.spawn()?;
+        let child_pid = child.id().context("detached child pid")? as i32;
+        let content = wait_for_text(&log_path, "sid=")?;
+        let sid = content
+            .split_whitespace()
+            .find_map(|part| part.strip_prefix("sid="))
+            .context("session id should be logged")?
+            .parse::<i32>()
+            .context("session id should parse")?;
+        let parent_sid = unsafe { libc::getsid(0) };
+
+        assert_eq!(sid, child_pid);
+        assert_ne!(sid, parent_sid);
+
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        Ok(())
     }
 
     fn write_package_manager_project_files(

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -359,17 +359,10 @@ function gitRepoRoot(cwd) {
   return runGit(['rev-parse', '--show-toplevel'], cwd);
 }
 
+const MAX_RELEVANT_PATCH_LINES = 6;
+
 function candidateGitPaths(repoRoot, filePath) {
   const resolvedRepoRoot = path.resolve(repoRoot);
-  const absolute = path.isAbsolute(filePath)
-    ? path.resolve(filePath)
-    : path.resolve(process.cwd(), filePath);
-  const relative = path.relative(resolvedRepoRoot, absolute);
-
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
-    return [];
-  }
-
   const candidates = [];
   const pushCandidate = value => {
     const candidate = String(value || '').trim();
@@ -379,10 +372,24 @@ function candidateGitPaths(repoRoot, filePath) {
     candidates.push(candidate);
   };
 
-  pushCandidate(relative);
-  pushCandidate(relative.split(path.sep).join('/'));
-  pushCandidate(absolute);
-  pushCandidate(absolute.split(path.sep).join('/'));
+  const absoluteCandidates = path.isAbsolute(filePath)
+    ? [path.resolve(filePath)]
+    : [
+        path.resolve(resolvedRepoRoot, filePath),
+        path.resolve(process.cwd(), filePath),
+      ];
+
+  for (const absolute of absoluteCandidates) {
+    const relative = path.relative(resolvedRepoRoot, absolute);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      continue;
+    }
+
+    pushCandidate(relative);
+    pushCandidate(relative.split(path.sep).join('/'));
+    pushCandidate(absolute);
+    pushCandidate(absolute.split(path.sep).join('/'));
+  }
 
   return candidates;
 }
@@ -404,7 +411,7 @@ function patchPreviewFromGitDiff(repoRoot, pathCandidates) {
           || (line.startsWith('+') && !line.startsWith('+++'))
           || (line.startsWith('-') && !line.startsWith('---'))
       )
-      .slice(0, 6);
+      .slice(0, MAX_RELEVANT_PATCH_LINES);
 
     if (relevant.length > 0) {
       return relevant.join('\n');

--- a/scripts/hooks/session-activity-tracker.js
+++ b/scripts/hooks/session-activity-tracker.js
@@ -359,44 +359,65 @@ function gitRepoRoot(cwd) {
   return runGit(['rev-parse', '--show-toplevel'], cwd);
 }
 
-function repoRelativePath(repoRoot, filePath) {
+function candidateGitPaths(repoRoot, filePath) {
+  const resolvedRepoRoot = path.resolve(repoRoot);
   const absolute = path.isAbsolute(filePath)
     ? path.resolve(filePath)
     : path.resolve(process.cwd(), filePath);
-  const relative = path.relative(repoRoot, absolute);
+  const relative = path.relative(resolvedRepoRoot, absolute);
+
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
-    return null;
+    return [];
   }
-  return relative.split(path.sep).join('/');
+
+  const candidates = [];
+  const pushCandidate = value => {
+    const candidate = String(value || '').trim();
+    if (!candidate || candidates.includes(candidate)) {
+      return;
+    }
+    candidates.push(candidate);
+  };
+
+  pushCandidate(relative);
+  pushCandidate(relative.split(path.sep).join('/'));
+  pushCandidate(absolute);
+  pushCandidate(absolute.split(path.sep).join('/'));
+
+  return candidates;
 }
 
-function patchPreviewFromGitDiff(repoRoot, repoRelative) {
-  const patch = runGit(
-    ['diff', '--no-ext-diff', '--no-color', '--unified=1', '--', repoRelative],
-    repoRoot
+function patchPreviewFromGitDiff(repoRoot, pathCandidates) {
+  for (const candidate of pathCandidates) {
+    const patch = runGit(
+      ['diff', '--no-ext-diff', '--no-color', '--unified=1', '--', candidate],
+      repoRoot
+    );
+    if (!patch) {
+      continue;
+    }
+
+    const relevant = patch
+      .split(/\r?\n/)
+      .filter(line =>
+        line.startsWith('@@')
+          || (line.startsWith('+') && !line.startsWith('+++'))
+          || (line.startsWith('-') && !line.startsWith('---'))
+      )
+      .slice(0, 6);
+
+    if (relevant.length > 0) {
+      return relevant.join('\n');
+    }
+  }
+
+  return undefined;
+}
+
+function trackedInGit(repoRoot, pathCandidates) {
+  return pathCandidates.some(candidate =>
+    runGit(['ls-files', '--error-unmatch', '--', candidate], repoRoot) !== null
   );
-  if (!patch) {
-    return undefined;
-  }
-
-  const relevant = patch
-    .split(/\r?\n/)
-    .filter(line =>
-      line.startsWith('@@')
-        || (line.startsWith('+') && !line.startsWith('+++'))
-        || (line.startsWith('-') && !line.startsWith('---'))
-    )
-    .slice(0, 6);
-
-  if (relevant.length === 0) {
-    return undefined;
-  }
-
-  return relevant.join('\n');
-}
-
-function trackedInGit(repoRoot, repoRelative) {
-  return runGit(['ls-files', '--error-unmatch', '--', repoRelative], repoRoot) !== null;
 }
 
 function enrichFileEventFromWorkingTree(toolName, event) {
@@ -409,14 +430,14 @@ function enrichFileEventFromWorkingTree(toolName, event) {
     return event;
   }
 
-  const repoRelative = repoRelativePath(repoRoot, event.path);
-  if (!repoRelative) {
+  const pathCandidates = candidateGitPaths(repoRoot, event.path);
+  if (pathCandidates.length === 0) {
     return event;
   }
 
   const tool = String(toolName || '').trim().toLowerCase();
-  const tracked = trackedInGit(repoRoot, repoRelative);
-  const patchPreview = patchPreviewFromGitDiff(repoRoot, repoRelative) || event.patch_preview;
+  const tracked = trackedInGit(repoRoot, pathCandidates);
+  const patchPreview = patchPreviewFromGitDiff(repoRoot, pathCandidates) || event.patch_preview;
   const diffPreview = buildDiffPreviewFromPatchPreview(patchPreview) || event.diff_preview;
 
   if (tool.includes('write')) {

--- a/tests/hooks/session-activity-tracker.test.js
+++ b/tests/hooks/session-activity-tracker.test.js
@@ -309,6 +309,58 @@ function runTests() {
     fs.rmSync(repoDir, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
+  (test('resolves repo-relative paths even when the hook runs from a nested cwd', () => {
+    const tmpHome = makeTempDir();
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-activity-tracker-nested-repo-'));
+
+    spawnSync('git', ['init'], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['config', 'user.email', 'ecc@example.com'], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['config', 'user.name', 'ECC Tests'], { cwd: repoDir, encoding: 'utf8' });
+
+    const srcDir = path.join(repoDir, 'src');
+    const nestedCwd = path.join(repoDir, 'subdir');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.mkdirSync(nestedCwd, { recursive: true });
+
+    const trackedFile = path.join(srcDir, 'app.ts');
+    fs.writeFileSync(trackedFile, 'const count = 1;\n', 'utf8');
+    spawnSync('git', ['add', 'src/app.ts'], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['commit', '-m', 'init'], { cwd: repoDir, encoding: 'utf8' });
+
+    fs.writeFileSync(trackedFile, 'const count = 2;\n', 'utf8');
+
+    const input = {
+      tool_name: 'Write',
+      tool_input: {
+        file_path: 'src/app.ts',
+        content: 'const count = 2;\n',
+      },
+      tool_output: { output: 'updated src/app.ts' },
+    };
+    const result = runScript(input, {
+      ...withTempHome(tmpHome),
+      CLAUDE_HOOK_EVENT_NAME: 'PostToolUse',
+      ECC_SESSION_ID: 'ecc-session-nested-cwd',
+    }, {
+      cwd: nestedCwd,
+    });
+    assert.strictEqual(result.code, 0);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'tool-usage.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.deepStrictEqual(row.file_events, [
+      {
+        path: 'src/app.ts',
+        action: 'modify',
+        diff_preview: 'const count = 1; -> const count = 2;',
+        patch_preview: '@@ -1 +1 @@\n-const count = 1;\n+const count = 2;',
+      },
+    ]);
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
   (test('prefers ECC_SESSION_ID over CLAUDE_SESSION_ID and redacts bash summaries', () => {
     const tmpHome = makeTempDir();
     const input = {

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -26,12 +26,11 @@ function main() {
   let failed = 0
 
   const repoRoot = path.join(__dirname, "..", "..")
-const packageJson = JSON.parse(
-  fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
-)
-const buildScript = path.join(repoRoot, "scripts", "build-opencode.js")
-const distEntry = path.join(repoRoot, ".opencode", "dist", "index.js")
-const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm"
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
+  )
+  const buildScript = path.join(repoRoot, "scripts", "build-opencode.js")
+  const distEntry = path.join(repoRoot, ".opencode", "dist", "index.js")
   const tests = [
     ["package.json exposes the OpenCode build and prepack hooks", () => {
       assert.strictEqual(packageJson.scripts["build:opencode"], "node scripts/build-opencode.js")
@@ -47,11 +46,12 @@ const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm"
       assert.ok(fs.existsSync(distEntry), ".opencode/dist/index.js should exist after build")
     }],
     ["npm pack includes the compiled OpenCode dist payload", () => {
-      const result = spawnSync(npmExecutable, ["pack", "--dry-run", "--json"], {
+      const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
         cwd: repoRoot,
         encoding: "utf8",
+        shell: process.platform === "win32",
       })
-      assert.strictEqual(result.status, 0, result.stderr)
+      assert.strictEqual(result.status, 0, result.error?.message || result.stderr)
 
       const packOutput = JSON.parse(result.stdout)
       const packagedPaths = new Set(packOutput[0]?.files?.map((file) => file.path) ?? [])

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -26,11 +26,12 @@ function main() {
   let failed = 0
 
   const repoRoot = path.join(__dirname, "..", "..")
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
-  )
-  const buildScript = path.join(repoRoot, "scripts", "build-opencode.js")
-  const distEntry = path.join(repoRoot, ".opencode", "dist", "index.js")
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
+)
+const buildScript = path.join(repoRoot, "scripts", "build-opencode.js")
+const distEntry = path.join(repoRoot, ".opencode", "dist", "index.js")
+const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm"
   const tests = [
     ["package.json exposes the OpenCode build and prepack hooks", () => {
       assert.strictEqual(packageJson.scripts["build:opencode"], "node scripts/build-opencode.js")
@@ -46,7 +47,7 @@ function main() {
       assert.ok(fs.existsSync(distEntry), ".opencode/dist/index.js should exist after build")
     }],
     ["npm pack includes the compiled OpenCode dist payload", () => {
-      const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+      const result = spawnSync(npmExecutable, ["pack", "--dry-run", "--json"], {
         cwd: repoRoot,
         encoding: "utf8",
       })


### PR DESCRIPTION
## Summary
- detach ECC2 background `run-session` launches into their own process session/group
- prevent started sessions from dying when the parent CLI process exits
- add regression coverage for the detached launch path

## Why
Real ECC2 sessions could launch and then stall with no output because the child runner was still tied to the invoking shell lifecycle.

## Validation
- cargo test -q --manifest-path ecc2/Cargo.toml
- real Claude-backed smoke: started a session and verified persisted `live-ok` output after parent exit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detach background `run-session` runners so `ecc2` sessions keep running after the CLI exits, and write runner startup stderr to a session-scoped log. Also improve Git path handling in the session-activity hook and make the `npm pack` test shell-safe on Windows to stabilize CI.

- **Bug Fixes**
  - Unix: use `setsid()` via `pre_exec` to start a new session.
  - Windows: set `DETACHED_PROCESS` and `CREATE_NEW_PROCESS_GROUP`.
  - Centralize in `configure_background_runner_command()` with a Unix test asserting a new session.
  - Persist runner startup stderr to `.claude/ecc2/logs/<session>.runner-stderr.log`.
  - Hook path resolution: prefer repo-relative paths and try multiple candidates (absolute/relative/POSIX/Windows) so diffs and tracking work from a nested cwd.
  - Tests: run `npm pack` via a shell on Windows to avoid path/exec issues.

<sup>Written for commit 99a60c0a66322f57e5cee8ceaff3dd87f977ddc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background runners now detach correctly on Unix and Windows, and their stderr is captured to a session-scoped log for troubleshooting.

* **Enhancements**
  * Improved file-path resolution for Git checks and diffs by trying multiple candidate paths, improving accuracy from nested working directories.

* **Tests**
  * Added tests and helpers validating detached runner behavior, stderr logging, path resolution, and updated platform-specific test invocation for package tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->