### PR TITLE
feat(skills): add CS academic writing and resume building skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,13 @@ everything-claude-code/
 |   |-- perl-testing/              # Perl TDD with Test2::V0, prove, Devel::Cover (NEW)
 |   |-- autonomous-loops/           # Autonomous loop patterns: sequential pipelines, PR loops, DAG orchestration (NEW)
 |   |-- plankton-code-quality/      # Write-time code quality enforcement with Plankton hooks (NEW)
+|   |-- abstract-methods-results-cs/ # Review Abstract, Methods, Results sections of CS papers (NEW)
+|   |-- academic-final-review-cs/   # Pre-submission checklist for CS research papers (NEW)
+|   |-- paper-structure-cs/         # Validate paper structure against academic standards (NEW)
+|   |-- sentence-clarity-cs/        # Edit CS paper sentences for clarity and conciseness (NEW)
+|   |-- harvard-resume-validator/   # Resume validation against Harvard College guidelines (NEW)
+|   |-- kickass-resume-validator/   # Resume validation against industry-standard guide (NEW)
+|   |-- resume-job-alignment/       # Resume-to-job alignment and tailoring (NEW)
 |
 |-- commands/         # Legacy slash-entry shims; prefer skills/
 |   |-- tdd.md              # /tdd - Test-driven development

--- a/skills/abstract-methods-results-cs/SKILL.md
+++ b/skills/abstract-methods-results-cs/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: abstract-methods-results-cs
+description: Review Abstract, Methods, and Results sections of CS research papers for scientific clarity, completeness, and rigor. Use this skill when you need to critique or improve these critical sections—check for clarity of objectives, method reproducibility, passive voice overuse, incomplete descriptions, unsupported claims, and missing context. Activate on any request involving "abstract", "methods", "results", "paper review", "scientific writing", or "CS research writing".
+origin: ECC
+---
+
+# Abstract-Methods-Results Reviewer (JSONL Format)
+
+You validate the Abstract, Methods, and Results sections of CS research papers. Output JSONL format—one issue per line, independent of other issues.
+
+## When to Activate
+
+Use this skill whenever you encounter requests to:
+- Review or critique a paper's Abstract, Methods, or Results sections
+- Improve clarity, rigor, or completeness in scientific writing
+- Check for reproducibility issues in method descriptions
+- Validate claims against reported data
+- Strengthen paper structure before submission
+- Assess passive voice overuse or vague writing
+- Ensure baseline comparisons and statistical rigor in results
+
+Keywords that trigger this skill: "abstract", "methods", "results", "paper review", "scientific writing", "CS research writing", "reproducibility", "methods section", "experimental design", "results reporting".
+
+## Your Task
+
+When given a paper or section to review, identify issues in Abstract, Methods, and Results. Each issue is reported separately with no dependencies on other issues.
+
+## Output Format (JSONL)
+
+Output exactly one JSON object per line. Each object represents one independent issue. Do NOT use array syntax—just newline-separated objects.
+
+## Issue Categories
+
+**Abstract issues:**
+- `vague_objective` - Objectives lack specificity (no metrics, unclear scope)
+- `missing_context` - No problem statement or motivation
+- `unsupported_claim` - Conclusions without supporting data mentioned
+- `passive_overuse` - More than 30% passive sentences
+
+**Methods issues:**
+- `incomplete_description` - Missing algorithm details, hyperparameters, or setup
+- `reproducibility_gap` - Reader cannot reproduce the work
+- `passive_overuse` - Methods written entirely in passive voice
+- `missing_detail` - Ambiguous section (dataset size, training duration, hardware)
+- `undefined_terms` - Jargon without definition in context
+
+**Results issues:**
+- `premature_conclusion` - Interprets results as conclusions (belongs in Discussion)
+- `unsupported_claim` - Claims not backed by reported metrics
+- `passive_presentation` - Results hidden in passive constructions
+- `missing_context` - Baseline/comparison method not stated
+- `incomplete_data` - Should report std dev, confidence intervals, statistical tests
+
+## Output Requirements
+
+- One issue per line (JSONL format)
+- Include `line` number (approximate, best effort)
+- Set `severity` to: `critical`, `important`, or `minor`
+- Keep `issue` and `suggested_fix` concise but complete
+- Do NOT group or pattern-match issues—report each independently
+
+---
+
+# Deep Guidance: Writing Abstract, Methods, and Results
+
+## Abstract Section
+
+### What Makes a Strong Abstract?
+
+A research abstract is a self-contained summary of your entire paper. Readers decide whether to read your full paper based on the abstract. It must balance completeness with brevity (typically 150-250 words depending on venue).
+
+**Structure of an effective abstract:**
+1. **Context (1-2 sentences)**: The broad problem domain or research area. Why does this problem matter?
+2. **Problem Statement (2-3 sentences)**: The specific gap, limitation, or question your work addresses. What is known? What is missing?
+3. **Approach (2-3 sentences)**: Your method, model, or solution at a high level. No deep technical details.
+4. **Results (2-3 sentences)**: Quantitative outcomes, improvements over baselines, or key findings. Include metrics and numbers.
+5. **Impact (1-2 sentences)**: Significance for the field, potential applications, or broader implications.
+
+### Common Abstract Mistakes
+
+- **Too vague**: "We propose a new approach to improve performance" — what approach? performance in what? compared to what?
+- **Missing baselines**: "Our method achieves 95% accuracy" — 95% compared to what? Is that good?
+- **No quantitative results**: Mentioning findings without numbers or percentages.
+- **Confusing jargon**: Using field-specific terms without brief explanation (especially problematic if abstract goes to general audience).
+- **Too long or too short**: Exceeding venue limits or omitting critical context.
+- **Results as discussion**: Interpreting findings (belongs in Discussion section, not Abstract).
+- **Promise vs. delivery**: Abstract claims benefits not supported by Results section.
+
+### Before/After: Weak vs. Strong Abstract
+
+**WEAK (vague, missing context and numbers):**
+
+Recent advances in natural language processing have opened new possibilities for understanding text. This paper proposes a novel transformer-based model for improving semantic understanding. We apply our model to several downstream tasks and demonstrate its effectiveness. Our results show that the model performs well across different domains. The work has implications for future research in NLP and could be useful for practical applications. This represents a significant contribution to the field and outperforms previous approaches.
+
+Problems: No specifics (which model? which tasks?), no numbers, vague claims ("performs well", "significant contribution"), no baseline comparison, reads like marketing copy.
+
+**STRONG (specific, contextual, quantitative):**
+
+Semantic understanding in NLP has improved dramatically with Transformer models, yet current architectures struggle with long-range dependencies in domain-specific text, particularly in biomedical and legal documents. We propose BiDomain-BERT, a dual-pathway Transformer that routes domain-specific tokens through specialized attention heads while maintaining shared semantic layers. We evaluate on five downstream tasks: MIMIC-III clinical notes (NER, relation extraction), SEC filings (entity linking, fact verification), and Wikipedia (coreference resolution). BiDomain-BERT achieves F1 improvements of 3.2-7.8 percentage points over BERT-base and comparable performance to domain-specific models (SciBERT, BioBERT) while using 18% fewer parameters. On the rare-token classification task, BiDomain-BERT outperforms specialized models by 5.4%, demonstrating that hybrid routing generalizes better than single-domain pretraining. These results suggest that parameter-efficient routing mechanisms are a viable path toward language models that excel across diverse specialized domains.
+
+Strengths: Clear problem (long-range dependencies in domain-specific text), specific approach (dual-pathway routing), concrete baselines (BERT-base, SciBERT, BioBERT), quantitative results with error metrics (F1 scores, parameter count), significance clearly stated (outperforms both generic and specialized models, generalizes better).
+
+### DO/DON'T: Abstract Patterns
+
+**DO:**
+- Start with domain context in 1-2 sentences (why readers should care)
+- Name the specific problem and your contribution explicitly
+- Include 3-5 quantitative results with comparison baselines
+- Use active voice ("We propose..." not "A novel method is proposed...")
+- Mention dataset names and domain (MIMIC-III, ImageNet, etc.)
+- End with significance or implications for the field
+- Write assuming readers know your field but not your specific paper
+
+**DON'T:**
+- Use vague intensifiers ("state-of-the-art", "novel", "powerful") without evidence
+- Cite references in abstracts (venue-dependent, but generally avoid)
+- Introduce new notation or abbreviations defined only in the paper
+- Oversell: abstract must match paper content exactly
+- Write in third person ("the authors propose") unless required by venue
+- Leave out negative results or limitations (mention them briefly)
+- Use percent improvements without absolute baselines ("+5% is not meaningful without context")
+
+### Venue-Specific Tips
+
+**ACM conferences** (SIGMOD, SIGPLAN, SIGIR, etc.):
+- Abstract typically 150-200 words
+- Often accepts structured abstracts (Problem | Approach | Results | Impact)
+- Emphasis on systems contribution and practical impact
+- Avoid too much math notation; use English for high-level ideas
+
+**IEEE conferences** (ICCV, ICML, AAAI, etc.):
+- Abstract typically 150-250 words
+- Highly technical; can include formalism and equations
+- Structured abstracts increasingly common: separate paragraphs for problem, contribution, method, results
+- Baselines and numerical comparisons expected
+
+**Journal submissions** (TOCS, TOPLAS, TIM, etc.):
+- Often 100-150 words (stricter limits than conferences)
+- More conservatively written; emphasis on rigor over novelty claims
+- Statistical significance must be mentioned if any hypothesis testing
+- Results section can reference supplemental materials
+
+**Workshop abstracts**:
+- Often 75-150 words (shorter)
+- More narrative, less rigorous than main conference
+- Position papers acceptable (future work, early-stage ideas)
+- Can be less quantitative if the idea is novel
+
+---
+
+## Methods Section
+
+### What Makes Methods Reproducible?
+
+The Methods section is where you earn the reader's trust. A reader should be able to implement your approach from this section alone. If they cannot, your work is not reproducible—even if results are strong.
+
+**Essential elements of reproducible methods:**
+
+1. **Dataset Description**
+   - Full name and source (with citation or URL)
+   - Size: number of samples, dimensionality, splits (train/val/test percentages)
+   - Preprocessing: how raw data was cleaned, normalized, augmented
+   - Availability: public, proprietary, or request from authors
+   - Class distribution or key statistics (especially for imbalanced data)
+
+2. **Hardware and Software Environment**
+   - CPU/GPU specifications (e.g., "single NVIDIA A100 40GB")
+   - Software versions (PyTorch 2.0.1, TensorFlow 2.11, CUDA 11.8)
+   - Memory/runtime constraints
+   - Code availability (GitHub repo, supplemental materials, archived via Zenodo)
+
+3. **Model Architecture**
+   - Explicit description or pseudocode of your model
+   - Diagram (Figure in appendix is acceptable)
+   - Exact dimensions, layer counts, attention heads, activation functions
+   - Skip connections, normalization choices, and initialization schemes
+   - If building on prior work, state modifications explicitly ("We add a residual path to the existing BiLSTM from Smith et al. [X]...")
+
+4. **Hyperparameters**
+   - Learning rate, batch size, optimizer, momentum, weight decay
+   - Initialization strategy (random seed, pretrained weights source)
+   - Training schedule (epochs, early stopping criteria, learning rate decay)
+   - Regularization techniques (dropout rates, L1/L2 penalties)
+   - If hyperparameters were tuned: describe search strategy, validation metric, final selection
+
+5. **Baselines and Comparison Methods**
+   - All baseline models explicitly named and referenced
+   - Baseline hyperparameters (or cite their papers for exact settings)
+   - Whether you reimplemented baselines or used published code
+   - Fair comparison: same train/test split, same preprocessing, same evaluation metrics
+
+6. **Evaluation Metrics and Protocols**
+   - Exact definition of each metric (precision, recall, F1, BLEU, ROUGE, etc.)
+   - Statistical significance testing (if applicable): test used, p-value threshold, confidence intervals
+   - Cross-validation strategy (k-fold, holdout, time-series split)
+   - Multiple runs and reporting of mean/std or confidence intervals
+
+### Common Methods Mistakes
+
+- **Incomplete algorithm description**: Pseudocode or equations missing; readers cannot tell what you actually implemented
+- **Vague hyperparameter selection**: "We use standard settings" or "We tuned the model" without specifics
+- **Missing preprocessing details**: How were images resized? How were text tokens preprocessed?
+- **Baseline reimplementation vs. published code**: You reimplemented a complex baseline incorrectly, and now baseline performance is artificially low
+- **Unfair comparisons**: Different training data, different preprocessing, or different train/test splits for baselines vs. your method
+- **No statistical rigor**: Single run with single seed; no confidence intervals or significance tests
+- **Hidden complexity**: "We then apply standard NLP pipeline" hides critical details
+- **Dependency on unavailable resources**: "We used internal company dataset (not available)" makes work non-reproducible
+
+### Before/After: Incomplete vs. Complete Methods Paragraph
+
+**INCOMPLETE (missing critical details):**
+
+We implemented a transformer-based model for sentiment analysis. The model was trained on the Stanford Sentiment Treebank (SST) dataset. We used standard preprocessing and tokenization. The model includes multiple attention heads and fully connected layers. We trained the model using Adam optimizer with a learning rate of 0.001. We compared against BERT and GPT models. The model achieved good performance on the test set.
+
+Problems: No architecture details (how many layers? how many heads?), no random seed, no dataset split information, "good performance" is meaningless, baselines are named but their hyperparameters and comparison method not specified, no statistical testing, preprocessing is "standard" (undefined).
+
+**COMPLETE (reproducible):**
+
+We implement a Transformer encoder with 6 layers, 12 attention heads, 768 hidden dimensions, and 3072 feedforward dimensions. We use sinusoidal positional encoding and apply layer normalization before each sublayer (pre-LN architecture). We initialized weights uniformly from [-0.1, 0.1] and used a fixed random seed (42) for all runs.
+
+We train on the Stanford Sentiment Treebank (SST-2, Socher et al., 2013), which contains 67,349 sentences. We use the official train/val/test split (70%/15%/15% = 6,920 test samples). Preprocessing: tokenization via nltk.tokenize, lowercasing, and padding to length 128. Class distribution is 50.3% positive / 49.7% negative (balanced).
+
+We use Adam optimizer (beta1=0.9, beta2=0.999, epsilon=1e-8) with learning rate 0.0001, batch size 32, and train for 15 epochs with early stopping (patience 3 on validation accuracy). We apply dropout at 0.1 before the output layer. Training on a single NVIDIA V100 GPU takes approximately 8 minutes per epoch.
+
+We compare against two baselines: (1) BERT-base (Devlin et al., 2019) fine-tuned with learning rate 2e-5, batch size 32, 3 epochs, and (2) a CNN with 100 filters of window size 3/4/5 followed by max-pooling and 2 fully connected layers. All baselines use the same SST-2 split, preprocessing, and random seed.
+
+We report accuracy, precision, recall, and F1 (macro) on the test set. We run each method 5 times with different random seeds and report mean and standard deviation. We perform significance testing using paired t-tests with alpha=0.05.
+
+Strengths: Architecture fully specified (layers, heads, dimensions, initialization), dataset with split percentages and class distribution, preprocessing steps explicit, hardware and runtime documented, hyperparameters with optimizer settings, baselines with implementation details, metrics and statistical rigor (5 runs, mean/std, t-tests).
+
+### DO/DON'T: Methods Patterns
+
+**DO:**
+- Use subsections (Dataset, Model Architecture, Training, Evaluation) for clarity
+- Cite the papers where baselines come from or link to their code
+- Describe the exact sequence of preprocessing steps (in order)
+- Include random seed and explain reproducibility measures
+- Specify hardware (GPU type, memory) and approximate runtime
+- Use numbered lists or tables for hyperparameters (tables are easier to scan)
+- Mention availability of code or supplemental materials
+- For novel methods, provide pseudocode or equations (or reference appendix)
+
+**DON'T:**
+- Say "we use standard preprocessing" or "we use common baselines" without specifics
+- Omit random seeds or initialization details
+- Report single runs without error bars or confidence intervals
+- Implement baselines from scratch without verifying against published results
+- Mix different train/test splits or preprocessing for baselines vs. your method
+- Use different evaluation metrics for baselines vs. your method
+- Assume readers know your internal codebase details
+- Defer critical architecture decisions to "we empirically determined" without explanation
+
+### LaTeX Tips for Methods
+
+**Hyperparameter tables** (cleaner than prose):
+
+```latex
+\begin{table}[h]
+  \centering
+  \begin{tabular}{lcc}
+    \toprule
+    \textbf{Parameter} & \textbf{Our Model} & \textbf{BERT-base} \\
+    \midrule
+    Layers & 6 & 12 \\
+    Hidden dimension & 768 & 768 \\
+    Attention heads & 12 & 12 \\
+    Dropout & 0.1 & 0.1 \\
+    Learning rate & 0.0001 & 0.00002 \\
+    Batch size & 32 & 32 \\
+    \bottomrule
+  \end{tabular}
+  \caption{Model and training hyperparameters.}
+\end{table}
+```
+
+**Algorithm pseudocode** (for non-trivial approaches):
+
+```latex
+\begin{algorithm}
+  \caption{Dual-Pathway Routing}
+  \begin{algorithmic}
+    \REQUIRE token sequence $x_1, \ldots, x_n$, routing weights $W_r$
+    \FOR{each token $x_i$}
+      \STATE compute routing score: $r_i = \text{softmax}(W_r x_i)$
+      \STATE route to domain head: $h_i^{dom} = \text{Attn}^{dom}(x_i)$ with probability $r_i[0]$
+      \STATE route to generic head: $h_i^{gen} = \text{Attn}^{gen}(x_i)$ with probability $r_i[1]$
+      \STATE combine: $h_i = r_i[0] \cdot h_i^{dom} + r_i[1] \cdot h_i^{gen}$
+    \ENDFOR
+    \RETURN $h_1, \ldots, h_n$
+  \end{algorithmic}
+\end{algorithm}
+```
+
+---
+
+## Results Section
+
+### How to Present Results Clearly
+
+The Results section reports what your experiments found. It is strictly factual—no interpretation, no claims about why results are good or bad (that belongs in Discussion). Results should be presented in an order that builds narrative: perhaps baseline comparisons first, then ablations, then error analysis.
+
+**Key principles:**
+1. **One figure or table per main claim**: Each figure/table should support exactly one key finding
+2. **Legible fonts and labels**: Axis labels, legend, and caption must be readable without magnification
+3. **Comparison to baselines first**: Report your method against established baselines before ablations
+4. **Error bars or confidence intervals**: Always report variability (standard deviation, confidence intervals, or range from multiple runs)
+5. **Statistical significance**: Report p-values, significance levels, or confidence intervals when making comparative claims
+6. **Avoid cherry-picking**: Report all results, including negative findings or edge cases
+7. **Consistent metrics**: Use the same evaluation metric for all conditions being compared
+
+### Tables vs. Figures
+
+**Use tables when:**
+- Comparing many numeric values (3+ conditions, 3+ metrics)
+- Exact numbers matter more than trends (e.g., reporting F1 scores to 2 decimal places)
+- You have discrete categories (different models, different domains, different datasets)
+- Space allows; tables are compact
+
+**Use figures when:**
+- You want to show a trend over a continuous variable (epochs, dataset size, hyperparameter values)
+- The pattern or distribution matters more than exact values
+- Comparing many items (e.g., 10+ methods on one metric); a bar chart is faster to parse than a table
+- Showing qualitative patterns (learning curves, confusion matrices, t-SNE visualizations)
+- You have limited space; figures can be wide and short
+
+**Key rule**: Never duplicate information across tables and text. If you report a number in a table, mention it in prose only when highlighting significance; reference the table ("As shown in Table 1").
+
+### Statistical Rigor in Results
+
+**Report variability for every quantitative claim:**
+
+Weak: "Our method achieves 92.3% accuracy."
+Better: "Our method achieves 92.3 ± 1.2% accuracy (mean ± std, 5 random seeds)."
+
+**State baseline selection and performance explicitly:**
+
+Weak: "We outperform prior work."
+Better: "On ImageNet, our method reaches 78.4% top-1 accuracy, compared to ResNet-50 (76.2%), EfficientNet-B4 (77.1%), and Vision Transformer (79.8%)."
+
+**For small differences, report confidence intervals and significance:**
+
+Weak: "Our method is 1% better."
+Better: "Method A: 85.2% ± 0.8% (95% CI: 83.8–86.6%), Method B: 84.1% ± 0.9% (95% CI: 82.8–85.4%), paired t-test p=0.032."
+
+**Explain why baselines may underperform:**
+
+If baseline performance seems low, state it explicitly: "BERT-base achieves 71.2% on this task (vs. 81.4% on standard GLUE), likely due to the highly specialized domain vocabulary." This prevents readers from thinking your baselines are weak implementations.
+
+### Before/After: Weak vs. Strong Results Reporting
+
+**WEAK (unsupported claims, missing context, no error bars):**
+
+Our model significantly outperforms existing approaches. We tested on ImageNet and achieved 78.5% top-1 accuracy. BERT baseline achieved 71% accuracy. Our method is clearly superior and shows state-of-the-art performance. The improvements are large and consistent across multiple runs. We also tested on CIFAR-10 and found similar patterns, with our method achieving 95.3% accuracy. The results demonstrate that our approach is robust and generalizes well.
+
+Problems: No standard deviations or confidence intervals, "significantly" is not defined, baseline selection is not justified, "consistent across multiple runs" without proof, no statistical testing, "state-of-the-art" is a claim not backed by comprehensive benchmarking, "large and consistent" is subjective.
+
+**STRONG (quantitative, rigorous, transparent):**
+
+Table 1 reports accuracy on ImageNet validation set (50K images). Our method achieves 78.5 ± 0.3% top-1 accuracy (mean ± std, 5 random seeds). This represents a 1.2 percentage point improvement over Vision Transformer ViT-B (77.3 ± 0.4%) and 2.3 points over ResNet-50 (76.2 ± 0.2%). Paired t-tests confirm that improvements over both baselines are statistically significant (ViT vs. ours: t=2.84, p=0.034; ResNet vs. ours: t=4.12, p=0.008). Note that our method uses a pretrained ImageNet-21K initialization (as do current SOTA methods); this is why baseline comparisons exclude ImageNet-1K-only models. Figure 3 shows per-class accuracy, revealing that improvements are concentrated in fine-grained categories (dog breeds, bird species) where spatial structure matters most; performance on general object classes (car, person) is similar across methods.
+
+We also evaluate on CIFAR-10 (test set, 10K images). Accuracy: 95.3 ± 0.2% (our method), 94.1 ± 0.3% (ResNet-18), 94.8 ± 0.2% (Vision Transformer). Statistical significance (paired t-test): p=0.041 vs. ResNet, p=0.072 vs. ViT (approaching significance, likely due to high baseline accuracy where improvements have less room to grow).
+
+Strengths: All numbers include standard deviations and sample count (5 runs), statistical significance reported with test type and p-values, baselines chosen to be contemporary (not straw men), acknowledges initialization differences (key factor in ImageNet results), shows per-class breakdown to explain where improvements come from, reports results on second dataset with caveats about diminishing returns, avoids "state-of-the-art" claims without comprehensive benchmarking.
+
+### Common Results Mistakes
+
+- **Premature conclusions**: "Our method is superior because of X" belongs in Discussion, not Results
+- **Missing baselines**: Reporting only your method without comparison (how do readers know it's good?)
+- **Baseline underperformance**: Baselines seem weaker than published; readers suspect unfair comparison or poor implementation
+- **No error bars**: Single runs with single seeds; readers cannot assess variability
+- **Overloaded tables**: 10+ columns with different units and metrics; impossible to parse quickly
+- **Inconsistent metrics**: Method A reported as accuracy, Method B as F1; results not directly comparable
+- **Results in prose form only**: Important findings not in figures or tables; hard to extract and compare
+- **Ignoring negative results**: Only reporting the successful experiment; hiding failed ablations or edge cases
+- **Unexplained outliers**: Figure shows one condition much worse; no discussion of why
+
+### DO/DON'T: Results Patterns
+
+**DO:**
+- Report all conditions and datasets, even if results are mixed
+- Include error bars, standard deviations, or confidence intervals on every quantitative claim
+- Use consistent evaluation metrics across all baselines and your method
+- Order results by narrative (baselines first, then your method, then ablations)
+- Caption figures and tables so they are understandable in isolation
+- Explain outliers or unexpected results (e.g., "Method X fails on sparse graphs; we include results but note this limitation")
+- Use statistical testing (t-tests, ANOVA) for small differences and larger claims
+- Highlight key numbers in bold or use color, but sparingly and consistently
+
+**DON'T:**
+- Report results without multiple random seeds or runs
+- Use different evaluation metrics for your method vs. baselines (e.g., macro F1 vs. micro)
+- Cherry-pick results (report only the dataset where your method is best)
+- Make interpretation claims ("our method is superior because...") in Results
+- Use vague descriptors ("large improvement", "very good", "competitive") without numbers
+- Forget to mention initialization, data splits, or preprocessing differences between your method and baselines
+- Present figures at unreadable resolution or with tiny fonts
+- Crowd too much into one table (split into multiple, use appendix if needed)
+
+### LaTeX Tips for Results
+
+**Tables with confidence intervals:**
+
+```latex
+\begin{table}[h]
+  \centering
+  \begin{tabular}{lrrrr}
+    \toprule
+    \textbf{Method} & \textbf{Accuracy} & \textbf{Precision} & \textbf{Recall} & \textbf{F1} \\
+    \midrule
+    ResNet-50 & 76.2 \scriptsize \pm 0.4 & 0.768 \pm 0.006 & 0.754 \pm 0.008 & 0.761 \pm 0.007 \\
+    ViT-B & 77.3 \pm 0.3 & 0.781 \pm 0.005 & 0.769 \pm 0.006 & 0.775 \pm 0.005 \\
+    \textbf{Ours} & \textbf{78.5} \pm \textbf{0.2} & \textbf{0.795} \pm \textbf{0.004} & \textbf{0.782} \pm \textbf{0.005} & \textbf{0.788} \pm \textbf{0.004} \\
+    \bottomrule
+  \end{tabular}
+  \caption{Accuracy, precision, recall, and F1 on ImageNet validation. All results are mean \pm std over 5 random seeds.}
+  \label{tab:imagenet}
+\end{table}
+```
+
+**Figure with error bars:**
+
+```latex
+\begin{figure}[h]
+  \centering
+  \includegraphics[width=0.6\textwidth]{learning_curve.pdf}
+  \caption{Validation accuracy over epochs. Curves show mean accuracy and shaded regions indicate \pm 1 std (5 random seeds). Our method (blue) converges faster and reaches higher accuracy than ResNet-50 (green) and ViT-B (orange).}
+  \label{fig:learning}
+\end{figure}
+```
+
+---
+
+## Quick Reference Checklist
+
+### Abstract Checklist
+
+- [ ] Problem is specific and bounded (not "improving performance" but "reducing latency in transformer decoding by X%")
+- [ ] Context/motivation in first 1-2 sentences (why this problem matters)
+- [ ] Approach name and high-level idea (method without deep technical detail)
+- [ ] 3-5 quantitative results with numbers and units (%F1, accuracy, speedup, etc.)
+- [ ] Baselines or comparisons named and with numbers (not just "outperforms existing work")
+- [ ] Significance or impact briefly stated (why results matter to the field)
+- [ ] No citations (venue-dependent, but standard for most conferences)
+- [ ] 150-250 words depending on venue
+- [ ] Active voice preferred; no vague intensifiers ("novel", "powerful", "state-of-the-art" without evidence)
+- [ ] No undefined jargon
+
+### Methods Checklist
+
+- [ ] Dataset: name, size, train/test split, source/availability
+- [ ] Preprocessing: exact steps in order (lowercasing, tokenization, padding, augmentation, etc.)
+- [ ] Model architecture: layers, dimensions, activation functions, initialization (text description or reference to figure)
+- [ ] All hyperparameters: learning rate, batch size, optimizer, momentum, regularization
+- [ ] Hardware and software: GPU type, memory, library versions (PyTorch/TensorFlow version), CUDA version
+- [ ] Random seed fixed and reported
+- [ ] Baselines: explicit names, citations, whether reimplemented or from published code
+- [ ] If baselines reimplemented: verification that results match published (sanity check)
+- [ ] Evaluation metrics: exact definitions and formulas if non-standard
+- [ ] Statistical testing: cross-validation strategy, confidence intervals, significance tests
+- [ ] Code availability mentioned (GitHub, Zenodo, supplemental materials)
+- [ ] Fair comparison: same preprocessing, same data, same train/test split for all methods
+
+### Results Checklist
+
+- [ ] Baseline results reported first, clearly labeled
+- [ ] Your method results vs. baselines with numbers and error bars
+- [ ] All reported metrics include standard deviation or confidence interval (not single runs)
+- [ ] Statistical significance reported if making comparative claims (p-values, t-tests)
+- [ ] Figures/tables: one per main finding, legible fonts, clear labels and caption
+- [ ] Ablation studies (if applicable) show contribution of each component
+- [ ] Error analysis or per-category breakdown (where does method succeed/fail?)
+- [ ] Edge cases or negative results reported (not cherry-picked)
+- [ ] No interpretation claims ("our method is superior because..."; save for Discussion)
+- [ ] Inconsistencies or unexpected results explained
+- [ ] Results organized in narrative order (baselines → main results → ablations)
+- [ ] No duplication: if result is in table, mention in prose only if highlighting significance

--- a/skills/abstract-methods-results-cs/evals/evals.json
+++ b/skills/abstract-methods-results-cs/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "abstract-methods-results-cs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Review this Abstract and Methods section from a machine learning paper:\n\nAbstract:\nWe propose a new approach to improve deep learning model performance. The method is based on advanced techniques and achieves better results on standard benchmarks. We demonstrate that our approach is effective across different domains.\n\nMethods:\nWe use a deep neural network architecture. The network is trained using gradient descent optimization. Data preprocessing was performed to normalize inputs. The model is evaluated using cross-validation. Various hyperparameters were tested to find optimal settings.",
+      "expected_output": "JSONL with issues including: vague objectives without metrics, unsupported claims, passive voice overuse, incomplete method description (missing details on architecture, hyperparameters, datasets)"
+    },
+    {
+      "id": 2,
+      "prompt": "Review this Results section:\n\nResults:\nOur method was tested on three datasets. The results show improvement over previous work. On dataset A, accuracy increased. Dataset B also showed good results. The approach generalizes well to different domains as shown by the results on dataset C.",
+      "expected_output": "JSONL with issues including: lack of specific metrics (should report actual numbers), no baseline comparison, passive voice, missing std dev/confidence intervals"
+    },
+    {
+      "id": 3,
+      "prompt": "Review this complete Abstract:\n\nAbstract:\nObject detection in real-time scenarios requires both accuracy and speed. We present FastDetect, a novel two-stage detector that achieves 95.3% mAP at 60 FPS on COCO dataset, outperforming previous state-of-the-art by 3.2 percentage points. Our core innovation is a selective region proposal mechanism that reduces candidate boxes by 40% without accuracy loss. We validate on three benchmarks and provide reproducible code.",
+      "expected_output": "JSONL with no critical issues (well-written abstract with metrics and clear claims); possibly minor notes"
+    }
+  ]
+}

