### PR TITLE
feat: add Astraflow provider support (global & China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@
 # Your Anthropic API key (https://console.anthropic.com)
 ANTHROPIC_API_KEY=
 
+# ─── Astraflow ────────────────────────────────────────────────────────────────
+# Astraflow is an OpenAI-compatible AI model aggregation platform (200+ models)
+# by UCloud / 优刻得. Sign up at https://astraflow.ucloud.cn/
+#
+# Global endpoint  (https://api-us-ca.umodelverse.ai/v1)
+ASTRAFLOW_API_KEY=
+# China endpoint   (https://api.modelverse.cn/v1)
+ASTRAFLOW_CN_API_KEY=
+
 # ─── GitHub ───────────────────────────────────────────────────────────────────
 # GitHub personal access token (for MCP GitHub server)
 GITHUB_TOKEN=

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -18,6 +18,8 @@ class ProviderType(str, Enum):
     CLAUDE = "claude"
     OPENAI = "openai"
     OLLAMA = "ollama"
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow_cn"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -3,12 +3,15 @@
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+from llm.providers.astraflow import AstraflowProvider, AstraflowCNProvider
 from llm.providers.resolver import get_provider, register_provider
 
 __all__ = (
     "ClaudeProvider",
     "OpenAIProvider",
     "OllamaProvider",
+    "AstraflowProvider",
+    "AstraflowCNProvider",
     "get_provider",
     "register_provider",
 )

--- a/src/llm/providers/astraflow.py
+++ b/src/llm/providers/astraflow.py
@@ -1,0 +1,222 @@
+"""Astraflow provider adapter (OpenAI-compatible, 200+ models).
+
+Astraflow is an AI model aggregation platform by UCloud / 优刻得.
+
+Endpoints
+---------
+Global : https://api-us-ca.umodelverse.ai/v1  (env: ASTRAFLOW_API_KEY)
+China  : https://api.modelverse.cn/v1         (env: ASTRAFLOW_CN_API_KEY)
+
+Sign up at https://astraflow.ucloud.cn/
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+from llm.core.interface import (
+    AuthenticationError,
+    ContextLengthError,
+    LLMProvider,
+    RateLimitError,
+)
+from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
+
+
+_ASTRAFLOW_GLOBAL_BASE_URL = "https://api-us-ca.umodelverse.ai/v1"
+_ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1"
+
+
+def _make_models(provider: ProviderType) -> list[ModelInfo]:
+    """Return a representative set of models available on Astraflow."""
+    return [
+        ModelInfo(
+            name="gpt-4o",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=True,
+            max_tokens=4096,
+            context_window=128000,
+        ),
+        ModelInfo(
+            name="gpt-4o-mini",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=True,
+            max_tokens=4096,
+            context_window=128000,
+        ),
+        ModelInfo(
+            name="claude-3-5-sonnet-20241022",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=True,
+            max_tokens=8192,
+            context_window=200000,
+        ),
+        ModelInfo(
+            name="claude-3-5-haiku-20241022",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=False,
+            max_tokens=4096,
+            context_window=200000,
+        ),
+        ModelInfo(
+            name="deepseek-chat",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=False,
+            max_tokens=4096,
+            context_window=64000,
+        ),
+        ModelInfo(
+            name="deepseek-r1",
+            provider=provider,
+            supports_tools=False,
+            supports_vision=False,
+            max_tokens=8192,
+            context_window=64000,
+        ),
+        ModelInfo(
+            name="gemini-1.5-pro",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=True,
+            max_tokens=8192,
+            context_window=1000000,
+        ),
+        ModelInfo(
+            name="gemini-1.5-flash",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=True,
+            max_tokens=8192,
+            context_window=1000000,
+        ),
+        ModelInfo(
+            name="llama-3.3-70b-instruct",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=False,
+            max_tokens=4096,
+            context_window=128000,
+        ),
+        ModelInfo(
+            name="qwen2.5-72b-instruct",
+            provider=provider,
+            supports_tools=True,
+            supports_vision=False,
+            max_tokens=4096,
+            context_window=128000,
+        ),
+    ]
+
+
+def _generate(client: OpenAI, input: LLMInput, default_model: str, provider: ProviderType) -> LLMOutput:
+    """Shared generation logic for both Astraflow endpoint variants."""
+    try:
+        params: dict[str, Any] = {
+            "model": input.model or default_model,
+            "messages": [msg.to_dict() for msg in input.messages],
+            "temperature": input.temperature,
+        }
+        if input.max_tokens:
+            params["max_tokens"] = input.max_tokens
+        if input.tools:
+            params["tools"] = [tool.to_dict() for tool in input.tools]
+
+        response = client.chat.completions.create(**params)
+        choice = response.choices[0]
+
+        tool_calls = None
+        if choice.message.tool_calls:
+            tool_calls = [
+                ToolCall(
+                    id=tc.id or "",
+                    name=tc.function.name,
+                    arguments={} if not tc.function.arguments else json.loads(tc.function.arguments),
+                )
+                for tc in choice.message.tool_calls
+            ]
+
+        return LLMOutput(
+            content=choice.message.content or "",
+            tool_calls=tool_calls,
+            model=response.model,
+            usage={
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            },
+            stop_reason=choice.finish_reason,
+        )
+    except Exception as e:
+        msg = str(e)
+        if "401" in msg or "authentication" in msg.lower():
+            raise AuthenticationError(msg, provider=provider) from e
+        if "429" in msg or "rate_limit" in msg.lower():
+            raise RateLimitError(msg, provider=provider) from e
+        if "context" in msg.lower() and "length" in msg.lower():
+            raise ContextLengthError(msg, provider=provider) from e
+        raise
+
+
+class AstraflowProvider(LLMProvider):
+    """Astraflow global endpoint provider (api-us-ca.umodelverse.ai).
+
+    Set ASTRAFLOW_API_KEY in your environment, or pass ``api_key`` explicitly.
+    """
+
+    provider_type = ProviderType.ASTRAFLOW
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        self.client = OpenAI(
+            api_key=api_key or os.environ.get("ASTRAFLOW_API_KEY"),
+            base_url=base_url or _ASTRAFLOW_GLOBAL_BASE_URL,
+        )
+        self._models = _make_models(ProviderType.ASTRAFLOW)
+
+    def generate(self, input: LLMInput) -> LLMOutput:
+        return _generate(self.client, input, self.get_default_model(), ProviderType.ASTRAFLOW)
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return bool(self.client.api_key)
+
+    def get_default_model(self) -> str:
+        return "gpt-4o-mini"
+
+
+class AstraflowCNProvider(LLMProvider):
+    """Astraflow China endpoint provider (api.modelverse.cn).
+
+    Set ASTRAFLOW_CN_API_KEY in your environment, or pass ``api_key`` explicitly.
+    """
+
+    provider_type = ProviderType.ASTRAFLOW_CN
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        self.client = OpenAI(
+            api_key=api_key or os.environ.get("ASTRAFLOW_CN_API_KEY"),
+            base_url=base_url or _ASTRAFLOW_CN_BASE_URL,
+        )
+        self._models = _make_models(ProviderType.ASTRAFLOW_CN)
+
+    def generate(self, input: LLMInput) -> LLMOutput:
+        return _generate(self.client, input, self.get_default_model(), ProviderType.ASTRAFLOW_CN)
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return bool(self.client.api_key)
+
+    def get_default_model(self) -> str:
+        return "gpt-4o-mini"

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -9,12 +9,15 @@ from llm.core.types import ProviderType
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+from llm.providers.astraflow import AstraflowProvider, AstraflowCNProvider
 
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.CLAUDE: ClaudeProvider,
     ProviderType.OPENAI: OpenAIProvider,
     ProviderType.OLLAMA: OllamaProvider,
+    ProviderType.ASTRAFLOW: AstraflowProvider,
+    ProviderType.ASTRAFLOW_CN: AstraflowCNProvider,
 }
 
 


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a fully-integrated LLM provider, following the exact same patterns as the existing `OpenAIProvider`, `ClaudeProvider`, and `OllamaProvider`.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Two endpoints are supported:

| Variant | Env var | Base URL |
|---|---|---|
| Global | `ASTRAFLOW_API_KEY` | `https://api-us-ca.umodelverse.ai/v1` |
| China | `ASTRAFLOW_CN_API_KEY` | `https://api.modelverse.cn/v1` |

Sign up at: https://astraflow.ucloud.cn/

---

## Changes

### New file — `src/llm/providers/astraflow.py`
A new provider module with two classes:
- `AstraflowProvider` — targets the **global** endpoint (`ASTRAFLOW_API_KEY`)
- `AstraflowCNProvider` — targets the **China** endpoint (`ASTRAFLOW_CN_API_KEY`)

Both reuse the OpenAI SDK (Astraflow is OpenAI-compatible), share error-handling and tool-call logic, and expose a representative set of the 200+ available models.

### Modified — `src/llm/core/types.py`
Adds `ASTRAFLOW = "astraflow"` and `ASTRAFLOW_CN = "astraflow_cn"` to `ProviderType`.

### Modified — `src/llm/providers/resolver.py`
- Imports `AstraflowProvider` and `AstraflowCNProvider`
- Registers both in `_PROVIDER_MAP`

### Modified — `src/llm/providers/__init__.py`
Exports `AstraflowProvider` and `AstraflowCNProvider` from the providers package.

### Modified — `.env.example`
Documents `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` with comments.

---

## Usage

```python
from llm.providers import get_provider
from llm.core.types import ProviderType

# Global endpoint
provider = get_provider(ProviderType.ASTRAFLOW)

# China endpoint
provider_cn = get_provider(ProviderType.ASTRAFLOW_CN)

# Or via environment variable
# LLM_PROVIDER=astraflow python ...
```

```bash
# .env
ASTRAFLOW_API_KEY=your-global-key
ASTRAFLOW_CN_API_KEY=your-china-key
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Astraflow as a new LLM provider with both global and China regional endpoints.
  * Users can now configure Astraflow by setting the appropriate API key environment variables for each region.
  * Astraflow provider includes full compatibility with chat completions and supports model management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Astraflow as an OpenAI-compatible LLM provider with global and China endpoints. This lets you use 200+ models through the same provider interface.

- **New Features**
  - Add `AstraflowProvider` (global) and `AstraflowCNProvider` (China).
  - Register in resolver and export from `llm.providers`; add `ASTRAFLOW` and `ASTRAFLOW_CN` to `ProviderType`.
  - Reuse chat, tools, and error handling patterns from existing providers.

- **Migration**
  - Set `ASTRAFLOW_API_KEY` for `https://api-us-ca.umodelverse.ai/v1` or `ASTRAFLOW_CN_API_KEY` for `https://api.modelverse.cn/v1`.
  - Select via `ProviderType.ASTRAFLOW` or `ProviderType.ASTRAFLOW_CN`, or set `LLM_PROVIDER=astraflow`.

<sup>Written for commit 56a296ffdd72c25e9c9569fcec0898a788f9d9e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

