### PR TITLE
fix: Windows ENOENT in claw.js + session-end.js subprocess corruption guard

### DIFF
--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -95,7 +95,8 @@ function askClaude(systemPrompt, history, userMessage, model) {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
     env: { ...process.env, CLAUDECODE: '' },
-    timeout: 300000,
+    timeout: 300000, 
+    shell: process.platform === 'win32',
   });
 
   if (result.error) {

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -178,6 +178,8 @@ function mergeSessionHeader(content, today, currentTime, metadata) {
 }
 
 async function main() {
+    // Skip if running inside an AI-summary subprocess to prevent overwriting parent session files
+  if (process.env.ECC_SUMMARY_SUBPROCESS === '1') process.exit(0);
   // Parse stdin JSON to get transcript_path
   let transcriptPath = null;
   try {


### PR DESCRIPTION
## What Changed

This PR fixes two independent bugs:

### Fix 1 — `scripts/claw.js` Windows ENOENT (closes #1469)

`askClaude()` calls `spawnSync('claude', args, {...})` without `shell: true`. On Windows, `claude` is installed as `claude.cmd` — a batch wrapper — and Node's `spawn` cannot resolve `.cmd` extensions via PATH without shell mode. This causes `spawn claude ENOENT` and `askClaude()` returns an error string.

**Change:** Added `shell: process.platform === 'win32'` to the `spawnSync` options in `askClaude()`. This mirrors the exact pattern already used in `scripts/hooks/mcp-health-check.js` after PR #1456, and only activates on Windows.

### Fix 2 — `scripts/hooks/session-end.js` subprocess corruption (closes #1494)

When `session-summary.js` spawns `claude -p ...` as a subprocess, the subprocess also fires the Stop hook chain including `session-end.js`. Both parent and subprocess compute the same session filename, so the subprocess overwrites the parent's valid summary with the AI-summarization prompt text.

**Change:** Added an early exit guard at the top of `main()` in `session-end.js`:
```js
if (process.env.ECC_SUMMARY_SUBPROCESS === '1') process.exit(0);
```
This prevents any subprocess that sets `ECC_SUMMARY_SUBPROCESS=1` from writing `.tmp` files. This is a safe, additive change — it does not affect any real user session.

## Why This Change

- Fix 1 unblocks all Windows users from using `claw.js` as an interactive REPL.
- Fix 2 prevents silent data corruption in `~/.claude/sessions/*.tmp` files that causes incorrect session summaries.

## Testing Done

- [x] Fix 1: Verified `shell: process.platform === 'win32'` pattern is consistent with existing mcp-health-check.js fix
- [x] Fix 2: Guard is additive and exits before any file writes — no regression on macOS/Linux
- [x] Both fixes are platform-safe (Windows-conditional for Fix 1, env-flag-conditional for Fix 2)
- [ ] Automated tests pass locally (`node tests/run-all.js`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows spawn errors in `scripts/claw.js` and prevents subprocesses from overwriting session summaries. Restores REPL usage on Windows and avoids silent `.tmp` corruption.

- **Bug Fixes**
  - Windows: run `spawnSync('claude', ...)` with `shell: process.platform === 'win32'` so `claude.cmd` resolves via PATH.
  - Guard: in `scripts/hooks/session-end.js`, exit early when `ECC_SUMMARY_SUBPROCESS=1` to skip writes and avoid overwriting the parent session.

<sup>Written for commit 9e533ab98663b1dcb5f6ffd4bb56c2de5ff76bd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for script execution.
  
* **Chores**
  * Enhanced subprocess initialization logic for better process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->