--- a/skills/academic-final-review-cs/SKILL.md
+++ b/skills/academic-final-review-cs/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: academic-final-review-cs
+description: Final pre-submission checklist for CS research papers. Verify abstract presence, all required sections, bibliography completeness, figure/table captions and citations, undefined terms, voice consistency, orphaned references, formatting standards, page counts, and venue-specific requirements. Use this skill as the final review before submission—a comprehensive yes/no/fix checklist to catch common issues. Trigger on "final review", "checklist", "before submission", "publication ready", "pre-submission check", or when the paper appears nearly complete but needs final verification.
+origin: ECC
+---
+
+# Academic Final Review Checklist (Delimited Output)
+
+You perform a final pre-submission review of CS research papers using a structured checklist. Output is delimited (pipe-separated), one verification item per line.
+
+## When to Activate
+
+Activate this skill when:
+- Paper draft is nearly complete (all major sections written, figures drafted, bibliography nearly final)
+- Author requests "final review", "pre-submission check", or "publication ready verification"
+- Paper is scheduled for submission within 1-2 weeks
+- Author is preparing to send to conference, journal, or archive
+- Major revision round is complete and last polish is needed
+- Resubmission to venue (after reviewer feedback) is in progress
+
+Do NOT activate if:
+- Paper still lacks major sections or figures
+- Significant content changes are still planned
+- Methods or results are not finalized
+- Bibliography is incomplete or very sparse
+
+## Your Task
+
+When given a complete (or nearly complete) paper, verify all standard academic requirements:
+- Structure completeness (all sections present)
+- Bibliography and citation consistency
+- Figure and table captions and placement
+- Term definitions and first-use clarity
+- Voice consistency throughout
+- Reference completeness
+- Formatting standards and venue compliance
+- Metadata and administrative details
+- Page count and layout compliance
+
+Output one checklist item per line with status and guidance.
+
+## Output Format (Pipe-Delimited)
+
+Use format: `item|status|guidance`
+
+Where:
+- `item` = checklist item name
+- `status` = `PASS`, `FAIL`, or `WARN` (warn for partial/inconsistent)
+- `guidance` = guidance text (empty if PASS, specific action if FAIL/WARN)
+
+```
+item|status|guidance
+Has abstract|PASS|
+Has introduction|PASS|
+Has methods|PASS|
+Has results|PASS|
+Has discussion|PASS|
+Has conclusion|PASS|
+Bibliography formatted|FAIL|Use consistent citation style. Found mixed APA/Chicago on lines 523, 561, 589. Reformat all to APA.
+All figures captioned|FAIL|Figure 3 ("Baseline Comparison") missing caption. Add descriptive caption explaining subfigures.
+All figures cited|FAIL|Figure 3 not cited in text. Add reference in Results section before Figure 3 appears.
+All tables captioned|PASS|
+All tables cited|PASS|
+No undefined terms|WARN|Term "BLEU score" used on line 142 without definition. Define on first use or reference standard citation.
+Consistent voice|WARN|Methods uses passive (75%), Results uses active (55%), Discussion uses passive (80%). Choose one and update for consistency.
+No orphaned references|PASS|
+Headings consistent|PASS|
+Page numbers present|PASS|
+Abstract word count|PASS|
+Author info complete|PASS|
+Keywords present|PASS|
+Acknowledgments section|PASS|
+Appendices referenced|PASS|
+Code/data availability|FAIL|Paper lacks data availability statement. Add section before conclusion or in appendix.
+Ethical considerations|WARN|Paper studies ML fairness but no ethics statement present. Add paragraph explaining ethical implications.
+Page count within limits|PASS|
+Font and margins|PASS|
+```
+
+## Checklist Items (Extended)
+
+| Item | What to verify |
+|------|-----------------|
+| Has abstract | Abstract section present and complete |
+| Has introduction | Introduction section present with motivation and contributions |
+| Has methods | Methods section present and reproducible |
+| Has results | Results section with data/metrics and quantitative evidence |
+| Has discussion | Discussion interprets results and acknowledges limitations |
+| Has conclusion | Conclusion summarizes contributions and suggests future work |
+| Bibliography formatted | All references use consistent citation style throughout |
+| All figures captioned | Every figure has descriptive caption (not just title) |
+| All figures cited | Every figure referenced in text before/near appearance |
+| All tables captioned | Every table has descriptive caption and column headers |
+| All tables cited | Every table referenced in text before/near appearance |
+| No undefined terms | Technical terms defined on first use or well-known |
+| Consistent voice | Paper doesn't switch between active/passive mid-section |
+| No orphaned references | All bibliography entries cited; no unreferenced entries |
+| Headings consistent | Same-level headings use same style and formatting |
+| Page numbers present | All pages numbered (if required by venue) |
+| Abstract word count | Abstract within venue limits (typically 150-250 words) |
+| Author info complete | All author names, affiliations, and contact info present |
+| Keywords present | Keywords listed (if required by venue, typically 5-8) |
+| Acknowledgments section | Acknowledgments present (funding, collaborators, resources) |
+| Appendices referenced | All appendices referenced in main text; no orphaned appendices |
+| Code/data availability | Code/data availability statement present or explanation provided |
+| Ethical considerations | Ethical statement present if applicable (fairness, privacy, harm) |
+| Page count within limits | Total page count (including references) meets venue requirements |
+| Font and margins | Font sizes, line spacing, and margins comply with venue standards |
+
+## How to Evaluate
+
+1. **Structure**: Visually scan for presence of all required sections
+2. **Bibliography**: Check citation format consistency; verify all references are cited; check style matches venue
+3. **Figures/Tables**: Ensure each has descriptive caption and is cited in text before/near appearance
+4. **Terms**: Check that jargon is defined on first use; flag technical terms without explanation
+5. **Voice**: Sample Methods, Results, Discussion; note if passive/active balance is inconsistent within sections
+6. **Formatting**: Spot-check heading levels, margins, fonts, line spacing for consistency
+7. **Metadata**: Verify abstract, keywords, author info, page count match venue requirements
+8. **Administrative**: Check for data/code statements, ethics sections, appendix references, acknowledgments
+9. **LaTeX-specific** (if applicable): Watch for overfull/underfull boxes, widow/orphan lines, float placement
+10. **Final Polish**: Read title, abstract, conclusion for typos; verify PDF metadata if submitting
+
+## Output Requirements
+
+- One checklist item per line (delimited format: `item|status|guidance`)
+- `status` must be exactly `PASS`, `FAIL`, or `WARN`
+- `guidance` is empty (``) for PASS items
+- `guidance` includes specific line numbers, examples, or actions for FAIL/WARN
+- Keep guidance concise but actionable (1-2 sentences max)
+- Report exactly the items listed in the extended table above (or a subset if some don't apply)
+- Do NOT add custom items; stick to the standard checklist
+- Order items in same sequence as the checklist table
+
+## Example Review Output
+
+```
+item|status|guidance
+Has abstract|PASS|
+Has introduction|PASS|
+Has methods|PASS|
+Has results|PASS|
+Has discussion|PASS|
+Has conclusion|PASS|
+Bibliography formatted|FAIL|Inconsistent style. Lines 45-120 use APA; lines 121-180 use Chicago. Convert all to APA: Author (Year) Title. Source.
+All figures captioned|FAIL|Figure 2 missing caption. Figures 4 and 5 have vague captions ("Results"). Make descriptive: e.g., "Figure 2: Convergence curves for baseline vs. proposed method."
+All figures cited|PASS|
+All tables captioned|WARN|Table 1 caption reads "Data" (too vague). Revise to "Table 1: Dataset statistics (sample size, feature count, class distribution)."
+All tables cited|FAIL|Table 3 appears on page 8 but not cited in text. Add reference in Results: "Table 3 shows comparison results."
+No undefined terms|FAIL|"Attention mechanism" used on line 42 without explanation. Add: "Attention mechanism (Vaswani et al., 2017) weights input representations."
+Consistent voice|WARN|Methods section is 90% passive; Results uses active voice (80%). Choose one style for whole paper. Recommend active for clarity.
+No orphaned references|PASS|
+Headings consistent|PASS|
+Page numbers present|FAIL|Pages 5-7 missing page numbers. Add page numbers to all pages using document settings.
+Abstract word count|FAIL|Abstract is 312 words; venue limit is 250. Remove 62 words by condensing background and focusing on contribution.
+Author info complete|WARN|Author email missing for second author. Add affiliation and email per venue guidelines.
+Keywords present|PASS|
+Acknowledgments section|PASS|
+Appendices referenced|FAIL|Appendix B ("Extended Results") not referenced in main text. Add reference in Results section or remove appendix.
+Code/data availability|FAIL|Paper lacks data availability statement. Add before conclusion: "Code and datasets are available at [repository URL]."
+Ethical considerations|WARN|Paper studies facial recognition but no ethics discussion. Add paragraph addressing privacy and fairness concerns.
+Page count within limits|PASS|
+Font and margins|PASS|
+```
+
+## LaTeX-Specific Checks (If Applicable)
+
+If the paper is written in LaTeX, additionally check:
+
+| Item | What to verify |
+|------|-----------------|
+| No overfull/underfull boxes | Compile with `pdflatex` and check `.log` for warnings; fix line breaks |
+| No widow/orphan lines | Last line of paragraph appears alone; first line appears alone at page break |
+| Float placement | Figures/tables appear reasonably close to first citation (same page or next) |
+| Bibliography style matches | `.bst` file (plain, acm, ieeetr, etc.) matches venue requirements |
+| Package conflicts | No conflicting packages (e.g., both `geometry` and `fullpage`); check console |
+| PDF metadata | PDF title, author, and keywords match document content |
+
+## Venue-Specific Checklists
+
+Adjust emphasis depending on target venue:
+
+### ACM Conference/Journal Submission
+- CCS concepts assigned and listed
+- References follow ACM reference format (author initials, venue, page ranges)
+- Rights management and permissions statement present
+- Author affiliations and email addresses complete
+- Funding information in acknowledgments
+- Do NOT include page numbers (ACM adds them during production)
+
+### IEEE Conference/Journal Submission
+- IEEE keywords present (5-7 technical terms)
+- References follow IEEE citation style (author initials, title in quotes)
+- Author biography section present (for some venues)
+- Abstract written in third person (common in IEEE)
+- Special characters properly encoded
+- Font: Times New Roman or similar serif (common requirement)
+
+### General Multi-Venue Checklist
+- Venue-specific formatting template applied (margins, fonts, spacing)
+- Submission deadline confirmed and calendar reminder set
+- Supplemental materials (code, data, video) prepared separately
+- Conflict-of-interest disclosures completed
+- PDF proofread for typos and rendering issues before final submission
+
+## DO and DON'T Patterns
+
+### DO
+
+- DO define all technical acronyms on first use (e.g., "Convolutional Neural Network (CNN)")
+- DO cite figures and tables in text BEFORE they appear
+- DO use active voice in Results (e.g., "Our method achieves 95% accuracy" not "95% accuracy is achieved")
+- DO include error bars, confidence intervals, or significance tests for quantitative results
+- DO provide specific page counts if venue requires (e.g., "main paper: 8 pages, appendix: 2 pages")
+- DO check that all section numbering is sequential and consistent
+- DO verify all external links (if any) are current and public-facing
+- DO have a second author review for typos and clarity before final submission
+- DO generate table of contents/outline to verify paper structure
+
+### DON'T
+
+- DON'T use "et al." for author citations unless there are 3+ authors
+- DON'T cite figures with vague captions ("Figure 1: Results") without explaining what results
+- DON'T assume readers know what "this paper" refers to; use clear pronouns
+- DON'T mix citation styles (e.g., some citations with URLs, some without)
+- DON'T submit PDF with track changes or comments visible
+- DON'T include author names in headers/footers (unless blind review explicitly requires it)
+- DON'T use footnotes for main content; use endnotes or appendix
+- DON'T leave citations as "[?]", "[ref]", or placeholder text
+- DON'T include figures from external sources without proper permissions/attribution
+- DON'T submit without spell-check (grammar and style checkers are helpful too)
+
+## Common Last-Minute Mistakes (Real Examples)
+
+| Mistake | How It Happens | How to Avoid |
+|---------|----------------|-------------|
+| References not cited in text | Author copies bibliography without checking; ends with 20 unreferenced entries | Run bibliography against text; cite all references or remove them |
+| Figure floats to wrong page | LaTeX `[h]` placement ignored; figure now 5 pages from first citation | Use `[tb]` or adjust preceding text to bring reference and figure closer |
+| Abstract exceeds limit | Author adds results during revision; forgets to trim abstract to word limit | Count words in abstract; trim to 250-word max after each revision |
+| Inconsistent capitalization in titles | Some references have "title case", others "sentence case" | Use BibTeX macro or manually standardize all reference titles |
+| Missing affiliation for an author | Fourth author added late; no affiliation recorded | Double-check author block; every name needs affiliation |
+| Undefined term on page 1 | "BLEU score" used in abstract without definition | Define all technical terms on first use, even in abstract |
+| Table columns misaligned in PDF | Works in Word/Google Docs but renders poorly as PDF | Export to PDF; check table alignment before final submission |
+| Orphaned heading at page break | Section heading appears alone at bottom of page | Adjust text above or use `\needspace{}` in LaTeX |
+| Bibliography incomplete | Author loses track of sources added late; some references incomplete | Do final pass: check every reference has author, year, title, venue, pages |
+| Author names in header (blind review) | Accidentally left author names in paper header | Search for author surnames; verify they don't appear outside author block |
+| Figure caption too brief | "Figure 3: Results" without explaining which results or metrics | Write caption as 1-2 sentence summary (caption should stand alone) |
+| Margin too narrow | Used default 0.5-inch margins; venue requires 1-inch | Check venue template; measure margins in document settings |
+
+## Quick Reference: 10-Minute Pre-Submission Checklist
+
+Use this condensed checklist right before final upload:
+
+```
+[  ] All 6+ main sections present (Intro, Methods, Results, Discussion, Conclusion, References)
+[  ] Abstract word count OK (e.g., <250 words)
+[  ] No [?], [ref], or placeholder citations
+[  ] All figures have captions and are cited in text
+[  ] All tables have captions and are cited in text
+[  ] No undefined technical terms (or all defined on first use)
+[  ] Bibliography style consistent (all APA or all IEEE, etc.)
+[  ] No author names in headers (if blind review)
+[  ] Page count within venue limits
+[  ] PDF exports cleanly without rendering errors
+[  ] Spell-check passed; no obvious typos
+[  ] Filenames correct and match submission requirements
+[  ] Keywords present (if required)
+[  ] Data/code availability statement present (if required)
+[  ] Ethics statement present (if applicable)
+[  ] Appendices referenced (or removed)
+[  ] One final proofread for clarity
+[  ] SUBMIT
+```
+
+## Teaching Notes
+
+When reviewing a paper, explain findings in concrete terms. Instead of saying "voice is inconsistent", point to specific pages/sections showing passive voice dominance. When flagging undefined terms, provide the definition the author should add. When citing formatting issues, reference both the problem (e.g., "Figure 5 not cited") and the solution (e.g., "Add 'Figure 5 shows...' in Results after line 247").
+
+---
+
+## Guidelines
+
+- **Binary thinking**: Each item is binary (present/absent, consistent/inconsistent). Avoid ambiguous status.
+- **Actionability**: Guidance must tell author exactly what to fix (line numbers, specific changes)
+- **Completeness**: Perform the full checklist; don't skip items
+- **Pre-submission focus**: This is the final check before sending to conference/journal; be thorough
+- **Venue awareness**: Ask about target venue if not obvious; tailor checks (ACM vs. IEEE vs. arXiv)
+- **Severity reporting**: Flag FAIL for blocking issues (missing sections, formatting violations); WARN for improvements (vague captions, minor inconsistencies)
+
+## Summary
+
+This skill provides a comprehensive final-review checklist for CS papers before submission. Use pipe-delimited output for easy parsing and clear status reporting. The checklist scales from 16 core items to 25+ extended items depending on paper completeness and venue requirements. Always include actionable guidance for FAIL and WARN items. Output is designed for machine parsing (delimited) but remains human-readable for author review.

--- a/skills/academic-final-review-cs/evals/evals.json
+++ b/skills/academic-final-review-cs/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "academic-final-review-cs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Perform a final review checklist on this paper description:\n\nA paper with all main sections (Abstract, Intro, Methods, Results, Discussion, Conclusion). Bibliography uses mixed citation styles (some APA, some Chicago). Figure 1 appears on page 5 with caption 'Results'. Figure 2 is captioned but never cited in text. All tables have captions and are cited. The word 'attention mechanism' is used on page 3 without definition. Methods section is written entirely in passive voice, while Results uses active voice.",
+      "expected_output": "Delimited output showing: PASS on structure, FAIL on bibliography formatting, FAIL on figure citations, WARN on undefined terms and voice consistency"
+    },
+    {
+      "id": 2,
+      "prompt": "Checklist review for submission readiness:\n\nPaper has: Abstract, Intro, Methods, Results, Discussion, Conclusion, Bibliography. All 5 figures are captioned and cited. All 3 tables are captioned and cited. Citation style is consistent (APA throughout). All technical terms are defined. Writing voice is consistently active. Page numbers present throughout. No orphaned references.",
+      "expected_output": "Delimited output with all PASS marks (well-prepared paper)"
+    },
+    {
+      "id": 3,
+      "prompt": "Review this incomplete paper:\n\nMissing: Introduction section, Discussion section. Bibliography is missing. Figures 1-3 have no captions. Only 2 of 4 figures are cited in text. Heading hierarchy inconsistent (# and ### without ##). References in text but no bibliography section. Methods written in passive voice (95%), Results in active (70%).",
+      "expected_output": "Delimited output showing multiple FAIL entries: missing sections, missing bibliography, uncaptioned figures, uncited figures, heading inconsistency, voice inconsistency"
+    }
+  ]
+}

