### PR TITLE
fix(hooks): handle object-shaped run() return in require-mode wrapper

### DIFF
--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -89,13 +89,38 @@ async function main() {
 
   if (hookModule && typeof hookModule.run === 'function') {
     try {
-      const output = hookModule.run(raw);
-      if (output !== null && output !== undefined) process.stdout.write(output);
+      // run() expects a parsed hook-input object (e.g. input.tool_input.file_path),
+      // not the raw JSON string. Parsing here aligns the require-mode behavior
+      // with the stdin-fallback path used by spawnSync hooks.
+      const input = raw.trim() ? JSON.parse(raw) : {};
+      const output = hookModule.run(input);
+
+      // Documented object-shaped return: { exitCode, stderr?, stdout? }
+      // Required so hooks like pre:config-protection can BLOCK with exit 2.
+      if (output && typeof output === 'object' && !Buffer.isBuffer(output)) {
+        if (output.stderr) {
+          const msg = output.stderr;
+          process.stderr.write(msg.endsWith('\n') ? msg : msg + '\n');
+        }
+        process.stdout.write(typeof output.stdout === 'string' ? output.stdout : raw);
+        const code = Number.isInteger(output.exitCode) ? output.exitCode : 0;
+        process.exit(code);
+      }
+
+      // Legacy string/Buffer return: write directly, exit 0
+      if (typeof output === 'string' || Buffer.isBuffer(output)) {
+        process.stdout.write(output);
+        process.exit(0);
+      }
+
+      // null/undefined/other: pass-through raw, non-blocking exit
+      process.stdout.write(raw);
+      process.exit(0);
     } catch (runErr) {
       process.stderr.write(`[Hook] run() error for ${hookId}: ${runErr.message}\n`);
       process.stdout.write(raw);
+      process.exit(0);
     }
-    process.exit(0);
   }
 
   // Legacy path: spawn a child Node process for hooks without run() export


### PR DESCRIPTION
## Summary

The require-mode fast path in `scripts/hooks/run-with-flags.js` has three
bugs that prevent hooks returning `{ exitCode, stderr }` (e.g.
`config-protection.js`) from blocking tool use. The fork-mode path and
each hook's stdin-fallback branch already handle this schema correctly;
the require-mode branch silently diverged.

## Bugs

1. **`run(raw)` was called with the unparsed JSON string.** Hook scripts
   expect the parsed input object (to read `input.tool_input.file_path`,
   etc.). As a result, `config-protection` always saw `file_path` as
   `undefined` and returned `{ exitCode: 0 }` — no BLOCK.

2. **`stdout.write(output)` threw at runtime when `run()` returned an
   object.** Node's `Writable.write` requires `string` / `Buffer`, so
   writing a plain object crashed the wrapper. Visible symptom:

   ```
   [Hook] run() error for pre:config-protection:
     The "chunk" argument must be of type string or an instance of Buffer,
     TypedArray, or DataView. Received an instance of Object
   ```

3. **`process.exit(0)` was hard-coded after `run()`**, discarding any
   non-zero `exitCode` the hook returned. BLOCK hooks (`exit 2`) silently
   passed through.

## Fix

Align require-mode with:
- The fork-mode path (lines 110–114 of the same file) which already
  respects `result.stdout` / `result.stderr` / exit code.
- Each hook's stdin-fallback branch (e.g. `config-protection.js` lines
  102–125) which calls `JSON.parse(raw)` before `run()` and exits 2 on
  `result.exitCode === 2`.

Specifically, in `run-with-flags.js`:
- Parse `raw` into an object before calling `run()`.
- If `run()` returns an object, honor the documented
  `{ exitCode, stderr?, stdout? }` schema (write stderr, write stdout
  or fall back to raw, exit with `exitCode`).
- Preserve legacy `string` / `Buffer` returns (write directly, exit 0).
- Preserve `null` / `undefined` pass-through (write raw, exit 0).

## Minimal repro (before fix)

Given a plugin with the ECC hooks enabled, edit any linter config file:

```bash
$ claude -p --include-hook-events --output-format=stream-json \
    "Edit /tmp/demo/.eslintrc.json to {rules:{no-console:off}}"
```

stream-json shows:

```
system/hook_response PreToolUse:Edit
  stderr: [Hook] run() error for pre:config-protection: ...
  outcome: success    <-- BLOCK signal lost
```

File is modified. BLOCK failed silently.

## After fix

Same command, after this patch:

```
system/hook_response PreToolUse:Edit
  exit_code: 2
  outcome: error
  stderr: BLOCKED: Modifying .eslintrc.json is not allowed...
```

Target file remains unchanged (verified by reading it back from disk).

## Test plan

- [x] Unit: wrapper invokes `config-protection.js` against
      `.eslintrc.json` -- exits 2 with correct stderr.
- [x] Unit: wrapper invokes `config-protection.js` against a
      non-protected `.ts` file -- exits 0.
- [x] Regression: `pre:bash:tmux-reminder` still prints the reminder for
      `npm install`.
- [x] Regression: `stop:check-console-log` does not crash on empty stdin.
- [x] E2E via `claude -p --include-hook-events`: Edit request on
      `.eslintrc.json` is blocked; target file is unmodified.

## Backward compatibility

The fix is strictly additive for hooks that already worked:
- `null` / `undefined` returns -> same behavior (pass-through, exit 0).
- `string` / `Buffer` returns -> same behavior (write directly, exit 0).
- Object returns -> newly honored (was broken before).

No hook that was working under the old code is affected.

## Notes

The fork-mode path (lines 110-114) and the stdin-fallback in each hook
were already correct. This PR only brings the require-mode fast path
into alignment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the require-mode wrapper so hooks that return objects can block tool use as intended. It now parses JSON input, writes stderr/stdout correctly, and exits with the hook’s exitCode.

- **Bug Fixes**
  - Parse `raw` into an object before calling `run(input)`.
  - Support `{ exitCode, stderr?, stdout? }` returns: write stderr/stdout (fallback to raw) and exit with `exitCode`.
  - Preserve legacy returns (string/Buffer, null/undefined) and prevent write crashes; align behavior with fork-mode.

<sup>Written for commit f2ed06f3f1335eed61319f998707a14908ee0325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

