### PR TITLE
fix(dashboard): replace 8 bare except with except Exception

### DIFF
--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -94,7 +94,7 @@ def load_skills(project_path: str) -> List[Dict]:
                                 if line.startswith('# '):
                                     description = line[2:].strip()[:100]
                                     break
-                    except:
+                    except Exception:
                         pass
                 
                 # Determine category
@@ -168,7 +168,7 @@ def load_commands(project_path: str) -> List[Dict]:
                             if line.startswith('# '):
                                 description = line[2:].strip()
                                 break
-                except:
+                except Exception:
                     pass
                 
                 commands.append({
@@ -262,7 +262,7 @@ class ECCDashboard(tk.Tk):
         try:
             self.icon_image = tk.PhotoImage(file='assets/images/ecc-logo.png')
             self.iconphoto(True, self.icon_image)
-        except:
+        except Exception:
             pass
         
         self.minsize(800, 600)
@@ -326,7 +326,7 @@ class ECCDashboard(tk.Tk):
             self.logo_image = tk.PhotoImage(file='assets/images/ecc-logo.png')
             self.logo_image = self.logo_image.subsample(2, 2)
             ttk.Label(header_frame, image=self.logo_image).pack(side=tk.LEFT, padx=(0, 10))
-        except:
+        except Exception:
             pass
         
         self.title_label = ttk.Label(header_frame, text="ECC Dashboard", font=('Open Sans', 18, 'bold'))
@@ -880,21 +880,21 @@ Project: github.com/affaan-m/everything-claude-code"""
         def update_widget_colors(widget):
             try:
                 widget.configure(background=bg_color)
-            except:
+            except Exception:
                 pass
             for child in widget.winfo_children():
                 try:
                     child.configure(background=bg_color)
-                except:
+                except Exception:
                     pass
                 try:
                     update_widget_colors(child)
-                except:
+                except Exception:
                     pass
-        
+
         try:
             update_widget_colors(self)
-        except:
+        except Exception:
             pass
         
         self.update()


### PR DESCRIPTION
## Summary

Addresses issue 2 of 4 in #1406 — \`ecc_dashboard.py\` had 8 bare \`except:\` clauses that silently swallow every exception, including \`SystemExit\`, \`KeyboardInterrupt\`, and \`MemoryError\`. This makes the dashboard misbehave in place of surfacing real failures and prevents clean \`Ctrl+C\` shutdown.

## Change

Replaced all 8 bare-except clauses at the following lines with \`except Exception:\`:

| Line (pre-patch) | Context |
|---|---|
| 97 | Skill description parsing |
| 171 | Command description parsing |
| 265 | Taskbar icon load |
| 329 | Header logo load |
| 883 | Widget background recolor (root) |
| 888 | Widget background recolor (children) |
| 892 | Recursive color update |
| 897 | Top-level recolor |

\`except Exception:\` still hides the expected transient errors (missing icon asset, tkinter background-color failures on exotic widgets, malformed skill/command metadata files) without masking interpreter-level signals.

This is the minimum fix recommended in #1406. The separate platform issue on \`self.state('zoomed')\` at line 260 (Linux/macOS no-op) is intentionally left for a follow-up so this PR stays narrow.

## Validation

- \`python3 -m py_compile ecc_dashboard.py\` — OK
- \`grep -c "^\s*except:$" ecc_dashboard.py\` — 0 (was 8)
- \`node tests/run-all.js\` — 1826 passed, 6 failed (identical to baseline on \`main\`; Python GUI file is not exercised by the JS suite)

Closes #1406 (issue 2 of 4).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced 8 bare `except:` clauses in `ecc_dashboard.py` with `except Exception:` to stop swallowing interpreter signals and restore clean Ctrl+C while keeping transient UI/asset errors quiet. Addresses #1406 (item 2/4).

- **Bug Fixes**
  - Updated exception handling in skill/command metadata parsing, icon/logo loads, and theme recolor recursion.
  - Prevents hiding `SystemExit`/`KeyboardInterrupt`; expected UI/asset errors remain ignored.
  - Does not change the `self.state('zoomed')` behavior noted in #1406.

<sup>Written for commit 649f8094607d95b8f9bafd0624f79accfd17e9e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced exception handling practices in internal code to improve robustness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->