--- a/skills/harvard-resume-validator/SKILL.md
+++ b/skills/harvard-resume-validator/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: harvard-resume-validator
+description: Validates and helps write resumes against Harvard College's official guidelines. Use this skill whenever you're working with resumes in Cowork—whether reviewing a .tex resume file, getting feedback on your current resume, or building a new one from scratch. Covers Harvard's standards for formatting, structure (education, experience, skills), action verbs, conciseness, tailoring to roles, and best practices. Trigger on phrases like "validate my resume", "review my resume against Harvard guidelines", "help me write a resume", "check my resume", or when you see a resume .tex file in the working folder that needs evaluation or improvement.
+compatibility: Requires LaTeX .tex files in the working folder; bash_tool for file operations
+origin: ECC
+---
+
+# Harvard Resume Validator & Builder
+
+A skill for validating resumes against Harvard College's official guidelines and helping you write or improve resumes that follow best practices.
+
+## When to Activate
+
+Use this skill when:
+- You have a `.tex` resume file in your Cowork working folder that needs validation or feedback
+- You want to check if your resume follows Harvard College's official guidelines
+- You're writing a new resume and want guidance on structure, content, and formatting
+- You need to understand action verbs, bullet point construction, or how to tailor your resume to specific roles
+- You want to ensure your resume follows best practices for ATS (Applicant Tracking Systems) and hiring managers
+
+## Core Guidelines from Harvard College
+
+Harvard's resume guide emphasizes:
+- **Structure**: Education, Experience, Leadership/Activities, Skills/Interests (optional categories included)
+- **Length**: Typically one page for undergraduates
+- **Action verbs**: Use strong, varied action words to start each bullet point
+- **Conciseness**: Eliminate unnecessary words; focus on impact and outcomes
+- **Tailoring**: Customize resumes for specific roles by highlighting relevant skills and experiences
+- **Formatting**: Consistent fonts, sizes, margins; clean, professional appearance
+- **Avoid**: Personal pronouns (I, me, we), flowery language, vague accomplishments
+
+## Skill Workflow
+
+### 1. Validating an Existing Resume
+
+When you have a `.tex` resume file:
+
+1. **Read the file** to understand current structure and content
+2. **Check against Harvard guidelines**:
+   - Does it have required sections (Education, Experience)?
+   - Are bullet points concise and action-verb-driven?
+   - Is it properly tailored to the target role/industry?
+   - Are there weaknesses in formatting, clarity, or impact?
+3. **Provide feedback** in a structured format:
+   - **Strengths**: What's working well
+   - **Issues**: Specific violations of Harvard guidelines (with line references)
+   - **Suggestions**: Concrete rewrites for problem areas
+   - **Priority fixes**: What to address first
+
+Output feedback as a clear, actionable report that you can reference when revising the file.
+
+### 2. Writing or Improving a Resume from Scratch
+
+When building a new resume or significantly revising one:
+
+1. **Interview** (ask about):
+   - What's your major/graduation year?
+   - What types of roles/industries are you targeting?
+   - What are your top 2-3 achievements or skills?
+   - Any leadership roles, internships, or relevant projects?
+
+2. **Structure** the resume with Harvard's recommended sections:
+   - **Header**: Name, contact info (city/state, email, phone)
+   - **Education**: School, degree, GPA (if 3.7+), relevant coursework, study abroad
+   - **Experience**: Job title, organization, dates, 3-5 bullet points (outcomes, skills)
+   - **Leadership/Activities**: Role, organization, impact (optional but valuable)
+   - **Skills/Interests**: Technical skills, languages, tools, interests
+
+3. **Guide on best practices**:
+   - Start each bullet with a strong action verb (Led, Designed, Increased, Optimized, etc.)
+   - Include metrics/outcomes where possible (e.g., "Increased engagement by 20%")
+   - Avoid pronouns; use past tense
+   - Keep bullets to 1-2 lines; eliminate filler words
+   - Tailor descriptions to highlight skills the target role values
+
+4. **Generate suggestions** for structure, wording, and emphasis based on their goals
+
+### 3. Providing Targeted Feedback
+
+For specific issues or sections:
+- **Bullet point critique**: Rewrite weak bullets with action verbs and impact
+- **Tailor guidance**: Suggest how to reframe experiences for specific industries (tech, finance, consulting, nonprofits, etc.)
+- **ATS optimization**: Ensure formatting won't break in automated screening systems
+- **Cover letter alignment**: Check that resume and cover letter tell a consistent story
+
+## Key Harvard Action Verbs
+
+Use these instead of generic words:
+
+**Leadership**: Led, Directed, Managed, Spearheaded, Championed, Orchestrated
+**Analysis**: Analyzed, Evaluated, Assessed, Examined, Investigated
+**Creation**: Designed, Developed, Created, Built, Established, Launched
+**Improvement**: Optimized, Improved, Enhanced, Refined, Strengthened, Accelerated
+**Communication**: Presented, Articulated, Communicated, Advocated, Pitched
+**Technical**: Implemented, Deployed, Engineered, Automated, Configured
+**Quantified Impact**: Increased, Reduced, Expanded, Streamlined, Generated
+
+## Example: Before & After
+
+**Weak bullet:**
+- Worked on a project to help students understand better
+
+**Strong bullet (Harvard-style):**
+- Designed interactive Python tutorials for 50+ CS students, resulting in 25% improvement in assignment completion rates
+
+## CS-Specific Resume Examples
+
+### Software Engineering Internship
+
+**Weak:**
+- Worked on backend stuff and fixed bugs during my internship at a startup
+
+**Strong (Harvard-aligned):**
+- Engineered REST API endpoints in Python/Flask serving 10K+ daily requests; reduced query latency by 40% through database indexing optimization
+- Debugged and resolved 15+ production issues across payment and user authentication systems, improving system reliability to 99.8% uptime
+
+### Research Assistant
+
+**Weak:**
+- Helped with a machine learning research project on image classification
+
+**Strong (Harvard-aligned):**
+- Implemented data preprocessing pipeline in PyTorch for 50K+ medical imaging dataset; contributed to paper achieving 94% classification accuracy
+- Conducted literature review spanning 80+ papers; synthesized findings into technical memo guiding model architecture design
+
+### Course Project
+
+**Weak:**
+- Built a web app for my CS class along with two teammates
+
+**Strong (Harvard-aligned):**
+- Architected full-stack e-commerce platform (React, Node.js, PostgreSQL) serving 200+ test users; led code review process and maintained 95%+ test coverage
+- Designed responsive UI achieving 98 Lighthouse score; implemented OAuth integration reducing registration friction by 30%
+
+### Hackathon / Side Project
+
+**Weak:**
+- Made an app at a hackathon that won a prize
+
+**Strong (Harvard-aligned):**
+- Built real-time collaboration tool (WebSocket, React, MongoDB) in 24 hours; won "Best Developer Experience" award at HackHarvard 2025 with 50+ beta users
+- Open-sourced project on GitHub earning 200+ stars; managed community contributions and released three feature-complete versions
+
+### Teaching Assistant
+
+**Weak:**
+- Helped teach CS50 and answered student questions
+
+**Strong (Harvard-aligned):**
+- Led weekly section for 30 CS50 students covering advanced C and Python concepts; improved section attendance by 45% through interactive problem-solving format
+- Developed and delivered 8 custom review sessions; contributed to 12% improvement in median section assignment scores compared to prior semester
+
+## LaTeX Resume Tips
+
+### Common LaTeX Resume Packages
+
+- **moderncv** — Professional, highly customizable templates; includes multiple color schemes and layouts
+- **awesome-cv** — Modern, feature-rich with colored sections and icons; good for tech roles
+- **altacv** — Flexible, minimalist design; excellent for creative alignment and column layouts
+- **resume** — Lightweight, simple structure; easiest for ATS compatibility
+- **deedy-resume** — Two-column layout with clean typography; popular in tech
+- **friggeri-cv** — Elegant, sidebar layout; visually distinctive but less ATS-friendly
+
+### ATS-Friendly LaTeX Formatting
+
+- **Stick to basic packages** — Avoid fancy packages (pgfplots, tikz, pstricks) that create images instead of text; ATS parsers cannot extract text from images
+- **Use standard commands** — Prefer `\textbf{}` and `\textit{}` over custom formatting macros; ensure text remains selectable
+- **Avoid multi-column layouts** — Some ATS systems read left-to-right linearly; sidebar or two-column designs may scramble content
+- **Use simple lists** — Prefer `itemize` with `\item` over custom list environments; test with `pdftotext` to verify content extraction
+- **Include hyperlinks properly** — Use `\href{}{}` for clickable links; include plain text URL fallback in plain-text version
+- **Consistent spacing** — Use `\vspace{}` sparingly; maintain uniform margins and line spacing for readability
+
+### Font Choices for Professional PDFs
+
+- **Serif fonts** (traditional) — Computer Modern, Times New Roman, Garamond; professional for consulting and finance
+- **Sans-serif fonts** (modern) — Helvetica, Arial, Source Sans Pro; clean, tech-friendly appearance
+- **Recommended combo** — Helvetica or Source Sans Pro with serif for section headers; 10-11pt body, 12-14pt headers
+- **Avoid** — Script fonts, heavy decorative fonts, mixed font sizes without clear hierarchy
+- **Compilation note** — Use pdflatex or xelatex; ensure fonts embed correctly in PDF (check properties; all fonts should be embedded, not substituted)
+
+### Common LaTeX Resume Pitfalls
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Overfull hbox | Lines overflow to margin; compiler warnings | Reduce margins, break long lines, use `\raggedright` sparingly |
+| Underfull hbox | Spacing feels off; weird gaps between words | Add explicit line breaks `\\` or use `\newline` |
+| Image inclusions | Resume cannot be parsed; looks broken in ATS | Avoid images; use text-based icons or Unicode symbols instead |
+| Custom macro nesting | Formatting breaks; unexpected bold/italics | Flatten macros; use only `\textbf`, `\textit`, `\texttt` |
+| Line spacing too tight | Hard to read; ATS struggles to separate lines | Add `\linespacing{1.15}` or use `\setspacing{1.15}` from setspace |
+| Itemize indentation | Bullets don't align or appear misaligned | Set `\leftmargin` and `\labelwidth` explicitly in item settings |
+
+### File Structure for Maintainability
+
+**Recommended structure:**
+```latex
+\documentclass{article}
+% Preamble: packages, custom commands, formatting
+\usepackage{resume}  % or moderncv, awesome-cv, etc.
+\usepackage[margin=0.5in]{geometry}
+
+% Define custom commands for repeated patterns
+\newcommand{\job}[4]{\textbf{#1} | #2 \\ #3 | #4}
+\newcommand{\bullet}[1]{\item #1}
+
+\begin{document}
+
+% Header (name, contact)
+\section*{Contact}
+
+% Education
+\section{Education}
+
+% Experience
+\section{Experience}
+
+% Projects
+\section{Projects}
+
+% Skills
+\section{Skills}
+
+\end{document}
+```
+
+**Maintainability tips:**
+- Define command shortcuts (`\job{}`, `\skill{}`, `\project{}`) at the top; reuse throughout
+- Separate sections with clear comments and spacing
+- Keep custom formatting minimal; rely on package defaults
+- Version control changes with git; track date modified
+- Test PDF output with `pdftotext` before submitting; ensure all text extracts cleanly
+
+## DO/DON'T Patterns
+
+### DOs
+
+- **DO** lead each bullet with a strong action verb (Led, Designed, Optimized, etc.)
+- **DO** include quantified impact whenever possible (percentages, numbers, user counts)
+- **DO** tailor your resume to the target role; highlight relevant skills and experiences
+- **DO** use consistent formatting (fonts, sizes, margins, bullet styles) throughout
+- **DO** keep your resume to one page as an undergraduate; use white space effectively
+- **DO** use past tense for all roles and experiences, even if ongoing at write time
+- **DO** include links to GitHub, portfolio, or relevant projects if they strengthen your candidacy
+- **DO** proofread multiple times; grammatical errors or typos are immediate red flags
+- **DO** test your resume in PDF form to catch formatting issues before submitting
+- **DO** get feedback from peers, mentors, or MCS advisors before finalizing
+
+### DON'Ts
+
+- **DON'T** use personal pronouns (I, me, we, us); let action verbs speak for themselves
+- **DON'T** include outdated or irrelevant experiences; prioritize recent and role-specific content
+- **DON'T** use generic descriptions like "Helped the team" or "Responsible for"; be specific and measurable
+- **DON'T** add unnecessary personal information (photo, age, marital status, nationality)
+- **DON'T** include reasons for leaving jobs, salary info, or references (provide separately if asked)
+- **DON'T** use flowery, vague language like "passionate about," "hardworking," or "team player" without evidence
+- **DON'T** exceed two lines per bullet point; condense and prioritize impact
+- **DON'T** use abbreviations without first explaining them (except widely recognized ones like API, AI, SQL)
+- **DON'T** include GPA if below 3.7; Harvard strong emphasis on meritocracy means low GPA may hurt more than help
+- **DON'T** use fancy LaTeX packages that break ATS parsing (tikz, pgfplots, custom graphics)
+- **DON'T** submit a resume without verifying it extracts cleanly as plain text via pdftotext
+- **DON'T** assume a one-size-fits-all resume; customize for each application
+
+## Section-by-Section Validation Checklist
+
+Use this checklist to quickly validate each section of your resume against Harvard standards:
+
+### Header
+
+- [ ] Full name is prominent (largest font on page)
+- [ ] City/state included (or "Remote" if applicable)
+- [ ] Email address is professional (firstname.lastname@... or similar)
+- [ ] Phone number is included and formatted consistently
+- [ ] Links are included (GitHub, portfolio, LinkedIn, personal website) if they add value
+- [ ] All contact info fits on one line or is neatly aligned
+- [ ] No unnecessary personal details (photo, age, pronouns unless you choose to include)
+
+### Education
+
+- [ ] School name, degree, and graduation date (or expected date) clearly listed
+- [ ] Major and minor (if applicable) are specified
+- [ ] GPA included only if 3.7 or above; otherwise omit
+- [ ] Relevant coursework listed (e.g., "Relevant Coursework: Data Structures, Algorithms, ML")
+- [ ] Awards, honors, or dean's list mentions are concise and notable
+- [ ] Study abroad, exchange programs, or special experiences are relevant to target role
+- [ ] No excessive course listings; select 4-6 most relevant courses
+
+### Experience
+
+- [ ] Each role includes: Job Title, Organization, Location (if space allows), Dates (Month Year - Month Year)
+- [ ] Dates are consistent in format (e.g., "June 2024 - August 2024")
+- [ ] Each role has 3-5 bullet points (no more than 6 without overflow)
+- [ ] Every bullet starts with a strong, varied action verb (avoid repeating "Managed" five times)
+- [ ] At least 50% of bullets include quantified impact (numbers, percentages, or measurable outcomes)
+- [ ] Bullets are tailored to the target role (remove irrelevant or generic tasks)
+- [ ] No personal pronouns (I, me, we); action verbs carry the narrative
+- [ ] All bullets are past tense, even if the role is current
+- [ ] No "Responsible for" or "Helped with" phrasing; use active achievements instead
+
+### Projects
+
+- [ ] Project title is clear and relevant to target role
+- [ ] Technologies/stack are listed (e.g., "React, Node.js, PostgreSQL")
+- [ ] Each project has 2-3 impact-focused bullets
+- [ ] Outcome or result is stated (users served, award won, article published, etc.)
+- [ ] Links to GitHub or live demo are included (if applicable and if they showcase polished work)
+- [ ] Personal projects are clearly labeled as such (not confused with coursework)
+- [ ] Dates are included (Month Year - Month Year) for clarity
+
+### Skills
+
+- [ ] Skills are organized into logical categories (Languages, Tools, Frameworks, etc.)
+- [ ] Only include skills you can confidently discuss in an interview
+- [ ] Technical skills are current and relevant to target roles
+- [ ] Soft skills are omitted or kept to 1-2 (e.g., avoid "Communication," "Leadership" without context)
+- [ ] No fluff like "Microsoft Word" or "Google Docs"
+- [ ] Order by relevance to target role (most relevant listed first)
+- [ ] Avoid generic descriptors like "Proficient in..." or "Experienced with..."; just list the skill
+- [ ] Total skills section fits in 3-5 lines; no overflow
+
+### Overall
+
+- [ ] Resume is exactly one page (no overflow, good use of white space)
+- [ ] Consistent font, size, and alignment throughout
+- [ ] Margins are 0.5 inch all around (standard)
+- [ ] PDF exports cleanly with all formatting intact
+- [ ] Text extracts cleanly when converted to plain text via pdftotext
+- [ ] No typos, grammatical errors, or inconsistent abbreviations
+- [ ] Resume has been reviewed by at least one peer or advisor
+
+## Output Format for Cowork
+
+When validating a `.tex` file, provide feedback in this JSON structure for easy machine parsing:
+
+```json
+{
+  "file_analyzed": "path/to/resume.tex",
+  "summary": "Brief overall assessment",
+  "sections": {
+    "section_name": {
+      "status": "pass|flag|rewrite",
+      "issues": ["issue1", "issue2"],
+      "suggestions": ["suggestion1", "suggestion2"],
+      "priority": "high|medium|low"
+    }
+  },
+  "top_3_fixes": [
+    "Fix 1: Specific action",
+    "Fix 2: Specific action",
+    "Fix 3: Specific action"
+  ],
+  "alignment_to_harvard": "percentage or qualitative"
+}
+```
+
+If you're writing a new resume, output a `.tex` template or LaTeX snippet ready to use.
+
+## Common Issues & How to Fix Them
+
+| Issue | Harvard Guideline | How to Fix |
+|-------|-------------------|-----------|
+| "Responsible for X" | Use action verbs | Change to "Led X" or "Managed X" |
+| "Helped the team do Y" | Show individual impact | "Designed Y that improved team efficiency by Z%" |
+| Generic skills list | Tailor to target role | Select skills matching the job description |
+| No metrics | Quantify outcomes | Add numbers: "Increased sales by 15%", "Served 200+ users" |
+| Too wordy | Concise bullets | Remove "I was" / "We decided to" — just state the action and result |
+| Inconsistent formatting | Professional appearance | Match font, size, margins, bullet style throughout |
+
+## Tips for Success
+
+- **Tailor every application**: Customize experience bullets to highlight skills the employer values
+- **Use metrics**: Numbers make accomplishments concrete and memorable
+- **Tell a story**: Your resume should reflect a coherent narrative about your skills and interests
+- **Test readability**: Print it or view as PDF to catch formatting issues
+- **Get feedback**: Share with peers or MCS advisors (Mignone Center for Career Success)
+
+---
+
+## Related Resources
+
+- Harvard's official guide: [Create a Strong Resume](https://careerservices.fas.harvard.edu/resources/create-a-strong-resume/)
+- MCS Resume Templates: Available in Crimson Careers portal
+- MCS Contact: mcs@fas.harvard.edu, 617-495-2595

