### PR TITLE
fix: Prefer .cursor/rules on Cursor install collisions and align rule copy

### DIFF
--- a/.cursor/rules/common-agents.md
+++ b/.cursor/rules/common-agents.md
@@ -6,7 +6,7 @@ alwaysApply: true
 
 ## Available Agents
 
-Located in `~/.claude/agents/`:
+Project agent definitions live in **`.cursor/agents/`** (one markdown file per agent). The high-level orchestration list and tables are in the repo-root **`AGENTS.md`** (Cursor reads this natively).
 
 | Agent | Purpose | When to Use |
 |-------|---------|-------------|

--- a/.cursor/rules/common-git-workflow.md
+++ b/.cursor/rules/common-git-workflow.md
@@ -13,7 +13,7 @@ alwaysApply: true
 
 Types: feat, fix, refactor, docs, test, chore, perf, ci
 
-Note: Attribution disabled globally via ~/.claude/settings.json.
+Note: Commit attribution and similar git metadata are controlled by **Cursor Settings** and your local **`git config`**, not by Claude Code’s `~/.claude/settings.json`.
 
 ## Pull Request Workflow
 

--- a/.cursor/rules/common-hooks.md
+++ b/.cursor/rules/common-hooks.md
@@ -2,21 +2,27 @@
 description: "Hooks system: types, auto-accept permissions, TodoWrite best practices"
 alwaysApply: true
 ---
-# Hooks System
+# Hooks System (Cursor)
 
-## Hook Types
+ECC registers hooks in **`.cursor/hooks.json`**. Implementations live under **`.cursor/hooks/`** and reuse shared logic via **`adapter.js`** and **`scripts/hooks/`** where applicable.
 
-- **PreToolUse**: Before tool execution (validation, parameter modification)
-- **PostToolUse**: After tool execution (auto-format, checks)
-- **Stop**: When session ends (final verification)
+## Hook events (examples)
 
-## Auto-Accept Permissions
+- **sessionStart** / **sessionEnd** — restore or persist session context
+- **beforeShellExecution** / **afterShellExecution** — shell safety, logging, git flow guardrails
+- **afterFileEdit** — auto-format, type checks, edit-time warnings
+- **beforeSubmitPrompt** — secret patterns in prompts
+- **beforeReadFile** / **beforeTabFileRead** — sensitive path warnings
+- **beforeMCPExecution** / **afterMCPExecution** — MCP audit logging
+
+See **`.cursor/hooks.json`** for the authoritative list wired for this project.
+
+## Auto-run and permissions
 
 Use with caution:
-- Enable for trusted, well-defined plans
-- Disable for exploratory work
-- Never use dangerously-skip-permissions flag
-- Configure `allowedTools` in `~/.claude.json` instead
+- Enable auto-run only for trusted, well-defined plans
+- Prefer stricter approval for exploratory work
+- Use **Cursor Settings** (Chat / Agent approval, sandbox, and tool permissions) instead of Claude Code’s `~/.claude.json` `allowedTools`
 
 ## TodoWrite Best Practices
 

--- a/.cursor/rules/common-performance.md
+++ b/.cursor/rules/common-performance.md
@@ -38,11 +38,10 @@ Lower context sensitivity tasks:
 
 Extended thinking is enabled by default, reserving up to 31,999 tokens for internal reasoning.
 
-Control extended thinking via:
-- **Toggle**: Option+T (macOS) / Alt+T (Windows/Linux)
-- **Config**: Set `alwaysThinkingEnabled` in `~/.claude/settings.json`
-- **Budget cap**: `export MAX_THINKING_TOKENS=10000`
-- **Verbose mode**: Ctrl+O to see thinking output
+Control reasoning / extended thinking (names vary by Cursor version):
+- **UI**: Use the Chat / Agent controls and **Cursor Settings** for model and reasoning options (there is no `~/.claude/settings.json` in Cursor)
+- **Budget cap** (when supported by your model backend): e.g. `export MAX_THINKING_TOKENS=10000`
+- **Verbose / trace**: use whatever your Cursor build exposes for chain-of-thought or debug output
 
 For complex tasks requiring deep reasoning:
 1. Ensure extended thinking is enabled (on by default)

