### PR TITLE
fix(gateguard): avoid disk write on every isChecked() call

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -95,10 +95,12 @@ function markChecked(key) {
 }
 
 function isChecked(key) {
+  // Read-only fast path: the hook fires on every tool invocation, so any
+  // disk write here shows up as measurable latency. markChecked() already
+  // persists last_active whenever state actually changes, which keeps the
+  // 30-minute inactivity timer fresh for any active editing session.
   const state = loadState();
-  const found = state.checked.includes(key);
-  saveState(state);
-  return found;
+  return state.checked.includes(key);
 }
 
 // Prune stale session files older than 1 hour

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -35,6 +35,11 @@ const STATE_FILE = path.join(STATE_DIR, `state-${SESSION_ID.replace(/[^a-zA-Z0-9
 // State expires after 30 minutes of inactivity
 const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
+// Throttle keep-alive writes on the read path: at most one write per 60s.
+// Protects the hot path (fires on every tool call) while still refreshing
+// last_active often enough that long single-file sessions don't expire.
+const READ_HEARTBEAT_MS = 60 * 1000;
+
 // Maximum checked entries to prevent unbounded growth
 const MAX_CHECKED_ENTRIES = 500;
 const MAX_SESSION_KEYS = 50;
@@ -95,12 +100,16 @@ function markChecked(key) {
 }
 
 function isChecked(key) {
-  // Read-only fast path: the hook fires on every tool invocation, so any
-  // disk write here shows up as measurable latency. markChecked() already
-  // persists last_active whenever state actually changes, which keeps the
-  // 30-minute inactivity timer fresh for any active editing session.
+  // Read path fires on every tool invocation, so default to no disk write.
+  // We only heartbeat last_active at most once per READ_HEARTBEAT_MS so that
+  // long single-file sessions don't hit the inactivity timeout, while still
+  // keeping ~99% of invocations fully read-only.
   const state = loadState();
-  return state.checked.includes(key);
+  const found = state.checked.includes(key);
+  if (found && Date.now() - (state.last_active || 0) > READ_HEARTBEAT_MS) {
+    saveState(state);
+  }
+  return found;
 }
 
 // Prune stale session files older than 1 hour

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -363,10 +363,11 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  // --- Test 12: reads of already-checked files do not rewrite state (perf) ---
+  // --- Test 12a: cached reads inside the heartbeat window stay read-only ---
   clearState();
-  if (test('does not rewrite state file when reading already-checked entries', () => {
-    const seededActive = Date.now() - (5 * 60 * 1000);
+  if (test('does not rewrite state file on cached read within heartbeat window', () => {
+    // Seeded 10s ago — well inside the 60s heartbeat window.
+    const seededActive = Date.now() - (10 * 1000);
     writeState({
       checked: ['/src/keep-alive.js'],
       last_active: seededActive
@@ -387,11 +388,40 @@ function runTests() {
 
     const mtimeAfter = fs.statSync(stateFile).mtimeMs;
     assert.strictEqual(mtimeAfter, mtimeBefore,
-      'cached-read fast path must not rewrite the state file');
+      'cached-read inside heartbeat window must not rewrite the state file');
 
     const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
     assert.strictEqual(after.last_active, seededActive,
-      'cached-read fast path must not touch last_active');
+      'cached-read inside heartbeat window must not touch last_active');
+  })) passed++; else failed++;
+
+  // --- Test 12b: cached reads past the heartbeat window refresh last_active ---
+  clearState();
+  if (test('refreshes last_active on cached read once heartbeat window elapses', () => {
+    // Seeded 5 minutes ago — well past the 60s heartbeat window, but still
+    // inside the 30-minute session timeout so the entry should survive.
+    const seededActive = Date.now() - (5 * 60 * 1000);
+    writeState({
+      checked: ['/src/long-session.js'],
+      last_active: seededActive
+    });
+
+    const result = runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: '/src/long-session.js', old_string: 'a', new_string: 'b' }
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    if (output.hookSpecificOutput) {
+      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+        'already-checked file should still be allowed after heartbeat');
+    }
+
+    const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.ok(after.last_active > seededActive,
+      'cached-read past the heartbeat window should refresh last_active');
+    assert.ok(after.checked.includes('/src/long-session.js'),
+      'checked entries should be preserved across the heartbeat write');
   })) passed++; else failed++;
 
   // --- Test 13: pruning preserves routine bash gate marker ---

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -363,17 +363,16 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  // --- Test 12: reads refresh active session state ---
+  // --- Test 12: reads of already-checked files do not rewrite state (perf) ---
   clearState();
-  if (test('touches last_active on read so active sessions do not age out', () => {
-    const staleButActive = Date.now() - (29 * 60 * 1000);
+  if (test('does not rewrite state file when reading already-checked entries', () => {
+    const seededActive = Date.now() - (5 * 60 * 1000);
     writeState({
       checked: ['/src/keep-alive.js'],
-      last_active: staleButActive
+      last_active: seededActive
     });
 
-    const before = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-    assert.strictEqual(before.last_active, staleButActive, 'seed state should use the expected timestamp');
+    const mtimeBefore = fs.statSync(stateFile).mtimeMs;
 
     const result = runHook({
       tool_name: 'Edit',
@@ -386,8 +385,13 @@ function runTests() {
         'already-checked file should still be allowed');
     }
 
+    const mtimeAfter = fs.statSync(stateFile).mtimeMs;
+    assert.strictEqual(mtimeAfter, mtimeBefore,
+      'cached-read fast path must not rewrite the state file');
+
     const after = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-    assert.ok(after.last_active > staleButActive, 'successful reads should refresh last_active');
+    assert.strictEqual(after.last_active, seededActive,
+      'cached-read fast path must not touch last_active');
   })) passed++; else failed++;
 
   // --- Test 13: pruning preserves routine bash gate marker ---


### PR DESCRIPTION
## Summary

Addresses issue 1 of 4 in #1406 — the gateguard PreToolUse hook was rewriting the entire state file on **every** tool invocation, purely to refresh \`last_active\`.

\`scripts/hooks/gateguard-fact-force.js\`: \`isChecked()\` is on the hot path (fires for every Edit/Write/Bash/MultiEdit), and each call was doing a full JSON serialise → temp-file write → \`fs.rename\`. This adds measurable synchronous I/O to the hook and violates the blocking-hook guideline in \`rules/\` (\`<200ms, no network\`).

## Change

- Removed the \`saveState(state)\` call from the read-only path in \`isChecked()\`.
- \`markChecked()\` already persists \`last_active\` whenever state actually changes (every new file gate, every new destructive-command gate, first bash per session), so the 30-minute inactivity timer still stays fresh for any active editing session.
- Added an inline comment explaining why the fast path is read-only.

## Test update

Test 12 previously asserted the buggy behaviour ("touches last_active on read so active sessions do not age out"). It has been rewritten to assert the correct behaviour: cached reads of already-checked entries must not rewrite the state file or touch \`last_active\`, verified via stat \`mtimeMs\` before/after plus a JSON diff against a seeded timestamp.

## Validation

- \`node tests/hooks/gateguard-fact-force.test.js\` — 13/13 passed
- \`node tests/run-all.js\` — 1826 passed (baseline on \`main\` is 1825; this PR adds one passing test, zero new failures)

Closes #1406 (issue 1 of 4).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `gateguard` from rewriting its state file on every `isChecked()` call, and adds a 60s heartbeat so cached reads only refresh `last_active` at most once per minute. This removes hot-path sync I/O while keeping long sessions alive.

- **Bug Fixes**
  - Read path is read-only by default; only persists when `last_active` is older than `READ_HEARTBEAT_MS` (60s).
  - Kept `last_active` updates in `markChecked()` when state actually changes.
  - Split Test 12 into 12a (no rewrite within heartbeat) and 12b (refresh after heartbeat) with `mtimeMs` and JSON assertions.

<sup>Written for commit ea3ec68709c8760664884c4af413d7d62ba98541. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary disk writes during read-only checks by adding a throttled heartbeat so session state is only refreshed when stale.
  * Preserved existing checked entries when heartbeat-triggered updates occur.

* **Tests**
  * Split and updated tests to assert reads within the heartbeat do not modify persisted state and reads after the heartbeat refresh last-active timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->