--- a/skills/harvard-resume-validator/SKILL.md
+++ b/skills/harvard-resume-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: harvard-resume-validator
 description: Validates and helps write resumes against Harvard College's official guidelines. Use this skill whenever you're working with a resume—whether reviewing a .tex resume file, getting feedback on your current resume, or building a new one from scratch. Covers Harvard's standards for formatting, structure (education, experience, skills), action verbs, conciseness, tailoring to roles, and best practices. Trigger on phrases like "validate my resume", "review my resume against Harvard guidelines", "help me write a resume", "check my resume", or when you see a resume .tex file that needs evaluation or improvement.
-origin: ECC
 origin: ECC
 ---
 

--- a/skills/harvard-resume-validator/SKILL.md
+++ b/skills/harvard-resume-validator/SKILL.md
@@ -1,7 +1,6 @@
 ---
-name: harvard-resume-validator
-description: Validates and helps write resumes against Harvard College's official guidelines. Use this skill whenever you're working with resumes in Cowork—whether reviewing a .tex resume file, getting feedback on your current resume, or building a new one from scratch. Covers Harvard's standards for formatting, structure (education, experience, skills), action verbs, conciseness, tailoring to roles, and best practices. Trigger on phrases like "validate my resume", "review my resume against Harvard guidelines", "help me write a resume", "check my resume", or when you see a resume .tex file in the working folder that needs evaluation or improvement.
-compatibility: Requires LaTeX .tex files in the working folder; bash_tool for file operations
+description: Validates and helps write resumes against Harvard College's official guidelines. Use this skill whenever you're working with a resume—whether reviewing a .tex resume file, getting feedback on your current resume, or building a new one from scratch. Covers Harvard's standards for formatting, structure (education, experience, skills), action verbs, conciseness, tailoring to roles, and best practices. Trigger on phrases like "validate my resume", "review my resume against Harvard guidelines", "help me write a resume", "check my resume", or when you see a resume .tex file that needs evaluation or improvement.
+origin: ECC
 origin: ECC
 ---
 

