### PR TITLE
fix(hooks): resolve MCP health-check spawn ENOENT on Windows

### DIFF
--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -315,12 +315,19 @@ function probeCommandServer(serverName, config) {
       resolve(result);
     }
 
+    // On Windows, commands like 'npx' are actually 'npx.cmd' batch files that
+    // require shell expansion to resolve. However, absolute paths (e.g.
+    // 'C:\Program Files\nodejs\node.exe') must NOT use shell mode because
+    // cmd.exe misparses paths containing spaces. Only enable shell for
+    // non-absolute commands that need PATH resolution.
+    const needsShell = process.platform === 'win32' && !path.isAbsolute(command);
     let child;
     try {
       child = spawn(command, args, {
         env: mergedEnv,
         cwd: process.cwd(),
-        stdio: ['pipe', 'ignore', 'pipe']
+        stdio: ['pipe', 'ignore', 'pipe'],
+        shell: needsShell
       });
     } catch (error) {
       finish({

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -377,7 +377,14 @@ function probeCommandServer(serverName, config) {
           // When spawned via shell on Windows, child is cmd.exe. kill() only
           // terminates the shell and leaves the real server process orphaned.
           // taskkill /T kills the entire process tree rooted at cmd.exe.
-          spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+          const killResult = spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+          if (killResult.error || (typeof killResult.status === 'number' && killResult.status !== 0)) {
+            // taskkill not on PATH, permission denied, or already exited.
+            // Best-effort fallback: signal the cmd.exe shell directly. The
+            // child tree may still leak if it already detached, but this at
+            // least kills the shell we spawned.
+            try { child.kill('SIGKILL'); } catch { /* ignore */ }
+          }
         } else {
           child.kill('SIGTERM');
           setTimeout(() => {

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -320,7 +320,17 @@ function probeCommandServer(serverName, config) {
     // 'C:\Program Files\nodejs\node.exe') must NOT use shell mode because
     // cmd.exe misparses paths containing spaces. Only enable shell for
     // non-absolute commands that need PATH resolution.
-    const needsShell = process.platform === 'win32' && !path.isAbsolute(command);
+    //
+    // Security: validate the command for shell metacharacters before enabling
+    // shell mode. cmd.exe treats &, |, <, >, ^, %, !, (, ), ;, and whitespace
+    // as operators/separators. A crafted command value from an MCP config file
+    // could otherwise inject arbitrary shell commands.
+    const UNSAFE_SHELL_CHARS = /[&|<>^%!()\s;]/;
+    const needsShell =
+      process.platform === 'win32' &&
+      typeof command === 'string' &&
+      !path.isAbsolute(command) &&
+      !UNSAFE_SHELL_CHARS.test(command);
     let child;
     try {
       child = spawn(command, args, {

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -373,18 +373,24 @@ function probeCommandServer(serverName, config) {
 
     const timer = setTimeout(() => {
       try {
-        child.kill('SIGTERM');
+        if (needsShell && child.pid && process.platform === 'win32') {
+          // When spawned via shell on Windows, child is cmd.exe. kill() only
+          // terminates the shell and leaves the real server process orphaned.
+          // taskkill /T kills the entire process tree rooted at cmd.exe.
+          spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+        } else {
+          child.kill('SIGTERM');
+          setTimeout(() => {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              // ignore
+            }
+          }, 200).unref?.();
+        }
       } catch {
         // ignore
       }
-
-      setTimeout(() => {
-        try {
-          child.kill('SIGKILL');
-        } catch {
-          // ignore
-        }
-      }, 200).unref?.();
 
       finish({
         ok: true,

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -457,6 +457,45 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await asyncTest('probes command servers using non-absolute commands (e.g. npx) via shell on Windows', async () => {
+    const tempDir = createTempDir();
+    const configPath = path.join(tempDir, 'claude.json');
+    const statePath = path.join(tempDir, 'mcp-health.json');
+    const serverScript = path.join(tempDir, 'shell-server.js');
+
+    try {
+      // Create a server script that stays alive
+      fs.writeFileSync(serverScript, "setInterval(() => {}, 1000);\n");
+
+      // Use 'node' (non-absolute) as the command — this requires PATH resolution,
+      // which on Windows needs shell: true because 'node' resolves to 'node.cmd'
+      // or 'node.exe' via PATHEXT. This simulates how 'npx' commands work.
+      writeConfig(configPath, {
+        mcpServers: {
+          shelltest: {
+            command: 'node',
+            args: [serverScript]
+          }
+        }
+      });
+
+      const input = { tool_name: 'mcp__shelltest__ping', tool_input: {} };
+      const result = runHook(input, {
+        CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
+        ECC_MCP_CONFIG_PATH: configPath,
+        ECC_MCP_HEALTH_STATE_PATH: statePath,
+        ECC_MCP_HEALTH_TIMEOUT_MS: '100'
+      });
+
+      assert.strictEqual(result.code, 0, `Expected non-absolute command to resolve via shell, got ${result.code}`);
+
+      const state = readState(statePath);
+      assert.strictEqual(state.servers.shelltest.status, 'healthy', 'Expected shell-resolved server to be marked healthy');
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -457,7 +457,7 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
-  if (await asyncTest('probes command servers using non-absolute commands (e.g. npx) via shell on Windows', async () => {
+  if (await asyncTest('probes command servers using non-absolute commands (e.g. npx) via PATH resolution', async () => {
     const tempDir = createTempDir();
     const configPath = path.join(tempDir, 'claude.json');
     const statePath = path.join(tempDir, 'mcp-health.json');
@@ -467,9 +467,10 @@ async function runTests() {
       // Create a server script that stays alive
       fs.writeFileSync(serverScript, "setInterval(() => {}, 1000);\n");
 
-      // Use 'node' (non-absolute) as the command — this requires PATH resolution,
-      // which on Windows needs shell: true because 'node' resolves to 'node.cmd'
-      // or 'node.exe' via PATHEXT. This simulates how 'npx' commands work.
+      // Use 'node' (non-absolute) as the command to exercise PATH-based resolution.
+      // On Windows, shell execution is especially relevant for commands exposed via
+      // batch wrappers such as 'npx.cmd'; using 'node' here simulates that class of
+      // non-absolute command without depending on npx being available in the environment.
       writeConfig(configPath, {
         mcpServers: {
           shelltest: {


### PR DESCRIPTION
## Summary

Fixes #1455 — MCP health-check hook fails on Windows with `spawn npx ENOENT`, blocking all MCP tool calls.

## Problem

`probeCommandServer()` uses `spawn(command, args)` without `shell: true`. On Windows, commands like `npx` are actually `npx.cmd` batch files that require shell expansion to resolve via PATH. Without shell mode, Node.js `spawn()` fails with `ENOENT`.

## Fix

Enable `shell: true` **only** for non-absolute commands on Windows:

```js
const needsShell = process.platform === 'win32' && !path.isAbsolute(command);
```

This correctly handles both cases:
- `npx` / `python` / `uvx` → non-absolute → needs shell on Windows for PATH/.cmd resolution
- `C:\Program Files\nodejs\node.exe` → absolute → must NOT use shell (cmd.exe misparses spaces in paths)

This matches how `attemptReconnect()` at line 436 already uses `shell: true`.

## Test

Added test: "probes command servers using non-absolute commands (e.g. npx) via shell on Windows" — uses `node` (non-absolute) as the command to verify PATH resolution works.

All 9 tests pass on Windows 10.

## Files changed

- `scripts/hooks/mcp-health-check.js` — add `shell: needsShell` to `probeCommandServer()` spawn
- `tests/hooks/mcp-health-check.test.js` — add test for non-absolute command resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows handling of health-check launches so commands use a shell only when required, and enhanced shutdown behavior to reliably terminate process trees and avoid lingering processes or false-negative health results.

* **Tests**
  * Added an end-to-end test that verifies the health check correctly launches a server and records it as healthy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP health-check on Windows by resolving spawn ENOENT for non-absolute commands and ensuring spawned processes are fully cleaned up. Non-absolute commands now run via the shell when safe; absolute paths bypass the shell.

- **Bug Fixes**
  - Windows: use `shell: true` only for non-absolute commands; absolute paths never use the shell. When shell is used, kill the full process tree with `taskkill /T /F`, falling back to `SIGKILL` if `taskkill` fails.
  - Harden spawn: validate `command` against metacharacters (`UNSAFE_SHELL_CHARS`) and require a string before enabling the shell.
  - Add a cross-platform test using `node` to verify PATH-based resolution marks the server healthy.

<sup>Written for commit 6d84a3c255c8af346b972bf48c6b3a44ca18cb62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

