### PR TITLE
chore: Add claude-hud plugin configuration and marketplace setup

### DIFF
--- a/.claude/.cpd-wrappers/jarrodwatts-claude-hud-project/.claude-plugin/marketplace.json
+++ b/.claude/.cpd-wrappers/jarrodwatts-claude-hud-project/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "cpd-jarrodwatts-claude-hud-project",
+  "owner": {
+    "name": "ClaudePluginHub CLI"
+  },
+  "plugins": [
+    {
+      "name": "claude-hud",
+      "source": {
+        "source": "github",
+        "repo": "jarrodwatts/claude-hud"
+      },
+      "strict": false
+    }
+  ]
+}

--- a/.claude/.cpd-wrappers/jarrodwatts-claude-hud-project/cpd-meta.json
+++ b/.claude/.cpd-wrappers/jarrodwatts-claude-hud-project/cpd-meta.json
@@ -1,0 +1,7 @@
+{
+  "ownerRepo": "jarrodwatts/claude-hud",
+  "pluginName": "claude-hud",
+  "marketplaceName": "cpd-jarrodwatts-claude-hud-project",
+  "scope": "project",
+  "cwd": "/home/user/everything-claude-code"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "cpd-jarrodwatts-claude-hud-project": {
+      "source": {
+        "source": "directory",
+        "path": "/home/user/everything-claude-code/.claude/.cpd-wrappers/jarrodwatts-claude-hud-project"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "claude-hud@cpd-jarrodwatts-claude-hud-project": true
+  }
+}


### PR DESCRIPTION
## What Changed
Added Claude plugin configuration files to enable the `claude-hud` plugin from the jarrodwatts/claude-hud repository:
- Created `.claude/.cpd-wrappers/jarrodwatts-claude-hud-project/marketplace.json` with plugin marketplace definition
- Created `.claude/.cpd-wrappers/jarrodwatts-claude-hud-project/cpd-meta.json` with plugin metadata
- Created `.claude/settings.json` to register the marketplace and enable the plugin

## Why This Change
This change integrates the claude-hud plugin into the project's Claude development environment, allowing the plugin to be available for use within Claude. The configuration establishes the plugin source from the GitHub repository and enables it at the project scope.

## Testing Done
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [x] `chore:` Maintenance/tooling

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Configuration files are self-documenting with clear structure

https://claude.ai/code/session_01Qe1PoFhrpk2mUKwNFMG998

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configuration to install and enable the `claude-hud` plugin at project scope. Registers a local marketplace (`cpd-jarrodwatts-claude-hud-project`) pointing to `jarrodwatts/claude-hud`, making the HUD available in the Claude dev environment.

- **New Features**
  - Real-time HUD for context health, tool activity, agent tracking, and todo progress.
  - Enabled by default via `.claude/settings.json`.

<sup>Written for commit 58249380cbdd36244b7aa95fec377bf6072c94d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added plugin configuration and metadata files for Claude HUD integration, including marketplace registration and plugin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->