### PR TITLE
Fix: The name of the plugin is incorrect.

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "everything-claude-code",
+  "name": "ecc",
   "version": "1.10.0",
   "description": "Battle-tested Claude Code plugin for engineering teams — 38 agents, 156 skills, 72 legacy command shims, production-ready hooks, and selective install workflows evolved through continuous real-world use",
   "author": {


### PR DESCRIPTION
The plugin name in .claude-plugin/plugin.json was updated from 'everything-claude-code' to 'ecc'. This change makes the plugin identifier more concise and aligns it with the project's official branding (ECC) and homepage (ecc.tools). This is the name used by Claude Code to identify and list the plugin.

Test: 1. Open the .claude-plugin/plugin.json file. 2. Verify that the 'name' property is now set to 'ecc'. 3. Load the plugin into the Claude Code environment and verify that it is identified and displayed as 'ecc' rather than the full repository name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin identifier to "ecc" for streamlined referencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the plugin identifier in `.claude-plugin/plugin.json` from `everything-claude-code` to `ecc` to match ECC branding and ecc.tools. This fixes how the plugin is listed in Claude Code so it appears as `ecc`.

<sup>Written for commit 7096beb19525d20b3bf0e8e4ede4bf91e191959a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

