### PR TITLE
fix(hooks): fix bug that gateguard can't get session id and block tool call repeatedly

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -27,13 +27,36 @@ const fs = require('fs');
 const path = require('path');
 
 // Session state — scoped per session to avoid cross-session races.
-// Prefer Claude-provided session IDs, but fall back to a stable per-project key
-// so API/proxy setups without CLAUDE_SESSION_ID do not re-trigger the gate on
-// every Bash invocation in the same workspace.
+// Prefer Claude-provided session IDs. When they are unavailable (for example in
+// API/proxy setups), derive a stable fallback from the transcript path or from
+// the project scope plus a parent-process fingerprint. This avoids both
+// per-invocation PID churn and cross-CLI state leakage in the same project.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
-const STABLE_FALLBACK_SCOPE = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-const STABLE_FALLBACK_ID = 'cwd-' + crypto.createHash('sha1').update(STABLE_FALLBACK_SCOPE).digest('hex').slice(0, 12);
-const SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.ECC_SESSION_ID || STABLE_FALLBACK_ID;
+
+function hashSessionKey(prefix, value) {
+  return prefix + crypto.createHash('sha1').update(value).digest('hex').slice(0, 16);
+}
+
+function resolveSessionId() {
+  if (process.env.CLAUDE_SESSION_ID) return process.env.CLAUDE_SESSION_ID;
+  if (process.env.ECC_SESSION_ID) return process.env.ECC_SESSION_ID;
+
+  if (process.env.CLAUDE_TRANSCRIPT_PATH) {
+    return hashSessionKey('transcript-', process.env.CLAUDE_TRANSCRIPT_PATH);
+  }
+
+  const scope = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const parentFingerprint = [
+    String(process.ppid || process.pid),
+    process.env.CLAUDE_CODE_ENTRYPOINT || '',
+    process.env.TMUX_PANE || process.env.TMUX || '',
+    process.env.TERM_SESSION_ID || ''
+  ].join('|');
+
+  return hashSessionKey('fallback-', `${scope}::${parentFingerprint}`);
+}
+
+const SESSION_ID = resolveSessionId();
 const STATE_FILE = path.join(STATE_DIR, `state-${SESSION_ID.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
 
 // State expires after 30 minutes of inactivity

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -25,6 +25,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { sanitizeSessionId } = require('../lib/utils');
 
 // Session state — scoped per session to avoid cross-session races.
 // Prefer Claude-provided session IDs. When they are unavailable (for example in
@@ -35,6 +36,15 @@ const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME 
 
 function hashSessionKey(prefix, value) {
   return prefix + crypto.createHash('sha1').update(value).digest('hex').slice(0, 16);
+}
+
+function sessionIdForStateFile(sessionId) {
+  const raw = String(sessionId || '');
+  const sanitized = sanitizeSessionId(raw);
+  if (sanitized.length > 0 && sanitized.length <= 64) {
+    return sanitized;
+  }
+  return hashSessionKey('sid-', raw || 'empty-session');
 }
 
 function resolveSessionId() {
@@ -57,7 +67,7 @@ function resolveSessionId() {
 }
 
 const SESSION_ID = resolveSessionId();
-const STATE_FILE = path.join(STATE_DIR, `state-${SESSION_ID.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
+const STATE_FILE = path.join(STATE_DIR, `state-${sessionIdForStateFile(SESSION_ID)}.json`);
 
 // State expires after 30 minutes of inactivity
 const SESSION_TIMEOUT_MS = 30 * 60 * 1000;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -37,7 +37,7 @@ const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME 
 function hashSessionKey(prefix, value) {
   return prefix + crypto.createHash('sha1').update(String(value)).digest('hex').slice(0, 16);
 }
-}
+
 
 function sessionIdForStateFile(sessionId) {
   const raw = String(sessionId || '');

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -35,7 +35,8 @@ const { sanitizeSessionId } = require('../lib/utils');
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
 
 function hashSessionKey(prefix, value) {
-  return prefix + crypto.createHash('sha1').update(value).digest('hex').slice(0, 16);
+  return prefix + crypto.createHash('sha1').update(String(value)).digest('hex').slice(0, 16);
+}
 }
 
 function sessionIdForStateFile(sessionId) {

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -68,15 +68,9 @@ function resolveSessionId(data = {}) {
     return hashSessionKey('transcript-', transcriptPath);
   }
 
+  // this may not happen in real usage. If it does, we at least get a stable fallback per project directory fingerprint, instead of per-invocation random IDs.
   const scope = data.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  const parentFingerprint = [
-    String(process.ppid || process.pid),
-    process.env.CLAUDE_CODE_ENTRYPOINT || '',
-    process.env.TMUX_PANE || process.env.TMUX || '',
-    process.env.TERM_SESSION_ID || ''
-  ].join('|');
-
-  return hashSessionKey('fallback-', `${scope}::${parentFingerprint}`);
+  return hashSessionKey('fallback-', scope);
 }
 
 function resolveStateFile(data = {}) {

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -40,7 +40,7 @@ function hashSessionKey(prefix, value) {
 
 function sessionIdForStateFile(sessionId) {
   const raw = String(sessionId || '');
-  const sanitized = sanitizeSessionId(raw);
+  const sanitized = sanitizeSessionId(raw) || '';
   if (sanitized.length > 0 && sanitized.length <= 64) {
     return sanitized;
   }

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -27,9 +27,13 @@ const fs = require('fs');
 const path = require('path');
 
 // Session state — scoped per session to avoid cross-session races.
-// Uses CLAUDE_SESSION_ID (set by Claude Code) or falls back to PID-based isolation.
+// Prefer Claude-provided session IDs, but fall back to a stable per-project key
+// so API/proxy setups without CLAUDE_SESSION_ID do not re-trigger the gate on
+// every Bash invocation in the same workspace.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
-const SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.ECC_SESSION_ID || `pid-${process.ppid || process.pid}`;
+const STABLE_FALLBACK_SCOPE = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const STABLE_FALLBACK_ID = 'cwd-' + crypto.createHash('sha1').update(STABLE_FALLBACK_SCOPE).digest('hex').slice(0, 12);
+const SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.ECC_SESSION_ID || STABLE_FALLBACK_ID;
 const STATE_FILE = path.join(STATE_DIR, `state-${SESSION_ID.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
 
 // State expires after 30 minutes of inactivity

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -47,9 +47,19 @@ function sessionIdForStateFile(sessionId) {
   return hashSessionKey('sid-', raw || 'empty-session');
 }
 
+function firstMeaningfulSessionId(...candidates) {
+  for (const candidate of candidates) {
+    if (sanitizeSessionId(candidate)) return candidate;
+  }
+  return null;
+}
+
 function resolveSessionId() {
-  if (process.env.CLAUDE_SESSION_ID) return process.env.CLAUDE_SESSION_ID;
-  if (process.env.ECC_SESSION_ID) return process.env.ECC_SESSION_ID;
+  const explicitSessionId = firstMeaningfulSessionId(
+    process.env.CLAUDE_SESSION_ID,
+    process.env.ECC_SESSION_ID
+  );
+  if (explicitSessionId) return explicitSessionId;
 
   if (process.env.CLAUDE_TRANSCRIPT_PATH) {
     return hashSessionKey('transcript-', process.env.CLAUDE_TRANSCRIPT_PATH);

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -54,18 +54,21 @@ function firstMeaningfulSessionId(...candidates) {
   return null;
 }
 
-function resolveSessionId() {
+function resolveSessionId(data = {}) {
   const explicitSessionId = firstMeaningfulSessionId(
+    data.session_id,
+    data.sessionId,
     process.env.CLAUDE_SESSION_ID,
     process.env.ECC_SESSION_ID
   );
   if (explicitSessionId) return explicitSessionId;
 
-  if (process.env.CLAUDE_TRANSCRIPT_PATH) {
-    return hashSessionKey('transcript-', process.env.CLAUDE_TRANSCRIPT_PATH);
+  const transcriptPath = data.transcript_path || data.transcriptPath || process.env.CLAUDE_TRANSCRIPT_PATH;
+  if (transcriptPath) {
+    return hashSessionKey('transcript-', transcriptPath);
   }
 
-  const scope = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const scope = data.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const parentFingerprint = [
     String(process.ppid || process.pid),
     process.env.CLAUDE_CODE_ENTRYPOINT || '',
@@ -76,8 +79,10 @@ function resolveSessionId() {
   return hashSessionKey('fallback-', `${scope}::${parentFingerprint}`);
 }
 
-const SESSION_ID = resolveSessionId();
-const STATE_FILE = path.join(STATE_DIR, `state-${sessionIdForStateFile(SESSION_ID)}.json`);
+function resolveStateFile(data = {}) {
+  const sessionId = resolveSessionId(data);
+  return path.join(STATE_DIR, `state-${sessionIdForStateFile(sessionId)}.json`);
+}
 
 // State expires after 30 minutes of inactivity
 const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -91,13 +96,13 @@ const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|g
 
 // --- State management (per-session, atomic writes, bounded) ---
 
-function loadState() {
+function loadState(stateFile) {
   try {
-    if (fs.existsSync(STATE_FILE)) {
-      const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+    if (fs.existsSync(stateFile)) {
+      const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
       const lastActive = state.last_active || 0;
       if (Date.now() - lastActive > SESSION_TIMEOUT_MS) {
-        try { fs.unlinkSync(STATE_FILE); } catch (_) { /* ignore */ }
+        try { fs.unlinkSync(stateFile); } catch (_) { /* ignore */ }
         return { checked: [], last_active: Date.now() };
       }
       return state;
@@ -121,30 +126,30 @@ function pruneCheckedEntries(checked) {
   return [...preserved, ...cappedSession, ...cappedFiles];
 }
 
-function saveState(state) {
+function saveState(stateFile, state) {
   try {
     state.last_active = Date.now();
     state.checked = pruneCheckedEntries(state.checked);
     fs.mkdirSync(STATE_DIR, { recursive: true });
     // Atomic write: temp file + rename prevents partial reads
-    const tmpFile = STATE_FILE + '.tmp.' + process.pid;
+    const tmpFile = stateFile + '.tmp.' + process.pid;
     fs.writeFileSync(tmpFile, JSON.stringify(state, null, 2), 'utf8');
-    fs.renameSync(tmpFile, STATE_FILE);
+    fs.renameSync(tmpFile, stateFile);
   } catch (_) { /* ignore */ }
 }
 
-function markChecked(key) {
-  const state = loadState();
+function markChecked(stateFile, key) {
+  const state = loadState(stateFile);
   if (!state.checked.includes(key)) {
     state.checked.push(key);
-    saveState(state);
+    saveState(stateFile, state);
   }
 }
 
-function isChecked(key) {
-  const state = loadState();
+function isChecked(stateFile, key) {
+  const state = loadState(stateFile);
   const found = state.checked.includes(key);
-  saveState(state);
+  saveState(stateFile, state);
   return found;
 }
 
@@ -252,6 +257,7 @@ function run(rawInput) {
   } catch (_) {
     return rawInput; // allow on parse error
   }
+  const stateFile = resolveStateFile(data);
 
   const rawToolName = data.tool_name || '';
   const toolInput = data.tool_input || {};
@@ -265,8 +271,8 @@ function run(rawInput) {
       return rawInput; // allow
     }
 
-    if (!isChecked(filePath)) {
-      markChecked(filePath);
+    if (!isChecked(stateFile, filePath)) {
+      markChecked(stateFile, filePath);
       return denyResult(toolName === 'Edit' ? editGateMsg(filePath) : writeGateMsg(filePath));
     }
 
@@ -277,8 +283,8 @@ function run(rawInput) {
     const edits = toolInput.edits || [];
     for (const edit of edits) {
       const filePath = edit.file_path || '';
-      if (filePath && !isChecked(filePath)) {
-        markChecked(filePath);
+      if (filePath && !isChecked(stateFile, filePath)) {
+        markChecked(stateFile, filePath);
         return denyResult(editGateMsg(filePath));
       }
     }
@@ -291,15 +297,15 @@ function run(rawInput) {
     if (DESTRUCTIVE_BASH.test(command)) {
       // Gate destructive commands on first attempt; allow retry after facts presented
       const key = '__destructive__' + crypto.createHash('sha256').update(command).digest('hex').slice(0, 16);
-      if (!isChecked(key)) {
-        markChecked(key);
+      if (!isChecked(stateFile, key)) {
+        markChecked(stateFile, key);
         return denyResult(destructiveBashMsg());
       }
       return rawInput; // allow retry after facts presented
     }
 
-    if (!isChecked(ROUTINE_BASH_SESSION_KEY)) {
-      markChecked(ROUTINE_BASH_SESSION_KEY);
+    if (!isChecked(stateFile, ROUTINE_BASH_SESSION_KEY)) {
+      markChecked(stateFile, ROUTINE_BASH_SESSION_KEY);
       return denyResult(routineBashMsg());
     }
 

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -183,14 +183,7 @@ function fallbackSessionId(env = {}) {
   }
 
   const scope = env.CLAUDE_PROJECT_DIR || process.cwd();
-  const parentFingerprint = [
-    String(process.pid),
-    env.CLAUDE_CODE_ENTRYPOINT || '',
-    env.TMUX_PANE || env.TMUX || '',
-    env.TERM_SESSION_ID || ''
-  ].join('|');
-
-  return hashSessionKey('fallback-', `${scope}::${parentFingerprint}`);
+  return hashSessionKey('fallback-', scope);
 }
 
 function runHookWithSessionId(input, sessionId, env = {}) {
@@ -240,6 +233,41 @@ function runBashHookWithInputSession(input, metadata = {}, env = {}) {
       ...process.env,
       ECC_HOOK_PROFILE: 'standard',
       GATEGUARD_STATE_DIR: stateDir,
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runBashHookWithFallbackOnly(input, metadata = {}, env = {}) {
+  const rawInput = typeof input === 'string'
+    ? input
+    : JSON.stringify({
+      ...metadata,
+      ...input
+    });
+  const result = spawnSync('node', [
+    runner,
+    'pre:bash:gateguard-fact-force',
+    'scripts/hooks/gateguard-fact-force.js',
+    'standard,strict'
+  ], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      GATEGUARD_STATE_DIR: stateDir,
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+      CLAUDE_TRANSCRIPT_PATH: '',
       ...env
     },
     timeout: 15000,
@@ -563,52 +591,55 @@ function runTests() {
     assert.ok(persisted.checked.length <= 500, 'pruned state should still honor the checked-entry cap');
   })) passed++; else failed++;
 
-  // --- Test 14: stable fallback works without session env vars ---
-  const fallbackEnv = {
-    CLAUDE_PROJECT_DIR: FALLBACK_PROJECT_DIR
+    // --- Test 14: fallback-only input still reuses state across retries ---
+  const fallbackOnlyEnv = {
+    CLAUDE_PROJECT_DIR: '/tmp/fallback-only-project'
   };
-  clearState(fallbackSessionId(buildFallbackHookEnv(fallbackEnv)));
-  if (test('denies first routine Bash and allows second without session env vars', () => {
+  clearState(fallbackSessionId(fallbackOnlyEnv));
+  if (test('reuses state when neither input nor env provides session metadata', () => {
     const input = {
       tool_name: 'Bash',
-      tool_input: { command: 'echo "hello"' }
+      tool_input: { command: 'echo "hello"' },
+      cwd: '/tmp/fallback-only-project'
     };
 
-    const result1 = runBashHookWithoutSession(input, fallbackEnv);
-    assert.strictEqual(result1.code, 0, 'first fallback call exit code should be 0');
+    const result1 = runBashHookWithFallbackOnly(input, {}, fallbackOnlyEnv);
+    assert.strictEqual(result1.code, 0, 'first fallback-only call exit code should be 0');
     const output1 = parseOutput(result1.stdout);
-    assert.ok(output1, 'first fallback call should produce JSON output');
+    assert.ok(output1, 'first fallback-only call should produce JSON output');
     assert.strictEqual(output1.hookSpecificOutput.permissionDecision, 'deny');
 
-    const result2 = runBashHookWithoutSession(input, fallbackEnv);
-    assert.strictEqual(result2.code, 0, 'second fallback call exit code should be 0');
+    const result2 = runBashHookWithFallbackOnly(input, {}, fallbackOnlyEnv);
+    assert.strictEqual(result2.code, 0, 'second fallback-only call exit code should be 0');
     const output2 = parseOutput(result2.stdout);
-    assert.ok(output2, 'second fallback call should produce valid JSON output');
+    assert.ok(output2, 'second fallback-only call should produce valid JSON output');
     if (output2.hookSpecificOutput) {
       assert.notStrictEqual(output2.hookSpecificOutput.permissionDecision, 'deny',
-        'should not deny second routine bash when using stable fallback');
+        'fallback-only session resolution should map retries to the same state file');
     } else {
       assert.strictEqual(output2.tool_name, 'Bash', 'pass-through should preserve input');
     }
   })) passed++; else failed++;
 
-  // --- Test 15: fallback isolates different CLI fingerprints in one project ---
+  // --- Test 15: fallback shares state for the same project scope ---
+  // Actually it should be isolated when 2 cli sessions are running at the same scope,
+  // but if there is no env and input to provide session information, the ppid and pid will be totally different
+  // and cause every call to be considered as a new one, blocking tool calling repeatly.
   const cliAEnv = {
-    CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR,
-    TMUX_PANE: '%101'
+    CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR
   };
   const cliBEnv = {
-    CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR,
-    TMUX_PANE: '%202'
+    CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR
   };
   clearState(fallbackSessionId(buildFallbackHookEnv(cliAEnv)));
   clearState(fallbackSessionId(buildFallbackHookEnv(cliBEnv)));
-  if (test('does not share fallback state across CLI fingerprints in the same project', () => {
+  if (test('shares fallback state across CLI fingerprints in the same project', () => {
     const input = {
       tool_name: 'Bash',
       tool_input: { command: 'echo "hello"' }
     };
 
+    //CLI A seeds the shared project-scope fallback state
     const cliAFirst = runBashHookWithoutSession(input, cliAEnv);
     const cliAFirstOutput = parseOutput(cliAFirst.stdout);
     assert.ok(cliAFirstOutput, 'CLI A first call should produce JSON output');
@@ -622,11 +653,16 @@ function runTests() {
         'CLI A second call should pass once its fallback state is set');
     }
 
+    //CLI B should reuse the same project-scope fallback state
     const cliBFirst = runBashHookWithoutSession(input, cliBEnv);
     const cliBFirstOutput = parseOutput(cliBFirst.stdout);
-    assert.ok(cliBFirstOutput, 'CLI B first call should produce JSON output');
-    assert.strictEqual(cliBFirstOutput.hookSpecificOutput.permissionDecision, 'deny',
-      'CLI B should not inherit CLI A fallback state');
+    assert.ok(cliBFirstOutput, 'CLI B first call should produce valid JSON output');
+    if (cliBFirstOutput.hookSpecificOutput) {
+      assert.notStrictEqual(cliBFirstOutput.hookSpecificOutput.permissionDecision, 'deny',
+        'CLI B should inherit the shared project-scope fallback state');
+    } else {
+      assert.strictEqual(cliBFirstOutput.tool_name, 'Bash', 'pass-through should preserve input');
+    }
   })) passed++; else failed++;
 
   // --- Test 16: long session IDs are reduced to a filesystem-safe state key ---
@@ -658,7 +694,7 @@ function runTests() {
     assert.ok(path.basename(persisted).length < 255, 'state filename should stay below common filesystem limits');
   })) passed++; else failed++;
 
-  // --- Test 17: hook input session metadata drives state reuse when env lacks it ---
+  // --- Test 17: hook input session metadata ---
   const inputSessionId = 'input-session-123';
   clearState(sessionIdForStateFile(inputSessionId));
   if (test('reuses state when session_id is only present in hook input', () => {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -221,6 +221,38 @@ function runHookWithSessionId(input, sessionId, env = {}) {
   };
 }
 
+function runBashHookWithInputSession(input, metadata = {}, env = {}) {
+  const rawInput = typeof input === 'string'
+    ? input
+    : JSON.stringify({
+      ...metadata,
+      ...input
+    });
+  const result = spawnSync('node', [
+    runner,
+    'pre:bash:gateguard-fact-force',
+    'scripts/hooks/gateguard-fact-force.js',
+    'standard,strict'
+  ], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      GATEGUARD_STATE_DIR: stateDir,
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
 function parseOutput(stdout) {
   try {
     return JSON.parse(stdout);
@@ -624,6 +656,44 @@ function runTests() {
     const persisted = sessionStateFile(sessionIdForStateFile(longSessionId));
     assert.ok(fs.existsSync(persisted), 'sanitized long-session state file should be created');
     assert.ok(path.basename(persisted).length < 255, 'state filename should stay below common filesystem limits');
+  })) passed++; else failed++;
+
+  // --- Test 17: hook input session metadata drives state reuse when env lacks it ---
+  const inputSessionId = 'input-session-123';
+  clearState(sessionIdForStateFile(inputSessionId));
+  if (test('reuses state when session_id is only present in hook input', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'echo "hello"' }
+    };
+    const metadata = {
+      session_id: inputSessionId,
+      transcript_path: '/tmp/transcripts/input-session-123.jsonl',
+      cwd: '/tmp/input-session-project'
+    };
+
+    const result1 = runBashHookWithInputSession(input, metadata, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+      CLAUDE_TRANSCRIPT_PATH: ''
+    });
+    assert.strictEqual(result1.code, 0, 'first hook-input session call exit code should be 0');
+    const output1 = parseOutput(result1.stdout);
+    assert.ok(output1, 'first hook-input session call should produce JSON output');
+    assert.strictEqual(output1.hookSpecificOutput.permissionDecision, 'deny');
+
+    const result2 = runBashHookWithInputSession(input, metadata, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+      CLAUDE_TRANSCRIPT_PATH: ''
+    });
+    assert.strictEqual(result2.code, 0, 'second hook-input session call exit code should be 0');
+    const output2 = parseOutput(result2.stdout);
+    assert.ok(output2, 'second hook-input session call should produce valid JSON output');
+    if (output2.hookSpecificOutput) {
+      assert.notStrictEqual(output2.hookSpecificOutput.permissionDecision, 'deny',
+        'hook input session metadata should map to the same state file on retry');
+    }
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -109,6 +109,39 @@ function runBashHook(input, env = {}) {
   };
 }
 
+function runBashHookWithoutSession(input, env = {}) {
+  const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
+  const hookEnv = {
+    ...process.env,
+    ECC_HOOK_PROFILE: 'standard',
+    GATEGUARD_STATE_DIR: stateDir,
+    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-fallback-project',
+    ...env
+  };
+
+  delete hookEnv.CLAUDE_SESSION_ID;
+  delete hookEnv.ECC_SESSION_ID;
+
+  const result = spawnSync('node', [
+    runner,
+    'pre:bash:gateguard-fact-force',
+    'scripts/hooks/gateguard-fact-force.js',
+    'standard,strict'
+  ], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: hookEnv,
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
 function parseOutput(stdout) {
   try {
     return JSON.parse(stdout);
@@ -417,6 +450,32 @@ function runTests() {
     const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
     assert.ok(persisted.checked.includes('__bash_session__'), 'pruned state should retain __bash_session__');
     assert.ok(persisted.checked.length <= 500, 'pruned state should still honor the checked-entry cap');
+  })) passed++; else failed++;
+
+  // --- Test 14: stable fallback works without session env vars ---
+  clearState();
+  if (test('denies first routine Bash and allows second without session env vars', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'echo "hello"' }
+    };
+
+    const result1 = runBashHookWithoutSession(input);
+    assert.strictEqual(result1.code, 0, 'first fallback call exit code should be 0');
+    const output1 = parseOutput(result1.stdout);
+    assert.ok(output1, 'first fallback call should produce JSON output');
+    assert.strictEqual(output1.hookSpecificOutput.permissionDecision, 'deny');
+
+    const result2 = runBashHookWithoutSession(input);
+    assert.strictEqual(result2.code, 0, 'second fallback call exit code should be 0');
+    const output2 = parseOutput(result2.stdout);
+    assert.ok(output2, 'second fallback call should produce valid JSON output');
+    if (output2.hookSpecificOutput) {
+      assert.notStrictEqual(output2.hookSpecificOutput.permissionDecision, 'deny',
+        'should not deny second routine bash when using stable fallback');
+    } else {
+      assert.strictEqual(output2.tool_name, 'Bash', 'pass-through should preserve input');
+    }
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { sanitizeSessionId } = require('../../scripts/lib/utils');
 
 const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
 const externalStateDir = process.env.GATEGUARD_STATE_DIR;
@@ -14,51 +15,6 @@ const tmpRoot = process.env.TMPDIR || process.env.TEMP || process.env.TMP || '/t
 const stateDir = externalStateDir || fs.mkdtempSync(path.join(tmpRoot, 'gateguard-test-'));
 // Use a fixed session ID so test process and spawned hook process share the same state file
 const TEST_SESSION_ID = 'gateguard-test-session';
-
-function sessionStateFile(sessionId) {
-  return path.join(stateDir, `state-${sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
-}
-
-const stateFile = sessionStateFile(TEST_SESSION_ID);
-
-function test(name, fn) {
-  try {
-    fn();
-    console.log(`  ✓ ${name}`);
-    return true;
-  } catch (error) {
-    console.log(`  ✗ ${name}`);
-    console.log(`    Error: ${error.message}`);
-    return false;
-  }
-}
-
-function clearState(sessionId = TEST_SESSION_ID) {
-  try {
-    const target = sessionStateFile(sessionId);
-    if (fs.existsSync(target)) {
-      fs.unlinkSync(target);
-    }
-  } catch (err) {
-    console.error(`  [clearState] failed to remove ${sessionStateFile(sessionId)}: ${err.message}`);
-  }
-}
-
-function writeExpiredState() {
-  try {
-    fs.mkdirSync(stateDir, { recursive: true });
-    const expired = {
-      checked: ['some_file.js', '__bash_session__'],
-      last_active: Date.now() - (31 * 60 * 1000) // 31 minutes ago
-    };
-    fs.writeFileSync(stateFile, JSON.stringify(expired), 'utf8');
-  } catch (_) { /* ignore */ }
-}
-
-function writeState(state) {
-  fs.mkdirSync(stateDir, { recursive: true });
-  fs.writeFileSync(stateFile, JSON.stringify(state), 'utf8');
-}
 
 function runHook(input, env = {}) {
   const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
@@ -128,6 +84,7 @@ function runBashHookWithoutSession(input, env = {}) {
 
   delete hookEnv.CLAUDE_SESSION_ID;
   delete hookEnv.ECC_SESSION_ID;
+  delete hookEnv.CLAUDE_TRANSCRIPT_PATH;
 
   const result = spawnSync('node', [
     runner,
@@ -153,6 +110,60 @@ function hashSessionKey(prefix, value) {
   return prefix + crypto.createHash('sha1').update(value).digest('hex').slice(0, 16);
 }
 
+function sessionIdForStateFile(sessionId) {
+  const raw = String(sessionId || '');
+  const sanitized = sanitizeSessionId(raw);
+  if (sanitized.length > 0 && sanitized.length <= 64) {
+    return sanitized;
+  }
+  return hashSessionKey('sid-', raw || 'empty-session');
+}
+
+function sessionStateFile(sessionId) {
+  return path.join(stateDir, `state-${sessionIdForStateFile(sessionId)}.json`);
+}
+
+const stateFile = sessionStateFile(TEST_SESSION_ID);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function clearState(sessionId = TEST_SESSION_ID) {
+  try {
+    const target = sessionStateFile(sessionId);
+    if (fs.existsSync(target)) {
+      fs.unlinkSync(target);
+    }
+  } catch (err) {
+    console.error(`  [clearState] failed to remove ${sessionStateFile(sessionId)}: ${err.message}`);
+  }
+}
+
+function writeExpiredState() {
+  try {
+    fs.mkdirSync(stateDir, { recursive: true });
+    const expired = {
+      checked: ['some_file.js', '__bash_session__'],
+      last_active: Date.now() - (31 * 60 * 1000) // 31 minutes ago
+    };
+    fs.writeFileSync(stateFile, JSON.stringify(expired), 'utf8');
+  } catch (_) { /* ignore */ }
+}
+
+function writeState(state) {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(stateFile, JSON.stringify(state), 'utf8');
+}
+
 function fallbackSessionId(env = {}) {
   if (env.CLAUDE_SESSION_ID) return env.CLAUDE_SESSION_ID;
   if (env.ECC_SESSION_ID) return env.ECC_SESSION_ID;
@@ -169,6 +180,34 @@ function fallbackSessionId(env = {}) {
   ].join('|');
 
   return hashSessionKey('fallback-', `${scope}::${parentFingerprint}`);
+}
+
+function runHookWithSessionId(input, sessionId, env = {}) {
+  const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
+  const result = spawnSync('node', [
+    runner,
+    'pre:bash:gateguard-fact-force',
+    'scripts/hooks/gateguard-fact-force.js',
+    'standard,strict'
+  ], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ECC_HOOK_PROFILE: 'standard',
+      GATEGUARD_STATE_DIR: stateDir,
+      CLAUDE_SESSION_ID: sessionId,
+      ...env
+    },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
 }
 
 function parseOutput(stdout) {
@@ -545,6 +584,35 @@ function runTests() {
     assert.ok(cliBFirstOutput, 'CLI B first call should produce JSON output');
     assert.strictEqual(cliBFirstOutput.hookSpecificOutput.permissionDecision, 'deny',
       'CLI B should not inherit CLI A fallback state');
+  })) passed++; else failed++;
+
+  // --- Test 16: long session IDs are reduced to a filesystem-safe state key ---
+  const longSessionId = 'session-' + 'x'.repeat(400);
+  clearState(sessionIdForStateFile(longSessionId));
+  if (test('allows retries when CLAUDE_SESSION_ID is extremely long', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'echo "hello"' }
+    };
+
+    const result1 = runHookWithSessionId(input, longSessionId);
+    assert.strictEqual(result1.code, 0, 'first long-session call exit code should be 0');
+    const output1 = parseOutput(result1.stdout);
+    assert.ok(output1, 'first long-session call should produce JSON output');
+    assert.strictEqual(output1.hookSpecificOutput.permissionDecision, 'deny');
+
+    const result2 = runHookWithSessionId(input, longSessionId);
+    assert.strictEqual(result2.code, 0, 'second long-session call exit code should be 0');
+    const output2 = parseOutput(result2.stdout);
+    assert.ok(output2, 'second long-session call should produce valid JSON output');
+    if (output2.hookSpecificOutput) {
+      assert.notStrictEqual(output2.hookSpecificOutput.permissionDecision, 'deny',
+        'long session IDs should still map to a stable state file');
+    }
+
+    const persisted = sessionStateFile(sessionIdForStateFile(longSessionId));
+    assert.ok(fs.existsSync(persisted), 'sanitized long-session state file should be created');
+    assert.ok(path.basename(persisted).length < 255, 'state filename should stay below common filesystem limits');
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -591,7 +591,7 @@ function runTests() {
     assert.ok(persisted.checked.length <= 500, 'pruned state should still honor the checked-entry cap');
   })) passed++; else failed++;
 
-    // --- Test 14: fallback-only input still reuses state across retries ---
+  // --- Test 14: fallback-only input still reuses state across retries ---
   const fallbackOnlyEnv = {
     CLAUDE_PROJECT_DIR: '/tmp/fallback-only-project'
   };
@@ -624,7 +624,7 @@ function runTests() {
   // --- Test 15: fallback shares state for the same project scope ---
   // Actually it should be isolated when 2 cli sessions are running at the same scope,
   // but if there is no env and input to provide session information, the ppid and pid will be totally different
-  // and cause every call to be considered as a new one, blocking tool calling repeatly.
+  // and cause every call to be considered as a new one, blocking tool calling repeatedly.
   const cliAEnv = {
     CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR
   };

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -13,6 +13,8 @@ const runner = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-fl
 const externalStateDir = process.env.GATEGUARD_STATE_DIR;
 const tmpRoot = process.env.TMPDIR || process.env.TEMP || process.env.TMP || '/tmp';
 const stateDir = externalStateDir || fs.mkdtempSync(path.join(tmpRoot, 'gateguard-test-'));
+const FALLBACK_PROJECT_DIR = '/tmp/ecc-gateguard-fallback-project';
+const SHARED_PROJECT_DIR = '/tmp/ecc-gateguard-shared-project';
 // Use a fixed session ID so test process and spawned hook process share the same state file
 const TEST_SESSION_ID = 'gateguard-test-session';
 
@@ -74,17 +76,7 @@ function runBashHook(input, env = {}) {
 
 function runBashHookWithoutSession(input, env = {}) {
   const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
-  const hookEnv = {
-    ...process.env,
-    ECC_HOOK_PROFILE: 'standard',
-    GATEGUARD_STATE_DIR: stateDir,
-    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-fallback-project',
-    ...env
-  };
-
-  delete hookEnv.CLAUDE_SESSION_ID;
-  delete hookEnv.ECC_SESSION_ID;
-  delete hookEnv.CLAUDE_TRANSCRIPT_PATH;
+  const hookEnv = buildFallbackHookEnv(env);
 
   const result = spawnSync('node', [
     runner,
@@ -112,11 +104,30 @@ function hashSessionKey(prefix, value) {
 
 function sessionIdForStateFile(sessionId) {
   const raw = String(sessionId || '');
-  const sanitized = sanitizeSessionId(raw);
+  const sanitized = sanitizeSessionId(raw) || '';
   if (sanitized.length > 0 && sanitized.length <= 64) {
     return sanitized;
   }
   return hashSessionKey('sid-', raw || 'empty-session');
+}
+
+function buildFallbackHookEnv(env = {}) {
+  const merged = {
+    ...process.env,
+    ECC_HOOK_PROFILE: 'standard',
+    GATEGUARD_STATE_DIR: stateDir,
+    CLAUDE_PROJECT_DIR: FALLBACK_PROJECT_DIR,
+    ...env
+  };
+
+  const {
+    CLAUDE_SESSION_ID: _claudeSessionId,
+    ECC_SESSION_ID: _eccSessionId,
+    CLAUDE_TRANSCRIPT_PATH: _claudeTranscriptPath,
+    ...hookEnv
+  } = merged;
+
+  return hookEnv;
 }
 
 function sessionStateFile(sessionId) {
@@ -522,9 +533,9 @@ function runTests() {
 
   // --- Test 14: stable fallback works without session env vars ---
   const fallbackEnv = {
-    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-fallback-project'
+    CLAUDE_PROJECT_DIR: FALLBACK_PROJECT_DIR
   };
-  clearState(fallbackSessionId(fallbackEnv));
+  clearState(fallbackSessionId(buildFallbackHookEnv(fallbackEnv)));
   if (test('denies first routine Bash and allows second without session env vars', () => {
     const input = {
       tool_name: 'Bash',
@@ -551,15 +562,15 @@ function runTests() {
 
   // --- Test 15: fallback isolates different CLI fingerprints in one project ---
   const cliAEnv = {
-    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-shared-project',
+    CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR,
     TMUX_PANE: '%101'
   };
   const cliBEnv = {
-    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-shared-project',
+    CLAUDE_PROJECT_DIR: SHARED_PROJECT_DIR,
     TMUX_PANE: '%202'
   };
-  clearState(fallbackSessionId(cliAEnv));
-  clearState(fallbackSessionId(cliBEnv));
+  clearState(fallbackSessionId(buildFallbackHookEnv(cliAEnv)));
+  clearState(fallbackSessionId(buildFallbackHookEnv(cliBEnv)));
   if (test('does not share fallback state across CLI fingerprints in the same project', () => {
     const input = {
       tool_name: 'Bash',

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -3,6 +3,7 @@
  */
 
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
@@ -13,7 +14,12 @@ const tmpRoot = process.env.TMPDIR || process.env.TEMP || process.env.TMP || '/t
 const stateDir = externalStateDir || fs.mkdtempSync(path.join(tmpRoot, 'gateguard-test-'));
 // Use a fixed session ID so test process and spawned hook process share the same state file
 const TEST_SESSION_ID = 'gateguard-test-session';
-const stateFile = path.join(stateDir, `state-${TEST_SESSION_ID}.json`);
+
+function sessionStateFile(sessionId) {
+  return path.join(stateDir, `state-${sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
+}
+
+const stateFile = sessionStateFile(TEST_SESSION_ID);
 
 function test(name, fn) {
   try {
@@ -27,13 +33,14 @@ function test(name, fn) {
   }
 }
 
-function clearState() {
+function clearState(sessionId = TEST_SESSION_ID) {
   try {
-    if (fs.existsSync(stateFile)) {
-      fs.unlinkSync(stateFile);
+    const target = sessionStateFile(sessionId);
+    if (fs.existsSync(target)) {
+      fs.unlinkSync(target);
     }
   } catch (err) {
-    console.error(`  [clearState] failed to remove ${stateFile}: ${err.message}`);
+    console.error(`  [clearState] failed to remove ${sessionStateFile(sessionId)}: ${err.message}`);
   }
 }
 
@@ -140,6 +147,28 @@ function runBashHookWithoutSession(input, env = {}) {
     stdout: result.stdout || '',
     stderr: result.stderr || ''
   };
+}
+
+function hashSessionKey(prefix, value) {
+  return prefix + crypto.createHash('sha1').update(value).digest('hex').slice(0, 16);
+}
+
+function fallbackSessionId(env = {}) {
+  if (env.CLAUDE_SESSION_ID) return env.CLAUDE_SESSION_ID;
+  if (env.ECC_SESSION_ID) return env.ECC_SESSION_ID;
+  if (env.CLAUDE_TRANSCRIPT_PATH) {
+    return hashSessionKey('transcript-', env.CLAUDE_TRANSCRIPT_PATH);
+  }
+
+  const scope = env.CLAUDE_PROJECT_DIR || process.cwd();
+  const parentFingerprint = [
+    String(process.pid),
+    env.CLAUDE_CODE_ENTRYPOINT || '',
+    env.TMUX_PANE || env.TMUX || '',
+    env.TERM_SESSION_ID || ''
+  ].join('|');
+
+  return hashSessionKey('fallback-', `${scope}::${parentFingerprint}`);
 }
 
 function parseOutput(stdout) {
@@ -453,20 +482,23 @@ function runTests() {
   })) passed++; else failed++;
 
   // --- Test 14: stable fallback works without session env vars ---
-  clearState();
+  const fallbackEnv = {
+    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-fallback-project'
+  };
+  clearState(fallbackSessionId(fallbackEnv));
   if (test('denies first routine Bash and allows second without session env vars', () => {
     const input = {
       tool_name: 'Bash',
       tool_input: { command: 'echo "hello"' }
     };
 
-    const result1 = runBashHookWithoutSession(input);
+    const result1 = runBashHookWithoutSession(input, fallbackEnv);
     assert.strictEqual(result1.code, 0, 'first fallback call exit code should be 0');
     const output1 = parseOutput(result1.stdout);
     assert.ok(output1, 'first fallback call should produce JSON output');
     assert.strictEqual(output1.hookSpecificOutput.permissionDecision, 'deny');
 
-    const result2 = runBashHookWithoutSession(input);
+    const result2 = runBashHookWithoutSession(input, fallbackEnv);
     assert.strictEqual(result2.code, 0, 'second fallback call exit code should be 0');
     const output2 = parseOutput(result2.stdout);
     assert.ok(output2, 'second fallback call should produce valid JSON output');
@@ -476,6 +508,43 @@ function runTests() {
     } else {
       assert.strictEqual(output2.tool_name, 'Bash', 'pass-through should preserve input');
     }
+  })) passed++; else failed++;
+
+  // --- Test 15: fallback isolates different CLI fingerprints in one project ---
+  const cliAEnv = {
+    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-shared-project',
+    TMUX_PANE: '%101'
+  };
+  const cliBEnv = {
+    CLAUDE_PROJECT_DIR: '/tmp/ecc-gateguard-shared-project',
+    TMUX_PANE: '%202'
+  };
+  clearState(fallbackSessionId(cliAEnv));
+  clearState(fallbackSessionId(cliBEnv));
+  if (test('does not share fallback state across CLI fingerprints in the same project', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'echo "hello"' }
+    };
+
+    const cliAFirst = runBashHookWithoutSession(input, cliAEnv);
+    const cliAFirstOutput = parseOutput(cliAFirst.stdout);
+    assert.ok(cliAFirstOutput, 'CLI A first call should produce JSON output');
+    assert.strictEqual(cliAFirstOutput.hookSpecificOutput.permissionDecision, 'deny');
+
+    const cliASecond = runBashHookWithoutSession(input, cliAEnv);
+    const cliASecondOutput = parseOutput(cliASecond.stdout);
+    assert.ok(cliASecondOutput, 'CLI A second call should produce valid JSON output');
+    if (cliASecondOutput.hookSpecificOutput) {
+      assert.notStrictEqual(cliASecondOutput.hookSpecificOutput.permissionDecision, 'deny',
+        'CLI A second call should pass once its fallback state is set');
+    }
+
+    const cliBFirst = runBashHookWithoutSession(input, cliBEnv);
+    const cliBFirstOutput = parseOutput(cliBFirst.stdout);
+    assert.ok(cliBFirstOutput, 'CLI B first call should produce JSON output');
+    assert.strictEqual(cliBFirstOutput.hookSpecificOutput.permissionDecision, 'deny',
+      'CLI B should not inherit CLI A fallback state');
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.


### PR DESCRIPTION
## What Changed
- Updated `scripts/hooks/gateguard-fact-force.js` so session resolution now prefers:
  - session information in rawInput
  - session information in process.env
  - transcript path if no session information
  - a hashed fallback derived from `CLAUDE_PROJECT_DIR` or `cwd`(This may lead 2 cli in the same project share state)
- Added regression coverage for:
  - missing session env vars still allowing retry within the same CLI session
  - different CLI fingerprints in the same project sharing fallback state

## Why This Change
Some API/proxy-based Claude Code setups do not provide `CLAUDE_SESSION_ID` or `ECC_SESSION_ID` to hook processes.

A PID-only fallback caused repeated gating because each hook invocation could look like a fresh session. 
A project-only fallback fixed that loop, but it also allowed multiple Claude CLI sessions in the same project to share GateGuard state. (Now it is a compromise for fallback only, and that should not happen.)

### Root cause
The process.env has no session information, which is transfered in rawInput. The STATE_FILE is initialized every call with different ppid and pid, which maps to different state files.

## Testing Done
- [x] Manual testing completed
- [ ] Automated tests pass locally (node tests/run-all.js)
- [x] Edge cases considered and tested

Additional testing performed:
- [x] `node tests/hooks/gateguard-fact-force.test.js`
- [x] Verified fallback behavior when session env vars are missing
- [x] Verified different CLI fingerprints in the same project *do share* fallback state

## Type of Change
- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactoring
- [ ] docs: Documentation
- [ ] test: Tests
- [ ] chore: Maintenance/tooling
- [ ] ci: CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes GateGuard session resolution with a deterministic fallback and safe state-file keys, so retries work even when Claude session IDs are missing and long/unsafe identifiers are hashed.

- **Bug Fixes**
  - Session ID resolution now prefers (in order): input `session_id`/`sessionId`, env `CLAUDE_SESSION_ID`/`ECC_SESSION_ID`, transcript path (`transcript_path` or `CLAUDE_TRANSCRIPT_PATH`), then a project-scoped hash (`cwd` or `CLAUDE_PROJECT_DIR`). Unsafe or >64-char IDs are sanitized or hashed for state files.
  - State files are strictly per-session (no PID churn). When no session metadata is provided, a stable project fallback is reused across separate CLI sessions in the same project.
  - Tests cover fallback reuse without env vars, shared project-scope fallback across different CLI sessions, input-only session metadata, and extremely long IDs staying filesystem-safe.

<sup>Written for commit 34acb8e9ea572aa39b5d0c8f2aba38c677839a7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deterministic per-session state files: state filenames now use sanitized or hashed session identifiers to ensure stable, isolated state and safe handling of very long or missing session tokens.

* **Tests**
  * Expanded tests for session fallback behavior, isolation across different CLI environment fingerprints, and long-session-id handling; added helpers to run hooks with and without session variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->