### PR TITLE
fix(hooks): scope session-start injection by shortId to prevent cross-cwd leakage

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -9,6 +9,7 @@
  * sessions and learned skills.
  */
 
+const path = require('path');
 const {
   getSessionsDir,
   getLearnedSkillsDir,
@@ -16,8 +17,10 @@ const {
   ensureDir,
   readFile,
   log,
-  output
+  output,
+  getSessionIdShort
 } = require('../lib/utils');
+const { parseSessionFilename } = require('../lib/session-manager');
 const { getPackageManager, getSelectionPrompt } = require('../lib/package-manager');
 const { listAliases } = require('../lib/session-aliases');
 const { detectProjectType } = require('../lib/project-detect');
@@ -33,9 +36,20 @@ async function main() {
   // Check for recent session files (last 7 days)
   const recentSessions = findFiles(sessionsDir, '*-session.tmp', { maxAge: 7 });
 
-  if (recentSessions.length > 0) {
-    const latest = recentSessions[0];
-    log(`[SessionStart] Found ${recentSessions.length} recent session(s)`);
+  // CRITICAL: Filter by the current invocation's shortId so sessions from
+  // other worktrees/cwds/projects are NEVER injected into this context.
+  // Before this filter, the hook picked the globally-newest session file and
+  // leaked it cross-worktree — e.g. worktree A received worktree B's summary,
+  // causing downstream agents to act on another worktree's task.
+  const currentShortId = getSessionIdShort();
+  const scopedSessions = recentSessions.filter(f => {
+    const parsed = parseSessionFilename(path.basename(f.path));
+    return parsed && parsed.shortId === currentShortId;
+  });
+
+  if (scopedSessions.length > 0) {
+    const latest = scopedSessions[0];
+    log(`[SessionStart] Found ${scopedSessions.length} recent session(s) for shortId=${currentShortId}`);
     log(`[SessionStart] Latest: ${latest.path}`);
 
     // Read and inject the latest session content into Claude's context
@@ -44,6 +58,8 @@ async function main() {
       // Only inject if the session has actual content (not the blank template)
       output(`Previous session summary:\n${content}`);
     }
+  } else if (recentSessions.length > 0) {
+    log(`[SessionStart] ${recentSessions.length} recent session(s) exist but none match shortId=${currentShortId}; skipping injection`);
   }
 
   // Check for learned skills

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -244,14 +244,17 @@ async function runTests() {
       fs.mkdirSync(sessionsDir, { recursive: true });
       fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
 
-      // Create a real session file
+      // Create a real session file whose shortId matches the invocation's
+      // shortId (last 8 chars of CLAUDE_SESSION_ID). session-start now scopes
+      // injection by shortId to prevent cross-worktree content leakage.
       const sessionFile = path.join(sessionsDir, '2026-02-11-efgh5678-session.tmp');
       fs.writeFileSync(sessionFile, '# Real Session\n\nI worked on authentication refactor.\n');
 
       try {
         const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
           HOME: isoHome,
-          USERPROFILE: isoHome
+          USERPROFILE: isoHome,
+          CLAUDE_SESSION_ID: 'test-fake-session-efgh5678'
         });
         assert.strictEqual(result.code, 0);
         assert.ok(result.stdout.includes('Previous session summary'), 'Should inject real session content');
@@ -3671,14 +3674,19 @@ async function runTests() {
       fs.mkdirSync(sessionsDir, { recursive: true });
       fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
 
+      // Both files share the same shortId so they match the current invocation
+      // (session-start scopes injection by shortId). maxAge filtering still
+      // excludes the 8-day-old one.
+      const SHORT_ID = 'testid01';
+
       // Create session file 6.9 days old (should be INCLUDED by maxAge:7)
-      const recentFile = path.join(sessionsDir, '2026-02-06-recent69-session.tmp');
+      const recentFile = path.join(sessionsDir, `2026-02-06-${SHORT_ID}-session.tmp`);
       fs.writeFileSync(recentFile, '# Recent Session\n\nRECENT CONTENT HERE');
       const sixPointNineDaysAgo = new Date(Date.now() - 6.9 * 24 * 60 * 60 * 1000);
       fs.utimesSync(recentFile, sixPointNineDaysAgo, sixPointNineDaysAgo);
 
       // Create session file 8 days old (should be EXCLUDED by maxAge:7)
-      const oldFile = path.join(sessionsDir, '2026-02-05-old8day-session.tmp');
+      const oldFile = path.join(sessionsDir, `2026-02-05-${SHORT_ID}-session.tmp`);
       fs.writeFileSync(oldFile, '# Old Session\n\nOLD CONTENT SHOULD NOT APPEAR');
       const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
       fs.utimesSync(oldFile, eightDaysAgo, eightDaysAgo);
@@ -3686,7 +3694,8 @@ async function runTests() {
       try {
         const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
           HOME: isoHome,
-          USERPROFILE: isoHome
+          USERPROFILE: isoHome,
+          CLAUDE_SESSION_ID: `fake-session-${SHORT_ID}`
         });
         assert.strictEqual(result.code, 0);
         assert.ok(result.stderr.includes('1 recent session'), `Should find 1 recent session (6.9-day included, 8-day excluded), stderr: ${result.stderr}`);
@@ -3711,20 +3720,25 @@ async function runTests() {
 
       const now = Date.now();
 
+      // Both files share the same shortId so both are in scope for this
+      // invocation (session-start scopes by shortId). The newest by mtime wins.
+      const SHORT_ID = 'samescp1';
+
       // Create older session (2 days ago)
-      const olderSession = path.join(sessionsDir, '2026-02-11-olderabc-session.tmp');
+      const olderSession = path.join(sessionsDir, `2026-02-11-${SHORT_ID}-session.tmp`);
       fs.writeFileSync(olderSession, '# Older Session\n\nOLDER_CONTEXT_MARKER');
       fs.utimesSync(olderSession, new Date(now - 2 * 86400000), new Date(now - 2 * 86400000));
 
       // Create newer session (1 day ago)
-      const newerSession = path.join(sessionsDir, '2026-02-12-newerdef-session.tmp');
+      const newerSession = path.join(sessionsDir, `2026-02-12-${SHORT_ID}-session.tmp`);
       fs.writeFileSync(newerSession, '# Newer Session\n\nNEWER_CONTEXT_MARKER');
       fs.utimesSync(newerSession, new Date(now - 1 * 86400000), new Date(now - 1 * 86400000));
 
       try {
         const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
           HOME: isoHome,
-          USERPROFILE: isoHome
+          USERPROFILE: isoHome,
+          CLAUDE_SESSION_ID: `fake-session-${SHORT_ID}`
         });
         assert.strictEqual(result.code, 0);
         assert.ok(result.stderr.includes('2 recent session'), `Should find 2 recent sessions, stderr: ${result.stderr}`);

--- a/tests/hooks/session-start-worktree-isolation.test.js
+++ b/tests/hooks/session-start-worktree-isolation.test.js
@@ -1,0 +1,167 @@
+/**
+ * Regression test for worktree / cwd isolation in session-start.js
+ *
+ * Bug: When multiple git worktrees (or any cwds) share the same user, the
+ * SessionStart hook picked the globally-newest `*-session.tmp` file from
+ * `~/.claude/sessions/` and injected it as "Previous session summary" into
+ * the context of every new session, regardless of which cwd/project/worktree
+ * the new session was actually for.
+ *
+ * Symptom: Cannith-dispatched Claude Agent SDK sessions in worktree A would
+ * receive worktree B's most recent session summary as context and then do
+ * tool calls as if the task was B's task.
+ *
+ * Fix: session-start.js must only inject a previous session summary whose
+ * filename's shortId matches the current invocation's shortId (as computed
+ * by getSessionIdShort() — last 8 chars of $CLAUDE_SESSION_ID, else the
+ * project/worktree basename). Cross-worktree content must not leak.
+ *
+ * Run with: node tests/hooks/session-start-worktree-isolation.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const scriptsDir = path.join(__dirname, '..', '..', 'scripts', 'hooks');
+const sessionStartScript = path.join(scriptsDir, 'session-start.js');
+
+/**
+ * Run session-start.js in a child process with a custom cwd/env and capture
+ * stdout/stderr. Mirrors the helper in hooks.test.js but exposes `cwd` so
+ * the hook's project-name detection reflects a specific worktree basename.
+ */
+function runSessionStart({ cwd, env }) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', [sessionStartScript], {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => (stdout += d));
+    proc.stderr.on('data', d => (stderr += d));
+    proc.stdin.end();
+    proc.on('close', code => resolve({ code, stdout, stderr }));
+    proc.on('error', reject);
+  });
+}
+
+/**
+ * Touch a file so its mtime is at least `ageSeconds` seconds old.
+ * Used to make worktree A's session file OLDER than worktree B's,
+ * so the buggy global-newest logic would prefer B.
+ */
+function setMtime(filePath, ageSeconds) {
+  const time = Date.now() / 1000 - ageSeconds;
+  fs.utimesSync(filePath, time, time);
+}
+
+async function main() {
+  const failures = [];
+
+  // Isolated $HOME so the test never touches the real ~/.claude
+  const isoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-worktree-isolation-'));
+  const sessionsDir = path.join(isoHome, '.claude', 'sessions');
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
+
+  // Two fake worktrees as cwds. Each has its own basename which
+  // getSessionIdShort() will fall back to when CLAUDE_SESSION_ID is unset.
+  // Basenames must be lowercase alphanumeric+hyphen with length >= 8 to
+  // match SESSION_FILENAME_REGEX in session-manager.js. Nesting them under
+  // isoHome keeps the test hermetic and avoids mkdtempSync's mixed-case suffix.
+  const basenameA = 'worktree-a-test';
+  const basenameB = 'worktree-b-test';
+  const worktreeA = path.join(isoHome, basenameA);
+  const worktreeB = path.join(isoHome, basenameB);
+  fs.mkdirSync(worktreeA, { recursive: true });
+  fs.mkdirSync(worktreeB, { recursive: true });
+
+  // Create two session files — one per worktree — with the real on-disk
+  // format `<date>-<shortId>-session.tmp`. The filename shortId is the
+  // worktree basename because CLAUDE_SESSION_ID is not set. The date must
+  // be today so the hook's 7-day maxAge filter keeps both files.
+  const today = new Date().toISOString().slice(0, 10);
+  const fileA = path.join(sessionsDir, `${today}-${basenameA}-session.tmp`);
+  const fileB = path.join(sessionsDir, `${today}-${basenameB}-session.tmp`);
+  fs.writeFileSync(
+    fileA,
+    '# Session: worktree A\n\n## Session Summary\n### Tasks\n- Working on TASK-A in worktree A\n'
+  );
+  fs.writeFileSync(
+    fileB,
+    '# Session: worktree B\n\n## Session Summary\n### Tasks\n- Working on TASK-B in worktree B\n'
+  );
+
+  // Make A OLDER than B. The pre-fix hook picks the newest *globally*, so
+  // it would pick B's summary regardless of which cwd we run in — that's
+  // the crosstalk.
+  setMtime(fileA, 120); // A is 2 minutes old
+  setMtime(fileB, 10);  // B is 10 seconds old (newest)
+
+  // --- Test 1: running in worktree A must inject A's summary, NOT B's ---
+  const resultA = await runSessionStart({
+    cwd: worktreeA,
+    env: { HOME: isoHome, USERPROFILE: isoHome, CLAUDE_SESSION_ID: '' }
+  });
+
+  try {
+    assert.strictEqual(resultA.code, 0, `exit code: ${resultA.code}, stderr=${resultA.stderr}`);
+    assert.ok(
+      resultA.stdout.includes('TASK-A'),
+      'session-start running in worktree A must inject worktree A\'s summary'
+    );
+    assert.ok(
+      !resultA.stdout.includes('TASK-B'),
+      'session-start running in worktree A must NOT leak worktree B\'s summary (CROSSTALK BUG)'
+    );
+    console.log('  PASS: worktree A does not receive worktree B\'s summary');
+  } catch (err) {
+    failures.push(`test 1 (worktree A isolation): ${err.message}`);
+    console.log(`  FAIL: ${err.message}`);
+  }
+
+  // --- Test 2: running in worktree B must still inject B's summary ---
+  const resultB = await runSessionStart({
+    cwd: worktreeB,
+    env: { HOME: isoHome, USERPROFILE: isoHome, CLAUDE_SESSION_ID: '' }
+  });
+
+  try {
+    assert.strictEqual(resultB.code, 0);
+    assert.ok(
+      resultB.stdout.includes('TASK-B'),
+      'session-start running in worktree B must inject worktree B\'s summary'
+    );
+    assert.ok(
+      !resultB.stdout.includes('TASK-A'),
+      'session-start running in worktree B must NOT leak worktree A\'s summary'
+    );
+    console.log('  PASS: worktree B receives its own summary');
+  } catch (err) {
+    failures.push(`test 2 (worktree B isolation): ${err.message}`);
+    console.log(`  FAIL: ${err.message}`);
+  }
+
+  // Cleanup (worktrees are inside isoHome, so one rmSync covers all)
+  fs.rmSync(isoHome, { recursive: true, force: true });
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} failure(s):`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('\nAll tests passed.');
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Test runner error:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Fixes a cross-worktree / cross-cwd content leak in the `SessionStart` hook.

Before this patch, `scripts/hooks/session-start.js` picked the globally-newest `*-session.tmp` file from `~/.claude/sessions/` and injected it as `Previous session summary` into the context of every new Claude session, regardless of which cwd/project/worktree the session was for.

**Symptom I observed in the wild:** a Claude Agent SDK session dispatched for worktree A received worktree B's session summary and began making tool calls as if the task belonged to B — content-level crosstalk across worktrees/projects that share `~/.claude/sessions/`.

## Type
- [x] Hook

## Fix

- Import `getSessionIdShort` from `../lib/utils` and `parseSessionFilename` from `../lib/session-manager`
- Compute the current invocation's `shortId` (last 8 chars of `$CLAUDE_SESSION_ID`, else project/worktree basename)
- Filter `recentSessions` down to only those whose filename `shortId` matches the current invocation
- If no file matches, skip injection entirely rather than fall back to the globally-newest file — a missing summary is far safer than a wrong one
- Log the mismatch case at `log(...)` level so operators can still see when recent sessions exist but don't belong to this invocation

No public API change, no new dependencies. Pure filter added to an existing code path.

## Testing

### New regression test
`tests/hooks/session-start-worktree-isolation.test.js` — simulates two worktrees (A, B) with session summaries where B's is newer on disk, then runs `session-start.js` once from each cwd and asserts:
- Running in worktree A stdout contains TASK-A and does NOT contain TASK-B
- Running in worktree B stdout contains TASK-B and does NOT contain TASK-A

Before the fix, test 1 fails: worktree A receives worktree B's summary (the globally-newest file), which is exactly the crosstalk bug.

### Existing tests updated
Three existing tests in `tests/hooks/hooks.test.js` previously relied on the globally-newest behaviour. They now pass `CLAUDE_SESSION_ID` so the invocation's shortId matches the test's session filename and the scenario still exercises the same code path:

- `injects real session content` — asserts real content still flows when shortIds match
- `excludes session files older than 7 days` — unified shortId across both recent/old files so maxAge filtering is what excludes the old one (the original intent)
- `injects newest session when multiple recent sessions exist` — both files share shortId so the newest-by-mtime still wins (the original intent)

No assertions weakened; each test still verifies exactly what it originally verified.

### Results

```
All 204 existing hooks.test.js tests pass.
2 new session-start-worktree-isolation.test.js tests pass.
evaluate-session.test.js and suggest-compact.test.js untouched — still pass.
```

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes previous session injection in the `SessionStart` hook by shortId to stop cross-cwd/worktree leaks. If no matching session exists, nothing is injected.

- **Bug Fixes**
  - Use `getSessionIdShort` and `parseSessionFilename` to compute the current shortId and filter `~/.claude/sessions/*-session.tmp` to only matching files; pick the newest within scope.
  - Skip injection when no files match and log the mismatch instead of falling back to the global newest file.
  - Add `tests/hooks/session-start-worktree-isolation.test.js` to cover worktree isolation; update three existing tests to set `CLAUDE_SESSION_ID`. No API or dependency changes.

<sup>Written for commit dcb28956335770fa716ca92df46cec5c0a1a72b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session content isolation to prevent previous session summaries from appearing in unrelated contexts.

* **Tests**
  * Updated session selection tests to validate scoped behavior.
  * Added regression test to verify session content remains isolated across different project contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->