### PR TITLE
fix: allow manual release workflow dispatch

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -15,6 +15,17 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to release or republish (e.g., v1.10.0)'
+        required: true
+        type: string
+      generate-notes:
+        description: 'Auto-generate release notes'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` to the reusable release workflow
- let operators rerun release publishing for an existing version tag like `v1.10.0`
- avoid inventing a separate manual release path when the reusable workflow already has the correct npm publish logic

## Testing
- python structural parse of `.github/workflows/reusable-release.yml`

Follow-up after merge: run the reusable release workflow for `v1.10.0` so npm catches up with the already-published GitHub release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `workflow_dispatch` to the reusable release workflow so maintainers can manually publish or republish a specific tag (e.g., `v1.10.0`) using the existing npm publish path. Supports optional auto-generated release notes.

- **New Features**
  - Manual trigger via `workflow_dispatch` with required `tag` input.
  - Optional `generate-notes` boolean input (default `true`).

<sup>Written for commit 8b5c0c1b070f8d7abaa5725950c11ac54fbe12d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

