### PR TITLE
docs: fix continuous-learning-v2 plugin quick start

### DIFF
--- a/docs/ja-JP/skills/continuous-learning-v2/SKILL.md
+++ b/docs/ja-JP/skills/continuous-learning-v2/SKILL.md
@@ -97,25 +97,9 @@ source: "session-observation"
 **プラグインとしてインストールした場合**（推奨）：
 
 ```json
-{
-  "hooks": {
-    "PreToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh pre"
-      }]
-    }],
-    "PostToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh post"
-      }]
-    }]
-  }
-}
-```
+プラグインの `hooks/hooks.json` が Claude Code v2.1+ で自動読み込みされるため、`~/.claude/settings.json` に追加の hook 設定は不要です。`observe.sh` はそこで既に登録されています。
+
+以前に `observe.sh` を `~/.claude/settings.json` にコピーした場合は、重複した `PreToolUse` / `PostToolUse` ブロックを削除してください。重複登録は二重実行と `${CLAUDE_PLUGIN_ROOT}` 解決エラーを引き起こします。この変数はプラグイン管理の `hooks/hooks.json` でのみ展開されます。
 
 **`~/.claude/skills`に手動でインストールした場合**：
 
@@ -126,14 +110,14 @@ source: "session-observation"
       "matcher": "*",
       "hooks": [{
         "type": "command",
-        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh pre"
+        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh"
       }]
     }],
     "PostToolUse": [{
       "matcher": "*",
       "hooks": [{
         "type": "command",
-        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh post"
+        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh"
       }]
     }]
   }

--- a/docs/ko-KR/skills/continuous-learning-v2/SKILL.md
+++ b/docs/ko-KR/skills/continuous-learning-v2/SKILL.md
@@ -141,28 +141,11 @@ Use functional patterns over classes when appropriate.
 
 **플러그인으로 설치한 경우** (권장):
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }],
-    "PostToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }]
-  }
-}
-```
+`~/.claude/settings.json`에 추가 hook 블록을 넣지 마세요. Claude Code v2.1+가 플러그인의 `hooks/hooks.json`을 자동으로 로드하며, `observe.sh`는 이미 그곳에 등록되어 있습니다.
 
-**수동으로 `~/.claude/skills`에 설치한 경우**:
+이전에 `observe.sh`를 `~/.claude/settings.json`에 복사했다면 중복된 `PreToolUse` / `PostToolUse` 블록을 제거하세요. 중복 등록은 이중 실행과 `${CLAUDE_PLUGIN_ROOT}` 해석 오류를 일으킵니다. 이 변수는 플러그인 소유 `hooks/hooks.json` 항목에서만 확장됩니다.
+
+**수동으로 `~/.claude/skills`에 설치한 경우**, 아래 내용을 `~/.claude/settings.json`에 추가하세요:
 
 ```json
 {

--- a/docs/tr/skills/continuous-learning-v2/SKILL.md
+++ b/docs/tr/skills/continuous-learning-v2/SKILL.md
@@ -141,28 +141,11 @@ Her proje 12 karakterlik bir hash ID alır (örn. `a1b2c3d4e5f6`). `~/.claude/ho
 
 **Plugin olarak kuruluysa** (önerilen):
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }],
-    "PostToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }]
-  }
-}
-```
+`~/.claude/settings.json` içine ek hook bloğu eklemeyin. Claude Code v2.1+ eklentinin `hooks/hooks.json` dosyasını otomatik yükler; `observe.sh` zaten orada kayıtlıdır.
 
-**`~/.claude/skills` dizinine manuel kuruluysa**:
+Daha önce `observe.sh` satırlarını `~/.claude/settings.json` içine kopyaladıysanız, yinelenen `PreToolUse` / `PostToolUse` bloğunu kaldırın. Yinelenen kayıt hem çift çalıştırmaya yol açar hem de `${CLAUDE_PLUGIN_ROOT}` çözümleme hatası üretir; bu değişken yalnızca eklentiye ait `hooks/hooks.json` girdilerinde genişletilir.
+
+**`~/.claude/skills` dizinine manuel kuruluysa**, aşağıdakini `~/.claude/settings.json` içine ekleyin:
 
 ```json
 {

--- a/docs/zh-CN/skills/continuous-learning-v2/SKILL.md
+++ b/docs/zh-CN/skills/continuous-learning-v2/SKILL.md
@@ -144,28 +144,11 @@ Use functional patterns over classes when appropriate.
 
 **如果作为插件安装**（推荐）：
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }],
-    "PostToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }]
-  }
-}
-```
+不需要在 `~/.claude/settings.json` 中额外添加 hooks。Claude Code v2.1+ 会自动加载插件的 `hooks/hooks.json`，其中已经注册了 `observe.sh`。
 
-**如果手动安装**到 `~/.claude/skills`：
+如果您之前把 `observe.sh` 复制到了 `~/.claude/settings.json`，请删除重复的 `PreToolUse` / `PostToolUse` 配置。重复注册会导致重复执行，并触发 `${CLAUDE_PLUGIN_ROOT}` 解析错误，因为该变量只会在插件自己的 `hooks/hooks.json` 中展开。
+
+**如果手动安装**到 `~/.claude/skills`，请将以下内容添加到 `~/.claude/settings.json`：
 
 ```json
 {

--- a/docs/zh-TW/skills/continuous-learning-v2/SKILL.md
+++ b/docs/zh-TW/skills/continuous-learning-v2/SKILL.md
@@ -92,7 +92,13 @@ source: "session-observation"
 
 ### 1. 啟用觀察 Hooks
 
-新增到你的 `~/.claude/settings.json`：
+**如果作為外掛安裝**（建議）：
+
+不需要在 `~/.claude/settings.json` 中額外加入 hook。Claude Code v2.1+ 會自動載入外掛的 `hooks/hooks.json`，其中已經註冊了 `observe.sh`。
+
+如果你之前把 `observe.sh` 複製到 `~/.claude/settings.json`，請移除重複的 `PreToolUse` / `PostToolUse` 區塊。重複註冊會造成重複執行，並觸發 `${CLAUDE_PLUGIN_ROOT}` 解析錯誤；這個變數只會在外掛自己的 `hooks/hooks.json` 中展開。
+
+**如果手動安裝到 `~/.claude/skills`**，新增到你的 `~/.claude/settings.json`：
 
 ```json
 {
@@ -101,14 +107,14 @@ source: "session-observation"
       "matcher": "*",
       "hooks": [{
         "type": "command",
-        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh pre"
+        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh"
       }]
     }],
     "PostToolUse": [{
       "matcher": "*",
       "hooks": [{
         "type": "command",
-        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh post"
+        "command": "~/.claude/skills/continuous-learning-v2/hooks/observe.sh"
       }]
     }]
   }

