### PR TITLE
fix(dashboard): reliability pass — narrow excepts, log silent failures, unify file launchers

### DIFF
--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -4,6 +4,7 @@ ECC Dashboard - Everything Claude Code GUI
 Cross-platform TkInter application for managing ECC components
 """
 
+import logging
 import tkinter as tk
 from tkinter import ttk, scrolledtext, messagebox
 import os
@@ -11,7 +12,13 @@ import json
 import subprocess
 from typing import Dict, List, Optional
 
-from scripts.lib.ecc_dashboard_runtime import build_terminal_launch, maximize_window
+from scripts.lib.ecc_dashboard_runtime import (
+    build_file_open_launch,
+    build_terminal_launch,
+    maximize_window,
+)
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # DATA LOADERS - Load ECC data from the project
@@ -98,8 +105,8 @@ def load_skills(project_path: str) -> List[Dict]:
                                 if line.startswith('# '):
                                     description = line[2:].strip()[:100]
                                     break
-                    except:
-                        pass
+                    except Exception:
+                        logger.exception("Failed to parse skill description from %s", skill_file)
                 
                 # Determine category
                 category = "General"
@@ -172,8 +179,8 @@ def load_commands(project_path: str) -> List[Dict]:
                             if line.startswith('# '):
                                 description = line[2:].strip()
                                 break
-                except:
-                    pass
+                except Exception:
+                    logger.exception("Failed to parse command description from %s", item)
                 
                 commands.append({
                     'name': cmd_name,
@@ -266,8 +273,8 @@ class ECCDashboard(tk.Tk):
         try:
             self.icon_image = tk.PhotoImage(file='assets/images/ecc-logo.png')
             self.iconphoto(True, self.icon_image)
-        except:
-            pass
+        except Exception:
+            logger.exception("Failed to load taskbar icon assets/images/ecc-logo.png")
         
         self.minsize(800, 600)
         
@@ -330,8 +337,8 @@ class ECCDashboard(tk.Tk):
             self.logo_image = tk.PhotoImage(file='assets/images/ecc-logo.png')
             self.logo_image = self.logo_image.subsample(2, 2)
             ttk.Label(header_frame, image=self.logo_image).pack(side=tk.LEFT, padx=(0, 10))
-        except:
-            pass
+        except Exception:
+            logger.exception("Failed to render header logo assets/images/ecc-logo.png")
         
         self.title_label = ttk.Label(header_frame, text="ECC Dashboard", font=('Open Sans', 18, 'bold'))
         self.title_label.pack(side=tk.LEFT)
@@ -799,19 +806,19 @@ Project: github.com/affaan-m/everything-claude-code"""
     
     def open_readme(self):
         """Open README in default browser/reader"""
-        import subprocess
         path = os.path.join(self.path_entry.get(), 'README.md')
         if os.path.exists(path):
-            subprocess.Popen(['xdg-open' if os.name != 'nt' else 'start', path])
+            argv, kwargs = build_file_open_launch(path)
+            subprocess.Popen(argv, **kwargs)
         else:
             messagebox.showerror("Error", "README.md not found")
-    
+
     def open_agents(self):
         """Open AGENTS.md"""
-        import subprocess
         path = os.path.join(self.path_entry.get(), 'AGENTS.md')
         if os.path.exists(path):
-            subprocess.Popen(['xdg-open' if os.name != 'nt' else 'start', path])
+            argv, kwargs = build_file_open_launch(path)
+            subprocess.Popen(argv, **kwargs)
         else:
             messagebox.showerror("Error", "AGENTS.md not found")
     
@@ -876,25 +883,28 @@ Project: github.com/affaan-m/everything-claude-code"""
         self.title_label.configure(font=(font_family, 18, 'bold'))
         self.version_label.configure(font=(font_family, 10))
         
+        # Many tkinter widgets (menus, system frames, notebook tabs) reject the
+        # `background` option silently; log at DEBUG so noise stays out of the
+        # default stream while still being discoverable when troubleshooting theming.
         def update_widget_colors(widget):
             try:
                 widget.configure(background=bg_color)
-            except:
-                pass
+            except Exception:
+                logger.debug("Skip background recolor on %r", widget, exc_info=True)
             for child in widget.winfo_children():
                 try:
                     child.configure(background=bg_color)
-                except:
-                    pass
+                except Exception:
+                    logger.debug("Skip background recolor on child %r", child, exc_info=True)
                 try:
                     update_widget_colors(child)
-                except:
-                    pass
-        
+                except Exception:
+                    logger.debug("Skip recursive recolor on child %r", child, exc_info=True)
+
         try:
             update_widget_colors(self)
-        except:
-            pass
+        except Exception:
+            logger.exception("Theme apply traversal failed at the root widget")
         
         self.update()
 

--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -886,16 +886,15 @@ Project: github.com/affaan-m/everything-claude-code"""
         # Many tkinter widgets (menus, system frames, notebook tabs) reject the
         # `background` option silently; log at DEBUG so noise stays out of the
         # default stream while still being discoverable when troubleshooting theming.
