### PR TITLE
feat: add Astraflow provider support (global + China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@
 # Your Anthropic API key (https://console.anthropic.com)
 ANTHROPIC_API_KEY=
 
+# ─── Astraflow (UCloud / 优刻得) ──────────────────────────────────────────────
+# Astraflow is an OpenAI-compatible aggregation platform supporting 200+ models.
+# Sign up: https://astraflow.ucloud.cn/
+#
+# Global endpoint (https://api-us-ca.umodelverse.ai/v1)
+ASTRAFLOW_API_KEY=
+# China endpoint  (https://api.modelverse.cn/v1)
+ASTRAFLOW_CN_API_KEY=
+
 # ─── GitHub ───────────────────────────────────────────────────────────────────
 # GitHub personal access token (for MCP GitHub server)
 GITHUB_TOKEN=

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -18,6 +18,8 @@ class ProviderType(str, Enum):
     CLAUDE = "claude"
     OPENAI = "openai"
     OLLAMA = "ollama"
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow_cn"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -3,12 +3,15 @@
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+from llm.providers.astraflow import AstraflowProvider, AstraflowCNProvider
 from llm.providers.resolver import get_provider, register_provider
 
 __all__ = (
     "ClaudeProvider",
     "OpenAIProvider",
     "OllamaProvider",
+    "AstraflowProvider",
+    "AstraflowCNProvider",
     "get_provider",
     "register_provider",
 )

--- a/src/llm/providers/astraflow.py
+++ b/src/llm/providers/astraflow.py
@@ -1,0 +1,172 @@
+"""Astraflow provider adapter (OpenAI-compatible, 200+ models).
+
+Astraflow is an AI model aggregation platform by UCloud (优刻得).
+Documentation and API key signup: https://astraflow.ucloud.cn/
+
+Two regional endpoints are supported via two separate provider classes:
+
+* ``AstraflowProvider``   — global endpoint (env: ASTRAFLOW_API_KEY)
+* ``AstraflowCNProvider`` — China  endpoint (env: ASTRAFLOW_CN_API_KEY)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+from llm.core.interface import (
+    AuthenticationError,
+    ContextLengthError,
+    LLMProvider,
+    RateLimitError,
+)
+from llm.core.types import LLMInput, LLMOutput, Message, ModelInfo, ProviderType, ToolCall
+
+
+_GLOBAL_BASE_URL: str = "https://api-us-ca.umodelverse.ai/v1"
+_CN_BASE_URL: str = "https://api.modelverse.cn/v1"
+
+
+class AstraflowProvider(LLMProvider):
+    """Astraflow global endpoint provider (ASTRAFLOW_API_KEY)."""
+
+    provider_type = ProviderType.ASTRAFLOW
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self.client = OpenAI(
+            api_key=api_key or os.environ.get("ASTRAFLOW_API_KEY"),
+            base_url=base_url or _GLOBAL_BASE_URL,
+        )
+        self._models = [
+            ModelInfo(
+                name="deepseek-v3",
+                provider=ProviderType.ASTRAFLOW,
+                supports_tools=True,
+                supports_vision=False,
+                max_tokens=8192,
+                context_window=128000,
+            ),
+            ModelInfo(
+                name="qwen-max",
+                provider=ProviderType.ASTRAFLOW,
+                supports_tools=True,
+                supports_vision=True,
+                max_tokens=8192,
+                context_window=32768,
+            ),
+            ModelInfo(
+                name="llama-3.3-70b-instruct",
+                provider=ProviderType.ASTRAFLOW,
+                supports_tools=True,
+                supports_vision=False,
+                max_tokens=8192,
+                context_window=128000,
+            ),
+            ModelInfo(
+                name="gpt-4o",
+                provider=ProviderType.ASTRAFLOW,
+                supports_tools=True,
+                supports_vision=True,
+                max_tokens=4096,
+                context_window=128000,
+            ),
+            ModelInfo(
+                name="claude-3-5-sonnet",
+                provider=ProviderType.ASTRAFLOW,
+                supports_tools=True,
+                supports_vision=True,
+                max_tokens=8192,
+                context_window=200000,
+            ),
+        ]
+
+    def generate(self, input: LLMInput) -> LLMOutput:
+        try:
+            params: dict[str, Any] = {
+                "model": input.model or self.get_default_model(),
+                "messages": [msg.to_dict() for msg in input.messages],
+                "temperature": input.temperature,
+            }
+            if input.max_tokens:
+                params["max_tokens"] = input.max_tokens
+            if input.tools:
+                params["tools"] = [tool.to_dict() for tool in input.tools]
+
+            response = self.client.chat.completions.create(**params)
+            choice = response.choices[0]
+
+            tool_calls = None
+            if choice.message.tool_calls:
+                tool_calls = [
+                    ToolCall(
+                        id=tc.id or "",
+                        name=tc.function.name,
+                        arguments={} if not tc.function.arguments else json.loads(tc.function.arguments),
+                    )
+                    for tc in choice.message.tool_calls
+                ]
+
+            return LLMOutput(
+                content=choice.message.content or "",
+                tool_calls=tool_calls,
+                model=response.model,
+                usage={
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                },
+                stop_reason=choice.finish_reason,
+            )
+        except Exception as e:
+            msg = str(e)
+            if "401" in msg or "authentication" in msg.lower():
+                raise AuthenticationError(msg, provider=self.provider_type) from e
+            if "429" in msg or "rate_limit" in msg.lower():
+                raise RateLimitError(msg, provider=self.provider_type) from e
+            if "context" in msg.lower() and "length" in msg.lower():
+                raise ContextLengthError(msg, provider=self.provider_type) from e
+            raise
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return bool(self.client.api_key)
+
+    def get_default_model(self) -> str:
+        return "deepseek-v3"
+
+
+class AstraflowCNProvider(AstraflowProvider):
+    """Astraflow China endpoint provider (ASTRAFLOW_CN_API_KEY)."""
+
+    provider_type = ProviderType.ASTRAFLOW_CN
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key or os.environ.get("ASTRAFLOW_CN_API_KEY"),
+            base_url=base_url or _CN_BASE_URL,
+        )
+        # Re-stamp all model entries with the correct provider type
+        self._models = [
+            ModelInfo(
+                name=m.name,
+                provider=ProviderType.ASTRAFLOW_CN,
+                supports_tools=m.supports_tools,
+                supports_vision=m.supports_vision,
+                max_tokens=m.max_tokens,
+                context_window=m.context_window,
+            )
+            for m in self._models
+        ]

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -9,12 +9,15 @@ from llm.core.types import ProviderType
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+from llm.providers.astraflow import AstraflowProvider, AstraflowCNProvider
 
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.CLAUDE: ClaudeProvider,
     ProviderType.OPENAI: OpenAIProvider,
     ProviderType.OLLAMA: OllamaProvider,
+    ProviderType.ASTRAFLOW: AstraflowProvider,
+    ProviderType.ASTRAFLOW_CN: AstraflowCNProvider,
 }
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,6 @@
 import pytest
 from llm.core.types import ProviderType
-from llm.providers import ClaudeProvider, OpenAIProvider, OllamaProvider, get_provider
+from llm.providers import ClaudeProvider, OpenAIProvider, OllamaProvider, AstraflowProvider, AstraflowCNProvider, get_provider
 
 
 class TestGetProvider:
@@ -22,6 +22,36 @@ class TestGetProvider:
     def test_get_provider_by_enum(self):
         provider = get_provider(ProviderType.CLAUDE)
         assert isinstance(provider, ClaudeProvider)
+
+    def test_get_astraflow_provider(self):
+        provider = get_provider("astraflow")
+        assert isinstance(provider, AstraflowProvider)
+        assert provider.provider_type == ProviderType.ASTRAFLOW
+
+    def test_get_astraflow_cn_provider(self):
+        provider = get_provider("astraflow_cn")
+        assert isinstance(provider, AstraflowCNProvider)
+        assert provider.provider_type == ProviderType.ASTRAFLOW_CN
+
+    def test_astraflow_default_model(self):
+        provider = get_provider("astraflow")
+        assert provider.get_default_model() == "deepseek-v3"
+
+    def test_astraflow_cn_default_model(self):
+        provider = get_provider("astraflow_cn")
+        assert provider.get_default_model() == "deepseek-v3"
+
+    def test_astraflow_list_models(self):
+        provider = get_provider("astraflow")
+        models = provider.list_models()
+        assert len(models) > 0
+        assert all(m.provider == ProviderType.ASTRAFLOW for m in models)
+
+    def test_astraflow_cn_list_models(self):
+        provider = get_provider("astraflow_cn")
+        models = provider.list_models()
+        assert len(models) > 0
+        assert all(m.provider == ProviderType.ASTRAFLOW_CN for m in models)
 
     def test_invalid_provider_raises(self):
         with pytest.raises(ValueError, match="Unknown provider type"):


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a fully-supported LLM provider, following the exact same patterns as the existing `OpenAIProvider`, `ClaudeProvider`, and `OllamaProvider`.

Astraflow is an OpenAI-compatible AI model aggregation platform that supports 200+ models via two regional endpoints:

| Region | Base URL | Env Var |
|--------|----------|---------|
| Global | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China  | `https://api.modelverse.cn/v1`         | `ASTRAFLOW_CN_API_KEY` |

Sign up at: https://astraflow.ucloud.cn/

---

## Changes

### `src/llm/core/types.py`
- Adds `ASTRAFLOW = "astraflow"` and `ASTRAFLOW_CN = "astraflow_cn"` to the `ProviderType` enum.

### `src/llm/providers/astraflow.py` *(new file)*
- Implements `AstraflowProvider` extending `LLMProvider`, re-using the `openai` SDK against both regional base URLs.
- Supports tools and vision; ships with a representative model list (`deepseek-v3`, `qwen-max`, `llama-3.3-70b-instruct`, `gpt-4o`, `claude-3-5-sonnet`).
- Separate `AstraflowCNProvider` subclass targets the China endpoint and `ASTRAFLOW_CN_API_KEY`.
- Error handling mirrors `OpenAIProvider` (401 → `AuthenticationError`, 429 → `RateLimitError`, context → `ContextLengthError`).

### `src/llm/providers/__init__.py`
- Exports `AstraflowProvider` and `AstraflowCNProvider`.

### `src/llm/providers/resolver.py`
- Imports and registers both providers into `_PROVIDER_MAP`.

### `.env.example`
- Documents `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY`.

### `tests/test_resolver.py`
- Adds resolver round-trip tests for `"astraflow"` and `"astraflow_cn"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Astraflow LLM provider with dual endpoint support: global and China-specific.
  * Integrates OpenAI-compatible API for seamless model access.
  * Supports DeepSeek v3 as default model.
  * Requires environment variable configuration for API key authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full Astraflow LLM provider support with global and China endpoints using the `openai` SDK. This unlocks 200+ models via `astraflow` and `astraflow_cn` with tool and vision support.

- **New Features**
  - Added `AstraflowProvider` (global) and `AstraflowCNProvider` (China); registered in resolver and exported.
  - Uses regional base URLs: global `https://api-us-ca.umodelverse.ai/v1`, China `https://api.modelverse.cn/v1`; default model `deepseek-v3`.
  - Maps 401/429/context length errors to existing exceptions; includes a representative model list.
  - Updated `.env.example` and added resolver tests for both providers.

- **Migration**
  - Set `ASTRAFLOW_API_KEY` for global or `ASTRAFLOW_CN_API_KEY` for China.
  - Use provider types: `"astraflow"` or `"astraflow_cn"`.

<sup>Written for commit df834991dec1a836cd937d2fbc5dfce912df294e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

