### PR TITLE
fix: document supported Claude hook install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,11 +703,27 @@ mkdir -p ~/.claude/commands
 cp everything-claude-code/commands/*.md ~/.claude/commands/
 ```
 
-#### Add hooks to settings.json
+#### Install hooks
 
-Manual install only: copy the hooks from `hooks/hooks.json` to your `~/.claude/settings.json` if you are not installing ECC as a Claude plugin.
+Do not copy the raw repo `hooks/hooks.json` into `~/.claude/settings.json` or `~/.claude/hooks/hooks.json`. That file is plugin/repo-oriented and still contains `${CLAUDE_PLUGIN_ROOT}` placeholders, so raw copying is not a supported manual install path.
+
+Use the installer to install only the Claude hook runtime so command paths are rewritten correctly:
+
+```bash
+# macOS / Linux
+bash ./install.sh --target claude --modules hooks-runtime
+```
+
+```powershell
+# Windows PowerShell
+pwsh -File .\install.ps1 --target claude --modules hooks-runtime
+```
+
+That writes resolved hooks to `~/.claude/hooks/hooks.json` and leaves any existing `~/.claude/settings.json` untouched.
 
 If you installed ECC via `/plugin install`, do not copy those hooks into `settings.json`. Claude Code v2.1+ already auto-loads plugin `hooks/hooks.json`, and duplicating them in `settings.json` causes duplicate execution and `${CLAUDE_PLUGIN_ROOT}` resolution failures.
+
+Windows note: the Claude config directory is `%USERPROFILE%\\.claude`, not `~/claude`.
 
 #### Configure MCPs
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -16,6 +16,22 @@ User request → Claude picks a tool → PreToolUse hook runs → Tool executes 
 
 ## Hooks in This Plugin
 
+## Installing These Hooks Manually
+
+For Claude Code manual installs, do not paste the raw repo `hooks.json` into `~/.claude/settings.json` or copy it directly into `~/.claude/hooks/hooks.json`. The checked-in file still contains `${CLAUDE_PLUGIN_ROOT}` placeholders and is meant to be installed through the ECC installer or loaded as a plugin.
+
+Use the installer instead so hook commands are rewritten against your actual Claude root:
+
+```bash
+bash ./install.sh --target claude --modules hooks-runtime
+```
+
+```powershell
+pwsh -File .\install.ps1 --target claude --modules hooks-runtime
+```
+
+That installs resolved hooks to `~/.claude/hooks/hooks.json`. On Windows, the Claude config root is `%USERPROFILE%\\.claude`.
+
 ### PreToolUse Hooks
 
 | Hook | Matcher | Behavior | Exit Code |

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -27,7 +27,7 @@ Usage: install.sh [--target <${LEGACY_INSTALL_TARGETS.join('|')}>] [--dry-run] [
        install.sh [--dry-run] [--json] --config <path>
 
 Targets:
-  claude       (default) - Install rules to ~/.claude/rules/
+  claude       (default) - Install ECC into ~/.claude/ (hooks, commands, agents, rules, skills)
   cursor       - Install rules, hooks, and bundled Cursor configs to ./.cursor/
   antigravity  - Install rules, workflows, skills, and agents to ./.agent/
 

--- a/tests/scripts/install-ps1.test.js
+++ b/tests/scripts/install-ps1.test.js
@@ -110,6 +110,17 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (!powerShellCommand) {
+    console.log('  - skipped help text test; PowerShell is not available in PATH');
+  } else if (test('exposes the corrected Claude target help text', () => {
+    const result = run(powerShellCommand, ['--help']);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(
+      result.stdout.includes('claude       (default) - Install ECC into ~/.claude/'),
+      'help text should describe the Claude target as a full ~/.claude install surface'
+    );
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/install-sh.test.js
+++ b/tests/scripts/install-sh.test.js
@@ -86,6 +86,15 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('exposes the corrected Claude target help text', () => {
+    const result = run(['--help']);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(
+      result.stdout.includes('claude       (default) - Install ECC into ~/.claude/'),
+      'help text should describe the Claude target as a full ~/.claude install surface'
+    );
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/manual-hook-install-docs.test.js
+++ b/tests/scripts/manual-hook-install-docs.test.js
@@ -1,0 +1,71 @@
+/**
+ * Regression coverage for supported manual Claude hook installation guidance.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const README = path.join(__dirname, '..', '..', 'README.md');
+const HOOKS_README = path.join(__dirname, '..', '..', 'hooks', 'README.md');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing manual hook install docs ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  const readme = fs.readFileSync(README, 'utf8');
+  const hooksReadme = fs.readFileSync(HOOKS_README, 'utf8');
+
+  if (test('README warns against raw hook file copying', () => {
+    assert.ok(
+      readme.includes('Do not copy the raw repo `hooks/hooks.json` into `~/.claude/settings.json` or `~/.claude/hooks/hooks.json`'),
+      'README should warn against unsupported raw hook copying'
+    );
+    assert.ok(
+      readme.includes('bash ./install.sh --target claude --modules hooks-runtime'),
+      'README should document the supported Bash hook install path'
+    );
+    assert.ok(
+      readme.includes('pwsh -File .\\install.ps1 --target claude --modules hooks-runtime'),
+      'README should document the supported PowerShell hook install path'
+    );
+    assert.ok(
+      readme.includes('%USERPROFILE%\\\\.claude'),
+      'README should call out the correct Windows Claude config root'
+    );
+  })) passed++; else failed++;
+
+  if (test('hooks/README mirrors supported manual install guidance', () => {
+    assert.ok(
+      hooksReadme.includes('do not paste the raw repo `hooks.json` into `~/.claude/settings.json` or copy it directly into `~/.claude/hooks/hooks.json`'),
+      'hooks/README should warn against unsupported raw hook copying'
+    );
+    assert.ok(
+      hooksReadme.includes('bash ./install.sh --target claude --modules hooks-runtime'),
+      'hooks/README should document the supported Bash hook install path'
+    );
+    assert.ok(
+      hooksReadme.includes('pwsh -File .\\install.ps1 --target claude --modules hooks-runtime'),
+      'hooks/README should document the supported PowerShell hook install path'
+    );
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- stop telling manual Claude users to raw-copy plugin-style hooks.json
- document the supported hooks-runtime install path for Bash and PowerShell
- clarify the real Claude config root on Windows and tighten installer help text

## Testing
- node tests/scripts/manual-hook-install-docs.test.js
- node tests/scripts/install-sh.test.js
- node tests/scripts/install-ps1.test.js
- node tests/scripts/install-apply.test.js

Closes #1362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual Claude hook installation by documenting the supported hooks-runtime install path and updating installer help text to prevent broken `${CLAUDE_PLUGIN_ROOT}` paths and duplicate execution. Also clarifies the correct Windows config root and adds tests to prevent regressions.

- **Bug Fixes**
  - Docs: stop raw-copy guidance; show `bash ./install.sh --target claude --modules hooks-runtime` and `pwsh -File .\install.ps1 --target claude --modules hooks-runtime`; note `%USERPROFILE%\.claude`; resolved hooks go to `~/.claude/hooks/hooks.json`.
  - Installer help: update `claude` target to “Install ECC into ~/.claude/ (hooks, commands, agents, rules, skills)”.
  - Tests: add `manual-hook-install-docs.test.js`; update `install-sh.test.js` and `install-ps1.test.js` to assert corrected help text.

<sup>Written for commit 18c90a7a174555d61e578825f6031fd02ba0135f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified hook installation instructions with explicit installer commands for both Windows and Unix systems
  * Clarified Windows configuration directory location (`%USERPROFILE%\.claude`)
  * Added warnings against copying raw hook configurations to prevent placeholder resolution and duplicate execution issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->