+        # The recursive call handles each child's own configure, so the loop just
+        # recurses — no per-child configure in addition (that was the pre-#1450
+        # shape and double-configured every descendant).
         def update_widget_colors(widget):
             try:
                 widget.configure(background=bg_color)
             except Exception:
                 logger.debug("Skip background recolor on %r", widget, exc_info=True)
             for child in widget.winfo_children():
-                try:
-                    child.configure(background=bg_color)
-                except Exception:
-                    logger.debug("Skip background recolor on child %r", child, exc_info=True)
                 try:
                     update_widget_colors(child)
                 except Exception:

--- a/scripts/lib/ecc_dashboard_runtime.py
+++ b/scripts/lib/ecc_dashboard_runtime.py
@@ -65,13 +65,30 @@ def build_file_open_launch(
     path: str,
     *,
     os_name: Optional[str] = None,
+    system_name: Optional[str] = None,
 ) -> Tuple[List[str], Dict[str, object]]:
     """Return safe argv/kwargs for opening an arbitrary file in the OS default handler.
 
     Mirrors the build_terminal_launch contract so dashboard callers can route every
     external launch through the same testable, injection-safe helper. The path is
     always passed as a separate argv entry, never interpolated into a shell string.
+
+    Per-platform launcher choice:
+      - Windows (``os.name == 'nt'``): ``start`` is a cmd.exe builtin, not a .exe,
+        so ``Popen(['start', path])`` raises FileNotFoundError. We spawn cmd.exe
+        and pass ``start "" <path>`` — the empty string is the window-title slot
+        ``start`` requires whenever its first quoted argument is a path.
+      - macOS (``platform.system() == 'Darwin'``): ``xdg-open`` does not ship; the
+        native handler is ``open``.
+      - Linux / other POSIX: ``xdg-open`` is the freedesktop standard.
     """
     resolved_os_name = os_name or os.name
-    launcher = 'start' if resolved_os_name == 'nt' else 'xdg-open'
-    return ([launcher, path], {})
+    resolved_system_name = system_name or platform.system()
+
+    if resolved_os_name == 'nt':
+        return (['cmd.exe', '/c', 'start', '', path], {})
+
+    if resolved_system_name == 'Darwin':
+        return (['open', path], {})
+
+    return (['xdg-open', path], {})

--- a/scripts/lib/ecc_dashboard_runtime.py
+++ b/scripts/lib/ecc_dashboard_runtime.py
@@ -59,3 +59,19 @@ def build_terminal_launch(
         ['x-terminal-emulator', '-e', 'bash', '-lc', 'cd -- "$1"; exec bash', 'bash', path],
         {},
     )
+
+
+def build_file_open_launch(
+    path: str,
+    *,
+    os_name: Optional[str] = None,
+) -> Tuple[List[str], Dict[str, object]]:
+    """Return safe argv/kwargs for opening an arbitrary file in the OS default handler.
+
+    Mirrors the build_terminal_launch contract so dashboard callers can route every
+    external launch through the same testable, injection-safe helper. The path is
+    always passed as a separate argv entry, never interpolated into a shell string.
+    """
+    resolved_os_name = os_name or os.name
+    launcher = 'start' if resolved_os_name == 'nt' else 'xdg-open'
+    return ([launcher, path], {})