--- a/.cursor/rules/golang-hooks.md
+++ b/.cursor/rules/golang-hooks.md
@@ -7,9 +7,9 @@ alwaysApply: false
 
 > This file extends the common hooks rule with Go specific content.
 
-## PostToolUse Hooks
+## After-edit behavior
 
-Configure in `~/.claude/settings.json`:
+Align tooling with the **`afterFileEdit`** hook in **`.cursor/hooks.json`** (extend **`.cursor/hooks/after-file-edit.js`** or add Go-specific hooks if needed):
 
 - **gofmt/goimports**: Auto-format `.go` files after edit
 - **go vet**: Run static analysis after editing `.go` files

--- a/.cursor/rules/kotlin-hooks.md
+++ b/.cursor/rules/kotlin-hooks.md
@@ -7,9 +7,9 @@ alwaysApply: false
 
 > This file extends the common hooks rule with Kotlin-specific content.
 
-## PostToolUse Hooks
+## After-edit behavior
 
-Configure in `~/.claude/settings.json`:
+Align tooling with the **`afterFileEdit`** hook in **`.cursor/hooks.json`** (extend **`.cursor/hooks/after-file-edit.js`** or add Kotlin-specific hooks if needed):
 
 - **ktfmt/ktlint**: Auto-format `.kt` and `.kts` files after edit
 - **detekt**: Run static analysis after editing Kotlin files

--- a/.cursor/rules/php-hooks.md
+++ b/.cursor/rules/php-hooks.md
@@ -7,9 +7,9 @@ alwaysApply: false
 
 > This file extends the common hooks rule with PHP specific content.
 
-## PostToolUse Hooks
+## After-edit behavior
 
-Configure in `~/.claude/settings.json`:
+Align tooling with the **`afterFileEdit`** hook in **`.cursor/hooks.json`** (extend **`.cursor/hooks/after-file-edit.js`** or add PHP-specific hooks if needed):
 
 - **Pint / PHP-CS-Fixer**: Auto-format edited `.php` files.
 - **PHPStan / Psalm**: Run static analysis after PHP edits in typed codebases.

--- a/.cursor/rules/python-hooks.md
+++ b/.cursor/rules/python-hooks.md
@@ -7,9 +7,9 @@ alwaysApply: false
 
 > This file extends the common hooks rule with Python specific content.
 
-## PostToolUse Hooks
+## After-edit behavior
 
-Configure in `~/.claude/settings.json`:
+Align tooling with the **`afterFileEdit`** hook in **`.cursor/hooks.json`** (extend **`.cursor/hooks/after-file-edit.js`** or add language-specific hooks if needed):
 
 - **black/ruff**: Auto-format `.py` files after edit
 - **mypy/pyright**: Run type checking after editing `.py` files

--- a/.cursor/rules/swift-hooks.md
+++ b/.cursor/rules/swift-hooks.md
@@ -7,9 +7,9 @@ alwaysApply: false
 
 > This file extends the common hooks rule with Swift specific content.
 
-## PostToolUse Hooks
+## After-edit behavior
 
-Configure in `~/.claude/settings.json`:
+Align tooling with the **`afterFileEdit`** hook in **`.cursor/hooks.json`** (extend **`.cursor/hooks/after-file-edit.js`** or add Swift-specific hooks if needed):
 
 - **SwiftFormat**: Auto-format `.swift` files after edit
 - **SwiftLint**: Run lint checks after editing `.swift` files

--- a/.cursor/rules/typescript-hooks.md
+++ b/.cursor/rules/typescript-hooks.md
@@ -7,9 +7,9 @@ alwaysApply: false
 
 > This file extends the common hooks rule with TypeScript/JavaScript specific content.
 
