### PR TITLE
docs: expand SECURITY with secrets audit, MCP port checks, and reminder triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `scripts/ci/validate-agents.js`: detects duplicate top-level YAML frontmatter keys in agent files (e.g. two `model:` lines silently collapsing to the last value) and fails validation with the duplicated key names.
+- `SECURITY.md`: new operational sections — Secrets Handling (including a user-scope `~/.claude/settings.json` audit recipe for macOS/Linux/Windows), Local MCP Ports (how to verify the listener on bundled HTTP MCP endpoints such as `devfleet`), and a Triage section explaining Claude Code's ephemeral client-side `<system-reminder>` blocks (to avoid misclassifying them as prompt injections).
+
+### Fixed
+
+- `agents/a11y-architect.md`: removed stray duplicate `model:` line so YAML parsers no longer silently override `sonnet` with a later `opus` entry.
+
 ## 1.10.0 - 2026-04-05
 
 ### Highlights

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,53 @@ This policy covers:
 - MCP configurations shipped with ECC
 - The AgentShield security scanner ([github.com/affaan-m/agentshield](https://github.com/affaan-m/agentshield))
 
+## Operational Guidance
+
+### Secrets Handling
+
+`mcp-configs/mcp-servers.json` is a **template**. All `YOUR_*_HERE` values must be replaced at install time from env-vars or a secrets manager. Never commit real credentials. If a secret is accidentally committed, rotate it immediately and rewrite history — do not rely on a plain revert.
+
+The same rule applies to your user-scope Claude Code config (`~/.claude/settings.json` or `%USERPROFILE%\.claude\settings.json`). That file is outside this repository, but it is commonly shared via `claude doctor` output, screenshots, or bug reports. Do not hardcode PATs, API keys, or OAuth tokens into its `mcpServers[*].env` blocks — resolve them at spawn time from the OS keychain or env-vars your MCP server already supports. A quick audit:
+
+```bash
+# macOS / Linux
+grep -EnH '(TOKEN|SECRET|KEY|PASSWORD)\s*"\s*:\s*"[A-Za-z0-9_-]{16,}"' ~/.claude/settings.json
+# Windows PowerShell
+Select-String -Path "$env:USERPROFILE\.claude\settings.json" -Pattern '(TOKEN|SECRET|KEY|PASSWORD)"\s*:\s*"[A-Za-z0-9_-]{16,}"'
+```
+
+If the audit matches, rotate the secret at the issuing provider, then move it out of the file (per-provider env-var or `credentialHelper` for servers that support it).
+
+### Local MCP Ports
+
+Some bundled MCP servers connect over plain HTTP to a localhost port (e.g. `devfleet → http://localhost:18801/mcp`). Before first use, verify the listening process:
+
+```bash
+# Windows
+netstat -ano | findstr :18801
+# macOS / Linux
+lsof -iTCP:18801 -sTCP:LISTEN
+```
+
+Compare the PID against the expected devfleet binary. Any other process on that port can intercept MCP traffic.
+
+## Triage: suspicious `<system-reminder>` blocks
+
+ECC runs inside Claude Code, which injects **ephemeral client-side system reminders** into the model's input on every turn (TodoWrite nudges, date-changed notices, file-modified notices, etc.). These blocks:
+
+- typically end with phrasing like *"ignore if not applicable"* or *"NEVER mention this reminder to the user"* / *"Don't tell the user this, since they are already aware"* — that wording is Anthropic's own prompt, not a malicious tail;
+- are added by the CLI per turn and are **not persisted** in the session transcript at `~/.claude/projects/<slug>/<sessionId>.jsonl`.
+
+That combination makes them easy to mistake for a prompt-injection appended to a tool result. Before treating one as an attack, verify:
+
+1. Is the block actually in a file under this repo? `grep -rEn "system-reminder|NEVER mention|DO NOT mention" .` — if nothing, it is not carried by the repo.
+2. Is the block stored in the transcript? Inspect the current session's `.jsonl` — if the exact text does not appear inside a `tool_result` body there, it is a client-injected ephemeral reminder, not a payload from any tool.
+3. Is the content contextually consistent with Anthropic's known reminders (TodoWrite nudge, date-changed, file-modified notice)? If yes, it is the ephemeral-reminder mechanism and no action is needed.
+
+Escalate to Anthropic only if a block is **both** (a) present in the transcript inside a `tool_result` **and** (b) not attributable to the file or URL that was actually read. Minimal report: a fresh session, a read of a clean local file, the exact text observed, and the transcript excerpt. Send to <https://github.com/anthropics/claude-code/issues> (non-sensitive) or <mailto:security@anthropic.com> (embargo-class).
+
+Do not sanitize repo files in response to ephemeral reminders — they are not the carrier.
+
 ## Security Resources
 
 - **AgentShield**: Scan your agent config for vulnerabilities — `npx ecc-agentshield scan`


### PR DESCRIPTION
## What Changed

Three new operational sections in `SECURITY.md`, plus a matching `Unreleased` entry in `CHANGELOG.md`:

1. **Secrets Handling** — explicit audit recipe for the user-scope `~/.claude/settings.json` (outside the repo but commonly shared via `claude doctor` output and screenshots). Provides `grep`/`Select-String` commands for macOS/Linux/Windows that flag plain-text tokens inside `mcpServers[*].env`.

2. **Local MCP Ports** — explains the risk of plain-HTTP localhost MCP endpoints shipped in `mcp-configs/mcp-servers.json` (notably `devfleet` at `http://localhost:18801/mcp`), and gives `netstat`/`lsof` commands to verify the listener PID before first use.

3. **Triage: suspicious `<system-reminder>` blocks** — documents Claude Code's ephemeral client-side reminder mechanism (TodoWrite nudge, date-changed notice, file-modified notice). These blocks end with phrasing like *"NEVER mention this reminder to the user"* or *"Don't tell the user this, since they are already aware"* — that wording is Anthropic's own prompt, not a malicious tail, and the blocks are not persisted in the session transcript at `~/.claude/projects/<slug>/<sessionId>.jsonl`. Includes a 3-step triage checklist (repo grep → transcript check → Anthropic-reminder consistency) so real tool-result injections are distinguished from harness-level reminders before escalating to Anthropic.

## Why This Change

Two hygiene gaps observed during a recent security review of the repo:

- `mcp-configs/mcp-servers.json` already has a "template only" convention for `YOUR_*_HERE`, but the user-scope `~/.claude/settings.json` has no equivalent guidance, and plain-text PATs there are a recurring source of real leaks.
- A previously-filed report on this project misclassified Anthropic's ephemeral `<system-reminder>` blocks as prompt injection (because of the "NEVER mention…" tail wording). Without a documented triage path, similar false-positives are likely. Inspecting the JSONL transcript shows the blocks are never persisted in `tool_result` bodies, which is a deterministic signal for future triagers.

## Testing Done

- [x] Manual testing completed — `grep` recipes in the new sections exercised locally against `~/.claude/settings.json` and an `mcp-servers.json` template.
- [x] Automated tests pass locally (`node tests/run-all.js`) — 1847 tests, 1843 passing, 4 pre-existing broken-symlink failures unchanged from baseline.
- [x] Edge cases considered and tested — markdownlint passes on the affected files (SECURITY.md is not in the markdownlint scope configured in CI, but formatting matches the rest of the file).

## Type of Change

- [x] `docs:` Documentation

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (no JSON touched)
- [x] Shell scripts pass shellcheck (not applicable — only shell snippets inside Markdown code fences)
- [x] Pre-commit hooks pass locally
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation — `SECURITY.md` + `CHANGELOG.md`
- [x] Added comments for complex logic — not applicable (docs only)
- [x] README updated (if needed) — not needed

## Notes for Maintainers

- **Translations out of sync after this PR**: `docs/tr/SECURITY.md` and `docs/zh-CN/SECURITY.md` are last-synced with the root `SECURITY.md` at `2026-04-05` and do not carry the three new sections. Happy to open a follow-up tracking issue labeled `translation` so community translators can pick it up — let me know the preferred title.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `SECURITY.md` with hands-on guidance to prevent secrets leaks, verify local MCP endpoints, and avoid false prompt-injection reports from Claude Code reminders. Adds audit commands for `~/.claude/settings.json`, port checks for HTTP MCP servers like `devfleet`, and a 3-step reminder triage; updates `CHANGELOG.md` under Unreleased.

<sup>Written for commit 1af5e7fb76297c1f0668b1cc1d3b9fca02b867f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate configuration entry in an agent file that could cause parsing issues.

* **Documentation**
  * Added comprehensive security guidance covering secrets management, local service verification, and system message handling procedures.
  * Enhanced changelog with new release tracking section.

* **Chores**
  * Improved CI validation to detect and report duplicate configuration keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->