### PR TITLE
fix(hooks): isolate session-end.js filename using transcript_path UUID (#1494)

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -190,14 +190,19 @@ async function main() {
 
   const sessionsDir = getSessionsDir();
   const today = getDateString();
-  // Prefer the real session UUID (first 8 chars) from transcript_path when available.
+  // Derive shortId from transcript_path UUID when available, using the SAME
+  // last-8-chars convention as getSessionIdShort(sessionId.slice(-8)). This keeps
+  // backward compatibility for normal sessions (the derived shortId matches what
+  // getSessionIdShort() would have produced from the same UUID), while making
+  // every session map to a unique filename based on its own transcript UUID.
+  //
   // Without this, a parent session and any `claude -p ...` subprocess spawned by
-  // another Stop-hook share the project-name fallback filename, and the subprocess
+  // another Stop hook share the project-name fallback filename, and the subprocess
   // overwrites the parent's summary. See issue #1494 for full repro details.
   let shortId = null;
   if (transcriptPath) {
-    const m = path.basename(transcriptPath).match(/([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i);
-    if (m) { shortId = m[1]; }
+    const m = path.basename(transcriptPath).match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i);
+    if (m) { shortId = m[1].slice(-8).toLowerCase(); }
   }
   if (!shortId) { shortId = getSessionIdShort(); }
   const sessionFile = path.join(sessionsDir, `${today}-${shortId}-session.tmp`);

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -16,6 +16,7 @@ const {
   getDateString,
   getTimeString,
   getSessionIdShort,
+  sanitizeSessionId,
   getProjectName,
   ensureDir,
   readFile,
@@ -202,7 +203,11 @@ async function main() {
   let shortId = null;
   if (transcriptPath) {
     const m = path.basename(transcriptPath).match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i);
-    if (m) { shortId = m[1].slice(-8).toLowerCase(); }
+    if (m) {
+      // Run through sanitizeSessionId() for byte-for-byte parity with
+      // getSessionIdShort(sessionId.slice(-8)).
+      shortId = sanitizeSessionId(m[1].slice(-8).toLowerCase());
+    }
   }
   if (!shortId) { shortId = getSessionIdShort(); }
   const sessionFile = path.join(sessionsDir, `${today}-${shortId}-session.tmp`);

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -179,14 +179,22 @@ function mergeSessionHeader(content, today, currentTime, metadata) {
 }
 
 async function main() {
-  // Parse stdin JSON to get transcript_path
+  // Parse stdin JSON to get transcript_path; fall back to env var on missing,
+  // empty, or non-string values as well as on malformed JSON.
   let transcriptPath = null;
   try {
     const input = JSON.parse(stdinData);
-    transcriptPath = input.transcript_path;
+    if (input && typeof input.transcript_path === 'string' && input.transcript_path.length > 0) {
+      transcriptPath = input.transcript_path;
+    }
   } catch {
-    // Fallback: try env var for backwards compatibility
-    transcriptPath = process.env.CLAUDE_TRANSCRIPT_PATH;
+    // Malformed stdin: fall through to the env-var fallback below.
+  }
+  if (!transcriptPath) {
+    const envTranscriptPath = process.env.CLAUDE_TRANSCRIPT_PATH;
+    if (typeof envTranscriptPath === 'string' && envTranscriptPath.length > 0) {
+      transcriptPath = envTranscriptPath;
+    }
   }
 
   const sessionsDir = getSessionsDir();

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -190,7 +190,16 @@ async function main() {
 
   const sessionsDir = getSessionsDir();
   const today = getDateString();
-  const shortId = getSessionIdShort();
+  // Prefer the real session UUID (first 8 chars) from transcript_path when available.
+  // Without this, a parent session and any `claude -p ...` subprocess spawned by
+  // another Stop-hook share the project-name fallback filename, and the subprocess
+  // overwrites the parent's summary. See issue #1494 for full repro details.
+  let shortId = null;
+  if (transcriptPath) {
+    const m = path.basename(transcriptPath).match(/([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i);
+    if (m) { shortId = m[1]; }
+  }
+  if (!shortId) { shortId = getSessionIdShort(); }
   const sessionFile = path.join(sessionsDir, `${today}-${shortId}-session.tmp`);
   const sessionMetadata = getSessionMetadata();
 

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -633,12 +633,14 @@ async function runTests() {
     passed++;
   else failed++;
 
-  // Regression test for #1494: transcript_path UUID takes precedence over fallback
+  // Regression test for #1494: transcript_path UUID-derived shortId (last 8 chars)
+  // isolates sibling subprocess invocations while preserving getSessionIdShort()
+  // backward compatibility (same `.slice(-8)` convention).
   if (
     await asyncTest('derives shortId from transcript_path UUID when available', async () => {
       const isoHome = path.join(os.tmpdir(), `ecc-session-transcript-${Date.now()}`);
       const transcriptUuid = 'abcdef12-3456-4789-a012-bcdef3456789';
-      const expectedShortId = 'abcdef12'; // First 8 chars of UUID
+      const expectedShortId = 'f3456789'; // Last 8 chars of UUID (matches getSessionIdShort convention)
       const transcriptPath = path.join(isoHome, 'transcripts', `${transcriptUuid}.jsonl`);
 
       try {
@@ -649,8 +651,9 @@ async function runTests() {
         await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson, {
           HOME: isoHome,
           USERPROFILE: isoHome,
-          // CLAUDE_SESSION_ID intentionally unset so that without the fix the project-name
-          // fallback would be used, exposing the filename collision described in #1494.
+          // Explicitly clear CLAUDE_SESSION_ID so parent env does not leak in and
+          // force the getSessionIdShort() fallback instead of the transcript path.
+          CLAUDE_SESSION_ID: ''
         });
 
         const sessionsDir = getCanonicalSessionsDir(isoHome);
@@ -659,6 +662,75 @@ async function runTests() {
         const sessionFile = path.join(sessionsDir, `${today}-${expectedShortId}-session.tmp`);
 
         assert.ok(fs.existsSync(sessionFile), `Session file with transcript UUID shortId should exist: ${sessionFile}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  // Regression test for #1494: uppercase UUID hex digits should be normalized to
+  // lowercase so the filename is consistent with getSessionIdShort()'s output.
+  if (
+    await asyncTest('normalizes transcript UUID shortId to lowercase', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-session-transcript-upper-${Date.now()}`);
+      const transcriptUuid = 'ABCDEF12-3456-4789-A012-BCDEF3456789';
+      const expectedShortId = 'f3456789'; // last 8 lowercased
+      const transcriptPath = path.join(isoHome, 'transcripts', `${transcriptUuid}.jsonl`);
+
+      try {
+        fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+        fs.writeFileSync(transcriptPath, '');
+
+        const stdinJson = JSON.stringify({ transcript_path: transcriptPath });
+        await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson, {
+          HOME: isoHome,
+          USERPROFILE: isoHome,
+          CLAUDE_SESSION_ID: ''
+        });
+
+        const sessionsDir = getCanonicalSessionsDir(isoHome);
+        const now = new Date();
+        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+        const sessionFile = path.join(sessionsDir, `${today}-${expectedShortId}-session.tmp`);
+
+        assert.ok(fs.existsSync(sessionFile), `Session file with lowercase shortId should exist: ${sessionFile}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  // Regression test for #1494: when CLAUDE_SESSION_ID and transcript_path refer to the
+  // same UUID, the derived shortId must be identical to the pre-fix behaviour so that
+  // existing .tmp files are not orphaned on upgrade.
+  if (
+    await asyncTest('matches getSessionIdShort when transcript UUID equals CLAUDE_SESSION_ID', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-session-transcript-match-${Date.now()}`);
+      const sessionUuid = '11223344-5566-4778-8899-aabbccddeeff';
+      const expectedShortId = 'ccddeeff'; // last 8 chars of both transcript UUID and CLAUDE_SESSION_ID
+      const transcriptPath = path.join(isoHome, 'transcripts', `${sessionUuid}.jsonl`);
+
+      try {
+        fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+        fs.writeFileSync(transcriptPath, '');
+
+        const stdinJson = JSON.stringify({ transcript_path: transcriptPath });
+        await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson, {
+          HOME: isoHome,
+          USERPROFILE: isoHome,
+          CLAUDE_SESSION_ID: sessionUuid
+        });
+
+        const sessionsDir = getCanonicalSessionsDir(isoHome);
+        const now = new Date();
+        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+        const sessionFile = path.join(sessionsDir, `${today}-${expectedShortId}-session.tmp`);
+
+        assert.ok(fs.existsSync(sessionFile), `Session filename should match the pre-fix CLAUDE_SESSION_ID-based name: ${sessionFile}`);
       } finally {
         fs.rmSync(isoHome, { recursive: true, force: true });
       }

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -651,8 +651,10 @@ async function runTests() {
         await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson, {
           HOME: isoHome,
           USERPROFILE: isoHome,
-          // Explicitly clear CLAUDE_SESSION_ID so parent env does not leak in and
-          // force the getSessionIdShort() fallback instead of the transcript path.
+          // Clear CLAUDE_SESSION_ID so parent-process env does not leak into the
+          // child and the test deterministically exercises the transcript_path
+          // branch (getSessionIdShort() is the alternative path that is not
+          // exercised here).
           CLAUDE_SESSION_ID: ''
         });
 

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -633,6 +633,40 @@ async function runTests() {
     passed++;
   else failed++;
 
+  // Regression test for #1494: transcript_path UUID takes precedence over fallback
+  if (
+    await asyncTest('derives shortId from transcript_path UUID when available', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-session-transcript-${Date.now()}`);
+      const transcriptUuid = 'abcdef12-3456-4789-a012-bcdef3456789';
+      const expectedShortId = 'abcdef12'; // First 8 chars of UUID
+      const transcriptPath = path.join(isoHome, 'transcripts', `${transcriptUuid}.jsonl`);
+
+      try {
+        fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+        fs.writeFileSync(transcriptPath, '');
+
+        const stdinJson = JSON.stringify({ transcript_path: transcriptPath });
+        await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson, {
+          HOME: isoHome,
+          USERPROFILE: isoHome,
+          // CLAUDE_SESSION_ID intentionally unset so that without the fix the project-name
+          // fallback would be used, exposing the filename collision described in #1494.
+        });
+
+        const sessionsDir = getCanonicalSessionsDir(isoHome);
+        const now = new Date();
+        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+        const sessionFile = path.join(sessionsDir, `${today}-${expectedShortId}-session.tmp`);
+
+        assert.ok(fs.existsSync(sessionFile), `Session file with transcript UUID shortId should exist: ${sessionFile}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
   if (
     await asyncTest('writes project, branch, and worktree metadata into new session files', async () => {
       const isoHome = path.join(os.tmpdir(), `ecc-session-metadata-${Date.now()}`);


### PR DESCRIPTION
## Summary

Fixes #1494 — `*-session.tmp` corruption when another Stop hook spawns a `claude` subprocess.

In my own setup, a custom AI-summarization Stop hook spawned `claude -p ...` to generate a session summary. That subprocess also fires the full Stop hook chain, so `scripts/hooks/session-end.js` is invoked a second time. Because `getSessionIdShort()` falls back to the project/worktree name when `CLAUDE_SESSION_ID` is unset, both invocations produced the **same** `{date}-{shortId}-session.tmp` path. The subprocess transcript only contained the summarization prompt, so its `### Tasks` ended up holding the prompt text and `Total user messages: 1`, overwriting the parent's valid summary.

## Type
- [x] Hook

## Fix

When stdin JSON (or `CLAUDE_TRANSCRIPT_PATH`) provides a `transcript_path`, derive `shortId` from the first 8 hex characters of the session UUID in the filename instead of always calling `getSessionIdShort()`. The existing fallback is preserved for cases without `transcript_path`, so nothing changes for other callers.

```js
let shortId = null;
if (transcriptPath) {
  const m = path.basename(transcriptPath).match(/([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i);
  if (m) shortId = m[1];
}
if (!shortId) shortId = getSessionIdShort();
```

Parent and subprocess invocations now resolve to different UUIDs, so they write to different files and do not collide.

## Testing

New regression test in `tests/hooks/hooks.test.js` (`derives shortId from transcript_path UUID when available`) runs `session-end.js` with stdin carrying a fake transcript path `/tmp/.../abcdef12-3456-4789-a012-bcdef3456789.jsonl`, without `CLAUDE_SESSION_ID` set, and asserts the resulting `.tmp` file name contains `abcdef12` (the UUID prefix) rather than the project-name fallback.

Full suite: `node tests/hooks/hooks.test.js` → **220 passed, 0 failed** on Windows 11 + Node 20.

## Notes / request for feedback

- This is my first contribution to this repo. I ran into the corruption while using a custom Stop hook in my own tooling and fixed it on my side, but the root cause is general enough that anyone spawning `claude` from another Stop hook would hit it. Happy to adjust the scope or style if you prefer a different direction.
- Side effect: the number of `.tmp` files under `~/.claude/sessions/` will grow faster because each real session now gets its own UUID-based file instead of reusing the project-name filename. Related open PRs #1481 / #1485 / #1493 are already tightening the read-side matching, so this should compose well with them, but if you want me to also touch up a retention or mtime-ordering pass on the read side in the same PR, let me know.
- Tested on Windows. The change is pure string parsing on `path.basename(...)` so macOS/Linux behavior should be identical, but I have not tested on those platforms.

If anything looks off, please comment and I will revise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents session summary `.tmp` collisions when a Stop hook spawns a `claude` subprocess by deriving the filename shortId from the `transcript_path` UUID when available. Parent and subprocess now write to different files while keeping names compatible with `getSessionIdShort()`.

- **Bug Fixes**
  - Derive `shortId` from the last 8 hex chars of the transcript UUID (from stdin or `CLAUDE_TRANSCRIPT_PATH`), lowercase it, and route through `sanitizeSessionId()` to match `getSessionIdShort()` and avoid collisions.
  - When stdin omits `transcript_path` or provides an empty/non-string value (or malformed JSON), fall back to `CLAUDE_TRANSCRIPT_PATH`; if still absent, fall back to `getSessionIdShort()`.
  - Add regression tests for UUID-derived `shortId`, lowercase normalization, and parity when `CLAUDE_SESSION_ID` equals the transcript UUID.

<sup>Written for commit 0c3fc7074e2efed089839e26d6deff6554856a43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session file naming now prefers the UUID from the session transcript (using the final 8 hex characters, normalized to lowercase), with the previous fallback preserved — reducing cross-session file conflicts.

* **Tests**
  * Added regression tests validating transcript-driven session naming, lowercase normalization, and behavior when an existing session ID matches the transcript UUID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->