### PR TITLE
fix(observe): skip Windows AppInstallerPythonRedirector.exe in resolve_python_cmd

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -27,18 +27,45 @@ if [ -z "$INPUT_JSON" ]; then
   exit 0
 fi
 
+_is_windows_app_installer_stub() {
+  # Windows 10/11 ships an "App Execution Alias" stub at
+  #   %LOCALAPPDATA%\Microsoft\WindowsApps\python.exe
+  #   %LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe
+  # Both are symlinks to AppInstallerPythonRedirector.exe which, when Python
+  # is not installed from the Store, neither launches Python nor honors "-c".
+  # Calls to it hang or print a bare "Python " line, silently breaking every
+  # JSON-parsing step in this hook. Detect and skip such stubs here.
+  local _candidate="$1"
+  [ -z "$_candidate" ] && return 1
+  local _resolved
+  _resolved="$(command -v "$_candidate" 2>/dev/null || true)"
+  [ -z "$_resolved" ] && return 1
+  case "$_resolved" in
+    *AppInstallerPythonRedirector.exe|*AppInstallerPythonRedirector.EXE) return 0 ;;
+  esac
+  # Also resolve one level of symlink on POSIX-like shells (Git Bash, WSL).
+  if command -v readlink >/dev/null 2>&1; then
+    local _target
+    _target="$(readlink -f "$_resolved" 2>/dev/null || readlink "$_resolved" 2>/dev/null || true)"
+    case "$_target" in
+      *AppInstallerPythonRedirector.exe|*AppInstallerPythonRedirector.EXE) return 0 ;;
+    esac
+  fi
+  return 1
+}
+
 resolve_python_cmd() {
   if [ -n "${CLV2_PYTHON_CMD:-}" ] && command -v "$CLV2_PYTHON_CMD" >/dev/null 2>&1; then
     printf '%s\n' "$CLV2_PYTHON_CMD"
     return 0
   fi
 
-  if command -v python3 >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1 && ! _is_windows_app_installer_stub python3; then
     printf '%s\n' python3
     return 0
   fi
 
-  if command -v python >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1 && ! _is_windows_app_installer_stub python; then
     printf '%s\n' python
     return 0
   fi
@@ -51,6 +78,11 @@ if [ -z "$PYTHON_CMD" ]; then
   echo "[observe] No python interpreter found, skipping observation" >&2
   exit 0
 fi
+
+# Propagate our stub-aware selection so detect-project.sh (which is sourced
+# below) does not re-resolve and silently fall back to the App Installer stub.
+# detect-project.sh honors an already-set CLV2_PYTHON_CMD.
+export CLV2_PYTHON_CMD="${CLV2_PYTHON_CMD:-$PYTHON_CMD}"
 
 # ─────────────────────────────────────────────
 # Extract cwd from stdin for project detection


### PR DESCRIPTION
# fix(observe): skip Windows AppInstallerPythonRedirector.exe in resolve_python_cmd

## Summary

On Windows 10/11 without Python installed from the Microsoft Store, `continuous-learning-v2`'s observation hook silently fails — `observations.jsonl` is never written, and the only artifact is an empty `.last-purge` file. Root cause is a Windows-specific "App Execution Alias" stub that the hook's `resolve_python_cmd` happily selects as `python3`.

This PR teaches `resolve_python_cmd` to detect and skip that stub, and also exports the stub-aware interpreter so the shared `detect-project.sh` does not re-resolve and re-select the stub.

Minimal diff: **1 file, +34 / -2**. POSIX-compatible. No behavior change on macOS / Linux / WSL.

## Problem

After a fresh ECC install on Windows 11 + Claude Desktop, `~/.claude/homunculus/` contained only:

```
.last-purge
evolved/
instincts/
projects/                  <-- empty
```

No `observations.jsonl`, no project-scoped subdirectories, no evidence that the hook ever ran successfully — but the hook was registered and `bash observe.sh` returned `exit 0` every time.

## Root Cause

Windows 10/11 ships two "App Execution Alias" stubs by default:

- `%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe`
- `%LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe`

Both are symlinks to `AppInstallerPythonRedirector.exe`. If the user has **not** installed Python from the Microsoft Store, invoking either of them:

- does **not** launch any Python interpreter,
- does **not** honor `-c`,
- prints a bare `Python ` line on stdout, and
- exits 0.

Concrete evidence on the reporter's box:

```console
$ which python3
/c/Users/sugig/AppData/Local/Microsoft/WindowsApps/python3

$ file $(which python3)
... : symbolic link to /c/Program Files/WindowsApps/Microsoft.DesktopAppInstaller_*/AppInstallerPythonRedirector.exe

$ python3 -c "print('hello')"
Python
$
```

`observe.sh`'s `resolve_python_cmd` prefers `python3` over `python`, so on affected Windows machines the hook picks up the stub first and every downstream `"$PYTHON_CMD" -c '...'` call returns an empty string:

```
++ echo '{"tool_name":"Bash",...,"cwd":"...",...}'
++ python3 -c 'import json, sys; ...'
++ echo ''
+ STDIN_CWD=                      <-- empty because the stub swallowed the call
```

Because `observe.sh` uses `set -e` and swallows many errors via `|| true`, the script still exits 0. `observations.jsonl` is never created, no error is surfaced to the user, and the bug looks like a silent permission / install failure.

A second, non-obvious wrinkle: `detect-project.sh` has its own `_clv2_resolve_python_cmd` which **unconditionally** overwrites `CLV2_PYTHON_CMD` when sourced. Even if `observe.sh` resolves a good interpreter first, the `source` below resets `CLV2_PYTHON_CMD=python3` and we are back to the stub.

## Fix

Single-file change in `skills/continuous-learning-v2/hooks/observe.sh`:

1. **New helper `_is_windows_app_installer_stub`**  
   Uses `command -v` to resolve the candidate, then checks the resolved path (and, on shells with `readlink`, the symlink target) for a trailing `AppInstallerPythonRedirector.exe`. Returns 0 when the candidate is the Windows stub.

2. **`resolve_python_cmd` now skips stub candidates**  
   ```diff
   -  if command -v python3 >/dev/null 2>&1; then
   +  if command -v python3 >/dev/null 2>&1 && ! _is_windows_app_installer_stub python3; then
        printf '%s\n' python3
        return 0
      fi

   -  if command -v python >/dev/null 2>&1; then
   +  if command -v python >/dev/null 2>&1 && ! _is_windows_app_installer_stub python; then
        printf '%s\n' python
        return 0
      fi
   ```

3. **Export `CLV2_PYTHON_CMD` before sourcing `detect-project.sh`**  
   `detect-project.sh` already honors an already-set `CLV2_PYTHON_CMD` (its own `_clv2_resolve_python_cmd` short-circuits on line 27), so a single `export CLV2_PYTHON_CMD="${CLV2_PYTHON_CMD:-$PYTHON_CMD}"` after detection is enough. **No change to `detect-project.sh` is required.**

Everything is POSIX-compatible. On macOS / Linux / WSL no filesystem path ends in `AppInstallerPythonRedirector.exe`, so `_is_windows_app_installer_stub` always returns 1 and behavior is unchanged.

## Testing

### Before the fix

```console
$ ls ~/.claude/homunculus/
.last-purge   evolved/   instincts/   projects/        # projects/ empty
```

Running the hook directly with a realistic payload (even with `CLAUDE_CODE_ENTRYPOINT=cli` set, ruling out the Layer 1 guard):

```console
$ echo '{"tool_name":"Bash","tool_input":{"command":"echo test"},
  "cwd":"C:\\Users\\...\\everything-claude-code","session_id":"...",
  "hook_event_name":"PostToolUse"}' \
  | env -u CLV2_PYTHON_CMD CLAUDE_CODE_ENTRYPOINT=cli \
    bash skills/continuous-learning-v2/hooks/observe.sh post
$ echo "exit=$?"
exit=0

$ ls ~/.claude/homunculus/projects/
# still empty
```

### After the fix

Same command, same environment, same stdin JSON, unmodified Windows environment (`python3` still points to the App Installer stub):

```console
$ wc -l ~/.claude/homunculus/projects/1d329d7393df/observations.jsonl
1
$ echo '{"tool_name":"Bash",...,"session_id":"upstream-final-001",...}' \
  | env -u CLV2_PYTHON_CMD CLAUDE_CODE_ENTRYPOINT=cli \
    bash skills/continuous-learning-v2/hooks/observe.sh post
$ wc -l ~/.claude/homunculus/projects/1d329d7393df/observations.jsonl
2
$ tail -n 1 ~/.claude/homunculus/projects/1d329d7393df/observations.jsonl
{"timestamp":"2026-04-19T22:28:36Z","event":"tool_complete","tool":"Bash",
 "session":"upstream-final-001","project_id":"1d329d7393df",
 "project_name":"everything-claude-code","output":""}
```

Δ lines = **+1** per hook invocation, as expected.

### Syntax & lint

```console
$ bash -n skills/continuous-learning-v2/hooks/observe.sh
# OK (exit 0)
```

### Platform matrix

| Platform | `python3` resolves to | Stub detected? | Interpreter used |
|---|---|---|---|
| Windows 11 (no Store Python) | `WindowsApps/python3.exe` → `AppInstallerPythonRedirector.exe` | **yes** | falls through to `python` (real CPython) |
| Windows 11 (Store Python installed) | real `python3.exe` | no | `python3` as before |
| macOS (Homebrew) | `/opt/homebrew/bin/python3` | no | `python3` as before |
| Ubuntu / Debian | `/usr/bin/python3` | no | `python3` as before |
| WSL 2 (Ubuntu) | `/usr/bin/python3` | no | `python3` as before |

## Environment

- OS: Windows 11 Pro 23H2
- Shell: Git Bash (`C:\Program Files\Git\bin\bash.exe`)
- Host: Claude Desktop 2.1.111 (entrypoint `claude-desktop`)
- ECC: v1.10.0
- `python3`: `AppInstallerPythonRedirector.exe` (Windows App Execution Alias, Python **not** installed from Store)
- `python`: CPython 3.12.10 at `C:\Users\<user>\AppData\Local\Programs\Python\Python312\python.exe`

## Related

- Downstream local workaround: a site-local `observe-wrapper.sh` that exports `CLV2_PYTHON_CMD=python` and `CLAUDE_CODE_ENTRYPOINT=cli` before exec'ing `observe.sh`. This PR supersedes the `CLV2_PYTHON_CMD=python` half of that workaround — the `ENTRYPOINT=cli` half is a **separate** Layer 1 guard discussion (Claude Desktop is currently not in the cli|sdk-ts allow-list) and will be filed as its own issue.
- No change to `detect-project.sh` in this PR. If reviewers prefer hardening `_clv2_resolve_python_cmd` symmetrically, that can be a follow-up — but the current fix already handles the shared-helper path via `CLV2_PYTHON_CMD` export.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python command resolution on Windows systems by implementing detection for App Execution Alias stubs, ensuring proper tool selection and more reliable script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and skip the Windows App Installer Python redirector when resolving the interpreter in `observe.sh`. Fixes silent failures on Windows where `observations.jsonl` wasn’t written if only the alias stub was present.

- **Bug Fixes**
  - Added `_is_windows_app_installer_stub` to detect `AppInstallerPythonRedirector.exe` and skip it when choosing `python3`/`python`.
  - Export the resolved interpreter to `CLV2_PYTHON_CMD` before sourcing `detect-project.sh` so it doesn’t reselect the stub.
  - Behavior unchanged on macOS/Linux/WSL; POSIX-compatible.

<sup>Written for commit 297e30b82f2322d777e33ba888a7d871476eae83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

