### PR TITLE
fix(hooks): add ECC_SESSION_STRICT_MATCH to prevent cross-project session fallback

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -202,7 +202,7 @@ function selectMatchingSession(sessions, cwd, currentProject) {
   // When ECC_SESSION_STRICT_MATCH=1, skip fallback to prevent cross-project
   // context injection. Without this, unrelated session data can silently
   // influence Claude's behavior in the wrong project.
-  if (fallbackSession && !process.env.ECC_SESSION_STRICT_MATCH) {
+  if (fallbackSession && process.env.ECC_SESSION_STRICT_MATCH !== '1') {
     return { session: fallbackSession, content: fallbackContent, matchReason: 'recency-fallback' };
   }
 

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -199,7 +199,10 @@ function selectMatchingSession(sessions, cwd, currentProject) {
   }
 
   // Fallback: most recent readable session (original behavior)
-  if (fallbackSession) {
+  // When ECC_SESSION_STRICT_MATCH=1, skip fallback to prevent cross-project
+  // context injection. Without this, unrelated session data can silently
+  // influence Claude's behavior in the wrong project.
+  if (fallbackSession && !process.env.ECC_SESSION_STRICT_MATCH) {
     return { session: fallbackSession, content: fallbackContent, matchReason: 'recency-fallback' };
   }
 


### PR DESCRIPTION
## What Changed

Added env var guard `ECC_SESSION_STRICT_MATCH` to `selectMatchingSession()` in `scripts/hooks/session-start.js`. When set to `1`, the recency fallback (which loads the most recent session regardless of project) is skipped. Only worktree-matched or project-name-matched sessions are injected.

**Diff is 4 lines** — a comment block + one conditional check wrapping the existing fallback.

## Why This Change

The recency fallback introduced in #1054 preserves backward compatibility but causes **cross-project context injection** in multi-project workflows. When no session matches the current worktree or project name, the fallback grabs whatever session was saved most recently — often from a completely unrelated project.

**Real-world impact observed:**
- Working in `~/.claude` (config management), Claude received injected context from a Shopify theme project
- Injected context included project-specific instructions, file paths, dev server state, and prior conversation tone
- After context compaction, Claude cannot distinguish injected session history from actual conversation — treats cross-project context as ground truth
- Claude then references non-existent files, assumes wrong conventions, adopts patterns from the wrong codebase

**Why this is hard to catch:**
- Session injection happens in SessionStart hook — users never see the injected content
- `matchReason: 'recency-fallback'` is only logged to stderr
- After compaction, injected session summary is indistinguishable from real conversation
- Symptoms look like normal Claude mistakes, not a systematic data source issue

**Usage:**

Add to `~/.claude/settings.json`:

```json
{
  "env": {
    "ECC_SESSION_STRICT_MATCH": "1"
  }
}
```

Or as environment variable: `export ECC_SESSION_STRICT_MATCH=1`

**Design choices:**
- Opt-in (not opt-out) — zero impact on existing users
- Env var naming follows established `ECC_` prefix convention (`ECC_SESSION_RETENTION_DAYS`, `ECC_DISABLED_HOOKS`, `ECC_OBSERVE_SKIP`)
- Builds on #1054's matching infrastructure, just closes the escape hatch

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally — 1869/1869 (`ECC_SESSION_STRICT_MATCH` must be unset when running tests, as the env var leaks into test child processes and causes fallback-dependent tests to fail expectedly)
- [x] `ECC_SESSION_STRICT_MATCH=1` + directory with no matching session → no session injected
- [x] `ECC_SESSION_STRICT_MATCH=1` + directory with matching worktree session → session injected correctly
- [x] `ECC_SESSION_STRICT_MATCH=1` + directory with matching project name session → session injected correctly
- [x] `ECC_SESSION_STRICT_MATCH` unset → recency fallback works as before (backward compat)
- [x] No regression in session pruning behavior
- [x] Edge cases considered and tested

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)

## Prior Art

Builds directly on previous contributor work:

- **#1054** (@kuqili) — added `selectMatchingSession()` with worktree/project matching + recency fallback. This PR closes the fallback escape hatch.
- **#1385** (@KeWang0622) — fixed hook bypassing `ECC_DISABLED_HOOKS` gating. Same pattern: ensuring env var controls work.
- **#399** (@ispaydeu) — introduced `ECC_OBSERVE_SKIP` guard. Same pattern: opt-in env var to prevent silent harm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ECC_SESSION_STRICT_MATCH` to enforce strict session matching and prevent cross-project fallback. When set to "1", `selectMatchingSession()` skips the recency fallback and only injects worktree- or project-matched sessions; default behavior remains unchanged.

- **Migration**
  - Enable by setting `ECC_SESSION_STRICT_MATCH=1` (env var or in settings).

<sup>Written for commit 837355c42c0abb9b4f8ea74ae97e1d923d5a6b28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session selection: when strict session matching mode is enabled, the app will no longer fall back to the most-recent readable session if the preferred session can't be used. This prevents unrelated session content from being injected and yields clearer error handling when no valid session is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->