### PR TITLE
feat(ci): detect duplicate YAML frontmatter keys in agent files

### DIFF
--- a/agents/a11y-architect.md
+++ b/agents/a11y-architect.md
@@ -3,7 +3,6 @@ name: a11y-architect
 description: Accessibility Architect specializing in WCAG 2.2 compliance for Web and Native platforms. Use PROACTIVELY when designing UI components, establishing design systems, or auditing code for inclusive user experiences.
 model: sonnet
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: opus
 ---
 
 You are a Senior Accessibility Architect. Your goal is to ensure that every digital product is Perceivable, Operable, Understandable, and Robust (POUR) for all users, including those with visual, auditory, motor, or cognitive disabilities.

--- a/scripts/ci/validate-agents.js
+++ b/scripts/ci/validate-agents.js
@@ -18,15 +18,23 @@ function extractFrontmatter(content) {
   if (!match) return null;
 
   const frontmatter = {};
+  const duplicates = [];
   const lines = match[1].split(/\r?\n/);
   for (const line of lines) {
+    // Only consider top-level keys (no leading whitespace) to avoid flagging
+    // nested YAML structures as duplicates.
+    if (/^\s/.test(line)) continue;
     const colonIdx = line.indexOf(':');
     if (colonIdx > 0) {
       const key = line.slice(0, colonIdx).trim();
       const value = line.slice(colonIdx + 1).trim();
+      if (Object.prototype.hasOwnProperty.call(frontmatter, key)) {
+        duplicates.push(key);
+      }
       frontmatter[key] = value;
     }
   }
+  Object.defineProperty(frontmatter, '__duplicates__', { value: duplicates, enumerable: false });
   return frontmatter;
 }
 
@@ -55,6 +63,11 @@ function validateAgents() {
       console.error(`ERROR: ${file} - Missing frontmatter`);
       hasErrors = true;
       continue;
+    }
+
+    if (frontmatter.__duplicates__.length > 0) {
+      console.error(`ERROR: ${file} - Duplicate frontmatter keys: ${[...new Set(frontmatter.__duplicates__)].join(', ')}`);
+      hasErrors = true;
     }
 
     for (const field of REQUIRED_FIELDS) {

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -1957,6 +1957,20 @@ function runTests() {
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 
+  if (test('rejects agent with duplicate top-level frontmatter keys', () => {
+    const testDir = createTestDir();
+    // Two `model:` lines — only the last wins silently in YAML, so this is a
+    // stealth-configuration vector (appear-as-sonnet, actually-run-as-opus).
+    fs.writeFileSync(path.join(testDir, 'dup-model.md'),
+      '---\nname: dup\nmodel: sonnet\ntools: Read, Write\ndescription: test\nmodel: opus\n---\n# Agent');
+
+    const result = runValidatorWithDir('validate-agents', 'AGENTS_DIR', testDir);
+    assert.strictEqual(result.code, 1, 'Should reject duplicate top-level YAML keys');
+    assert.ok(result.stderr.includes('Duplicate frontmatter keys'), 'Should report duplicate keys');
+    assert.ok(result.stderr.includes('model'), 'Should name the duplicated key');
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
   // ── Round 52: command inline backtick refs, workflow whitespace, code-only rules ──
   console.log('\nRound 52: validate-commands (inline backtick refs):');
 


### PR DESCRIPTION
## What Changed

- `scripts/ci/validate-agents.js` now fails when an agent's frontmatter has duplicate top-level keys. `extractFrontmatter` tracks duplicates on top-level lines (lines with leading whitespace are treated as nested and ignored), exposes them through a non-enumerable `__duplicates__` property, and `validateAgents` reports `Duplicate frontmatter keys: <names>`.
- `agents/a11y-architect.md` had exactly this shape — two `model:` lines on rows 4 and 6 (`sonnet` then `opus`). To a reviewer it read as `sonnet`; the runtime silently loaded `opus`. Kept `model: sonnet`, dropped the stray second declaration.
- `tests/ci/validators.test.js`: new fixture-based test `rejects agent with duplicate top-level frontmatter keys`.

## Why This Change

The current parser uses `indexOf(':')` + plain object assignment, so a duplicate key silently overwrites the first value without any signal. This makes stealth-configuration regressions easy — an agent that reads as one model to a human reviewer can run as a different (more expensive or more privileged) model at runtime. Fixing just `a11y-architect.md` does not prevent the class of bug from coming back; the CI check does.

## Testing Done

- [x] Manual testing completed — `node scripts/ci/validate-agents.js` passes on the 48 existing agent files.
- [x] Automated tests pass locally (`node tests/run-all.js`) — 1847 tests, 1843 passing, 4 pre-existing broken-symlink failures unchanged from baseline on Windows.
- [x] Edge cases considered and tested — nested YAML (lines with leading whitespace) is not flagged; BOM + CRLF frontmatter still parses; the synthetic duplicate-key fixture fails with the expected error.

## Type of Change

- [x] `feat:` New feature — duplicate-key detection in `validate-agents.js`
- [x] `fix:` Bug fix — duplicate `model:` key in `agents/a11y-architect.md`

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (no JSON touched)
- [x] Shell scripts pass shellcheck (not applicable)
- [x] Pre-commit hooks pass locally (repo has no git pre-commit hooks)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation — none required for this change
- [x] Added comments for complex logic — `__duplicates__` helper and the nested-line skip are commented
- [x] README updated (if needed) — not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration validation to detect duplicate keys in agent settings, preventing invalid configurations from being used.

* **Tests**
  * Added test coverage for duplicate key detection in agent configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI check to detect duplicate top-level YAML frontmatter keys in agent files and fix one affected agent. This prevents silent overrides (e.g., two model lines) that change runtime behavior.

- **New Features**
  - `scripts/ci/validate-agents.js` now fails when duplicate top-level YAML keys are found and prints the key names.
  - `extractFrontmatter` tracks duplicates via a non-enumerable `__duplicates__`; indented (nested) lines are ignored.
  - Added a test that rejects agents with duplicate top-level keys.

- **Bug Fixes**
  - Removed the stray second `model:` from `agents/a11y-architect.md` (kept `model: sonnet`).

<sup>Written for commit 8810b2668833fef3c88410ae8bc1e1505cdc06f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