--- a/scripts/lib/ecc_dashboard_runtime.py
+++ b/scripts/lib/ecc_dashboard_runtime.py
@@ -74,10 +74,13 @@ def build_file_open_launch(
     always passed as a separate argv entry, never interpolated into a shell string.
 
     Per-platform launcher choice:
-      - Windows (``os.name == 'nt'``): ``start`` is a cmd.exe builtin, not a .exe,
-        so ``Popen(['start', path])`` raises FileNotFoundError. We spawn cmd.exe
-        and pass ``start "" <path>`` — the empty string is the window-title slot
-        ``start`` requires whenever its first quoted argument is a path.
+      - Windows (``os.name == 'nt'``): invoke ``explorer.exe`` directly with the
+        path as a single argv entry. Explorer hands the file to ShellExecute
+        (same mechanism ``os.startfile`` uses under the hood) and — crucially —
+        avoids cmd.exe entirely, so path metacharacters like ``&`` / ``|`` / ``^``
+        are never interpreted as command separators. Earlier drafts that routed
+        through ``cmd.exe /c start "" <path>`` re-introduced cmd parsing on the
+        Windows branch; this does not.
       - macOS (``platform.system() == 'Darwin'``): ``xdg-open`` does not ship; the
         native handler is ``open``.
       - Linux / other POSIX: ``xdg-open`` is the freedesktop standard.
@@ -86,7 +89,7 @@ def build_file_open_launch(
     resolved_system_name = system_name or platform.system()
 
     if resolved_os_name == 'nt':
-        return (['cmd.exe', '/c', 'start', '', path], {})
+        return (['explorer.exe', path], {})
 
     if resolved_system_name == 'Darwin':
         return (['open', path], {})

--- a/tests/scripts/ecc-dashboard.test.js
+++ b/tests/scripts/ecc-dashboard.test.js
@@ -114,7 +114,7 @@ print(json.dumps({'argv': argv, 'kwargs': kwargs}))
     assert.deepStrictEqual(parsed.kwargs, {});
   })) passed++; else failed++;
 
-  if (test('build_file_open_launch wraps Windows start through cmd.exe with title placeholder', () => {
+  if (test('build_file_open_launch routes Windows through explorer.exe without cmd.exe', () => {
     const output = runPython(`
 import importlib.util, json
 spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
@@ -124,13 +124,15 @@ argv, kwargs = module.build_file_open_launch(r'C:\\\\Users\\\\user\\\\proj\\\\RE
 print(json.dumps({'argv': argv, 'kwargs': kwargs}))
 `);
     const parsed = JSON.parse(output);
-    // start is a cmd.exe builtin, not a .exe — Popen needs cmd.exe /c start "" <path>.
-    // Empty quoted string is the window-title slot start requires when the first
-    // quoted argument is a path. Asserting the full argv catches future drift.
+    // explorer.exe is a standalone .exe, so Popen invokes it via CreateProcessW
+    // without going through cmd.exe. That means path metacharacters like '&', '|'
+    // and '^' stay literal — the shell never sees them. Asserting the full argv
+    // catches any future drift back toward cmd.exe.
     assert.deepStrictEqual(
       parsed.argv,
-      ['cmd.exe', '/c', 'start', '', 'C:\\\\Users\\\\user\\\\proj\\\\README.md & del C:\\\\*']
+      ['explorer.exe', 'C:\\\\Users\\\\user\\\\proj\\\\README.md & del C:\\\\*']
     );
+    assert.ok(parsed.argv[0] !== 'cmd.exe', 'launcher must not go through cmd.exe');
     assert.deepStrictEqual(parsed.kwargs, {});
   })) passed++; else failed++;
 

--- a/tests/scripts/ecc-dashboard.test.js
+++ b/tests/scripts/ecc-dashboard.test.js
@@ -86,6 +86,36 @@ print(json.dumps({'argv': argv, 'kwargs': kwargs}))
     assert.ok(Object.prototype.hasOwnProperty.call(parsed.kwargs, 'creationflags'));
   })) passed++; else failed++;
 