--- a/skills/kickass-resume-validator/SKILL.md
+++ b/skills/kickass-resume-validator/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: kickass-resume-validator
+description: Validates and helps write resumes following "How to Write a Kickass Resume" industry-standard guidelines. Use this skill whenever you're working with resumes in Cowork—whether reviewing a .tex resume file, getting feedback on your current resume, or building a new one from scratch. Covers formatting, structure (header, education, work experience, projects, skills), action verbs, impact metrics, ATS compliance, and tailoring for specific roles. Trigger on phrases like "validate my resume", "review my resume against kickass guidelines", "help me write a kickass resume", "check my resume", or when you see a resume .tex file in the working folder.
+compatibility: Requires LaTeX .tex files in the working folder; bash_tool for file operations
+origin: ECC
+---
+
+# Kickass Resume Validator & Builder
+
+A skill for validating resumes against "How to Write a Kickass Resume" industry standards and helping you write or improve resumes that get noticed.
+
+## When to Activate
+
+Use this skill when:
+- You have a `.tex` resume file in your Cowork working folder that needs validation or feedback
+- You want to check if your resume follows "How to Write a Kickass Resume" industry best practices
+- You're writing a new resume and want guidance on structure, content, and formatting
+- You need to understand action verbs, impact metrics, and how to tailor your resume to specific roles
+- You want to ensure your resume is ATS-compliant (parseable by automated systems)
+- You're applying to tech, startup, or competitive roles where the resume needs to stand out
+
+## Core Guidelines from "How to Write a Kickass Resume"
+
+This skill is based on the industry-standard guide that emphasizes:
+
+### Structure & Formatting
+- **One page maximum** (Letter size: 8.5 x 11 inches)
+- **Consistent formatting**: fonts, styles, capitalization, punctuation, date formats
+- **Clean, professional fonts**: Arial or Times New Roman (ATS-compliant)
+- **Strategic section ordering**: Students → Education first; Professionals → Experience first
+- **ATS compliance**: Avoid fancy templates; keep it simple and scannable
+
+### Header
+- **Legal name** (bolded, larger font)
+- **Optional**: Desired role (if applying to diverse positions)
+- **Email**: Professional, regularly checked
+- **Phone number**: Formatted consistently
+- **LinkedIn URL & Portfolio links**: Make them clickable; keep current
+- **Location**: City, State (no full address needed); consider "Open to relocation" if relevant
+
+### Education
+- **University name, degree, major/minor, location**
+- **GPA**: Only if 3.5 or above
+- **Expected graduation date**: Include month and year for students
+- **Do not list**: Transferred-from schools, incomplete degrees, high school (after sophomore year)
+- **Do not list certifications as "In Progress"** — only completed certifications count
+
+### Work Experience
+- **Role Title, Company, Location, Dates** (Month Year - Month Year)
+- **3-5 bullet points** per role (more for longer tenure)
+- **Start with action verbs**: Led, Designed, Developed, Created, etc.
+- **Include metrics**: Quantified impact (%, $, users, time saved, efficiency gains)
+- **Focus on accomplishments**: What did you build? What changed? What was the outcome?
+- **One-liner summary** (optional): Brief context before bullets if role is unclear
+- **Self-employment**: Same format but emphasize company building, revenue, team leadership
+
+### Projects
+- **Project name, description, technologies used, outcome/impact**
+- **Personal/school projects are valuable** — include if they demonstrate relevant skills
+- **Can replace or supplement work experience** for students without extensive internships
+- **Show completeness**: Working projects on GitHub/portfolio links are better than descriptions
+
+### Skills
+- **Keep it organized**: Group by category (Languages, Tools/Frameworks, Concepts, etc.)
+- **Tailor to the role**: Include skills matching the job description
+- **Balance breadth and depth**: Show both breadth (many technologies) and depth (mastery)
+- **Include relevant technical AND soft skills** if space allows
+- **Order by relevance**: Most relevant to target role first
+
+### Industry Involvement
+- **Hackathons, volunteering, conference speaking, mentorship, community organizing**
+- **Shows initiative and passion** beyond just paid work
+- **Use same action verb format** as work experience
+- **Include impact**: Team mentored, attendees helped, event size, outcomes
+
+## Skill Workflow
+
+### 1. Validating an Existing Resume
+
+When you have a `.tex` resume file:
+
+1. **Read the file** to understand structure and content
+2. **Check against "Kickass Resume" standards**:
+   - Is it one page? Are fonts professional?
+   - Is the section order strategic for your situation (student/professional)?
+   - Do headers clearly delineate sections?
+   - Are action verbs strong and varied?
+   - Are there metrics/outcomes in every bullet?
+   - Is it ATS-compliant (no fancy templates, clean structure)?
+   - Are dates consistent? Is formatting uniform?
+3. **Provide feedback** in structured format:
+   - **Strengths**: What's working well
+   - **Issues**: Specific violations of "Kickass Resume" guidelines (with section references)
+   - **Suggestions**: Concrete rewrites with stronger action verbs and metrics
+   - **Priority fixes**: What to address first (high/medium/low)
+   - **ATS compliance**: Is it parseable by automated systems?
+
+Output feedback as a clear, actionable report that you can reference when revising.
+
+### 2. Writing or Improving a Resume from Scratch
+
+When building a new resume or significantly revising one:
+
+1. **Interview** (ask about):
+   - What's your current situation? (Student, recent grad, professional, career changer?)
+   - What roles/companies/industries are you targeting?
+   - What are your top 3 achievements or proudest projects?
+   - What internships, jobs, projects, or volunteering have you done?
+   - What technical skills, tools, or languages do you know?
+   - Any leadership, hackathons, speaking, or industry involvement?
+
+2. **Structure** the resume strategically:
+   - **Students**: Header → Education → Work Experience → Projects → Skills → (Industry Involvement)
+   - **Professionals**: Header → Work Experience → Education → Projects → Skills → (Industry Involvement)
+   - **Career changers**: Tailor section order to highlight most relevant experience
+
+3. **Guide on best practices**:
+   - Start each bullet with strong action verb (Led, Designed, Built, Created, Developed, etc.)
+   - Include metrics: percentages, dollars, user numbers, time saved, efficiency gains
+   - Show outcomes: What changed? What was the impact?
+   - Keep bullets 1-2 lines; eliminate filler words
+   - Tailor descriptions to highlight skills matching target role
+   - Group skills by category for clarity and ATS readability
+
+4. **Generate suggestions** for structure, wording, emphasis, and tailoring based on goals
+
+### 3. Providing Targeted Feedback
+
+For specific issues or roles:
+- **Weak bullet point critique**: Rewrite with action verbs and metrics
+- **Metric identification**: Help you think through what to quantify
+- **Role-specific tailoring**: Suggest how to emphasize relevant skills for target industry
+- **ATS optimization**: Ensure formatting won't break in automated screening
+- **Comparison**: Show before/after to demonstrate improvement
+
+## Key "Kickass Resume" Action Verbs
+
+Organized by category for easy reference:
+
+**Management/Leadership**: Led, Managed, Directed, Coordinated, Organized, Initiated, Established, Developed, Improved, Increased, Streamlined, Oversaw
+
+**Communication/People**: Communicated, Presented, Collaborated, Negotiated, Resolved, Influenced, Recruited, Mentored, Coached, Facilitated
+
+**Technical**: Built, Designed, Engineered, Programmed, Developed, Implemented, Debugged, Integrated, Deployed, Optimized, Automated
+
+**Research/Analysis**: Analyzed, Researched, Investigated, Identified, Evaluated, Determined, Examined, Discovered, Measured, Assessed
+
+**Financial/Data**: Managed, Reduced, Increased, Projected, Forecasted, Calculated, Analyzed, Balanced, Optimized, Improved
+
+**Creative**: Created, Designed, Conceptualized, Developed, Initiated, Established, Revitalized, Transformed, Built
+
+## Example: Before & After
+
+**Weak bullet:**
+- Worked on a project to help with the backend
+
+**Strong bullet (Kickass-style):**
+- Built scalable backend API using Python and PostgreSQL, supporting 10,000+ monthly active users and reducing query latency by 40%
+
+---
+
+**Why it's stronger:**
+- Action verb: "Built" (specific and powerful)
+- Technology: "Python and PostgreSQL" (concrete, technical)
+- Metrics: "10,000+ users" and "40%" (quantified impact)
+- Outcome: Clear deliverable and result
+
+## CS-Specific Resume Examples
+
+Real-world before/after examples for common CS resume bullets, applying Kickass guidelines (action verb + tech + metric + outcome):
+
+### Backend Engineering
+
+**Weak:**
+- Worked on backend development for an internal microservice
+
+**Strong:**
+- Engineered distributed microservice architecture using Node.js and Redis, reducing payment processing latency from 2.1s to 350ms and supporting 500+ concurrent transactions per second
+
+**Why:** Action verb (Engineered), specific tech (Node.js, Redis), quantified metrics (2.1s→350ms, 500+ TPS), clear outcome (payment processing improved)
+
+---
+
+### Frontend/Fullstack
+
+**Weak:**
+- Built a web app with React for displaying user data
+
+**Strong:**
+- Built interactive React dashboard with TypeScript and D3.js visualizations, improving data query load time by 65% through lazy loading and enabling 2,000+ enterprise users to run custom reports
+
+**Why:** Action verb (Built), tech stack (React, TypeScript, D3.js), metrics (65% improvement, 2,000+ users), outcome (custom reports enabled)
+
+---
+
+### DevOps/Infrastructure
+
+**Weak:**
+- Set up CI/CD pipeline and managed cloud infrastructure
+
+**Strong:**
+- Designed and deployed automated CI/CD pipeline using GitHub Actions and AWS ECS, reducing deployment time from 45 minutes to 8 minutes and decreasing production incidents by 70% through improved testing coverage
+
+**Why:** Action verb (Designed and deployed), specific tools (GitHub Actions, AWS ECS), metrics (45m→8m, 70% incident reduction), outcome (faster deployments, higher reliability)
+
+---
+
+### Machine Learning/Data Science
+
+**Weak:**
+- Trained machine learning models for recommendation system
+
+**Strong:**
+- Developed gradient boosting recommendation model in Python using XGBoost and scikit-learn, achieving 94% precision on test set and increasing click-through rate by 18% in production affecting 50,000+ daily active users
+
+**Why:** Action verb (Developed), tech (Python, XGBoost, scikit-learn), metrics (94% precision, 18% CTR lift, 50K+ users), outcome (deployed, measured impact)
+
+---
+
+### Open Source Contribution
+
+**Weak:**
+- Contributed to open source projects
+
+**Strong:**
+- Contributed 12 merged pull requests to React core library, including refactor of reconciliation algorithm that improved initial render performance by 12% in 18% of real-world applications; contributions reviewed and approved by core maintainers
+
+**Why:** Action verb (Contributed), specificity (12 PRs, React core), metrics (12% perf improvement, affected 18% of apps), outcome (merged, core maintainer approval)
+
+---
+
+## DO/DON'T Patterns
+
+Quick reference for Kickass guidelines to remember during resume writing:
+
+### DO
+
+1. **Start every bullet with a strong action verb** - Led, Built, Designed, Engineered, Developed, Optimized, Deployed, Improved, Increased, Reduced, Automated, Coordinated
+2. **Include at least one quantified metric per bullet** - %, $, time saved, users impacted, scale achieved, efficiency gains
+3. **Show measurable outcome or impact** - What changed? How was success defined? (e.g., "reducing latency by 40%" vs. "latency was reduced")
+4. **Tailor the resume to the job description** - Reorder bullets or sections to prioritize skills matching the target role
+5. **Keep bullets concise** - Aim for 1-2 lines max; eliminate filler words like "helped", "responsible for", "worked on"
+6. **Group related skills by category** - Languages, Frameworks, Tools, Concepts, Databases, Cloud Platforms for clarity
+7. **Include technical depth and breadth** - Show both mastery of specific technologies and range of capabilities
+8. **List only completed degrees and certifications** - No "In Progress" unless it's expected graduation date (for students)
+
+### DON'T
+
+1. **Don't use weak verbs** - Avoid: "Responsible for", "Helped with", "Worked on", "Was involved in", "Contributed to" (use specific action verbs instead)
+2. **Don't exceed one page** - Every word must justify its space; cut ruthlessly and use 10.5pt font minimum for readability
+3. **Don't list generic skills without context** - "Problem Solving" and "Team Player" are assumed; list specific technical skills instead
+4. **Don't use fancy templates or graphics** - ATS systems may parse them incorrectly; stick to clean, simple formatting
+5. **Don't include personal details** - No photo, birthday, marital status, ethnicity, political affiliation; stick to professional contact info
+6. **Don't repeat the same action verb in consecutive bullets** - Vary your language; use a thesaurus for synonyms (Built, Engineered, Designed, Developed)
+7. **Don't claim credit for team accomplishments without clarity** - If it was collaborative, clarify your role: "Led team of 4 engineers to..." rather than just "Built..."
+8. **Don't use acronyms without context the first time** - Spell out "CI/CD" or "API" at least once if the ATS parser might not recognize them
+
+## Quick Validation Checklist
+
+Use this condensed section-by-section checklist for fast resume validation:
+
+### Header
+- [ ] Name is bolded and prominent
+- [ ] Email is professional (no nicknames) and regularly monitored
+- [ ] Phone number is formatted consistently
+- [ ] LinkedIn URL and portfolio/GitHub links are current and clickable (https://)
+- [ ] Location includes city and state (no full street address)
+
+### Education
+- [ ] Degree, major, university name, and location are included
+- [ ] Expected graduation date (for students) or graduation date is in Month Year format
+- [ ] GPA listed only if 3.5 or above
+- [ ] No high school listed (if 2+ years of college completed)
+- [ ] No "In Progress" certifications (only completed ones count)
+
+### Work Experience
+- [ ] Each role has Title, Company, Location, Dates (Month Year - Month Year)
+- [ ] 3-5 bullets per role (scale with tenure)
+- [ ] Every bullet starts with a strong action verb
+- [ ] Every bullet includes at least one metric (%, $, users, time, scale)
+- [ ] Bullets show outcome/impact, not just tasks performed
+- [ ] Bullets are 1-2 lines max (concise, no filler)
+
+### Projects
+- [ ] Project name, description, and technologies are clear
+- [ ] Include outcome or impact (shipped, users, GitHub stars, hackathon placement)
+- [ ] Links to GitHub or live demo are included if available
+- [ ] Action verbs and metrics follow same Kickass guidelines as work experience
+
+### Skills
+- [ ] Skills are organized by category (Languages, Frameworks, Tools, Concepts, etc.)
+- [ ] Skills are ordered by relevance to target role
+- [ ] No generic "soft skills" (Team Player, Communication) without context
+- [ ] Technical depth and breadth are both demonstrated
+- [ ] Matches 5+ skills from job description
+
+### Formatting & ATS
+- [ ] Resume is exactly one page (or close to it)
+- [ ] Fonts are professional and consistent (Arial, Calibri, or Times New Roman)
+- [ ] Date formats are consistent throughout (e.g., Jan 2023 - Mar 2024)
+- [ ] Section headers are clear and consistent
+- [ ] No fancy graphics, icons, colors, or multi-column layouts
+- [ ] PDF version renders correctly (no missing text or formatting)
+
+### Role Alignment
+- [ ] Section order matches your situation (Education first for students, Experience first for professionals)
+- [ ] Most relevant experience/projects appear first
+- [ ] Resume emphasizes skills matching the target role
+- [ ] No irrelevant experience taking up space
+
+## LaTeX Resume Tips
+
+Since you'll often be working with `.tex` resume files, here are key guidelines for ATS-friendly LaTeX formatting and common pitfalls:
+
+### ATS-Friendly LaTeX Formatting
+
+- **Use standard document classes**: article, moderncv, or res (avoid fancy custom classes)
+- **Stick to simple packages**: geometry, fancyhdr for headers/footers, xcolor for basic colors (avoid tikz, PSTricks, fancy-frame packages)
+- **Avoid tables for layout** - ATS parsers may miss content in table cells; use lists or newlines instead
+- **Use simple section headers**: \section{} with no special formatting (no \Large, \textit{}, colored boxes)
+- **Limit font styling**: Bold (\textbf{}) and italics (\textit{}) are safe; avoid small caps (\textsc{}), fancy fonts
+- **Keep margins reasonable**: 0.5-1 inch on all sides; wide margins waste space on one-page resume
+- **Use itemize or enumerate for bullets**: Standard LaTeX lists are ATS-safe
+
+### Font & Package Recommendations
+
+- **Safe fonts**: Computer Modern (default), Helvetica (via helvet), Times (via mathptmx)
+- **Avoid**: Wingdings, Symbol, or non-standard fonts that ATS may not recognize
+- **Package essentials**:
+  - geometry: Set margins
+  - enumitem: Customize bullet spacing and list formatting
+  - hyperref: Create clickable links (ATS can extract URLs)
+  - xcolor: For subtle accent colors (use sparingly)
+- **Avoid these packages**: tikz, pstricks, fancybox, background, pgfplots (ATS may fail to parse)
+
+### Common LaTeX Pitfalls & Solutions
+
+| Pitfall | Problem | Solution |
+|---------|---------|----------|
+| Hbox warnings (Overfull/Underfull) | Text overflow or loose spacing, causes formatting issues | Use \raggedright on long text; reduce font size; break lines manually with \\  |
+| Special characters not rendering | Accents, dashes, quotes display incorrectly in ATS | Use UTF-8 encoding; escape special chars: \~{n}, \'{e}, -- (en-dash), --- (em-dash) |
+| Encoding issues (encoding not declared) | Resume text may become unreadable in some parsers | Add \usepackage[utf8]{inputenc} at top; save file as UTF-8 |
+| Fancy headers/footers on one page | Header/footer info may be lost in ATS parsing | Use simple \pagestyle{plain} or no header/footer; put all critical info in body |
+| Multi-column layouts | ATS parser may skip entire columns | Use single column; use nested lists or indentation for hierarchy instead |
+| Footnotes or references | ATS may not capture footnote text | Convert to inline text or parentheses; avoid \footnote{} |
+| Micro-spacing hacks (\vspace, \hspace) | May be ignored or cause text reflow in ATS | Use enumitem margins and parskip instead; avoid hacky spacing |
+| PDF-only features (transparency, images) | ATS extracts text, not images; transparency may be lost | Use only grayscale shapes if needed; no embedded images (except small icons as text) |
+
+### LaTeX Resume Templates (ATS Safety)
+
+**Safe/Recommended:**
+- Plain article class with basic formatting (highest ATS compatibility)
+- Overleaf "Simple Resume" or "Clean CV" templates (often ATS-tested)
+- moderncv (some styles are ATS-safe; test the PDF)
+
+**Caution/Test First:**
+- Fancy resume classes (check PDF rendering in ATS tester)
+- Color-heavy designs (ATS may drop colors but preserve text)
+- Multi-column templates (verify single-column fallback works)
+
+**Avoid:**
+- TikZ-based designs
+- Infographic-style resumes
+- Templates requiring custom fonts not in LaTeX default
+- Design templates prioritizing looks over parse-ability
+
+**ATS Test Before Submitting:**
+Use free online ATS resume checkers (e.g., Resumeworded, Jobscan, or LinkedIn's PDF parser) to verify your .tex compiled PDF is readable by automated systems.
+
+## Output Format for Cowork
+
+When validating a `.tex` file, provide feedback in this JSON structure:
+
+```json
+{
+  "file_analyzed": "path/to/resume.tex",
+  "summary": "Brief overall assessment against Kickass guidelines",
+  "situation": "student|recent_grad|professional",
+  "one_page": "yes|no - critical for Kickass standard",
+  "sections": {
+    "section_name": {
+      "status": "pass|flag|rewrite",
+      "issues": ["issue1", "issue2"],
+      "suggestions": ["suggestion1", "suggestion2"],
+      "priority": "high|medium|low"
+    }
+  },
+  "ats_compliance": "yes|no - explain if no",
+  "top_3_fixes": [
+    "Fix 1: Specific action",
+    "Fix 2: Specific action",
+    "Fix 3: Specific action"
+  ],
+  "alignment_to_kickass": "percentage or qualitative",
+  "actionable_metrics": "How to quantify achievements in your resume"
+}
+```
+
+If you're writing a new resume, output a `.tex` template or LaTeX snippet ready to use.
+
+## Common Issues & How to Fix Them
+
+| Issue | Kickass Guideline | How to Fix |
+|-------|-------------------|-----------|
+| Resume is 2+ pages | One page only | Remove or condense least relevant experiences; reduce font if needed |
+| Inconsistent formatting | Be consistent throughout | Standardize fonts, styles, date formats, punctuation in all sections |
+| No metrics on bullets | Quantify everything | Add %, $, users served, time saved, efficiency gains, people managed |
+| Weak action verbs | Start with strong verbs | Replace "worked on", "helped", "responsible for" with Led, Built, Designed, etc. |
+| Too generic | Tailor to role | Rewrite to emphasize skills matching job description |
+| No projects listed | Add projects for students | Include school projects, hackathons, personal projects with outcomes |
+| Fancy template | ATS compliance | Switch to clean, simple template (Arial/Times New Roman, simple formatting) |
+| No location info | Include city, state | Add your location or "Open to relocation" to header |
+
+## Tips for Success
+
+- **One page is sacred**: Be ruthless about what makes the cut; tailor for each application
+- **Action verbs drive impact**: Every bullet should start with a power verb from the Kickass list
+- **Metrics tell the story**: Numbers make achievements memorable and credible
+- **Tailor strategically**: Reorder sections based on your situation (student/professional/career changer)
+- **ATS matters**: Use simple formatting so your resume doesn't get lost in automated screening
+- **Section order is strategic**: Put your strongest section first (Education for students, Experience for professionals)
+- **Skills should be organized**: Group by type (Languages, Tools, Concepts) for clarity
+- **Industry involvement shows passion**: Hackathons, volunteering, and speaking demonstrate you care beyond just a paycheck
+
+---
+
+## Related Resources
+
+- Original guide: "How to Write a Kickass Resume" (included in this skill)
+- Tools: Grammarly (free grammar checking)
+- Testing: Review with friends, mentors, or university career center
+- ATS testing: Use online ATS resume checkers to verify formatting
+
+---
+
+**Skill Version**: 1.0  
+**Based on**: "How to Write a Kickass Resume" industry-standard guide  
+**Platform**: Cowork (LaTeX .tex files)  
+**Audience**: CS/tech students and early-career professionals  

--- a/skills/paper-structure-cs/SKILL.md
+++ b/skills/paper-structure-cs/SKILL.md
@@ -1,0 +1,633 @@
+---
+name: paper-structure-cs
+description: Validate paper structure against academic standards: required sections present, correct ordering, proper heading hierarchy, bibliography completeness, and section consistency. Use this skill when checking if a paper follows standard academic structure (Abstract, Intro, Methods, Results, Discussion, Conclusion, Bibliography), when reviewing a table of contents against actual sections, or when verifying section flow and heading levels. Trigger on "paper structure", "section order", "heading hierarchy", "missing sections", "check structure", "outline review", "paper organization", "section flow", or similar.
+origin: ECC
+---
+
+# Paper Structure Validator (JSONL with optional dependencies)
+
+You validate the structural organization of CS research papers. Output JSONL format—one issue per line. Some issues may have optional `depends_on` markers to indicate lightweight sequencing.
+
+## When to Activate
+
+Activate this skill when:
+- A paper (outline, draft, or submission) needs structural validation before review
+- You're unsure if a paper follows standard academic conventions
+- A paper has been reorganized and sections need re-verification
+- Checking if a paper fits a specific venue's structural requirements (ACM, IEEE, NeurIPS, etc.)
+- Reviewing section coherence, transitions, and logical flow
+- Validating heading hierarchy and consistency across a document
+- Comparing a Table of Contents against actual paper sections
+- Identifying structural gaps or orphaned sections that don't fit the flow
+
+## Your Task
+
+When given a paper outline, table of contents, or full paper, verify:
+- All required sections present (Abstract, Intro, Methods, Results, Discussion, Conclusion)
+- Sections in correct order and logical flow
+- Heading levels follow proper hierarchy (no # → ### skips)
+- Bibliography present and complete
+- Table of Contents (if present) matches actual sections
+- Section transitions and flow are logical
+- Heading naming conventions are consistent
+- Section balance and proportionality (no single 20-page Methods section, etc.)
+
+## Output Format (JSONL)
+
+Output exactly one JSON object per line. Use optional `depends_on` to mark lightweight dependencies (not complex relationships like tesis-validator).
+
+```jsonl
+{"id": "struct_001", "type": "missing_section", "section": "Methods", "severity": "critical", "issue": "Methods section not found", "suggested_fix": "Add Methods section after Literature Review and before Results", "depends_on": null}
+{"id": "struct_002", "type": "heading_skip", "location": "Line 45", "current_heading": "# Introduction", "next_heading": "### Related Work", "severity": "important", "issue": "Heading hierarchy skips level (# to ###)", "suggested_fix": "Insert ## heading between # and ###", "depends_on": null}
+{"id": "struct_003", "type": "section_order", "current_position": 6, "section": "Bibliography", "expected_position": "Last", "severity": "important", "issue": "Bibliography appears before Conclusion", "suggested_fix": "Move Bibliography to end of paper", "depends_on": null}
+{"id": "struct_004", "type": "toc_mismatch", "issue": "TOC lists 'Experimental Setup' but paper has 'Methodology'", "severity": "minor", "suggested_fix": "Update TOC to match actual section title, or rename section for consistency", "depends_on": "struct_001"}
+```
+
+## Issue Categories
+
+- `missing_section` - Required section (Abstract, Methods, Results, Discussion, Conclusion) not found
+- `section_order` - Sections in wrong sequence (e.g., Results before Methods)
+- `heading_skip` - Heading hierarchy violates standard (# → ## → ###, no skips to ###)
+- `heading_level_inconsistent` - Similar-importance sections use different heading levels
+- `toc_mismatch` - Table of Contents doesn't match actual sections
+- `missing_bibliography` - Paper has no bibliography or references section
+- `citation_incomplete` - References cited in text not in bibliography (or vice versa)
+- `orphaned_section` - Section present but not mentioned in TOC
+
+## How to Evaluate
+
+1. **Required sections**: Check for Abstract, Introduction, Methods, Results, Discussion, Conclusion
+2. **Order**: Verify logical flow (Abstract → Intro → Methods → Results → Discussion → Conclusion → Bibliography)
+3. **Headings**: Ensure proper nesting (no jumps; consistent levels for parallel sections)
+4. **Bibliography**: Verify completeness and match against in-text citations
+5. **TOC consistency**: If TOC present, all sections must match
+
+## Output Requirements
+
+- One issue per line (JSONL format)
+- Assign unique `id` for reference (e.g., "struct_001", "struct_002")
+- `severity`: `critical` (structure broken), `important` (confusing/non-standard), or `minor` (cosmetic)
+- Use optional `depends_on: "struct_ID"` only if an issue logically depends on another being fixed first (rare)
+- Keep `issue` and `suggested_fix` concise
+- Include `location` if referencing a specific line or heading
+- Do NOT create complex dependency chains—only flag true prerequisites
+
+## Example Review
+
+Given a paper outline:
+
+```
+1. Abstract
+2. Related Work
+3. Methods
+4. Results
+5. Conclusion
+6. Bibliography
+```
+
+Output:
+
+```jsonl
+{"id": "struct_001", "type": "missing_section", "section": "Introduction", "severity": "critical", "issue": "Introduction section missing between Abstract and Related Work", "suggested_fix": "Add Introduction section after Abstract to provide problem context and motivation", "depends_on": null}
+{"id": "struct_002", "type": "missing_section", "section": "Discussion", "severity": "important", "issue": "Discussion section missing before Conclusion", "suggested_fix": "Add Discussion section between Results and Conclusion to interpret findings", "depends_on": "struct_001"}
+{"id": "struct_003", "type": "section_order", "current_position": 2, "section": "Related Work", "expected_position": "After Introduction", "severity": "important", "issue": "Related Work appears before Introduction (should establish context first)", "suggested_fix": "Reorder: Abstract → Introduction → Related Work → Methods → Results → Discussion → Conclusion", "depends_on": "struct_001"}
+```
+
+---
+
+## Standard CS Paper Structures
+
+### Conference Papers (4–6 pages, short format)
+
+Typical structure for short conference submissions (e.g., ACM CHI Extended Abstracts, IEEE workshops):
+
+| Section | Required | Notes |
+|---------|----------|-------|
+| Abstract | Yes | 100–150 words; problem, approach, results |
+| Introduction | Yes | Motivate the problem; state contributions clearly |
+| Related Work | Yes | Brief (0.5–1 page); cite key prior work |
+| Methods / Approach | Yes | How you solved the problem (concise) |
+| Results / Evaluation | Yes | Key findings; minimal detail |
+| Discussion | No | Optional if space-constrained; can merge with Results |
+| Conclusion | Yes | Summary; future work; 2–3 sentences |
+| Bibliography | Yes | All citations complete |
+
+**Heading Levels**: # (main sections), ## (subsections only if needed)
+
+### Conference Papers (8–12 pages, long format)
+
+Typical structure for main conference track submissions (e.g., SIGCHI, SIGMOD, NeurIPS):
+
+| Section | Required | Notes |
+|---------|----------|-------|
+| Abstract | Yes | 150–250 words; context, contribution, impact |
+| Introduction | Yes | 1–2 pages; problem statement, motivation, contributions (often bulleted) |
+| Related Work | Yes | 1–1.5 pages; related systems, baselines, positioning |
+| Methods / Approach / System Design | Yes | 2–3 pages; detailed enough to reproduce |
+| Evaluation / Results | Yes | 2–3 pages; metrics, analysis, comparison to baselines |
+| Discussion | Yes | 0.5–1 page; limitations, implications, lessons learned |
+| Conclusion | Yes | 0.25–0.5 page; summary, future work |
+| Bibliography | Yes | 40–80 citations typical |
+
+**Heading Levels**: # (main sections), ## (subsections), ### (only if many subsections)
+
+### Journal Articles (12+ pages)
+
+Typical structure for extended journal publications (e.g., ACM Transactions, IEEE TSE):
+
+| Section | Required | Notes |
+|---------|----------|-------|
+| Abstract | Yes | 200–300 words; complete problem and solution overview |
+| Introduction | Yes | 2–3 pages; extensive motivation, contributions, roadmap |
+| Related Work | Yes | 2–3 pages; thorough coverage of prior work |
+| Methods / Methodology / System Design | Yes | 3–5 pages; sufficient detail for full reproduction |
+| Evaluation / Results | Yes | 3–5 pages; multiple experiments, ablations, detailed analysis |
+| Discussion | Yes | 1–2 pages; interpretation, limitations, broader impacts |
+| Conclusion | Yes | 0.5–1 page; summary, future directions, open questions |
+| Acknowledgments | Optional | If applicable (funding, contributors) |
+| Bibliography | Yes | 100+ citations typical |
+
+**Heading Levels**: # (main), ## (subsections), ### (sub-subsections if deep nesting)
+
+### Workshop Papers (4–6 pages)
+
+Typical structure for workshop submissions (narrow scope, preliminary work):
+
+| Section | Required | Notes |
+|---------|----------|-------|
+| Abstract | Yes | 75–125 words; concise problem and status |
+| Introduction | Yes | Brief (0.5 page); quick context |
+| Related Work | Optional | 0.25–0.5 page; can integrate into intro |
+| Approach / Methodology | Yes | 1–1.5 pages; focused description |
+| Preliminary Results / Status | Yes | 1–1.5 pages; initial findings or progress update |
+| Discussion / Future Work | Yes | 0.5 page; next steps |
+| Bibliography | Yes | 15–30 citations |
+
+**Heading Levels**: # (main sections), ## (subsections only if necessary)
+
+## Venue-Specific Structure Requirements
+
+### ACM Format (SIGCHI, SIGMOD, SIGKDD, etc.)
+
+**Typical expectations:**
+- Abstract before Introduction (separate page if > 6 pages)
+- Introduction → Related Work → Approach → Evaluation → Discussion → Conclusion
+- Related Work often after Introduction (context first, then novelty)
+- Subsections within Methods (e.g., "Data Collection", "Analysis Procedure")
+- "Limitations" often as subsection of Discussion or standalone
+- Acknowledgments section common (funding, participants)
+
+**Heading conventions:**
+- Use ## for main subsections within sections
+- Avoid deep nesting (### rare)
+- Descriptive names: "Study Design" rather than "Methodology"
+
+**Bibliography style:** Typically numerical [1], [2], etc., or author-year (Chicago notes-bibliography)
+
+### IEEE Format (TSE, TKDE, Access, etc.)
+
+**Typical expectations:**
+- Abstract, Introduction, Related Work in tight sequence
+- "System Design" or "Technical Approach" as primary section
+- Results/Evaluation as separate main section
+- Conclusion brief (0.5 page)
+- References (not Bibliography)
+
+**Heading conventions:**
+- Section numbers: I. Introduction, II. Related Work, III. System Design, IV. Evaluation, V. Conclusion
+- Subsections numbered (A, B, C under each section)
+- No deep nesting beyond two levels
+
+**Bibliography style:** IEEE numbered citations [1], [2], etc.
+
+### Springer LNCS Format (ECML, ICCV, CAV, etc.)
+
+**Typical expectations:**
+- Abstract, Introduction, Related Work
+- Methods / Approach
+- Experiments / Results
+- Discussion (optional; can merge with results)
+- Conclusion
+- Appendices (if needed)
+
+**Heading conventions:**
+- Subsections allowed but keep shallow (no ### → #### chains)
+- Descriptive section names: "Experimental Setup", "Results and Analysis"
+- Capitalize main sections; sentence case for subsections
+
+**Bibliography style:** Numbered references [1], [2], etc.
+
+### NeurIPS / ICML Style (ML conferences)
+
+**Typical expectations:**
+- Abstract, Introduction
+- Related Work often after Introduction (or integrated)
+- Method / Methodology
+- Experiments
+- Results (detailed analysis, ablation studies)
+- Discussion (brief; often merged with results)
+- Conclusion + Future Work
+- References
+
+**Special features:**
+- "Preliminaries" section common (notation, background)
+- Ablation studies as subsection of Results
+- Hyperparameter details in Appendix
+- Results organized by baselines / datasets
+
+**Heading conventions:**
+- Simple, flat structure: main sections only
+- Subsections as ## if needed (e.g., "3.1 Baseline Comparisons")
+- No excessive nesting
+
+## Heading Hierarchy Best Practices
+
+### Proper Nesting Rules
+
+```
+# Main Section Title (only ONE per paper structure level)
+  ## Subsection (primary subdivision)
+    ### Sub-subsection (tertiary; use sparingly)
+      #### Sub-sub-subsection (AVOID in academic papers)
+```
+
+**DO:** 
+- Use one # per main section
+- Use ## for the first level of subdivision within a section
+- Use ### only when you have 3+ subsections under a ##
+- Keep maximum depth at 3 levels (# → ## → ###)
+
+**DON'T:**
+- Skip levels (# → ### is wrong; insert ## in between)
+- Use # for subsections
+- Nest more than 3 levels deep
+- Use #### or deeper in academic papers
+
+### Heading Naming Conventions
+
+**DO:**
+- Use descriptive, specific titles: "Machine Learning Pipeline Design", not "Technical Approach"
+- Use parallel structure across parallel sections: "Experiment 1", "Experiment 2", "Experiment 3"
+- Use sentence case for most headings in LNCS/IEEE; title case for ACM
+- Include units if relevant: "Results on MNIST Dataset" instead of just "Results"
+
+**DON'T:**
+- Use vague titles: "Methods", "System", "Implementation" (be specific)
+- Mix naming styles: don't have both "3.1. Data Processing" and "3.2 algorithm details"
+- Use overly long headings (>10 words)
+- Use special characters or math symbols in headings (hard to parse)
+
+### Example: Proper Heading Hierarchy
+
+Bad:
+```
+# Introduction
+## Background
+### Motivation
+#### Problem Statement
+## Related Work
+# Methods
+### Algorithm Design
+## Results
+```
+
+Good:
+```
+# Introduction
+## Motivation
+## Problem Statement
+## Contributions
+
+# Related Work
+## Systems Approaches
+## Machine Learning Baselines
+
+# Methods
+## Data Collection
+## Feature Engineering
+## Algorithm Design
+
+# Evaluation
+## Experimental Setup
+## Results
+## Ablation Studies
+
+# Discussion
+
+# Conclusion
+```
+
+## Section Flow and Transitions
+
+### Establishing Logical Connections
+
+**Within-section flow:**
+- Start with clearest, most concrete concept
+- Build toward complexity or abstraction
+- Use transitional phrases: "Building on this foundation...", "As a result...", "To address this..."
+- End with a forward-looking statement that bridges to next section
+
+**Between-section transitions:**
+- **Intro → Related Work:** "Prior work has explored [X], but left open [Y]. We address [Y] by..."
+- **Related Work → Methods:** "Unlike prior approaches, we propose..."
+- **Methods → Evaluation:** "To validate these ideas, we conducted [type of evaluation]..."
+- **Evaluation → Discussion:** "These results suggest that...", "Our findings align with [prior work] because..."
+- **Discussion → Conclusion:** "In summary, we have shown that..."
+
+**Example transition sequence (full paper):**
+
+Abstract: "We propose a novel algorithm for [problem]. Evaluation shows X% improvement."
+
+Intro: "The core challenge is [problem]. This matters because [impact]. Prior work has done [what], but missed [gap]. We introduce [contribution]."
+
+Related Work: "Systems like [A] and [B] address related problems. However, they assume [assumption], which limits [outcome]. Our approach differs by [key distinction]."
+
+Methods: "To overcome these limitations, we designed [system]. The key insight is [insight]. Our pipeline has three stages: [Stage 1], [Stage 2], [Stage 3]."
+
+Results: "We evaluated [system] on [benchmark]. Results show [finding 1], [finding 2], and [finding 3]. Compared to baselines, we achieve [comparison]."
+
+Discussion: "These results validate our hypothesis because [reasoning]. The X% improvement over [baseline] suggests that [interpretation]. Interestingly, [observation about unexpected result]. However, [limitation]. This work contributes to the broader field by [impact]."
+
+Conclusion: "We presented [contribution]. Our evaluation demonstrates [key finding]. Future work includes [direction 1] and [direction 2]."
+
+## DO/DON'T Patterns for Structure
+
+### DO
+
+- **DO place Related Work after Introduction.** Readers need context before understanding novelty.
+- **DO use subsections for long methods.** Break 5+ page Methods into "Data", "Algorithm", "Implementation" subsections.
+- **DO end each section with a forward-looking or concluding statement.** Don't let sections end abruptly.
+- **DO group Results by experiment type or dataset** if you have multiple experiments. Use subsections.
+- **DO include a Limitations subsection in Discussion.** Transparency builds credibility.
+- **DO use consistent heading capitalization throughout.** Pick Title Case or sentence case and stick to it.
+- **DO cite Related Work within Introduction** to ground the problem; use Related Work section for deeper survey.
+- **DO use tables/figures to break up dense Methods sections.** A table of hyperparameters is faster than prose.
+
+### DON'T
+
+- **DON'T put all Related Work into the Introduction.** Related Work deserves its own section.
+- **DON'T bury the main contribution.** State it explicitly in Intro (often as bullet list).
+- **DON'T use cryptic abbreviations in headings.** "RNN-GRU Tuning Strategies" is worse than "Hyperparameter Selection for Recurrent Networks".
+- **DON'T mix narrative and results in Methods.** Methods describes what you did; Results describe what happened.
+- **DON'T skip heading levels.** (# → ### violates document structure; insert ## between.)
+- **DON'T use inconsistent section naming.** "Experimental Evaluation" vs. "Evaluation Setup" in the same paper is jarring.
+- **DON'T add orphaned subsections.** Every ## should have at least 2–3 subsections, or merge into parent.
+- **DON'T leave sections with no internal structure when they exceed 1.5 pages.** Add ## subsections for readability.
+
+## Common Structural Anti-Patterns
+
+### Wall of Text Methods
+
+**Problem:** A 4-page Methods section with no subsections, no figures, no structure.
+
+**Symptom:** Readers cannot skim or locate key details. Methods becomes a narrative slog.
+
+**Fix:**
+```
+## Methods
+### Data Collection
+  [1 paragraph: source, size, format]
+### Preprocessing
+  [1 paragraph: normalization, filtering]
+  [Figure 1: Pipeline diagram]
+### Algorithm Design
+  [Explain core insight]
+  [Pseudocode or equation block]
+### Implementation Details
+  [Libraries, hyperparameters, reproducibility info]
+```
+
+### Results Dumping
+
+**Problem:** The Results section lists 47 tables without interpretation or narrative thread.
+
+**Symptom:** Readers don't know which results matter or why they're presented in this order.
+
+**Fix:**
+```
+## Evaluation
+### Baseline Comparison
+  [1–2 sentences explaining why these baselines matter]
+  [Table 1: Baseline comparison]
+  [1 paragraph: Key takeaway from Table 1]
+
+### Ablation Study
+  [1 sentence: Which component are we removing?]
+  [Table 2: Ablation results]
+  [1 paragraph: What does this tell us?]
+
+### Sensitivity Analysis
+  [1 sentence: What parameter are we varying?]
+  [Figure 2: Sensitivity plots]
+  [1 paragraph: Implications]
+```
+
+### Conclusion that Repeats Abstract
+
+**Problem:** Conclusion is a word-for-word restatement of the Abstract.
+
+**Symptom:** Readers have learned nothing new by the end.
+
+**Fix:**
+```
+## Conclusion
+
+In this work, we proposed [contribution].
+Our evaluation on [benchmarks] demonstrated [result].
+This validates [hypothesis] because [reasoning].
+
+Beyond this specific problem, our approach opens avenues for [broader implication].
+Future work should explore [direction 1] and [direction 2] to address [gap].
+```
+
+### Related Work as Literature Dump
+
+**Problem:** A wall of citations with no structure. "Smith et al. [1] studied X. Jones et al. [2] studied Y. Brown et al. [3] studied Z."
+
+**Symptom:** Readers cannot identify the intellectual landscape or how your work positions relative to it.
+
+**Fix:**
+```
+## Related Work
+### Early Approaches: Static Analysis
+  [2–3 sentences synthesizing early work]
+  [Citations: A, B, C]
+
+### Recent Advances: Learned Representations
+  [2–3 sentences on modern approaches]
+  [Citations: D, E, F]
+
+### Open Challenges
+  [1 paragraph: What gaps remain?]
+  [Citations: relevant work on these gaps]
+
+Our contribution differs from this body of work by [key distinction].
+We address the limitation of [limitation] through [method].
+```
+
+## LaTeX Structure Tips
+
+### Section and Subsection Conventions
+
+```latex
+\section{Introduction}
+\label{sec:intro}
+  % Avoid \subsection for short sections
+  % Use only if >1.5 pages
+
+\section{Related Work}
+\label{sec:related}
+  % Use \subsection to organize by topic
+  \subsection{Systems Approaches}
+  \label{sec:related:systems}
+    % Content here
+  \subsection{Learning-Based Methods}
+  \label{sec:related:learning}
+    % Content here
+
+\section{Methods}
+\label{sec:methods}
+  \subsection{Problem Formulation}
+  \label{sec:methods:formulation}
+  \subsection{Algorithm Design}
+  \label{sec:methods:algo}
+  \subsection{Implementation}
+  \label{sec:methods:impl}
+
+\section{Evaluation}
+\label{sec:eval}
+  \subsection{Experimental Setup}
+  \label{sec:eval:setup}
+  \subsection{Main Results}
+  \label{sec:eval:main}
+  \subsection{Ablation Studies}
+  \label{sec:eval:ablation}
+
+\section{Discussion}
+\label{sec:discussion}
+  % Usually no subsections; 1 section is enough
+
+\section{Conclusion}
+\label{sec:conclusion}
+  % No subsections; too short
+```
+
+### Label Naming Convention
+
+Use hierarchical label names to make cross-references clear:
+
+```latex
+\label{sec:methods:algo}      % sec:SECTION:SUBSECTION
+\label{fig:pipeline}           % fig:DESCRIPTIVE_NAME
+\label{tbl:results}            % tbl:DESCRIPTIVE_NAME
+\label{eq:loss_function}       % eq:DESCRIPTIVE_NAME
+```
+
+**Reference them explicitly:**
+```latex
+As shown in Figure~\ref{fig:pipeline} and Table~\ref{tbl:results},
+the algorithm (Eq.~\ref{eq:loss_function}) outperforms baselines
+as detailed in Section~\ref{sec:eval:main}.
+```
+
+### Enforcing Consistency
+
+Use a preamble macro to standardize heading usage:
+
+```latex
+\newcommand{\sechead}[1]{\section{#1}}
+\newcommand{\subsechead}[1]{\subsection{#1}}
+```
+
+And enforce: "Never use \subsubsection; use \subsection for all subdivisions."
+
+## Quick Reference: Paper Structure Template
+
+### 8–12 Page Conference Paper Template
+
+```
+Abstract (150–250 words)
+
+1. Introduction (1–2 pages)
+   1.1 Motivation
+   1.2 Problem Statement
+   1.3 Contributions (bulleted)
+
+2. Related Work (1–1.5 pages)
+   2.1 [Topic 1: e.g., Systems Approaches]
+   2.2 [Topic 2: e.g., Learning Methods]
+
+3. Methods (2–3 pages)
+   3.1 Problem Formulation
+   3.2 Proposed Approach
+   3.3 Implementation Details
+
+4. Evaluation (2–3 pages)
+   4.1 Experimental Setup
+   4.2 Baseline Comparisons
+   4.3 Ablation Studies
+
+5. Discussion (0.5–1 page)
+   5.1 Key Findings
+   5.2 Limitations
+
+6. Conclusion (0.25–0.5 page)
+
+References
+```
+
+### Journal Paper Template (12+ pages)
+
+```
+Abstract (200–300 words)
+
+1. Introduction (2–3 pages)
+   1.1 Motivation and Context
+   1.2 Problem Statement
+   1.3 Key Contributions
+   1.4 Organization of Paper
+
+2. Related Work (2–3 pages)
+   2.1 [Subtopic 1]
+   2.2 [Subtopic 2]
+   2.3 [Subtopic 3]
+   Positioning relative to prior work
+
+3. Methods (3–5 pages)
+   3.1 Preliminaries / Notation
+   3.2 Problem Formulation
+   3.3 Proposed Method
+   3.4 Theoretical Analysis (if applicable)
+   3.5 Implementation and Reproducibility
+
+4. Evaluation (3–5 pages)
+   4.1 Experimental Setup
+   4.2 Baseline Systems
+   4.3 Quantitative Results
+   4.4 Qualitative Analysis
+   4.5 Ablation and Sensitivity Studies
+
+5. Discussion (1–2 pages)
+   5.1 Interpretation of Results
+   5.2 Broader Impact and Implications
+   5.3 Limitations and Threats to Validity
+
+6. Conclusion (0.5–1 page)
+   6.1 Summary of Contributions
+   6.2 Future Directions
+   6.3 Open Questions
+
+Acknowledgments (if applicable)
+References
+Appendices (if needed)
+```
+
+## Guidelines
+
+- **Structural rigor**: Academic papers follow a standard format; deviations should be flagged
+- **Light dependencies**: Only use `depends_on` for true sequential dependencies (e.g., can't check "TOC matches sections" if sections aren't defined yet)
+- **Completeness**: Every standard section must be present; missing = critical
+- **Hierarchy**: Heading levels matter for readability and document generation; enforce consistency
+- **Venue awareness**: Different venues (ACM, IEEE, NeurIPS) have slightly different expectations; note deviations
+- **Section balance**: Long, dense sections (>3 pages) should be subdivided; short sections (<0.5 page) may be too thin
+- **Flow and transitions**: Sections should connect logically with explicit transitions, not jump abruptly

--- a/skills/paper-structure-cs/evals/evals.json
+++ b/skills/paper-structure-cs/evals/evals.json
@@ -12,7 +12,9 @@
       "expected_output": "JSONL flagging heading_skip issues (# to ### without ##) and heading_level_inconsistent (Methods section jumps to ### instead of ##)"
     },
     {
+    {
+      "id": 3,
+      "prompt": "Check the heading hierarchy of this paper outline:\n\n# 1. Introduction\n## 1.1 Background\n### 1.1.1 Motivation\n#### 1.1.1.1 Problem Details\n# 2. Methods\n## 2.1 Algorithm\n# 3. Results",
       "expected_output": "JSONL with one or two issues: heading_level_inconsistent or heading_skip flagging #### (fourth-level heading depth violates the skill's 3-level maximum); remainder of structure is correct"
     }
-  ]
 }

--- a/skills/paper-structure-cs/evals/evals.json
+++ b/skills/paper-structure-cs/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "paper-structure-cs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Validate the structure of this paper outline:\n\nTable of Contents:\n1. Abstract\n2. Related Work\n3. Methodology\n4. Results\n5. Conclusion\n6. References",
+      "expected_output": "JSONL identifying missing sections: Introduction (critical), Discussion (important), and incorrect ordering of Related Work (should follow Introduction)"
+    },
+    {
+      "id": 2,
+      "prompt": "Check this paper's heading hierarchy:\n\n# 1. Introduction\n## 1.1 Problem Statement\n### 1.1.1 Motivation\n# 2. Methods\n### 2.1 Algorithm Description\n## 2.2 Implementation\n# 3. Results",
+      "expected_output": "JSONL flagging heading_skip issues (# to ### without ##) and heading_level_inconsistent (Methods section jumps to ### instead of ##)"
+    },
+    {
+      "id": 3,
+      "prompt": "Review this paper structure for completeness:\n\n1. Abstract - Present\n2. Introduction - Present\n3. Related Work - Present\n4. Methods - Present\n5. Experiments/Results - Present\n6. Discussion - Present\n7. Conclusion - Present\n8. Bibliography - Present (all in-text citations matched)\n\nTable of Contents matches all sections. Headings follow ## ### #### hierarchy consistently.",
+      "expected_output": "JSONL with minimal issues (well-structured); possibly minor formatting notes"
+    }
+  ]
+}

--- a/skills/paper-structure-cs/evals/evals.json
+++ b/skills/paper-structure-cs/evals/evals.json
@@ -12,9 +12,9 @@
       "expected_output": "JSONL flagging heading_skip issues (# to ### without ##) and heading_level_inconsistent (Methods section jumps to ### instead of ##)"
     },
     {
-    {
       "id": 3,
       "prompt": "Check the heading hierarchy of this paper outline:\n\n# 1. Introduction\n## 1.1 Background\n### 1.1.1 Motivation\n#### 1.1.1.1 Problem Details\n# 2. Methods\n## 2.1 Algorithm\n# 3. Results",
       "expected_output": "JSONL with one or two issues: heading_level_inconsistent or heading_skip flagging #### (fourth-level heading depth violates the skill's 3-level maximum); remainder of structure is correct"
     }
+  ]
 }

--- a/skills/paper-structure-cs/evals/evals.json
+++ b/skills/paper-structure-cs/evals/evals.json
@@ -12,9 +12,7 @@
       "expected_output": "JSONL flagging heading_skip issues (# to ### without ##) and heading_level_inconsistent (Methods section jumps to ### instead of ##)"
     },
     {
-      "id": 3,
-      "prompt": "Review this paper structure for completeness:\n\n1. Abstract - Present\n2. Introduction - Present\n3. Related Work - Present\n4. Methods - Present\n5. Experiments/Results - Present\n6. Discussion - Present\n7. Conclusion - Present\n8. Bibliography - Present (all in-text citations matched)\n\nTable of Contents matches all sections. Headings follow ## ### #### hierarchy consistently.",
-      "expected_output": "JSONL with minimal issues (well-structured); possibly minor formatting notes"
+      "expected_output": "JSONL with one or two issues: heading_level_inconsistent or heading_skip flagging #### (fourth-level heading depth violates the skill's 3-level maximum); remainder of structure is correct"
     }
   ]
 }

