### PR TITLE
feat(hooks): gateguard instruction-first with conflict detection

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -150,9 +150,10 @@ function writeGateMsg(filePath) {
     `Before creating ${safe}, present these facts:`,
     '',
     '1. Quote the user\'s current instruction verbatim',
-    '2. Confirm no existing file serves the same purpose (use Glob)',
-    '3. If the existing code\'s patterns conflict with the user\'s instruction, state the conflict explicitly. When in conflict, the user\'s instruction takes priority.',
-    '4. If this file reads/writes data files, check one real record and verify field names, structure, and date format match your implementation (use redacted or synthetic values, not raw production data)',
+    '2. Name the file(s) and line(s) that will call this new file',
+    '3. Confirm no existing file serves the same purpose (use Glob)',
+    '4. If the existing code\'s patterns conflict with the user\'s instruction, state the conflict explicitly. When in conflict, the user\'s instruction takes priority.',
+    '5. If this file reads/writes data files, check one real record and verify field names, structure, and date format match your implementation (use redacted or synthetic values, not raw production data)',
     '',
     'Present the facts, then retry the same operation.'
   ].join('\n');

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -9,7 +9,8 @@
  * The act of investigation creates awareness that self-evaluation never did.
  *
  * Gates:
- *   - Edit/Write: quote instruction first, list importers, detect conflicts (instruction wins), verify data schemas
+ *   - Edit: quote instruction, list importers, list affected public API, detect conflicts (instruction wins), verify data schemas
+ *   - Write: quote instruction, name call sites, check duplicates, detect conflicts (instruction wins), verify data schemas
  *   - Bash (destructive): list targets, rollback plan, quote instruction
  *   - Bash (routine): quote current instruction (once per session)
  *
@@ -135,8 +136,9 @@ function editGateMsg(filePath) {
     '',
     '1. Quote the user\'s current instruction verbatim (to confirm the change is in scope)',
     '2. List ALL files that import/require this file (use Grep)',
-    '3. If the existing code\'s patterns conflict with the user\'s instruction, state the conflict explicitly. When in conflict, the user\'s instruction takes priority.',
-    '4. If this file reads/writes data files, check one real record and verify field names, structure, and date format match your implementation (use redacted or synthetic values, not raw production data)',
+    '3. List the public functions/classes affected by this change',
+    '4. If the existing code\'s patterns conflict with the user\'s instruction, state the conflict explicitly. When in conflict, the user\'s instruction takes priority.',
+    '5. If this file reads/writes data files, check one real record and verify field names, structure, and date format match your implementation (use redacted or synthetic values, not raw production data)',
     '',
     'Present the facts, then retry the same operation.'
   ].join('\n');

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -9,7 +9,7 @@
  * The act of investigation creates awareness that self-evaluation never did.
  *
  * Gates:
- *   - Edit/Write: list importers, affected API, verify data schemas, quote instruction
+ *   - Edit/Write: quote instruction first, list importers, detect conflicts (instruction wins), verify data schemas
  *   - Bash (destructive): list targets, rollback plan, quote instruction
  *   - Bash (routine): quote current instruction (once per session)
  *
@@ -133,10 +133,10 @@ function editGateMsg(filePath) {
     '',
     `Before editing ${safe}, present these facts:`,
     '',
-    '1. List ALL files that import/require this file (use Grep)',
-    '2. List the public functions/classes affected by this change',
-    '3. If this file reads/writes data files, show field names, structure, and date format (use redacted or synthetic values, not raw production data)',
-    '4. Quote the user\'s current instruction verbatim',
+    '1. Quote the user\'s current instruction verbatim (to confirm the change is in scope)',
+    '2. List ALL files that import/require this file (use Grep)',
+    '3. If the existing code\'s patterns conflict with the user\'s instruction, state the conflict explicitly. When in conflict, the user\'s instruction takes priority.',
+    '4. If this file reads/writes data files, check one real record and verify field names, structure, and date format match your implementation (use redacted or synthetic values, not raw production data)',
     '',
     'Present the facts, then retry the same operation.'
   ].join('\n');
