### PR TITLE
feat(mcp-configs): add longhand for lossless Claude Code session history

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -41,6 +41,11 @@
       "args": ["omega-memory", "serve"],
       "description": "Persistent agent memory with semantic search, multi-agent coordination, and knowledge graphs — run via uvx (richer than the basic memory store)"
     },
+    "longhand": {
+      "command": "longhand",
+      "args": ["mcp-server"],
+      "description": "Lossless Claude Code session history — indexes every tool call, file edit, and thinking block from ~/.claude/projects into local SQLite + ChromaDB. Complementary to memory/omega-memory (which store synthesized memory); Longhand indexes raw session truth before Claude Code rotates the JSONL. 17 tools incl. recall, search_in_context, replay_file, recall_project_status. Install: pip install longhand && longhand setup. ~126ms queries, zero API calls."
+    },
     "sequential-thinking": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -44,7 +44,7 @@
     "longhand": {
       "command": "longhand",
       "args": ["mcp-server"],
-      "description": "Lossless Claude Code session history — indexes every tool call, file edit, and thinking block from ~/.claude/projects into local SQLite + ChromaDB. Complementary to memory/omega-memory (which store synthesized memory); Longhand indexes raw session truth before Claude Code rotates the JSONL. 17 tools incl. recall, search_in_context, replay_file, recall_project_status. Install: pip install longhand && longhand setup. ~126ms queries, zero API calls."
+      "description": "Lossless Claude Code session history — indexes raw tool calls, file edits, and thinking blocks from ~/.claude/projects/*.jsonl into local SQLite + ChromaDB before Claude Code rotates them. Complements memory/omega-memory (synthesized) with verbatim recall. Install: pip install longhand && longhand setup"
     },
     "sequential-thinking": {
       "command": "npx",


### PR DESCRIPTION
## What this does

Adds `longhand` as a third memory option in `mcp-configs/mcp-servers.json`, alongside the existing `memory` (@modelcontextprotocol/server-memory) and `omega-memory` entries.

## Why

The two existing memory servers store **synthesized** memory — an assistant chooses what to record, structures it into a knowledge graph, and the record is a summarization of past interactions.

Longhand solves a different problem: **lossless capture of what Claude Code already writes to disk.** Claude Code writes every session to `~/.claude/projects/*.jsonl` (tool calls, file edits, thinking blocks, all verbatim). Claude Code rotates these files after a few weeks; Longhand indexes them into local SQLite + ChromaDB before they're gone and exposes 17 tools for fuzzy recall across the full session history.

Use cases `memory` and `omega-memory` don't cover:

- *"Show me the exact edit I made to auth.ts three weeks ago"*
- *"Find the webhook fix from that session with the stripe bug"*
- *"Replay the file state when I committed abc123"*
- *"What did we decide about X, three projects back"*

Raw session records, not synthesized memory. Complement, not replacement.

## Differentiation

| Server | Stores | Best for |
|---|---|---|
| `memory` | Knowledge graph | Cross-session structured facts the assistant curates |
| `omega-memory` | Semantic + multi-agent | Richer knowledge graph with search |
| `longhand` | Raw Claude Code session logs | Forensic recall — *"what did I actually do"* over months of history |

## Unvetted-package check

Per `CONTRIBUTING.md`'s skill adaptation policy (*"do not ship a skill whose main value is telling users to install an unvetted package"*):

- MIT licensed
- Published on PyPI as `longhand` (currently v0.5.11)
- Official MCP Registry listing (`io.github.Wynelson94/longhand`)
- PulseMCP-listed, #852 weekly rank in the MCP ecosystem
- Glama A/A/A tier (security / license / quality)
- 171 passing unit tests, security-audited with zero critical findings
- 354 unique cloners in the first 14 days since first public release

Write-up: https://dev.to/wynelson94/why-i-built-a-lossless-alternative-to-ai-memory-summarization-40cl

## Context-window footprint

The `_comments.context_warning` notes: *"Keep under 10 MCPs enabled to preserve context window."* Longhand is designed with token budget in mind — a full `recall` call across 100+ sessions returns ~4K tokens (smaller than reading a single raw JSONL would cost). Token budget is an explicit README section.

## How to enable

```json
"longhand": {
  "command": "longhand",
  "args": ["mcp-server"],
  "description": "..."
}
```

Setup: `pip install longhand && longhand setup` — ingests existing `~/.claude/projects/` history and installs the auto-ingest hook so new sessions are captured on close.

Happy to adjust the description or placement. Thanks for maintaining this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `longhand` as a third memory option in `mcp-configs/mcp-servers.json` for lossless Claude Code session history. It indexes raw `~/.claude/projects/*.jsonl` into local SQLite + ChromaDB, complements `@modelcontextprotocol/server-memory` and `omega-memory`, and the config description is now one line for consistency.

- **New Features**
  - Added `longhand` entry with `command: "longhand"` and `args: ["mcp-server"]`.
  - Enables exact recall of tool calls, file edits, and thinking blocks without external APIs.

- **Migration**
  - Install and ingest history: `pip install longhand && longhand setup`.

<sup>Written for commit 29b5ca02b72d627e5f5f51cfee598c0885c68a86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "longhand" MCP server option that locally indexes session artifacts and provides verbatim recall alongside existing synthesized memory, backed by local databases for quicker, persistent access.

* **Chores**
  * Added new MCP server configuration entry, expanding available server options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->