### PR TITLE
docs: add community skill ecosystem notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,14 @@ Please contribute! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 - Testing strategies (different frameworks, visual regression)
 - Domain-specific knowledge (ML, data engineering, mobile)
 
+### Community Ecosystem Notes
+
+These are not bundled with ECC and are not audited by this repo, but they are worth knowing about if you are exploring the broader Claude Code skills ecosystem:
+
+- [claude-seo](https://github.com/AgriciDaniel/claude-seo) — SEO-focused skill and agent collection
+- [claude-ads](https://github.com/AgriciDaniel/claude-ads) — Ad-audit and paid-growth workflow collection
+- [claude-cybersecurity](https://github.com/AgriciDaniel/claude-cybersecurity) — Security-oriented skill and agent collection
+
 ---
 
 ## Cursor IDE Support


### PR DESCRIPTION
## Summary
- add a small community ecosystem note in the main README
- reference a few notable community skill repos without implying ECC bundles or audits them
- keep the section informational and out of the shipped install surface

## Testing
- node tests/plugin-manifest.test.js

Closes #1365

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Community Ecosystem Notes” section to the README to highlight notable community skills and make discovery easier. It links to `claude-seo`, `claude-ads`, and `claude-cybersecurity`, and clearly states they are not bundled with or audited by ECC and do not affect the install surface.

<sup>Written for commit 68ee51f1e38c02651d4d2e14d1f20fb3ad1af5c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