+  if (test('build_file_open_launch routes POSIX through xdg-open with path as a separate argv entry', () => {
+    const output = runPython(`
+import importlib.util, json
+spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+argv, kwargs = module.build_file_open_launch('/tmp/proj/README.md; rm -rf ~', os_name='posix')
+print(json.dumps({'argv': argv, 'kwargs': kwargs}))
+`);
+    const parsed = JSON.parse(output);
+    assert.deepStrictEqual(parsed.argv, ['xdg-open', '/tmp/proj/README.md; rm -rf ~']);
+    assert.deepStrictEqual(parsed.kwargs, {});
+  })) passed++; else failed++;
+
+  if (test('build_file_open_launch routes Windows through start with path as a separate argv entry', () => {
+    const output = runPython(`
+import importlib.util, json
+spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+argv, kwargs = module.build_file_open_launch(r'C:\\\\Users\\\\user\\\\proj\\\\README.md & del C:\\\\*', os_name='nt')
+print(json.dumps({'argv': argv, 'kwargs': kwargs}))
+`);
+    const parsed = JSON.parse(output);
+    assert.strictEqual(parsed.argv[0], 'start');
+    assert.ok(parsed.argv[1].includes('README.md & del'), 'path with metacharacters must remain literal');
+    assert.ok(parsed.argv[1].includes('C:'), 'windows drive prefix should be preserved');
+    assert.deepStrictEqual(parsed.kwargs, {});
+  })) passed++; else failed++;
+
   if (test('maximize_window falls back to Linux zoom attribute when zoomed state is unsupported', () => {
     const output = runPython(`
 import importlib.util, json

--- a/tests/scripts/ecc-dashboard.test.js
+++ b/tests/scripts/ecc-dashboard.test.js
@@ -86,13 +86,13 @@ print(json.dumps({'argv': argv, 'kwargs': kwargs}))
     assert.ok(Object.prototype.hasOwnProperty.call(parsed.kwargs, 'creationflags'));
   })) passed++; else failed++;
 
-  if (test('build_file_open_launch routes POSIX through xdg-open with path as a separate argv entry', () => {
+  if (test('build_file_open_launch routes Linux through xdg-open with path as a separate argv entry', () => {
     const output = runPython(`
 import importlib.util, json
 spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
-argv, kwargs = module.build_file_open_launch('/tmp/proj/README.md; rm -rf ~', os_name='posix')
+argv, kwargs = module.build_file_open_launch('/tmp/proj/README.md; rm -rf ~', os_name='posix', system_name='Linux')
 print(json.dumps({'argv': argv, 'kwargs': kwargs}))
 `);
     const parsed = JSON.parse(output);
@@ -100,19 +100,37 @@ print(json.dumps({'argv': argv, 'kwargs': kwargs}))
     assert.deepStrictEqual(parsed.kwargs, {});
   })) passed++; else failed++;
 
-  if (test('build_file_open_launch routes Windows through start with path as a separate argv entry', () => {
+  if (test('build_file_open_launch routes macOS through native open command', () => {
     const output = runPython(`
 import importlib.util, json
 spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
-argv, kwargs = module.build_file_open_launch(r'C:\\\\Users\\\\user\\\\proj\\\\README.md & del C:\\\\*', os_name='nt')
+argv, kwargs = module.build_file_open_launch('/Users/me/proj/README.md; touch ~/pwn', os_name='posix', system_name='Darwin')
 print(json.dumps({'argv': argv, 'kwargs': kwargs}))
 `);
     const parsed = JSON.parse(output);
-    assert.strictEqual(parsed.argv[0], 'start');
-    assert.ok(parsed.argv[1].includes('README.md & del'), 'path with metacharacters must remain literal');
-    assert.ok(parsed.argv[1].includes('C:'), 'windows drive prefix should be preserved');
+    assert.deepStrictEqual(parsed.argv, ['open', '/Users/me/proj/README.md; touch ~/pwn']);
+    assert.deepStrictEqual(parsed.kwargs, {});
+  })) passed++; else failed++;
+
+  if (test('build_file_open_launch wraps Windows start through cmd.exe with title placeholder', () => {
+    const output = runPython(`
+import importlib.util, json
+spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+argv, kwargs = module.build_file_open_launch(r'C:\\\\Users\\\\user\\\\proj\\\\README.md & del C:\\\\*', os_name='nt', system_name='Windows')
+print(json.dumps({'argv': argv, 'kwargs': kwargs}))
+`);
+    const parsed = JSON.parse(output);
+    // start is a cmd.exe builtin, not a .exe — Popen needs cmd.exe /c start "" <path>.
+    // Empty quoted string is the window-title slot start requires when the first
+    // quoted argument is a path. Asserting the full argv catches future drift.
+    assert.deepStrictEqual(
+      parsed.argv,
+      ['cmd.exe', '/c', 'start', '', 'C:\\\\Users\\\\user\\\\proj\\\\README.md & del C:\\\\*']
+    );
     assert.deepStrictEqual(parsed.kwargs, {});
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary

A focused reliability pass on \`ecc_dashboard.py\` and \`scripts/lib/ecc_dashboard_runtime.py\`, in the same module surface that already grew test coverage in #1439. Three related cleanups in one commit:

1. **Narrow exception handling** — replace the eight remaining bare \`except:\` clauses with \`except Exception:\` so \`SystemExit\` / \`KeyboardInterrupt\` / \`MemoryError\` propagate cleanly. Each block now logs context via a module-level logger.
2. **Logging policy** — the recursive widget recolor walker uses \`logger.debug(..., exc_info=True)\` instead of \`logger.exception\` because tkinter rejects the \`background\` option on many widget classes (menus, system frames, notebook tabs); logging at INFO/ERROR there would flood the default stream on every theme apply.
3. **Unify file launchers** — add \`build_file_open_launch(path, *, os_name=None)\` to the runtime helper, mirroring the \`build_terminal_launch\` contract introduced by #1439. Route \`open_readme\` and \`open_agents\` through it so every external launch the dashboard performs goes through the same testable, injection-safe argv-construction path. Removes the duplicate inline \`import subprocess\` in those methods.

## Why this PR exists

\`ecc_dashboard.py\` had eight \`except:\` clauses that silently swallow every exception, including signal-level ones (\`SystemExit\`, \`KeyboardInterrupt\`, \`MemoryError\`). \`#1406\` flagged this. At the same time, \`#1424\` flagged \`open_terminal\` command injection and the \`self.state('zoomed')\` cross-platform crash; both of those were already addressed in \`#1439\`'s new \`ecc_dashboard_runtime.py\` helpers (\`maximize_window\`, \`build_terminal_launch\`), but \`open_readme\` and \`open_agents\` were left calling \`subprocess.Popen\` directly with the same argv-construction style. Extending the helper to cover all three launch sites finishes the job and lets us close \`#1424\` with a coherent codebase rather than a partially-applied fix.

## Tests

- Cover \`build_file_open_launch\` in \`tests/scripts/ecc-dashboard.test.js\` with POSIX and Windows cases. Both assert that paths containing shell metacharacters (\`; rm -rf ~\`, \`& del C:\\*\`) survive as literal argv entries — the same threat-model property the existing \`build_terminal_launch\` tests verify.

## Validation

- \`python3 -m py_compile ecc_dashboard.py scripts/lib/ecc_dashboard_runtime.py\` — OK
- \`node tests/scripts/ecc-dashboard.test.js\` — 5/5 passed (3 existing + 2 new)
- \`node tests/run-all.js\` — 1856 passed (baseline on \`main\` is 1854; +2 new passing tests, **zero new failures**)

Closes #1406 (issue 2 of 4 — dashboard bare except).
Closes #1424 (open_terminal command injection + zoomed crash were addressed in #1439's runtime helpers; this PR closes the issue by extending the same pattern to the remaining file-launch surface).

Supersedes #1420 (the original bare-except-only PR — closing it in favour of this consolidated reliability pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced silent failure paths with logged exception handling to surface errors during asset loading, parsing, and theme application.

* **Improvements**
  * More robust theme application with per-widget logging on failures.
  * More reliable cross-platform file opening so READMEs and files launch consistently on Windows, macOS, and Linux.

* **Tests**
  * Added cross-platform tests validating file-opening behavior on Linux, macOS, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dashboard reliability by narrowing exception handling, logging silent failures, unifying file opens through a safe launcher, and simplifying the theme apply walker to avoid double configuration. Windows now uses `explorer.exe` to bypass cmd parsing; paths stay literal to prevent injection.

- **Bug Fixes**
  - Replace bare `except:` with `except Exception` and log context; critical signals now propagate.
  - Theme recolor logs at DEBUG with `exc_info=True` to avoid noise when widgets reject `background`.
  - Add `build_file_open_launch(...)`; route README/AGENTS through it. Windows uses `explorer.exe`, macOS uses `open`, Linux uses `xdg-open`—paths stay literal argv entries.
  - Closes #1406 and #1424.

- **Refactors**
  - Simplified theme apply walker by removing redundant per-child configure; recursion configures each widget once.

<sup>Written for commit f64dbca532a101ca9344f50d2ca3786fd656aa37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

