### PR TITLE
Fix: fix(hooks): GateGuard permanently blocks all operations on Windows — fs.renameSync EEXIST not handled

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -27,9 +27,9 @@ const fs = require('fs');
 const path = require('path');
 
 // Session state — scoped per session to avoid cross-session races.
-// Uses CLAUDE_SESSION_ID (set by Claude Code) or falls back to PID-based isolation.
+// Uses CLAUDE_SESSION_ID (set by Claude Code) or falls back to stable CWD-based isolation.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
-const SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.ECC_SESSION_ID || `pid-${process.ppid || process.pid}`;
+const SESSION_ID = process.env.CLAUDE_SESSION_ID || process.env.ECC_SESSION_ID || `cwd-${crypto.createHash('sha256').update(process.cwd()).digest('hex').slice(0, 16)}`;
 const STATE_FILE = path.join(STATE_DIR, `state-${SESSION_ID.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
 
 // State expires after 30 minutes of inactivity
@@ -82,6 +82,9 @@ function saveState(state) {
     // Atomic write: temp file + rename prevents partial reads
     const tmpFile = STATE_FILE + '.tmp.' + process.pid;
     fs.writeFileSync(tmpFile, JSON.stringify(state, null, 2), 'utf8');
+    // On Windows, fs.renameSync throws EEXIST if the destination exists.
+    // Unlink first to ensure cross-platform replacement.
+    try { fs.unlinkSync(STATE_FILE); } catch (_) { /* ignore if not exists */ }
     fs.renameSync(tmpFile, STATE_FILE);
   } catch (_) { /* ignore */ }
 }


### PR DESCRIPTION
Fixed two critical issues on Windows: 1) Handled EEXIST error in fs.renameSync by unlinking the destination file before renaming, ensuring state is correctly persisted across atomic writes. 2) Replaced the unstable pid/ppid fallback for SESSION_ID with a stable hash of the current working directory. This ensures that hook invocations within the same project context share a consistent state file even when spawned through process wrappers that change parent PIDs.

Test: On a Windows environment without CLAUDE_SESSION_ID set, trigger a GateGuard fact-forcing check (e.g., by running a Bash command). Verify that the command is blocked initially. Provide the requested facts/instruction quote and retry the same command. Verify that the command is now permitted and that only a single state file (matching the stable CWD hash) is created in the .gateguard directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GateGuard blocking on Windows by safely replacing the state file and using a stable session key. This prevents EEXIST errors during atomic writes and keeps session state consistent across process wrappers.

- **Bug Fixes**
  - Unlink destination before `fs.renameSync` to handle Windows EEXIST and ensure atomic state replacement.
  - Replace PID-based fallback with a stable CWD hash for `SESSION_ID` when `CLAUDE_SESSION_ID` is unset, so hooks in the same project share one state file.

<sup>Written for commit 9a523996300de4efb6387ab67a4bc19d4a0dbd42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

