### PR TITLE
fix(continuous-learning-v2): accept claude-desktop as valid entrypoint

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -103,7 +103,7 @@ fi
 # Non-interactive SDK automation is still filtered by Layers 2-5 below
 # (ECC_HOOK_PROFILE=minimal, ECC_SKIP_OBSERVE=1, agent_id, path exclusions).
 case "${CLAUDE_CODE_ENTRYPOINT:-cli}" in
-  cli|sdk-ts) ;;
+  cli|sdk-ts|claude-desktop) ;;
   *) exit 0 ;;
 esac
 


### PR DESCRIPTION
## Summary

The `observe.sh` hook in `skills/continuous-learning-v2/` currently gates on `CLAUDE_CODE_ENTRYPOINT`, allowing only `cli` and `sdk-ts`. Users running Claude Code from the **Claude Desktop app** have `CLAUDE_CODE_ENTRYPOINT=claude-desktop`, so the hook silently no-ops and no observations are captured.

## Change

One-line fix to `skills/continuous-learning-v2/hooks/observe.sh:106`:

```diff
 case "${CLAUDE_CODE_ENTRYPOINT:-cli}" in
-  cli|sdk-ts) ;;
+  cli|sdk-ts|claude-desktop) ;;
   *) exit 0 ;;
 esac
```

## Verification

Tested locally on Windows 11 / Claude Desktop. Before the patch, `observations.jsonl` was empty for 13 days despite active use. After the patch, observations capture successfully on every tool call, projects auto-register in `~/.claude/homunculus/projects/`, and the instinct pipeline resumes.

## Test plan
- [ ] `echo '{"hook_event_name":"PostToolUse","tool_name":"Read","cwd":"<any>"}' | CLAUDE_CODE_ENTRYPOINT=claude-desktop bash hooks/observe.sh post` — should append to `~/.claude/homunculus/projects/<hash>/observations.jsonl`
- [ ] The other Layer 2-5 guards (minimal profile, ECC_SKIP_OBSERVE, subagent, excluded paths) still short-circuit correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed entrypoint handling for claude-desktop to be treated consistently with other CLI-based entrypoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `claude-desktop` as a valid `CLAUDE_CODE_ENTRYPOINT` in `skills/continuous-learning-v2/hooks/observe.sh` so observations are captured when using Claude Desktop. Previously the hook exited early; now projects and observations are created.

- **Bug Fixes**
  - Add `claude-desktop` to the entrypoint case guard (`cli|sdk-ts|claude-desktop`); other Layer 2–5 guards remain unchanged.

<sup>Written for commit cecc953951381ac9c7f1e3a900e602cbac4f2559. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