@@ -149,10 +149,10 @@ function writeGateMsg(filePath) {
     '',
     `Before creating ${safe}, present these facts:`,
     '',
-    '1. Name the file(s) and line(s) that will call this new file',
+    '1. Quote the user\'s current instruction verbatim',
     '2. Confirm no existing file serves the same purpose (use Glob)',
-    '3. If this file reads/writes data files, show field names, structure, and date format (use redacted or synthetic values, not raw production data)',
-    '4. Quote the user\'s current instruction verbatim',
+    '3. If the existing code\'s patterns conflict with the user\'s instruction, state the conflict explicitly. When in conflict, the user\'s instruction takes priority.',
+    '4. If this file reads/writes data files, check one real record and verify field names, structure, and date format match your implementation (use redacted or synthetic values, not raw production data)',
     '',
     'Present the facts, then retry the same operation.'
   ].join('\n');

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -138,6 +138,8 @@ function runTests() {
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Fact-Forcing Gate'));
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('import/require'));
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('/src/app.js'));
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('conflict'), 'should include conflict detection step');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('instruction takes priority'), 'should include instruction-priority directive');
   })) passed++; else failed++;
 
   // --- Test 2: allows second Edit on same file ---
@@ -175,6 +177,9 @@ function runTests() {
     assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('creating'));
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('instruction'));
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('call this new file'), 'should require caller identification');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('conflict'), 'should include conflict detection step');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('instruction takes priority'), 'should include instruction-priority directive');
   })) passed++; else failed++;
 
   // --- Test 4: denies destructive Bash, allows retry ---

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -174,7 +174,7 @@ function runTests() {
     assert.ok(output, 'should produce JSON output');
     assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('creating'));
-    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('call this new file'));
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('instruction'));
   })) passed++; else failed++;
 
   // --- Test 4: denies destructive Bash, allows retry ---


### PR DESCRIPTION
## What Changed

Reorders GateGuard gate steps to reduce anchoring bias from buggy existing code.

**Old order (v1):**
1. List importers
2. List affected API
3. Verify data schemas
4. Quote instruction
5. Note conflicts

**New order:**
1. **Quote instruction first** (anchors on correct behavior)
2. List importers
3. **Detect conflicts — state them, then follow instruction**
4. Verify data schemas

## Why This Change

When the gate asked "list existing patterns" *before* "quote the instruction", the LLM anchored on buggy patterns and followed them instead of the user's instruction.

**Concrete example:** On a codebase with intentional `return {"error": "..."}` (200 status) error handling, the user's instruction said "return 404 if not found." The old gate order made the LLM investigate existing patterns first → it found the 200+error-body pattern → it followed the bug instead of the instruction. Score: **3/10**.

Adding "When in conflict, the user's instruction takes priority" to the gate message fixes this. The LLM now states the conflict explicitly, then follows the instruction.

## Evidence

A/B tested with hooks physically active (not prompt injection), 3 tasks:

| Task | Gated | Ungated | Gap |
| --- | --- | --- | --- |
| Analytics module | 8.0 | 6.5 | +1.5 |
| Webhook validator | 10.0 | 7.0 | +3.0 |
| Analytics (re-test) | 8.0 | 6.5 | +1.5 |
| **Average** | **8.7** | **6.7** | **+2.0** |

Ungated errors caught by the gate:
- Used threshold 0.6 when codebase uses 0.7
- Missed `source_law_ids` / `source_ghost_ids` fields
- Returned plain dicts instead of matching existing dataclass patterns

## Testing Done

- [x] `node tests/hooks/gateguard-fact-force.test.js` — 13 passed, 0 failed
- [x] Updated test assertion for Write gate (new step 1 is "instruction" not "call sites")
- [x] PyPI gateguard-ai v0.3.0 published with same change (Python version)

## Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix

## Checklist
- [x] No secrets or API keys committed
- [x] Tests pass
- [x] Follows conventional commits format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GateGuard instruction-first for edit and write hooks, with explicit conflict detection where the instruction wins. Restores the write flow’s call-site check and the edit gate’s public API enumeration; tests updated for the new steps.

- **New Features**
  - Edit: 1) quote instruction, 2) list importers, 3) list affected public API, 4) state conflicts (instruction wins), 5) verify schemas from a real record.
  - Write: 1) quote instruction, 2) call-site check, 3) duplicate check, 4) state conflicts (instruction wins), 5) verify schemas from a real record.

- **Bug Fixes**
  - Restored write gate caller identification step.
  - Restored edit gate public API enumeration and fixed gate docstring (separate Edit/Write descriptions).
  - Tests assert conflict detection and the “instruction takes priority” directive for both gates.

<sup>Written for commit b6558f805438818b8476b324ffbf07fad836a2a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Checklist ordering updated so the user instruction is quoted up front and steps reflowed.
  * Added explicit conflict-detection rule: when patterns conflict, the user instruction takes priority.
  * Verification refined to require checking one real record against the implementation for field/format validation.

* **Tests**
  * Assertions updated to expect explicit “conflict” and “instruction takes priority” reasoning.
  * Write-case checks strengthened to require instruction context and caller-identification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->