--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -138,32 +138,13 @@ Each project gets a 12-character hash ID (e.g., `a1b2c3d4e5f6`). A registry file
 
 ### 1. Enable Observation Hooks
 
-Add to your `~/.claude/settings.json`.
-
 **If installed as a plugin** (recommended):
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }],
-    "PostToolUse": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh"
-      }]
-    }]
-  }
-}
-```
+No extra `settings.json` hook block is required. Claude Code v2.1+ auto-loads the plugin `hooks/hooks.json`, and `observe.sh` is already registered there.
 
-**If installed manually** to `~/.claude/skills`:
+If you previously copied `observe.sh` into `~/.claude/settings.json`, remove that duplicate `PreToolUse` / `PostToolUse` block. Duplicating the plugin hook causes double execution and `${CLAUDE_PLUGIN_ROOT}` resolution errors because that variable is only available inside plugin-managed `hooks/hooks.json` entries.
+
+**If installed manually** to `~/.claude/skills`, add this to your `~/.claude/settings.json`:
 
 ```json
 {

--- a/tests/docs/continuous-learning-v2-docs.test.js
+++ b/tests/docs/continuous-learning-v2-docs.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+const skillDocs = [
+  'skills/continuous-learning-v2/SKILL.md',
+  'docs/zh-CN/skills/continuous-learning-v2/SKILL.md',
+  'docs/tr/skills/continuous-learning-v2/SKILL.md',
+  'docs/ko-KR/skills/continuous-learning-v2/SKILL.md',
+  'docs/ja-JP/skills/continuous-learning-v2/SKILL.md',
+  'docs/zh-TW/skills/continuous-learning-v2/SKILL.md',
+];
+
+console.log('\n=== Testing continuous-learning-v2 install docs ===\n');
+
+for (const relativePath of skillDocs) {
+  const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+  test(`${relativePath} does not tell plugin users to register observe.sh through CLAUDE_PLUGIN_ROOT`, () => {
+    assert.ok(
+      !content.includes('${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/hooks/observe.sh'),
+      'Plugin quick start should not tell users to copy observe.sh into settings.json'
+    );
+  });
+}
+
+const englishSkill = fs.readFileSync(
+  path.join(repoRoot, 'skills/continuous-learning-v2/SKILL.md'),
+  'utf8'
+);
+
+test('English continuous-learning-v2 skill says plugin installs auto-load hooks/hooks.json', () => {
+  assert.ok(englishSkill.includes('auto-loads the plugin `hooks/hooks.json`'));
+});
+
+test('English continuous-learning-v2 skill tells plugin users to remove duplicated settings.json hooks', () => {
+  assert.ok(englishSkill.includes('remove that duplicate `PreToolUse` / `PostToolUse` block'));
+});
+
+if (failed > 0) {
+  console.log(`\nFailed: ${failed}`);
+  process.exit(1);
+}
+
+console.log(`\nPassed: ${passed}`);


### PR DESCRIPTION
## Summary
- fix continuous-learning-v2 plugin quick start docs
- keep manual install hook JSON examples, but remove stale plugin `settings.json` hook guidance
- add a regression test so plugin docs cannot drift back to `${CLAUDE_PLUGIN_ROOT}/.../observe.sh`

## Validation
- node tests/docs/continuous-learning-v2-docs.test.js
- node tests/docs/install-identifiers.test.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified plugin installation instructions—no manual hook configuration needed for Claude Code v2.1+.
  * Added guidance to remove any duplicate hook entries from previous versions to avoid double execution.
  * Clarified manual installation setup steps.
  * Updated documentation across multiple languages (English, Japanese, Korean, Turkish, Simplified Chinese, Traditional Chinese).

* **Tests**
  * Added documentation validation to prevent configuration regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `continuous-learning-v2` quick start by removing stale guidance to add plugin hooks to `~/.claude/settings.json` and clarifying that Claude Code v2.1+ auto-loads the plugin `hooks/hooks.json`.
Manual install steps remain and now use a single `observe.sh` command (no `pre`/`post` args), and a test guards against reintroducing `${CLAUDE_PLUGIN_ROOT}/.../observe.sh` in docs.

<sup>Written for commit 104d7d4cb5cda4cd4c652d51fa57464404b0be92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

