### PR TITLE
fix(dashboard): scan agents/ directory for accurate count

### DIFF
--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -23,31 +23,44 @@ def get_project_path() -> str:
 
 
 def load_agents(project_path: str) -> List[Dict]:
-    """Load agents from AGENTS.md"""
-    agents_file = os.path.join(project_path, "AGENTS.md")
-    agents = []
-    
-    if os.path.exists(agents_file):
-        with open(agents_file, 'r', encoding='utf-8') as f:
-            content = f.read()
-            
-        # Parse agent table from AGENTS.md
-        lines = content.split('\n')
-        in_table = False
-        for line in lines:
-            if '| Agent | Purpose | When to Use |' in line:
-                in_table = True
+    """Load agents by scanning the agents/ directory.
+
+    Parses YAML frontmatter (name, description) from each agent file.
+    The directory is the source of truth — AGENTS.md is hand-maintained
+    and drifts out of sync.
+    """
+    agents_dir = os.path.join(project_path, "agents")
+    agents: List[Dict] = []
+
+    if os.path.isdir(agents_dir):
+        for item in sorted(os.listdir(agents_dir)):
+            if not item.endswith('.md'):
                 continue
-            if in_table and line.startswith('|'):
-                parts = [p.strip() for p in line.split('|')]
-                if len(parts) >= 4 and parts[1] and parts[1] != 'Agent':
-                    agents.append({
-                        'name': parts[1],
-                        'purpose': parts[2],
-                        'when_to_use': parts[3]
-                    })
-    
-    # Fallback default agents if file not found
+            agent_path = os.path.join(agents_dir, item)
+            name = os.path.splitext(item)[0]
+            description = ''
+            try:
+                with open(agent_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+            except OSError:
+                content = ''
+            if content.startswith('---'):
+                end = content.find('\n---', 3)
+                if end != -1:
+                    for fm_line in content[3:end].splitlines():
+                        stripped = fm_line.strip()
+                        if stripped.startswith('name:'):
+                            name = stripped.split(':', 1)[1].strip().strip('"\'')
+                        elif stripped.startswith('description:'):
+                            description = stripped.split(':', 1)[1].strip().strip('"\'')
+            agents.append({
+                'name': name,
+                'purpose': description,
+                'when_to_use': description,
+                'path': agent_path,
+            })
+
+    # Fallback default agents if directory not found
     if not agents:
         agents = [
             {'name': 'planner', 'purpose': 'Implementation planning', 'when_to_use': 'Complex features, refactoring'},


### PR DESCRIPTION
## Summary

`bun run dashboard` showed **27 agents** even though 48 ship in `agents/`. `load_agents()` was parsing a hand-maintained table in `AGENTS.md` that had drifted out of sync with the actual agent files, while `load_skills()` and `load_commands()` already scan their directories directly.

Switch `load_agents()` to the same directory-scanning pattern, parsing the YAML frontmatter (`name`, `description`) of each agent file. The returned dict shape (`name`, `purpose`, `when_to_use`) is preserved so the rest of the UI is unchanged; a new `path` key is added for parity with `load_skills()`.

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Bug fix (dashboard)

## Testing

- Ran `python3 -c "…load_agents(project_path)…"` (with tkinter stubbed) and confirmed it now returns **48 agents** with parsed names and descriptions, matching `ls agents/*.md | wc -l`.
- Ran `node tests/run-all.js` — **1867 / 1867 passed**, no regressions.

## Checklist
- [x] Follows format guidelines
- [x] Tested (dashboard loader + full test suite)
- [x] No sensitive info
- [x] Clear description

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard’s agent count by scanning the `agents/` directory instead of parsing stale `AGENTS.md`, keeping the list accurate and in sync.

- **Bug Fixes**
  - Updated `load_agents()` to scan `agents/` and parse YAML frontmatter (`name`, `description`).
  - Preserved output shape (`name`, `purpose`, `when_to_use`); added `path` for parity with `load_skills()`.
  - Aligns with `load_skills()`/`load_commands()` and resolves the undercount of agents.

<sup>Written for commit 2a41e759c880de2bb527f0dfe7093ae23beaa339. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved agent loading mechanism to automatically discover agents from markdown files in the agents directory, replacing the previous static configuration approach. Agent metadata is now extracted from file-based frontmatter, enabling more flexible agent management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->