### PR TITLE
Fix: bug(gateguard): race condition in session state read-modify-write path

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -76,14 +76,37 @@ function pruneCheckedEntries(checked) {
 
 function saveState(state) {
   try {
-    state.last_active = Date.now();
-    state.checked = pruneCheckedEntries(state.checked);
     fs.mkdirSync(STATE_DIR, { recursive: true });
-    // Atomic write: temp file + rename prevents partial reads
-    const tmpFile = STATE_FILE + '.tmp.' + process.pid;
-    fs.writeFileSync(tmpFile, JSON.stringify(state, null, 2), 'utf8');
+
+    // 1. Prepare base state from what's currently in memory
+    let mergedChecked = state.checked || [];
+    let mergedLastActive = state.last_active || 0;
+
+    // 2. Merge with current disk state to prevent overwriting concurrent updates (Option 2: Merge-style saves)
+    try {
+      if (fs.existsSync(STATE_FILE)) {
+        const disk = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+        if (Array.isArray(disk.checked)) {
+          // Union of checked items, preserving order (disk items first, then memory items)
+          mergedChecked = Array.from(new Set([...disk.checked, ...mergedChecked]));
+        }
+        if (typeof disk.last_active === 'number') {
+          mergedLastActive = Math.max(mergedLastActive, disk.last_active);
+        }
+      }
+    } catch (_) { /* ignore disk read errors, proceed with memory state */ }
+
+    // 3. Finalize state: update heartbeat and prune to bounded size
+    const finalState = {
+      checked: pruneCheckedEntries(mergedChecked),
+      last_active: Math.max(mergedLastActive, Date.now())
+    };
+
+    // 4. Atomic write: temp file + rename prevents partial reads
+    const tmpFile = STATE_FILE + '.tmp.' + process.pid + '.' + Math.random().toString(36).slice(2, 6);
+    fs.writeFileSync(tmpFile, JSON.stringify(finalState, null, 2), 'utf8');
     fs.renameSync(tmpFile, STATE_FILE);
-  } catch (_) { /* ignore */ }
+  } catch (_) { /* ignore all errors to ensure hook never blocks */ }
 }
 
 function markChecked(key) {


### PR DESCRIPTION
The fix addresses a race condition in the session state read-modify-write path by implementing a 'merge-style save' strategy. Previously, `saveState` would simply overwrite the session file with the current in-memory snapshot, which could lead to data loss if two concurrent hook processes were running for the same session. Now, `saveState` performs a raw read of the current on-disk state immediately before writing, merges it with the in-memory state (creating a union of 'checked' keys and taking the maximum 'last_active' timestamp), and then performs an atomic write via a temp file. This ensures that checks performed by parallel processes are additive rather than destructive. A random suffix was also added to the temp file path to further reduce collision risks.

Test: 1. Set `CLAUDE_SESSION_ID=test_race`. 2. Run two instances of the hook script nearly simultaneously, each attempting to `markChecked` a different file (e.g., `file_A` and `file_B`). 3. Verify the resulting session JSON file in the state directory (`.gateguard/state-test_race.json`) contains both `file_A` and `file_B` in its `checked` array, regardless of which process finished first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data persistence reliability by enhancing state merging and conflict resolution logic.
  * Strengthened error handling to prevent system blocking during data save operations.
  * Enhanced collision resistance for temporary file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in GateGuard session saves by merging on-disk and in-memory state before an atomic write, preventing lost `checked` entries during parallel runs. Fixes #1441.

- **Bug Fixes**
  - `saveState` now does a merge-style save: unions `checked` and takes the max `last_active` with the on-disk state.
  - Uses an atomic write via a temp file with PID + random suffix to avoid collisions.

<sup>Written for commit 4cf12e81b8c161fcbc366b425f786c3f6484d2f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

