### PR TITLE
fix(harness-audit): detect ECC plugin under marketplaces/ subdirectory

### DIFF
--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -196,7 +196,9 @@ function findPluginInstall(rootDir) {
   ];
   const candidateRoots = [
     path.join(rootDir, '.claude', 'plugins'),
+    path.join(rootDir, '.claude', 'plugins', 'marketplaces'),
     homeDir && path.join(homeDir, '.claude', 'plugins'),
+    homeDir && path.join(homeDir, '.claude', 'plugins', 'marketplaces'),
   ].filter(Boolean);
   const candidates = candidateRoots.flatMap((pluginsDir) =>
     pluginDirs.flatMap((pluginDir) => [


### PR DESCRIPTION
## Summary

`findPluginInstall()` in `scripts/harness-audit.js` only scans two candidate roots:

```
{rootDir}/.claude/plugins/
{HOME}/.claude/plugins/
```

But current Claude Code marketplace installs live one directory deeper:

```
{HOME}/.claude/plugins/marketplaces/{ecc,everything-claude-code}/...
```

As a result, running `node scripts/harness-audit.js repo` on any consumer project reports `consumer-plugin-install: false` even when ECC is fully installed via the Claude Code plugin marketplace. This costs 4 points from the Tool Coverage category.

## Fix

Add the `marketplaces/` intermediate directory to `candidateRoots`. Purely additive — existing paths still resolve, and the new ones only match when the marketplace layout is present. Both legacy and current install layouts are recognized after this change.

```diff
   const candidateRoots = [
     path.join(rootDir, '.claude', 'plugins'),
+    path.join(rootDir, '.claude', 'plugins', 'marketplaces'),
     homeDir && path.join(homeDir, '.claude', 'plugins'),
+    homeDir && path.join(homeDir, '.claude', 'plugins', 'marketplaces'),
   ].filter(Boolean);
```

## Reproduction

1. Install ECC via the Claude Code plugin marketplace
2. `cd` into any consumer project
3. `node ~/.claude/plugins/marketplaces/everything-claude-code/scripts/harness-audit.js repo`
4. Observe `consumer-plugin-install: false` despite a working install

After the patch, the same invocation correctly reports `consumer-plugin-install: true`.

## Test plan

- [x] Applied locally against a marketplace-installed ECC copy — `findPluginInstall()` now returns the real `plugin.json` path under `marketplaces/`.
- [x] Legacy layout (no `marketplaces/` directory) still resolves through the original two paths.
- [ ] Maintainer to re-run `scripts/harness-audit.js repo` on a consumer project to confirm the Tool Coverage score recovers the 4 points.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `findPluginInstall()` in `scripts/harness-audit.js` to also scan `.claude/plugins/marketplaces/`, so ECC installed via the Claude Code marketplace is detected. This fixes false `consumer-plugin-install: false` results and restores 4 Tool Coverage points without affecting legacy installs.

<sup>Written for commit aa96279ecc9b0b043d72afd8704305396b1052f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced plugin detection to recognize plugins stored in marketplace subdirectories, improving installation reliability and compatibility across marketplace sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->