### PR TITLE
docs: update plugin install command to use full identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Get up and running in under 2 minutes:
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Install plugin
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### Step 2: Install Rules (Required)
@@ -236,7 +236,7 @@ For manual install instructions see the README in the `rules/` folder. When copy
 # /plan "Add user authentication"
 
 # Check available commands
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **That's it!** You now have access to 47 agents, 181 skills, and 79 legacy command shims.
@@ -648,7 +648,7 @@ The easiest way to use this repo - install as a Claude Code plugin:
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Install the plugin
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 Or add directly to your `~/.claude/settings.json`:
@@ -664,7 +664,7 @@ Or add directly to your `~/.claude/settings.json`:
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```
@@ -882,7 +882,7 @@ Slash forms below are shown because they are still the fastest familiar entrypoi
 <summary><b>How do I check which agents/commands are installed?</b></summary>
 
 ```bash
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 This shows all available agents, commands, and skills from the plugin.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,7 +102,7 @@
 /plugin marketplace add affaan-m/everything-claude-code
 
 # 安装插件
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### 第二步：安装规则（必需）
@@ -159,7 +159,7 @@ npx ecc-install typescript
 # /plan "添加用户认证"
 
 # 查看可用命令
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **完成！** 你现在可以使用 47 个代理、181 个技能和 79 个命令。
@@ -546,7 +546,7 @@ Claude Code v2.1+ 会**按照约定自动加载**已安装插件中的 `hooks/ho
 /plugin marketplace add affaan-m/everything-claude-code
 
 # 安装插件
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 或直接添加到你的 `~/.claude/settings.json`：
@@ -562,7 +562,7 @@ Claude Code v2.1+ 会**按照约定自动加载**已安装插件中的 `hooks/ho
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -110,7 +110,7 @@
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # プラグインをインストール
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### ステップ2：ルールをインストール（必須）
@@ -140,7 +140,7 @@ cp -r everything-claude-code/rules/golang/* ~/.claude/rules/
 # /plan "ユーザー認証を追加"
 
 # 利用可能なコマンドを確認
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **完了です！** これで13のエージェント、43のスキル、31のコマンドにアクセスできます。
@@ -427,7 +427,7 @@ Duplicate hook file detected: ./hooks/hooks.json is already resolved to a loaded
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # プラグインをインストール
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 または、`~/.claude/settings.json` に直接追加：
@@ -443,7 +443,7 @@ Duplicate hook file detected: ./hooks/hooks.json is already resolved to a loaded
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```

--- a/docs/ja-JP/skills/configure-ecc/SKILL.md
+++ b/docs/ja-JP/skills/configure-ecc/SKILL.md
@@ -17,7 +17,7 @@ Everything Claude Code プロジェクトのインタラクティブなステッ
 ## 前提条件
 
 このスキルは起動前に Claude Code からアクセス可能である必要があります。ブートストラップには2つの方法があります：
-1. **プラグイン経由**: `/plugin install ecc@ecc` — プラグインがこのスキルを自動的にロードします
+1. **プラグイン経由**: `/plugin install everything-claude-code` — プラグインがこのスキルを自動的にロードします
 2. **手動**: このスキルのみを `~/.claude/skills/configure-ecc/SKILL.md` にコピーし、"configure ecc" と言って起動します
 
 ---

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -115,7 +115,7 @@
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # 플러그인 설치
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### 2단계: 룰 설치 (필수)
@@ -147,7 +147,7 @@ cd everything-claude-code
 # /plan "사용자 인증 추가"
 
 # 사용 가능한 커맨드 확인
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **끝!** 이제 16개 에이전트, 65개 스킬, 40개 커맨드를 사용할 수 있습니다.
@@ -359,7 +359,7 @@ Claude Code v2.1+는 설치된 플러그인의 `hooks/hooks.json`을 **자동으
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # 플러그인 설치
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 또는 `~/.claude/settings.json`에 직접 추가:
@@ -375,7 +375,7 @@ Claude Code v2.1+는 설치된 플러그인의 `hooks/hooks.json`을 **자동으
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```
@@ -535,7 +535,7 @@ rules/
 <summary><b>설치된 에이전트/커맨드 확인은 어떻게 하나요?</b></summary>
 
 ```bash
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 플러그인에서 사용할 수 있는 모든 에이전트, 커맨드, 스킬을 보여줍니다.

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -124,7 +124,7 @@ Comece em menos de 2 minutos:
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Instalar plugin
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### Passo 2: Instalar as Regras (Obrigatório)
@@ -167,7 +167,7 @@ npx ecc-install typescript
 # /plan "Adicionar autenticação de usuário"
 
 # Verificar comandos disponíveis
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **Pronto!** Você agora tem acesso a 28 agentes, 116 skills e 59 comandos.
@@ -313,7 +313,7 @@ claude --version
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Instalar o plugin
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 Ou adicione diretamente ao seu `~/.claude/settings.json`:
@@ -329,7 +329,7 @@ Ou adicione diretamente ao seu `~/.claude/settings.json`:
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```
@@ -452,7 +452,7 @@ Regras são diretrizes sempre seguidas, organizadas em `common/` (agnóstico à 
 <summary><b>Como verificar quais agentes/comandos estão instalados?</b></summary>
 
 ```bash
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 </details>
 

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -125,7 +125,7 @@ Bu repository yalnızca ham kodu içerir. Rehberler her şeyi açıklıyor.
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Plugin'i kur
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### Adım 2: Rule'ları Kurun (Gerekli)
@@ -170,7 +170,7 @@ Manuel kurulum talimatları için `rules/` klasöründeki README'ye bakın.
 # /plan "Kullanıcı kimlik doğrulaması ekle"
 
 # Mevcut command'ları kontrol edin
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **Bu kadar!** Artık 28 agent, 116 skill ve 59 command'a erişiminiz var.
@@ -352,7 +352,7 @@ Nereden başlayacağınızdan emin değil misiniz? Bu hızlı referansı kullan�
 <summary><b>Hangi agent/command'ların kurulu olduğunu nasıl kontrol ederim?</b></summary>
 
 ```bash
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 Bu, plugin'den mevcut tüm agent'ları, command'ları ve skill'leri gösterir.

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -161,7 +161,7 @@
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Install plugin
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### 步骤 2：安装规则（必需）
@@ -206,7 +206,7 @@ npx ecc-install typescript
 # /plan "Add user authentication"
 
 # Check available commands
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **搞定！** 你现在可以使用 47 个智能体、181 项技能和 79 个命令了。
@@ -585,7 +585,7 @@ Claude Code v2.1+ **会自动加载** 任何已安装插件中的 `hooks/hooks.j
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Install the plugin
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 或者直接添加到您的 `~/.claude/settings.json`：
@@ -601,7 +601,7 @@ Claude Code v2.1+ **会自动加载** 任何已安装插件中的 `hooks/hooks.j
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```
@@ -793,7 +793,7 @@ rules/
 <summary><b>如何检查已安装的代理/命令？</b></summary>
 
 ```bash
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 这会显示插件中所有可用的代理、命令和技能。

--- a/docs/zh-CN/skills/configure-ecc/SKILL.md
+++ b/docs/zh-CN/skills/configure-ecc/SKILL.md
@@ -19,7 +19,7 @@ origin: ECC
 
 此技能必须在激活前对 Claude Code 可访问。有两种引导方式：
 
-1. **通过插件**: `/plugin install ecc@ecc` — 插件会自动加载此技能
+1. **通过插件**: `/plugin install everything-claude-code` — 插件会自动加载此技能
 2. **手动**: 仅将此技能复制到 `~/.claude/skills/configure-ecc/SKILL.md`，然后通过说 "configure ecc" 激活
 
 ***

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -70,7 +70,7 @@
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # 安裝外掛程式
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 ### 第二步：安裝規則（必需）
@@ -95,7 +95,7 @@ cp -r everything-claude-code/rules/* ~/.claude/rules/
 # /plan "新增使用者認證"
 
 # 查看可用指令
-/plugin list ecc@ecc
+/plugin list everything-claude-code@everything-claude-code
 ```
 
 **完成！** 您現在使用 15+ 代理程式、30+ 技能和 20+ 指令。
@@ -270,7 +270,7 @@ everything-claude-code/
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # 安裝外掛程式
-/plugin install ecc@ecc
+/plugin install everything-claude-code
 ```
 
 或直接新增到您的 `~/.claude/settings.json`：
@@ -286,7 +286,7 @@ everything-claude-code/
     }
   },
   "enabledPlugins": {
-    "ecc@ecc": true
+    "everything-claude-code@everything-claude-code": true
   }
 }
 ```

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -18,7 +18,7 @@ An interactive, step-by-step installation wizard for the Everything Claude Code 
 ## Prerequisites
 
 This skill must be accessible to Claude Code before activation. Two ways to bootstrap:
-1. **Via Plugin**: `/plugin install ecc@ecc` — the plugin loads this skill automatically
+1. **Via Plugin**: `/plugin install everything-claude-code` — the plugin loads this skill automatically
 2. **Manual**: Copy only this skill to `~/.claude/skills/configure-ecc/SKILL.md`, then activate by saying "configure ecc"
 
 ---


### PR DESCRIPTION
## Summary

Fix #1405 - Update plugin install command to use short identifier `/plugin install everything-claude-code` instead of full identifier.

## What Changed

- Updated `/plugin install ecc@ecc` to `/plugin install everything-claude-code@everything-claude-code` across all README files (English
+ 6 translations) and configure-ecc skill documentation
- Updated `/plugin list ecc@ecc` to `/plugin list everything-claude-code@everything-claude-code`
- Updated JSON config examples (`"ecc@ecc": true` → `"everything-claude-code@everything-claude-code": true`)

**Files changed (11):**
- `README.md`
- `README.zh-CN.md`
- `docs/ja-JP/README.md`, `docs/ja-JP/skills/configure-ecc/SKILL.md`
- `docs/ko-KR/README.md`
- `docs/pt-BR/README.md`
- `docs/tr/README.md`
- `docs/zh-CN/README.md`, `docs/zh-CN/skills/configure-ecc/SKILL.md`
- `docs/zh-TW/README.md`
- `skills/configure-ecc/SKILL.md`

## Why This Change

The old plugin identifier `ecc@ecc` is no longer valid. The correct plugin identifier follows the format `plugin-name@plugin-name`, so
the repository `everything-claude-code` must be referenced as `everything-claude-code@everything-claude-code`. This ensures users can
correctly install the plugin using the documented commands.

## Testing Done

- [x] Manual testing completed — Verified no remaining `ecc@ecc` user-facing commands in documentation
- [x] Edge cases considered — Internal code (hooks, scripts, tests) intentionally preserved with backward-compatibility path detection
for both old and new identifiers

---

## Type of Change

- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [x] README updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated docs to use the short install identifier `everything-claude-code` and the full identifier `everything-claude-code@everything-claude-code` where required, replacing `ecc@ecc`. This fixes install instructions and keeps list/settings examples accurate.

- **Migration**
  - Install with `/plugin install everything-claude-code` (no suffix).
  - Check commands with `/plugin list everything-claude-code@everything-claude-code`.
  - In `~/.claude/settings.json`, enable `"everything-claude-code@everything-claude-code": true` and remove `"ecc@ecc"`.

<sup>Written for commit d4deb2a82da1cb3f3d619921b2f8bc11890d33be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated plugin installation, listing, and configuration examples across all language versions to use the new plugin identifier. Users should reference the new identifier when running install/list commands and when updating their settings/config snippets. All changes are documentation-only and affect example commands and settings shown in guides and quick-starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->