-## PostToolUse Hooks
+## After-edit behavior
 
-Configure in `~/.claude/settings.json`:
+ECC implements this stack via **`afterFileEdit`** in **`.cursor/hooks.json`** (see **`.cursor/hooks/after-file-edit.js`**):
 
 - **Prettier**: Auto-format JS/TS files after edit
 - **TypeScript check**: Run `tsc` after editing `.ts`/`.tsx` files

--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -52,12 +52,14 @@ module.exports = createInstallTargetAdapter({
           pathIndex,
         }));
     }).sort((left, right) => {
+      // Prefer repo `.cursor/` (platform-native rules and hooks) over flattened `rules/`
+      // so Cursor-specific copy wins on filename collisions (e.g. common-agents.mdc).
       const getPriority = value => {
-        if (value === 'rules') {
+        if (value === '.cursor') {
           return 0;
         }
 
-        if (value === '.cursor') {
+        if (value === 'rules') {
           return 1;
         }
 

--- a/tests/lib/install-manifests.test.js
+++ b/tests/lib/install-manifests.test.js
@@ -124,11 +124,11 @@ function runTests() {
     );
     assert.ok(
       plan.operations.some(operation => (
-        operation.sourceRelativePath === 'rules/common/agents.md'
+        operation.sourceRelativePath === '.cursor/rules/common-agents.md'
         && operation.destinationPath === path.join(projectRoot, '.cursor', 'rules', 'common-agents.mdc')
         && operation.strategy === 'flatten-copy'
       )),
-      'Should produce Cursor .mdc rules while preferring rules-core over duplicate platform copies'
+      'Should produce Cursor .mdc rules while preferring .cursor/rules over duplicate rules-core copies'
     );
   })) passed++; else failed++;
 

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -93,8 +93,9 @@ function runTests() {
     const hooksJson = plan.operations.find(operation => (
       normalizedRelativePath(operation.sourceRelativePath) === '.cursor/hooks.json'
     ));
+    // Use a rules/ path with no twin under .cursor/rules so rules-core flatten still appears after .cursor.
     const preserved = plan.operations.find(operation => (
-      normalizedRelativePath(operation.sourceRelativePath) === 'rules/common/coding-style.md'
+      normalizedRelativePath(operation.sourceRelativePath) === 'rules/perl/coding-style.md'
     ));
 
     assert.ok(hooksJson, 'Should preserve non-rule Cursor platform config files');
@@ -105,7 +106,7 @@ function runTests() {
     assert.strictEqual(preserved.strategy, 'flatten-copy');
     assert.strictEqual(
       preserved.destinationPath,
-      path.join(projectRoot, '.cursor', 'rules', 'common-coding-style.mdc')
+      path.join(projectRoot, '.cursor', 'rules', 'perl-coding-style.mdc')
     );
   })) passed++; else failed++;
 
@@ -236,8 +237,8 @@ function runTests() {
     assert.strictEqual(commonAgentsDestinations.length, 1, 'Should keep only one common-agents.mdc operation');
     assert.strictEqual(
       normalizedRelativePath(commonAgentsDestinations[0].sourceRelativePath),
-      'rules/common/agents.md',
-      'Should prefer rules-core when cursor platform rules would collide'
+      '.cursor/rules/common-agents.md',
+      'Should prefer native .cursor/rules when rules-core would collide'
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## What Changed

- **`.cursor/rules` (10 Markdown rule files):** Reworded Claude Code–specific paths so they match the **Cursor project layout**:
  - **`common-agents.md`:** Agents live under **`.cursor/agents/`**; the overview table is in the repo-root **`AGENTS.md`** (no more `~/.claude/agents/`).
  - **`common-hooks.md`:** Documents **`.cursor/hooks.json`**, **`.cursor/hooks/`**, and Cursor hook events; permissions point to **Cursor Settings** instead of `~/.claude.json`.
  - **`common-performance.md`**, **`common-git-workflow.md`**, and language **`*-hooks.md`:** Removed or reframed references to `~/.claude/settings.json` in favor of Cursor UI / project hooks.
- **`scripts/lib/install-targets/cursor-project.js`:** When resolving manifest installs, **sort `.cursor` paths before `rules`**. If **`rules-core`** (flattened `rules/`) and **`platform-configs`** (`.cursor/rules`) both emit the **same `.mdc` path**, the **`.cursor/rules`** copy wins—so installed rules no longer pick up `rules/common/agents.md` (Claude-oriented text) over the curated Cursor rules.
- **Tests:** Updated **`tests/lib/install-targets.test.js`** and **`tests/lib/install-manifests.test.js`** (collision source is now `.cursor/rules/common-agents.md`; scaffold test uses **`rules/perl/coding-style.md`**, which has no twin under `.cursor/rules`, to prove `rules-core` flattening still runs).

## Why This Change

- After `install.sh --target cursor --profile full`, files like **`common-agents.mdc`** could still mention **`~/.claude/agents`**, which contradicts a Cursor-only, project-local **`.cursor/`** install.
- Root cause: **deduplication kept the first operation**; **`rules`** was ordered **before** **`.cursor`**, so flattened **`rules/common/agents.md`** overwrote the **`.cursor/rules`** content.
- Reordering makes **native Cursor rules take precedence** on filename collisions.

## Testing Done

- [x] Manual testing completed (re-run install and confirm **`common-agents.mdc`** reflects **`.cursor/agents`** / **`AGENTS.md`**)
- [x] Automated tests pass locally (`node tests/lib/install-targets.test.js`, `node tests/lib/install-manifests.test.js`; full suite: `node tests/run-all.js`)
- [x] Edge cases considered and tested (collisions: `.cursor` wins; rules-only files such as **`perl-coding-style`** still install from **`rules/`**)

## Type of Change

- [x] `fix:` Bug fix  
- [ ] `feat:` New feature  
- [ ] `refactor:` Code refactoring  
- [ ] `docs:` Documentation  
- [x] `test:` Tests  
- [ ] `chore:` Maintenance/tooling  
- [ ] `ci:` CI/CD changes  

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)  
- [x] JSON files validate cleanly  
- [ ] Shell scripts pass shellcheck (if applicable)  
- [ ] Pre-commit hooks pass locally (if configured)  
- [x] No sensitive data exposed in logs or output  
- [x] Follows conventional commits format  

## Documentation

- [ ] Updated relevant documentation  
- [x] Added comments for complex logic (priority sort in **`cursor-project.js`**)  
- [ ] README updated (if needed)  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer `.cursor/rules` over flattened `rules/` during Cursor installs so native Cursor rule files win on filename collisions. Also updated rule docs to use Cursor project paths and hooks; tests lock in the new precedence.

- **Bug Fixes**
  - Install planning now processes `.cursor` before `rules` in `scripts/lib/install-targets/cursor-project.js`, so duplicates like `common-agents.mdc` come from `.cursor/rules`.
  - Rule files reference `.cursor/agents`, `.cursor/hooks.json`, and Cursor Settings instead of `~/.claude/*`.
  - Tests assert `.cursor/rules` precedence and confirm `rules-core` flattening still runs for files without a `.cursor` twin (e.g., `rules/perl/coding-style.md`).

<sup>Written for commit 886cb034c8d2e2dac4735c9d58658bc301a112fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to direct users to Cursor Settings and `.cursor/hooks.json` for managing hooks and post-edit behaviors, replacing references to prior Claude settings locations.
  * Clarified that agent definitions are stored in `.cursor/agents/` and hook configurations use the `afterFileEdit` hook system.
  * Revised documentation to reflect Cursor-native controls for reasoning, extended-thinking, and git commit attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->