### PR TITLE
fix(dashboard): keep Windows terminal launch paths out of cmd.exe args

### DIFF
--- a/scripts/lib/ecc_dashboard_runtime.py
+++ b/scripts/lib/ecc_dashboard_runtime.py
@@ -45,7 +45,7 @@ def build_terminal_launch(
     if resolved_os_name == 'nt':
         creationflags = getattr(subprocess, 'CREATE_NEW_CONSOLE', 0)
         return (
-            ['cmd.exe', '/k', 'cd', '/d', path],
+            ['cmd.exe'],
             {
                 'cwd': path,
                 'creationflags': creationflags,

--- a/tests/scripts/ecc-dashboard.test.js
+++ b/tests/scripts/ecc-dashboard.test.js
@@ -69,20 +69,20 @@ print(json.dumps({'argv': argv, 'kwargs': kwargs}))
     assert.deepStrictEqual(parsed.kwargs, {});
   })) passed++; else failed++;
 
-  if (test('build_terminal_launch uses cwd + CREATE_NEW_CONSOLE style launch on Windows', () => {
+  if (test('build_terminal_launch keeps Windows metachar paths out of the cmd.exe command string', () => {
     const output = runPython(`
-import importlib.util, json
+import importlib.util, json, subprocess
 spec = importlib.util.spec_from_file_location("ecc_dashboard_runtime", r"""${runtimeHelpersPath}""")
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
-argv, kwargs = module.build_terminal_launch(r'C:\\\\Users\\\\user\\\\proj & del C:\\\\*', os_name='nt', system_name='Windows')
-print(json.dumps({'argv': argv, 'kwargs': kwargs}))
+path = r'C:\\\\tmp\\\\proj&del'
+argv, kwargs = module.build_terminal_launch(path, os_name='nt', system_name='Windows')
+print(json.dumps({'argv': argv, 'kwargs': kwargs, 'cmdline': subprocess.list2cmdline(argv), 'path': path}))
 `);
     const parsed = JSON.parse(output);
-    assert.deepStrictEqual(parsed.argv.slice(0, 4), ['cmd.exe', '/k', 'cd', '/d']);
-    assert.strictEqual(parsed.argv[4], parsed.kwargs.cwd);
-    assert.ok(parsed.argv[4].includes('proj & del'), 'path should remain a literal argv entry');
-    assert.ok(parsed.argv[4].includes('C:'), 'windows drive prefix should be preserved');
+    assert.deepStrictEqual(parsed.argv, ['cmd.exe']);
+    assert.strictEqual(parsed.kwargs.cwd, parsed.path);
+    assert.ok(!parsed.cmdline.includes(parsed.path), 'metachar path should not appear in the cmd.exe command string');
     assert.ok(Object.prototype.hasOwnProperty.call(parsed.kwargs, 'creationflags'));
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- remove the selected project path from the Windows `cmd.exe` argument string in `build_terminal_launch()`
- keep the target directory selection in `cwd` only
- add a regression test proving a Windows metachar path stays out of the serialized `cmd.exe` command line

## Root cause
The current Windows helper returns:

```python
['cmd.exe', '/k', 'cd', '/d', path]
```

That embeds the selected path directly into the `cmd.exe` command string even though `subprocess.Popen(..., cwd=path)` already provides an out-of-band working-directory channel.

For a path such as `C:\tmp\proj&del`, the current helper serializes to a command line equivalent to:

```text
cmd.exe /k cd /d C:\tmp\proj&del
```

The shell does not need to parse the path at all here.

## Why keep the scope this small
Recent dashboard fixes in this repo have landed fastest when they stayed tightly bound to one validated behavior and one regression test.

This PR intentionally stays narrower than the broader dashboard reliability work in #1450:
- no file-launcher changes
- no logging changes
- no exception-handling cleanup
- only the validated Windows terminal-launch surface on current `main`

## Change
Windows now launches with:

```python
['cmd.exe']
```

and relies on:

```python
cwd=path
```

so the selected project path no longer appears in the `cmd.exe` command string.

## Testing
- `python3 -m py_compile ecc_dashboard.py scripts/lib/ecc_dashboard_runtime.py`
- `node tests/scripts/ecc-dashboard.test.js`
- `node tests/hooks/gateguard-fact-force.test.js`
- `node tests/hooks/bash-hook-dispatcher.test.js`

Fixes #1472