--- a/skills/resume-job-alignment/SKILL.md
+++ b/skills/resume-job-alignment/SKILL.md
@@ -1,0 +1,618 @@
+---
+name: resume-job-alignment
+description: Aligns and tailors resumes to specific job postings. Use this skill in Cowork when you have both a resume (.tex file) and a job description (.md file) in your working folder. The skill analyzes alignment between your resume and job requirements, identifies missing or weak areas, and provides specific reframing suggestions and before/after examples. Trigger on phrases like "tailor my resume for this job", "align my resume with job posting", "how should I emphasize skills for this role", "does my resume match this job", or when you see both resume.tex and job_description.md files in the working folder.
+compatibility: Requires .tex resume file and .md job description in working folder; works with both Harvard and Kickass resume validators
+origin: ECC
+---
+
+# Resume-Job Alignment & Tailoring
+
+A skill for analyzing how well your resume matches a specific job posting and providing targeted guidance on what to emphasize, reframe, or add to improve alignment.
+
+## When to Activate
+
+Activate this skill when:
+- You see both `resume.tex` (or `.tex` resume file) and `job_description.md` in your working folder
+- You explicitly request resume tailoring ("tailor my resume for this job", "align with this job posting")
+- You ask about job fit ("does my resume match this job?", "should I apply for this role?")
+- You need to compare specific experience against job requirements
+- You're applying to multiple roles and need guidance on emphasis differences
+- You want to understand what gaps exist before investing in an application
+
+This skill is most effective when you have both documents ready to analyze together.
+
+## When to Use This Skill
+
+Use this skill when:
+- You have a specific job posting and want to tailor your resume to match it
+- You want to understand how your experience aligns with job requirements
+- You need guidance on which achievements to emphasize for a particular role
+- You want to reframe existing bullets to highlight relevant skills
+- You're not sure if you should apply because your resume doesn't seem to match
+- You want to know what gaps exist between your background and the role
+- You need before/after examples showing how to reframe bullets for the specific job
+- You're applying to multiple similar roles and want to optimize your approach
+
+## How This Skill Works (Overview)
+
+### The Alignment Framework
+
+This skill analyzes three dimensions:
+
+1. **Requirement Matching**: What does the job require? What do you have?
+2. **Emphasis Analysis**: What skills/experiences should be highlighted? Are they currently visible?
+3. **Gap Identification**: What's missing? What's weak? What needs reframing?
+
+Then it provides:
+- **Validation**: How well aligned is your resume to this job?
+- **Tailoring Suggestions**: How to reframe existing content to match job priorities
+- **Before/After Examples**: Concrete rewrites showing improved alignment
+- **Priority Roadmap**: What to change first, second, third for maximum impact
+
+## Core Workflow
+
+### Step 1: Parse Job Posting
+Skill reads the job description and extracts:
+- **Required qualifications**: Hard requirements (Python, X years experience, etc.)
+- **Nice-to-have qualifications**: Preferred but not required
+- **Key skills/technologies**: Technical stack, methodologies, tools
+- **Soft skills**: Communication, collaboration, leadership, creativity
+- **Domain-specific knowledge**: Industry, research areas, specific problems
+- **Team/role context**: What kind of person fits? What's the working environment?
+
+### Step 2: Analyze Your Resume
+Skill reads your `.tex` resume and maps:
+- **Technical skills**: What languages, tools, frameworks you have
+- **Experience**: Roles, projects, achievements, impact
+- **Domain knowledge**: Research areas, industries, problem spaces you've worked in
+- **Soft skills**: Leadership, communication, collaboration demonstrated
+- **Gaps**: What's missing relative to job requirements
+
+### Step 3: Generate Alignment Analysis
+Skill compares and produces:
+- **Coverage percentage**: How many job requirements you demonstrate?
+- **Strength assessment**: For each requirement, is it weak/moderate/strong?
+- **Priority gaps**: What's most important to address for this specific role?
+- **Reframing opportunities**: Where can existing content be repositioned?
+
+### Step 4: Provide Tailoring Guidance
+
+For each identified gap or weakness, skill provides:
+- **Why it matters**: Why this specific skill/experience matters for the role
+- **Current state**: What you have or how it's currently positioned
+- **Suggested reframe**: How to emphasize/reword existing content
+- **Before/after examples**: Concrete bullet rewrites
+- **If missing entirely**: How to address a complete gap
+
+## Output Format for Cowork
+
+```json
+{
+  "job_title": "Anthropic Fellows Program - AI Safety",
+  "resume_analyzed": "resume.tex",
+  "overall_alignment": "78%",
+  "alignment_breakdown": {
+    "required_qualifications": "85%",
+    "nice_to_have": "60%",
+    "technical_skills": "80%",
+    "soft_skills": "75%",
+    "domain_knowledge": "70%"
+  },
+  "key_matches": [
+    "Strong Python programming background",
+    "ML research project experience",
+    "Experience with large language models"
+  ],
+  "gaps": [
+    {
+      "requirement": "Experience with empirical ML research",
+      "your_status": "Have some project experience but not emphasized",
+      "priority": "high",
+      "suggestion": "Reframe projects to highlight empirical methodology and results"
+    }
+  ],
+  "tailoring_suggestions": [
+    {
+      "section": "experience",
+      "current_bullet": "Built ML system using TensorFlow",
+      "job_focus": "Job emphasizes empirical research and reproducibility",
+      "suggested_rewrite": "Designed and conducted empirical evaluation of ML model robustness across 50K+ test cases, publishing results and open-sourcing evaluation framework",
+      "why_better": "Emphasizes empirical rigor, publication/sharing (key for AI safety research)"
+    }
+  ],
+  "priority_roadmap": [
+    "High: Emphasize any research or publication work (AI safety values empirical rigor)",
+    "High: Highlight open-source contributions (shows commitment to transparency)",
+    "Medium: Add metrics showing scale of work (10K+ users, large models, etc.)",
+    "Medium: Emphasize collaboration and mentorship (research community matters)"
+  ]
+}
+```
+
+## Key Principles This Skill Follows
+
+### Doesn't Contradict Harvard or Kickass Guidelines
+- All suggestions maintain **one-page format** (Kickass rule)
+- All rewrites use **strong action verbs** (both Harvard & Kickass)
+- All suggestions include **metrics** (both frameworks)
+- Respects **strategic section ordering** (Kickass)
+- Maintains **formatting consistency** (Kickass) and **professional standards** (Harvard)
+- Suggestions work within resume structure, not against it
+
+### Focus on Reframing, Not Fabrication
+- **Never suggests adding false qualifications**
+- Only reframes what you actually have
+- Shows how to emphasize relevant aspects of real experience
+- Identifies when something is genuinely missing (and suggests workarounds or alternatives)
+
+### Context-Aware Tailoring
+- Understands different job types (research vs. engineering vs. product vs. economics)
+- Recognizes job-specific priorities (what matters most for this role)
+- Provides role-specific action verbs and framing
+- Considers company/team culture (startup vs. established, safety-focused vs. product-focused)
+
+### Provides Concrete Examples
+- Before/after bullets showing transformation
+- Explains why each change improves alignment
+- Shows multiple valid approaches (not one "correct" way)
+- Demonstrates how same achievement can be framed differently
+
+## Example: Job Requirement → Tailoring Suggestion
+
+**Job Requirement**: "Experience with empirical ML research; track record of publishing or sharing work publicly"
+
+**Your Current Resume** (weak):
+"Built and trained a neural network model using PyTorch for image classification"
+
+**Analysis**: 
+- You did ML research (good), but doesn't emphasize empirical methodology or public sharing
+- Doesn't show reproducibility or publication mindset
+
+**Suggested Rewrite** (strong):
+"Designed empirical evaluation framework for neural network robustness, testing 50K+ adversarial examples and publishing methodology on GitHub (200+ stars), resulting in adoption by 5+ research groups"
+
+**Why It's Stronger**:
+- "Empirical evaluation framework" → emphasizes research rigor
+- "50K+ adversarial examples" → quantifies scope
+- "Publishing on GitHub" → shows commitment to open science
+- "200+ stars" → demonstrates community validation
+- "Adoption by 5+ research groups" → shows impact on field
+
+---
+
+## CS-Specific Alignment Scenarios
+
+### Scenario 1: CS Student → SWE Internship at FAANG
+
+**Job Requirement Excerpt**:
+"3+ months internship experience preferred. Strong foundation in data structures and algorithms. Experience shipping production code. Collaboration with cross-functional teams. Python or C++ required."
+
+**Current Resume Bullet** (weak):
+"Completed Data Structures course project: Implemented heap-based priority queue with sorting algorithms"
+
+**Gap Analysis**:
+- Shows algorithm knowledge but no production/shipping context
+- Lacks collaboration signal
+- Doesn't mention language explicitly
+- Sounds academic, not engineering-focused
+
+**Suggested Rewrite** (strong):
+"Implemented and deployed production-grade priority queue system in Python handling 100K+ daily requests, collaborated with 2 teammates on design reviews, and achieved 20% latency improvement through algorithm optimization"
+
+**Why Better**:
+- "Deployed production-grade" → shipping signal
+- "100K+ daily requests" → scale and real usage
+- "Collaborated with 2 teammates on design reviews" → cross-functional collaboration
+- "Python" → explicit tech stack match
+- "20% latency improvement" → measurable optimization impact
+
+---
+
+### Scenario 2: Research-Focused Student → ML Engineer at Tech Company
+
+**Job Requirement Excerpt**:
+"Experience scaling ML systems. Fluent in PyTorch or TensorFlow. Ability to move quickly from research to prototype to production. Experience with MLOps, monitoring, or model deployment."
+
+**Current Resume Bullet** (weak):
+"Published paper on adversarial robustness in computer vision. Trained deep neural networks using PyTorch."
+
+**Gap Analysis**:
+- Strong research credential but no production/scaling context
+- PyTorch mentioned but not emphasized for systems thinking
+- No deployment or MLOps experience visible
+- Missing "rapid iteration" and "shipping" signals
+
+**Suggested Rewrite** (strong):
+"Shipped production ML pipeline for adversarial robustness detection in PyTorch, scaling from 10 test images to 10M production images, implemented monitoring dashboard detecting model drift, and reduced inference latency 40% through quantization—published methodology in peer-reviewed venue"
+
+**Why Better**:
+- "Shipped production ML pipeline" → production engineer mindset, not just researcher
+- "Scaling from 10 test images to 10M production images" → explicitly shows scaling journey
+- "Implemented monitoring dashboard detecting model drift" → MLOps/deployment experience
+- "Reduced inference latency 40% through quantization" → optimization and production constraints
+- "Published methodology" → maintains research credibility while showing engineering ownership
+
+---
+
+### Scenario 3: Coursework-Heavy Student → Startup SWE Role
+
+**Job Requirement Excerpt**:
+"Scrappy builder comfortable wearing multiple hats. Full-stack experience valuable. Quick learning and rapid iteration. Shipped features users love. Startup experience or side projects preferred."
+
+**Current Resume Bullets** (weak):
+"Completed full-stack web development course. Built React frontend and Node.js backend for assignment. Received 95/100 on final project."
+
+**Gap Analysis**:
+- Coursework doesn't signal shipped product or user impact
+- No "scrappy" or "iteration" signal
+- No business/user outcome mentioned
+- Sounds academic, not builder-minded
+- Missing evidence of learning quickly
+
+**Suggested Rewrite** (strong):
+"Built and shipped full-stack task management app (React + Node.js) with 150+ active users in first month, iterated rapidly based on user feedback adding real-time collaboration and batch operations, and grew to 500+ users through word-of-mouth—demonstrates full-stack ownership and user-centric iteration in resource-constrained environment"
+
+**Why Better**:
+- "Built and shipped" → action verb showing shipping ownership
+- "150+ active users in first month" → real impact and traction
+- "Iterated rapidly based on user feedback" → scrappy/iteration signal
+- "Adding real-time collaboration and batch operations" → concrete shipping examples
+- "Grew to 500+ users through word-of-mouth" → user love and product quality signal
+- "Resource-constrained environment" → startup mindset without explicitly saying side project
+
+---
+
+## Common Job Posting Types & What They Value
+
+### AI Safety Research
+**Cares About**: Empirical rigor, open-source contributions, reproducibility, publication mindset, safety-focused thinking
+**Reframe Toward**: Research methodology, public sharing, measured results, collaborative spirit
+
+### ML Engineering
+**Cares About**: Scalable systems, performance optimization, production experience, cross-functional collaboration
+**Reframe Toward**: Scale (users, data, throughput), optimization metrics, deployment experience, team impact
+
+### Product Management
+**Cares About**: User impact, stakeholder management, strategic thinking, communication, shipped features
+**Reframe Toward**: User metrics, leadership moments, shipping velocity, revenue/business impact
+
+### Economics/Policy Research
+**Cares About**: Research methodology, analytical thinking, ability to write about findings, interdisciplinary thinking
+**Reframe Toward**: Research rigor, insights/conclusions, clear communication, diverse perspectives
+
+---
+
+## Analysis Dimensions
+
+The skill analyzes alignment across multiple dimensions:
+
+### 1. Technical Skills Alignment
+- Does your resume mention required technologies/languages?
+- Are they emphasized with concrete usage examples?
+- Suggestions: Reorder skills section, add projects using required tech, show depth in key areas
+
+### 2. Experience Level Match
+- Does your background match the seniority/type of experience needed?
+- Can you demonstrate the required level of impact?
+- Suggestions: Reframe to show appropriate scope, highlight relevant experience tier, add metrics
+
+### 3. Domain Knowledge
+- Do you have relevant industry/field background?
+- Is your domain-specific knowledge visible?
+- Suggestions: Emphasize relevant projects/roles, add context showing domain understanding
+
+### 4. Soft Skills Demonstrated
+- Are required soft skills (communication, leadership, collaboration) visible in your bullets?
+- How do you demonstrate these concretely?
+- Suggestions: Add context showing these skills, reframe individual achievement as team effort
+
+### 5. Research/Output Mindset
+- For research roles: Do you show research methodology, publication mindset, rigor?
+- For engineering roles: Do you show shipping, performance, scale?
+- Suggestions: Reframe to emphasize role-appropriate outputs and thinking
+
+### 6. Growth/Learning Trajectory
+- Does your resume show progression and growth?
+- Can you demonstrate adaptability and learning in relevant areas?
+- Suggestions: Highlight how you took on new challenges, learned new skills
+
+---
+
+## Keyword Extraction Methodology
+
+This skill identifies job requirements using a tiered approach:
+
+### Hard Requirements vs. Nice-to-Have Signals
+
+**Hard Requirements** (must-haves):
+- Typically in "Required Qualifications" section
+- Use language like "must have", "required", "essential", "required X years of"
+- Examples: "Python required", "3+ years experience", "BS in Computer Science"
+- **Resume action**: Every hard requirement should map to at least one resume bullet
+
+**Nice-to-Have Signals** (preferred):
+- In "Preferred Qualifications" or "Nice-to-have" sections
+- Use language like "preferred", "nice-to-have", "a plus", "valuable", "helpful"
+- Examples: "Experience with cloud deployment preferred", "Publications a plus"
+- **Resume action**: Nice-to-haves improve alignment but aren't blockers
+
+**Implicit Requirements** (read between the lines):
+- Requirements hidden in job description narrative
+- Examples: "Fast-paced environment" = startup, high context-switching; "Cross-functional collaboration" = communication + stakeholder management skills; "Shipped products at scale" = production engineering, not just academic projects
+- **Resume action**: Mirror the language and context in your bullets
+
+### Hidden Requirement Detection Patterns
+
+**Environment signals**:
+- "Fast-paced" → expect frequent context-switching, rapid iteration, shipping velocity
+- "Stable, long-term project" → depth expertise, deep codebase understanding, focus
+- "Cross-functional teams" → communication, collaboration, ability to explain work to non-engineers
+- "Early-stage startup" → scrappiness, wearing multiple hats, rapid learning
+- "Large organization" → formal processes, documentation, mentorship/leadership
+
+**Problem-space signals**:
+- "Real-time systems" → low-latency, distributed systems, concurrency experience
+- "Research" → methodology rigor, publication mindset, novel problems
+- "Production at scale" → monitoring, debugging, optimization, DevOps thinking
+- "Consulting" → client communication, business impact framing, broad tech exposure
+
+**Culture signals**:
+- "Diverse team" → inclusive collaboration, communication across backgrounds
+- "Open-source culture" → public code contributions, community involvement, transparency
+- "Data-driven" → metrics fluency, experimentation mindset, analytical thinking
+- "Mission-driven" → ability to articulate company values, long-term thinking
+
+### Tech Stack Keyword Matching Strategies
+
+**Explicit matching**:
+- Job says "Python" → your resume must mention Python
+- Job says "AWS" → mention AWS (or specific services like EC2, Lambda)
+- Job says "React" → mention React (not just "JavaScript" or "frontend")
+- **Resume action**: If you have the tech, surface it. If missing critical tech, consider addressing in cover letter or being strategic about which bullets use required keywords
+
+**Technology family matching**:
+- Job wants "cloud deployment" → AWS, GCP, Azure all count (mention the one you have)
+- Job wants "relational database" → PostgreSQL, MySQL, Oracle all fit (mention yours explicitly)
+- Job wants "testing frameworks" → pytest, Jest, RSpec all demonstrate testing thinking
+- **Resume action**: Use specific tech names, not generic categories; employers search for exact keywords
+
+**Competency-based matching**:
+- Job wants "distributed systems thinking" → look for bullets about scalability, handling concurrency, database replication
+- Job wants "API design" → look for REST, GraphQL, or service design work (not just "API consumption")
+- Job wants "optimization mindset" → look for performance improvements, latency reduction, throughput gains
+- **Resume action**: Use domain-specific language matching the job posting; "optimization" beats "made it faster"
+
+**Hidden tech/skills signals**:
+- Job posting length/sophistication hints at role complexity
+- Multiple specialized tools mentioned → deep technical depth expected
+- Vague skills ("good communication") → likely interviews will test collaboration heavily
+- Heavy emphasis on one skill → that's the bottleneck they're trying to solve
+- **Resume action**: Allocate resume real estate proportional to job emphasis; if job emphasizes testing 3x, ensure you have testing visibility
+
+---
+
+## DO/DON'T Patterns for Strong Alignment
+
+### DO: Strong Alignment Patterns
+
+1. **DO map every hard requirement to a resume bullet**: If job requires Python, every mention of Python should appear somewhere in your resume. Not just "used Python once" but clear Python ownership.
+
+2. **DO use the job posting's language**: If job says "empirical research", use "empirical"; if job says "shipped production features", use "shipped". Mirror terminology shows deep understanding.
+
+3. **DO quantify impact using job-relevant metrics**: For research roles, quantify via publication count or citations. For engineering, quantify via users/scale/performance. For startup, quantify via growth/retention.
+
+4. **DO show progression within bullets**: "Implemented → optimized → scaled" tells a better story than one static achievement. Shows learning and ownership progression.
+
+5. **DO emphasize cross-functional collaboration when job values it**: "Collaborated with design team to ship feature" beats "Shipped feature". Explicitly name the collaboration pattern.
+
+6. **DO connect past experience to future role**: If applying to AI safety research but resume shows ML engineering, reframe to show "rigorous empirical thinking" not just "fast iteration".
+
+7. **DO highlight rare/differentiated skills prominently**: If job needs distributed systems and you built one, lead with that. Don't bury unique experience.
+
+8. **DO address genuine gaps with workarounds**: If job wants 5 years and you have 2, emphasize "rapid learning" or "shipped production systems" showing capability despite experience delta.
+
+### DON'T: Misalignment Anti-Patterns
+
+1. **DON'T keyword-stuff without context**: Mentioning "Python, Java, C++, Rust, Go, Kotlin, Swift" looks unfocused. Show depth in 3-5 languages, not breadth across 10.
+
+2. **DON'T use vague verbs for specific jobs**: "Worked on ML" fails for ML engineer role. Use "designed", "optimized", "shipped", "debugged", "scaled"—verbs that match the job's needs.
+
+3. **DON'T mention irrelevant nice-to-haves if space-constrained**: One-page resume (Kickass rule). Don't sacrifice required skill visibility to show every nice-to-have. Prioritize hard requirements.
+
+4. **DON'T fabricate or exaggerate skills**: "Led ML team" when you took one course appears during interviews. Stick to what's real. Reframing is powerful; dishonesty isn't.
+
+5. **DON'T ignore soft-skill requirements**: "Communication skills" in job posting isn't filler. Show collaboration, mentorship, or clear writing in your bullets.
+
+6. **DON'T bury critical alignment in weak position**: If you're strong in required skill, don't hide it in "Other Projects". Put it in main experience or skills section.
+
+7. **DON'T apply identical resume to different role types**: SWE internship and ML internship require different emphasis (shipping vs. research). Same base resume, different tailoring per role.
+
+8. **DON'T ignore the role's seniority level**: Applying to "senior engineer" role but resume shows junior-level bullets ("Completed project for class") signals misalignment. Reframe to show scope and mentorship appropriate to level.
+
+---
+
+## Quick Alignment Checklist
+
+Before submitting a tailored resume, run through this rapid checklist:
+
+**Required Skills Coverage** (5 min):
+- [ ] Every hard requirement appears somewhere in resume
+- [ ] Critical hard requirements appear in 2+ places (skills section + experience bullets)
+- [ ] Use exact terminology from job posting (if job says "PyTorch", don't just say "deep learning")
+
+**Emphasis & Framing** (5 min):
+- [ ] Reframed bullets match job's priorities (if job emphasizes shipping, emphasize shipped features not just completed projects)
+- [ ] Action verbs match job type (research = designed/analyzed; engineering = shipped/optimized; startup = shipped/scaled)
+- [ ] Quantified metrics using job-relevant units (users/scale for engineering, publication count for research)
+
+**Soft Skills Visibility** (3 min):
+- [ ] Collaboration/communication explicitly mentioned if job requires it
+- [ ] Leadership or mentorship visible if job emphasizes people management
+- [ ] Learning agility shown if startup/fast-paced role
+
+**Format & Standards** (2 min):
+- [ ] One-page limit maintained (Kickass rule)
+- [ ] All suggestions use strong action verbs (Harvard + Kickass requirement)
+- [ ] Metrics present for quantifiable achievements
+- [ ] No vague phrases like "worked on", "helped with", "contributed to" (replace with ownership verbs)
+
+**Authenticity Check** (2 min):
+- [ ] All reframing reflects actual achievements (no fabrication)
+- [ ] Emphasis shifts are honest (you actually did these things, just highlighting them differently)
+- [ ] Tone maintains your authentic voice (not jarringly different from LinkedIn/cover letter)
+
+---
+
+## What This Skill Doesn't Do
+
+- **Doesn't fabricate experience**: Only reframes what you actually have
+- **Doesn't violate Kickass/Harvard standards**: All suggestions maintain both frameworks
+- **Doesn't write the entire resume**: Provides targeted tailoring suggestions, not a full rewrite
+- **Doesn't make decisions for you**: Suggests options and explains tradeoffs; you decide
+- **Doesn't guarantee outcomes**: Alignment is one factor; interview performance matters too
+- **Doesn't override your authenticity**: Suggestions respect your actual background and values
+
+## Integration with Kickass & Harvard Validators
+
+This skill is **designed to work alongside** the Kickass and Harvard validators:
+
+1. **First, validate your base resume**: Use the kickass-resume-validator or harvard-resume-validator to ensure one-page format, strong verbs, metrics
+2. **Then, tailor for specific role**: Use this skill to reframe existing content for the job
+3. **Finally, re-validate**: Run Kickass or Harvard validator again to ensure changes maintain standards
+
+All suggestions from this skill will be compatible with both frameworks—you won't have to choose between "tailored" and "following best practices."
+
+---
+
+## Complete Integration Workflow with Validators
+
+The recommended sequence uses all three skills together for maximum impact:
+
+### Phase 1: Baseline Validation (5-10 min)
+
+**Step 1a**: Run `kickass-resume-validator` on your resume.tex
+- Validates one-page format, action verbs, metric presence
+- Identifies any formatting violations or weak bullets
+- Output: List of baseline improvements to make before tailoring
+
+**Step 1b**: (Optional) Run `harvard-resume-validator` to confirm Harvard College guidelines
+- Ensures compliance with Harvard standards
+- May highlight different patterns than Kickass
+- Output: Additional perspectives on resume quality
+
+**Decision Point**: Fix critical formatting issues now before tailoring (don't tailor a resume that violates one-page rule)
+
+### Phase 2: Job-Specific Tailoring (10-15 min)
+
+**Step 2a**: Prepare job materials
+- Save job description as `.md` file in working folder
+- Ensure resume.tex is in same folder
+- Open both documents so you can reference them
+
+**Step 2b**: Run resume-job-alignment skill (this skill)
+- Provide resume.tex and job_description.md
+- Get alignment analysis with coverage %, gaps, and suggestions
+- Output: Specific reframe suggestions with before/after examples
+
+**Step 2c**: Apply tailoring suggestions to resume.tex
+- Update 2-3 bullets with highest priority gaps
+- Reframe using suggested language patterns
+- Focus on hard requirements first, nice-to-haves second
+- Keep one-page format (Kickass constraint)
+
+### Phase 3: Quality Assurance (5 min)
+
+**Step 3a**: Run `kickass-resume-validator` again
+- Confirm tailored bullets still meet quality standards
+- Check that action verbs are strong
+- Verify metrics are present and meaningful
+- Ensure formatting hasn't drifted
+
+**Step 3b**: (Optional) Run resume-job-alignment skill again
+- Re-check alignment % after changes
+- Confirm gaps are addressed
+- Identify any remaining weak spots
+
+**Decision Point**: If alignment improved and Kickass validates, ready to submit. If still gaps, iterate Steps 2c-3b
+
+### Phase 4: Final Polish (2-3 min)
+
+**Step 4a**: Harvard validation (optional final check)
+- Run `harvard-resume-validator` to ensure final version meets standards
+- Particularly useful if applying to Harvard or similar institutions
+
+**Step 4b**: Manual review
+- Read resume aloud to catch awkward phrasing
+- Verify quantification is accurate
+- Check that you'd confidently explain each bullet in interview
+
+**Decision Point**: Submit with confidence
+
+---
+
+## Example Workflow in Cowork
+
+```
+Step 1: Validate baseline resume
+Run: kickass-resume-validator on resume.tex
+Output: "8 bullets need stronger verbs, add metrics to 3 bullets"
+
+Step 2: Fix validation issues
+Update resume with better action verbs and metrics
+Goal: Pass Kickass baseline
+
+Step 3: Tailor for specific job
+Put resume.tex and anthropic_job.md in working folder
+Run: resume-job-alignment skill
+Output: "78% aligned overall, gaps in open-source contributions, 
+         publication mindset not emphasized"
+
+Step 4: Apply tailoring suggestions
+Reframe 3 bullets to emphasize research rigor and GitHub work
+Update skills section to mention open-source contributions
+Keep one-page format (remove lower-priority bullets)
+
+Step 5: Re-validate tailored resume
+Run: kickass-resume-validator on updated resume.tex
+Output: "All bullets now have strong verbs and metrics, formatting clean"
+
+Step 6: Confirm improved alignment
+Run: resume-job-alignment skill again
+Output: "Alignment improved to 88%, open-source now visible, 
+         publication mindset clear, ready to submit"
+
+Step 7: Final Harvard check (optional)
+Run: harvard-resume-validator
+Output: "Meets Harvard standards, professional presentation solid"
+
+Step 8: Submit tailored resume with confidence
+```
+
+---
+
+## Tips for Best Results
+
+1. **Be honest about your background**: Only reframe what's real; don't fabricate
+2. **Understand the role**: Read the full job posting, not just the title
+3. **Prioritize**: Focus on high-priority gaps first
+4. **Test multiple approaches**: Skill may suggest different ways to frame same achievement
+5. **Iterate**: Run Kickass/Harvard validator after applying changes
+6. **Tailor each application**: Different roles within same company may need different emphasis
+7. **Know when to apply anyway**: Even 70-80% alignment can be worth applying if you're interested
+8. **Don't over-tailor**: Maintain authenticity; slight emphasis shift > complete reinvention
+
+---
+
+## Related Skills
+
+- **kickass-resume-validator**: Ensure resume follows best practices (one-page, metrics, verbs)
+- **harvard-resume-validator**: Ensure Harvard College guidelines are followed
+- **Both validators**: Run after applying tailoring suggestions to confirm changes maintain standards
+
+---
+
+**Skill Version**: 1.0  
+**Purpose**: Resume-job alignment and tailoring guidance  
+**Platform**: Cowork (.tex resume + .md job description)  
+**Integrates With**: Kickass and Harvard resume validators  
+**Audience**: CS/tech students and professionals tailoring resumes  

--- a/skills/sentence-clarity-cs/SKILL.md
+++ b/skills/sentence-clarity-cs/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: sentence-clarity-cs
+description: Edit sentences in CS research papers for clarity, conciseness, and readability. Use this skill whenever you see unclear, overly long, or awkwardly structured sentences. Identifies sentence length issues (>25 words), ambiguous pronouns, weak verbs, passive voice, deeply nested clauses, and unclear referents. Trigger on "sentence clarity", "fix my sentences", "make this clearer", "awkward phrasing", "simplify this", or when noticing written prose in academic papers that could be tightened.
+origin: ECC
+---
+
+# Sentence Clarity Editor for CS Papers
+
+You review sentences in CS research papers and suggest improvements for clarity, conciseness, and readability. Output JSONL format—one sentence issue per line, independent of others. This skill targets the specific patterns that make academic CS writing dense, hard to parse, and less impactful than it should be.
+
+## When to Activate
+
+Use this skill when:
+- Reviewing draft paper sections (Abstract, Introduction, Methods, Results, Discussion, Related Work)
+- Author says "sentence clarity", "make this clearer", "fix my writing", "awkward phrasing", "simplify this"
+- You notice written prose in academic CS papers that has any of these characteristics:
+  - Sentences longer than 25 words
+  - Heavy use of passive voice or weak linking verbs
+  - Ambiguous pronouns (this, it, they, that) with unclear referents
+  - Deeply nested clauses (3+ levels of nesting: main + relative clause + parenthetical, etc.)
+  - Nominalization chains ("the implementation of the system enables the improvement of performance")
+  - Hedging or filler phrases that weaken assertions
+  - Dense jargon without context
+- During pre-submission review to polish paper clarity before camera-ready
+
+## Your Task
+
+When given paper text, identify sentences that are unclear, too long, use weak verbs, employ excessive passive voice, or have ambiguous pronouns. Each sentence issue is independent; fixing one doesn't affect validation of others. Focus on sentences that, when tightened, will improve reader comprehension and paper impact.
+
+## Output Format (JSONL)
+
+Output exactly one JSON object per line. Each object is one sentence-level improvement opportunity. Keep each JSON object on a single line (no wrapping).
+
+## Issue Categories
+
+- `sentence_length` - More than 25 words or excessively nested (hard to parse, breaks reader attention)
+- `weak_verb` - Passive voice, "is/are" constructions, nominalizations ("make use of" → "use")
+- `ambiguous_pronoun` - "this", "it", "they" without clear referent (reader must backtrack)
+- `passive_voice` - Sentence uses passive when active is clearer or stronger
+- `nested_clauses` - More than 2 levels of nesting (parenthetical inside relative clause inside main clause)
+- `unclear_referent` - Demonstrative pronoun ("this", "that", "these") pointing to vague or distant antecedent
+- `nominalization` - Overuse of noun forms from verbs ("the implementation" instead of "implementing"; "the consideration of" instead of "considering")
+- `hedge_language` - Filler phrases that weaken assertions ("it should be noted that", "it is worth mentioning that", "somewhat", "arguably")
+
+## Before/After Examples (Real CS Paper Prose)
+
+These examples show actual patterns from CS research writing, with the problem identified and the fix applied.
+
+### Example 1: Excessive Sentence Length + Multiple Weak Verbs
+
+**Original (38 words):**
+"The performance of our system, which integrates multiple machine learning models with real-time data processing capabilities, is evaluated against several baseline systems on a diverse set of benchmarks that span different application domains."
+
+**Problem:** Sentence length, passive voice ("is evaluated"), unclear what "our system" does until the end.
+
+**Improved (28 words):**
+"We evaluate our system—which integrates multiple ML models with real-time data processing—against baseline systems across diverse benchmarks spanning different application domains."
+
+**Why:** Active voice ("We evaluate") immediately clarifies agency. Reduced word count. Subordination using em-dash makes the relationship clearer. Abbreviation of "machine learning" to "ML" in academic context is acceptable.
+
+---
+
+### Example 2: Ambiguous Pronoun Reference
+
+**Original:**
+"The algorithm processes distributed data and applies hierarchical clustering, which improves scalability and reduces latency. This is a key advantage in production systems."
+
+**Problem:** "This" is ambiguous—does it refer to the algorithm, clustering, improving scalability, reducing latency, or the combination?
+
+**Improved:**
+"The algorithm processes distributed data and applies hierarchical clustering, reducing latency and improving scalability—key advantages in production systems."
+
+**Why:** Eliminates vague pronoun by directly connecting the benefit to the action. Shorter and more direct.
+
+---
+
+### Example 3: Nominalization Chain (Action Hidden Behind Nouns)
+
+**Original:**
+"The implementation of our framework enables the efficient processing of large-scale datasets, with the result being a significant reduction in query execution time."
+
+**Problem:** Three nominalizations obscure the main actions. Passive construction ("with the result being") weakens the claim.
+
+**Improved:**
+"Our framework processes large-scale datasets efficiently and reduces query execution time significantly."
+
+**Why:** Verbs (processes, reduces) replace nominalizations (implementation, processing, reduction). Stronger, more readable, 40% shorter.
+
+---
+
+### Example 4: Passive Voice + Unclear Agent
+
+**Original:**
+"It was observed that the proposed approach was more efficient than the baseline in 87% of test cases."
+
+**Problem:** Passive voice hides who made the observation. "It was observed" is filler. Vague passive "was more efficient" without stating what makes it efficient.
+
+**Improved:**
+"Our approach outperformed the baseline in 87% of test cases."
+
+**Why:** Active voice identifies the agent (implicitly, the paper/authors). Stronger verb "outperformed" replaces weak "was more efficient than". Direct and quantitative.
+
+---
+
+### Example 5: Deeply Nested Clauses
+
+**Original:**
+"The optimization strategy, which is based on a greedy heuristic that prioritizes nodes with the highest degree (a metric that measures local connectivity), proves effective for graphs with power-law degree distributions."
+
+**Problem:** Three levels of nesting (main clause > relative clause > parenthetical). Reader must hold multiple contexts in mind.
+
+**Improved:**
+"The greedy optimization strategy prioritizes high-degree nodes (a measure of local connectivity) and proves effective for power-law graphs."
+
+**Why:** Eliminated one level of nesting. Replaced passive "is based on" with active "prioritizes". Clearer progression of ideas.
+
+---
+
+### Example 6: Hedge Language + Weak Assertions
+
+**Original:**
+"It could be argued that the proposed method is somewhat better than existing approaches in certain scenarios, though this observation arguably warrants further investigation."
+
+**Problem:** Five hedging phrases ("could be argued", "somewhat", "in certain scenarios", "arguably", "arguably warrants") undermine confidence. Passive construction.
+
+**Improved:**
+"Our method outperforms existing approaches in scenarios with sparse data; we analyze the conditions that enable this advantage in Section 5."
+
+**Why:** Makes the claim concrete and specific rather than hedged. Promises investigation rather than timidly suggesting it. Positions future work as contribution, not apology.
+
+---
+
+## DO/DON'T Patterns for Clear CS Writing
+
+### DO
+
+- Use active voice: "We implement X" instead of "X is implemented"
+- Use strong verbs: "optimizes", "reduces", "enables", "achieves" instead of "is" + adjective
+- Keep sentences under 25 words; if longer, use em-dashes or semicolons to break internal clauses
+- Clarify pronouns immediately: "We propose Algorithm Y, which reduces latency" (not "This reduces latency" later)
+- Put the agent (subject) early in the sentence: "Algorithm X reduces..." not "The reduction enabled by Algorithm X is..."
+- Use parallel structure: "Our method reduces latency, improves accuracy, and scales to 1M nodes" (not mixed passive/active)
+- Define jargon on first use: "Our approach uses vector quantization (VQ), a compression technique..."
+- Use specific numbers: "improves by 23%" instead of "significantly improves"
+
+### DON'T
+
+- Avoid noun chains: "machine learning model training dataset optimization approach" (use active clauses instead)
+- Avoid "It is" constructions: "It is worth noting that..." or "It is shown that..." or "It should be noted that..."
+- Avoid buried verbs: "The implementation of our method enables a 30% reduction in memory overhead" → "Our method reduces memory overhead by 30%"
+- Avoid vague demonstratives without referents: Never use "This" or "That" at the start of a sentence unless the previous sentence contains a single clear noun it refers to
+- Avoid excessive subordination: Don't nest more than 2 levels deep
+- Avoid weak passives: "was found to be", "was observed to", "is considered to be" (just use the adjective)
+- Avoid hedging when you have data: "appears to suggest" instead of "shows" when you have experimental evidence
+
+---
+
+## Common CS Writing Anti-Patterns
+
+These phrases should trigger refactoring:
+
+| Anti-Pattern | Better Alternative |
+|--------------|-------------------|
+| "It should be noted that..." | Delete. State the fact directly. |
+| "In order to..." | Use "To" instead. ("To optimize X, we..." not "In order to optimize X, we...") |
+| "The fact that..." | Remove "The fact that" and use the clause directly. ("Since Y is slow" not "The fact that Y is slow...") |
+| "It is worth mentioning that..." | Delete and rewrite. ("Algorithm Y converges faster" not "It is worth mentioning that Algorithm Y converges faster") |
+| "It can be seen that..." | State the observation directly. ("Our results show that..." not "It can be seen that...") |
+| "It is known that..." | Replace with "Prior work shows that..." or "X shows that..." |
+| "somewhat/relatively/fairly/quite" | Delete or replace with precise quantification. ("reduces latency by 15%" not "somewhat reduces latency") |
+| "arguably/one could argue" | State the claim directly with evidence or hedging data. Delete if you have proof. |
+| "the issue of X" / "the problem of X" | Replace with the root noun. ("memory overhead" not "the problem of memory overhead") |
+| "due to the fact that" | Replace with "because" or "since". |
+| "on the other hand" | Use "In contrast" or "However" with an agent doing something. |
+| "a method/technique/approach is presented" | "We present a method..." (active agent). |
+| "the implementation of the system" | Determine what the system actually does and use that verb. |
+
+---
+
+## Venue-Specific Tips
+
+### ACM Conferences (SIGMOD, OSDI, PLDI, POPL, CCS, etc.)
+
+- Prefer "we" over passive voice (ACM culture favors author agency)
+- Use precise metrics and quantification (not "significantly" without numbers)
+- Keep abstracts under 150 words, often under 100
+- Use "paper" to refer to your work: "This paper presents..." or "In this paper, we..."
+- Avoid "novel" unless truly unprecedented—show impact instead
+
+### IEEE Transactions & Conferences
+
+- More accepting of passive voice, but active is still preferred
+- Require precise problem statements in Introduction
+- Use section numbering and cross-references heavily
+- Tables and figures should be self-contained (captions should summarize results, not just label)
+- Acronyms must be defined on first use
+
+### General Best Practices (Most Venues)
+
+- Introduction: clarify problem, contribution, and why it matters (in that order)
+- Related Work: position your contribution relative to prior art (don't just list papers)
+- Methods: pseudocode or algorithms > prose descriptions when possible
+- Results: lead with the key finding; don't make readers infer the main point
+- Discussion: address limitations explicitly; don't hide weaknesses
+- Use first person in Methods/Results (we performed, we observe); third person in Related Work if comparing
+
+---
+
+## LaTeX-Specific Clarity Considerations
+
+When writing sentences destined for LaTeX:
+
+- **Line breaks in LaTeX don't affect output formatting.** You can write long sentences freely, but readers see them as wrapped on screen. Still keep sentences under 25 words for comprehension (not just visual aesthetics).
+- **Math mode breaks clarity.** Use \(x\) for inline math, not $x$, for screen readers and future accessibility. Introduce variables in prose first: "Let \(x\) denote..." (not just "Consider $x$...").
+- **Avoid sentence fragments after math.** "We define $\mathcal{G} = (V, E)$" is better than "Define $\mathcal{G} = (V, E)$ where..." for clarity.
+- **Use \cite{} close to the claim.** "Our method [4] is efficient" not "Our method is efficient. [4] proves this."
+- **TikZ/PGF figure captions should not require the figure to be understood.** Write: "Algorithm 1: Cache-aware merging. We prioritize in-cache prefixes (blue) before accessing main memory (gray)." Not: "Figure 1."
+- **Common LaTeX clarity issues:**
+  - `\textit{something} is` → use `\textup` or roman for nouns, italics for emphasis only
+  - Orphaned `$...$` expressions in prose → embed them in clauses: "reduce latency $\ell$ by" not "reduce latency. $\ell$..."
+  - Overuse of `\emph{}` → reserve for single key words per paragraph
+  - Undefined notation: always define symbols before use, even if standard in your subfield
+
+---
+
+## Quick Reference Checklist
+
+When reviewing your own sentences, ask:
+
+- [ ] **Is this sentence under 25 words?** If not, can I break it with an em-dash, semicolon, or period?
+- [ ] **Who is the subject (agent)?** Is it clear in the first few words?
+- [ ] **What verb appears in the main clause?** Is it strong or weak ("reduces" vs "is able to reduce")?
+- [ ] **Do any pronouns appear (this, it, they, that)?** Do they have a single clear antecedent in the previous sentence?
+- [ ] **How many levels of nesting?** If more than 2, rewrite using multiple sentences.
+- [ ] **Are there nominalization chains?** ("implementation of...", "optimization of...") Can I use the root verb instead?
+- [ ] **Is passive voice justified?** (E.g., "Errors were counted by hand" might be acceptable if the agent is irrelevant, but "Our approach was evaluated on benchmarks" should be active.)
+- [ ] **Any hedge words?** ("somewhat", "arguably", "appears to") Can I replace them with data or delete them?
+
+---
+
+## Output Format (JSONL)
+
+Output exactly one JSON object per line. Each object is one sentence-level improvement opportunity.
+
+## Output Requirements
+
+- One sentence per line (JSONL format)
+- Include `line` number (approximate, where the sentence begins)
+- `problem_type` must be one of the categories listed above (sentence_length, weak_verb, ambiguous_pronoun, passive_voice, nested_clauses, unclear_referent, nominalization, or hedge_language)
+- Include `current` (original sentence, possibly truncated if very long—but show enough context to be useful)
+- Include `suggested` (revised sentence)
+- `reason` explains the improvement in one sentence (focus on impact: clarity, brevity, strength, directness)
+- Keep output concise—each JSON object should fit on one line
+- Do NOT group related sentences—report each independently
+- Order suggestions by line number

--- a/skills/sentence-clarity-cs/evals/evals.json
+++ b/skills/sentence-clarity-cs/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "sentence-clarity-cs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Edit these sentences for clarity:\n\n1. The machine learning algorithm that was developed by researchers over a two-year period and was trained on massive datasets containing millions of images was evaluated on the ImageNet benchmark.\n\n2. This approach has been shown to have better performance than previous methods.\n\n3. When the data was processed, it was normalized and then it was used to train the model.",
+      "expected_output": "JSONL with sentence improvements: sentence_length (47+ words → shortened), weak_verb (passive voice converted to active), ambiguous_pronoun (clarify 'it' and 'this')"
+    },
+    {
+      "id": 2,
+      "prompt": "Improve clarity of this research methodology description:\n\nThe experiment was designed to test whether the proposed framework could achieve comparable results when applied to real-world scenarios, which involved collecting data from five different sources and processing it through multiple validation stages before final evaluation was performed.",
+      "expected_output": "JSONL highlighting sentence_length issue and suggesting active voice restructuring"
+    },
+    {
+      "id": 3,
+      "prompt": "Review this paragraph for clarity:\n\nWe use gradient descent to optimize the loss function. Parameters are initialized randomly and then are updated iteratively. The convergence criterion is met when the gradient norm falls below a threshold.",
+      "expected_output": "JSONL with minimal issues (reasonably clear); possibly flag one weak passive construction"
+    }
+  ]
+}


### PR DESCRIPTION
## What Changed

Adds 7 new skills across two domains and updates README with directory listings.

**CS Academic Writing (4 skills with evals):**
- `abstract-methods-results-cs` — Review Abstract, Methods, Results sections with before/after examples and venue-specific guidance
- `academic-final-review-cs` — 25-item pre-submission checklist with LaTeX-specific and venue-specific checks
- `paper-structure-cs` — Structure validation with templates for conference, journal, and workshop papers
- `sentence-clarity-cs` — Sentence-level clarity editing with 6 before/after examples using CS prose

**Resume Building (3 skills):**
- `harvard-resume-validator` — Resume validation against Harvard College guidelines with CS-specific examples and LaTeX tips
- `kickass-resume-validator` — Resume validation against industry-standard guide with ATS compliance checks
- `resume-job-alignment` — Resume-to-job alignment with keyword extraction methodology and integration workflow with both validators

12 files changed, 3,180 lines added.

## Why This Change

No skills in the repo currently cover academic CS writing or resume building. The 4 academic skills cover the full writing-to-submission pipeline. The 3 resume skills work as a pipeline: validate with Harvard or Kickass, then tailor with the alignment skill. All include venue-specific guidance (ACM/IEEE/Springer), LaTeX tips, When to Activate sections, DO/DON'T patterns, and concrete before/after examples.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [x] Added comments for complex logic
- [x] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds seven skills for CS paper writing and resume building, with structured outputs, LaTeX-aware checks, and ATS-ready resume validation and tailoring. README updated; `paper-structure-cs` evals further expanded with additional heading/order cases and config fixes.

- **New Features**
  - CS Academic Writing: `abstract-methods-results-cs`, `paper-structure-cs`, `sentence-clarity-cs`, `academic-final-review-cs` with JSONL/delimited outputs, venue-specific guidance, LaTeX-aware checks, and evals; `paper-structure-cs` evals expanded for heading hierarchy and ordering edge cases.
  - Resume Building: `harvard-resume-validator`, `kickass-resume-validator`, `resume-job-alignment` with ATS checks and a tailoring workflow; README lists the new skill directories.

- **Bug Fixes**
  - `harvard-resume-validator`: minor guidance/metadata tweaks for clarity.

<sup>Written for commit 49d2b0d95ad83336dc0d570c0d4895756d66b57d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seven new skills for paper review and resume workflows: abstract-methods-results-cs, academic-final-review-cs, paper-structure-cs, sentence-clarity-cs, harvard-resume-validator, kickass-resume-validator, resume-job-alignment.
* **Documentation**
  * Added comprehensive skill specifications, activation triggers, output contracts, checklists, and usage guidance for each new skill.
* **Tests**
  * Added evaluation configurations and sample cases to validate each new skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->