### PR TITLE
feat: add Astraflow provider support (global + China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@
 #   cp .env.example .env
 #   # Then edit .env with your actual values
 
+# ─── Astraflow (UCloud / 优刻得) ──────────────────────────────────────────────
+# OpenAI-compatible platform supporting 200+ models (https://astraflow.ucloud.cn/)
+# Global endpoint:  https://api-us-ca.umodelverse.ai/v1
+ASTRAFLOW_API_KEY=
+# China endpoint:   https://api.modelverse.cn/v1
+ASTRAFLOW_CN_API_KEY=
+
 # ─── Anthropic ────────────────────────────────────────────────────────────────
 # Your Anthropic API key (https://console.anthropic.com)
 ANTHROPIC_API_KEY=

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -18,6 +18,8 @@ class ProviderType(str, Enum):
     CLAUDE = "claude"
     OPENAI = "openai"
     OLLAMA = "ollama"
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow_cn"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -3,12 +3,15 @@
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+from llm.providers.astraflow import AstraflowProvider, AstraflowCNProvider
 from llm.providers.resolver import get_provider, register_provider
 
 __all__ = (
     "ClaudeProvider",
     "OpenAIProvider",
     "OllamaProvider",
+    "AstraflowProvider",
+    "AstraflowCNProvider",
     "get_provider",
     "register_provider",
 )

--- a/src/llm/providers/astraflow.py
+++ b/src/llm/providers/astraflow.py
@@ -1,0 +1,205 @@
+"""Astraflow provider adapter (OpenAI-compatible, UCloud / 优刻得).
+
+Global endpoint : https://api-us-ca.umodelverse.ai/v1  (env: ASTRAFLOW_API_KEY)
+China endpoint  : https://api.modelverse.cn/v1         (env: ASTRAFLOW_CN_API_KEY)
+Sign up         : https://astraflow.ucloud.cn/
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+from llm.core.interface import (
+    AuthenticationError,
+    ContextLengthError,
+    LLMProvider,
+    RateLimitError,
+)
+from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
+
+_GLOBAL_BASE_URL = "https://api-us-ca.umodelverse.ai/v1"
+_CN_BASE_URL = "https://api.modelverse.cn/v1"
+
+# Popular models available on the Astraflow platform.
+# Both provider variants expose the same catalogue; the only difference is
+# the endpoint and API-key environment variable used.
+_ASTRAFLOW_MODELS: list[dict[str, Any]] = [
+    {
+        "name": "gpt-4o",
+        "supports_tools": True,
+        "supports_vision": True,
+        "max_tokens": 4096,
+        "context_window": 128000,
+    },
+    {
+        "name": "gpt-4o-mini",
+        "supports_tools": True,
+        "supports_vision": True,
+        "max_tokens": 4096,
+        "context_window": 128000,
+    },
+    {
+        "name": "claude-3-5-sonnet-20241022",
+        "supports_tools": True,
+        "supports_vision": True,
+        "max_tokens": 8192,
+        "context_window": 200000,
+    },
+    {
+        "name": "claude-3-5-haiku-20241022",
+        "supports_tools": True,
+        "supports_vision": False,
+        "max_tokens": 8192,
+        "context_window": 200000,
+    },
+    {
+        "name": "deepseek-chat",
+        "supports_tools": True,
+        "supports_vision": False,
+        "max_tokens": 4096,
+        "context_window": 64000,
+    },
+    {
+        "name": "deepseek-reasoner",
+        "supports_tools": False,
+        "supports_vision": False,
+        "max_tokens": 8000,
+        "context_window": 64000,
+    },
+    {
+        "name": "gemini-2.0-flash",
+        "supports_tools": True,
+        "supports_vision": True,
+        "max_tokens": 8192,
+        "context_window": 1000000,
+    },
+    {
+        "name": "llama-3.3-70b-instruct",
+        "supports_tools": True,
+        "supports_vision": False,
+        "max_tokens": 4096,
+        "context_window": 128000,
+    },
+]
+
+
+def _build_models(provider: ProviderType) -> list[ModelInfo]:
+    return [
+        ModelInfo(
+            name=m["name"],
+            provider=provider,
+            supports_tools=m["supports_tools"],
+            supports_vision=m["supports_vision"],
+            max_tokens=m["max_tokens"],
+            context_window=m["context_window"],
+        )
+        for m in _ASTRAFLOW_MODELS
+    ]
+
+
+def _make_generate(provider_type: ProviderType):  # noqa: ANN001
+    """Return a generate() implementation bound to *provider_type*."""
+
+    def generate(self: "_AstraflowBase", input: LLMInput) -> LLMOutput:  # type: ignore[name-defined]
+        try:
+            params: dict[str, Any] = {
+                "model": input.model or self.get_default_model(),
+                "messages": [msg.to_dict() for msg in input.messages],
+                "temperature": input.temperature,
+            }
+            if input.max_tokens:
+                params["max_tokens"] = input.max_tokens
+            if input.tools:
+                params["tools"] = [tool.to_dict() for tool in input.tools]
+
+            response = self.client.chat.completions.create(**params)
+            choice = response.choices[0]
+
+            tool_calls = None
+            if choice.message.tool_calls:
+                tool_calls = [
+                    ToolCall(
+                        id=tc.id or "",
+                        name=tc.function.name,
+                        arguments=({} if not tc.function.arguments else json.loads(tc.function.arguments)),
+                    )
+                    for tc in choice.message.tool_calls
+                ]
+
+            return LLMOutput(
+                content=choice.message.content or "",
+                tool_calls=tool_calls,
+                model=response.model,
+                usage={
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                },
+                stop_reason=choice.finish_reason,
+            )
+        except Exception as e:
+            msg = str(e)
+            if "401" in msg or "authentication" in msg.lower():
+                raise AuthenticationError(msg, provider=provider_type) from e
+            if "429" in msg or "rate_limit" in msg.lower():
+                raise RateLimitError(msg, provider=provider_type) from e
+            if "context" in msg.lower() and "length" in msg.lower():
+                raise ContextLengthError(msg, provider=provider_type) from e
+            raise
+
+    return generate
+
+
+class _AstraflowBase(LLMProvider):
+    """Shared base for both Astraflow endpoint variants."""
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return bool(self.client.api_key)
+
+    def get_default_model(self) -> str:
+        return "gpt-4o-mini"
+
+
+class AstraflowProvider(_AstraflowBase):
+    """Astraflow global endpoint (https://api-us-ca.umodelverse.ai/v1).
+
+    Requires the environment variable ``ASTRAFLOW_API_KEY``.
+    Sign up at https://astraflow.ucloud.cn/
+    """
+
+    provider_type = ProviderType.ASTRAFLOW
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        self.client = OpenAI(
+            api_key=api_key or os.environ.get("ASTRAFLOW_API_KEY"),
+            base_url=base_url or _GLOBAL_BASE_URL,
+        )
+        self._models = _build_models(ProviderType.ASTRAFLOW)
+
+    generate = _make_generate(ProviderType.ASTRAFLOW)
+
+
+class AstraflowCNProvider(_AstraflowBase):
+    """Astraflow China endpoint (https://api.modelverse.cn/v1).
+
+    Requires the environment variable ``ASTRAFLOW_CN_API_KEY``.
+    Sign up at https://astraflow.ucloud.cn/
+    """
+
+    provider_type = ProviderType.ASTRAFLOW_CN
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        self.client = OpenAI(
+            api_key=api_key or os.environ.get("ASTRAFLOW_CN_API_KEY"),
+            base_url=base_url or _CN_BASE_URL,
+        )
+        self._models = _build_models(ProviderType.ASTRAFLOW_CN)
+
+    generate = _make_generate(ProviderType.ASTRAFLOW_CN)

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -9,12 +9,15 @@ from llm.core.types import ProviderType
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+from llm.providers.astraflow import AstraflowProvider, AstraflowCNProvider
 
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.CLAUDE: ClaudeProvider,
     ProviderType.OPENAI: OpenAIProvider,
     ProviderType.OLLAMA: OllamaProvider,
+    ProviderType.ASTRAFLOW: AstraflowProvider,
+    ProviderType.ASTRAFLOW_CN: AstraflowCNProvider,
 }
 
 


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a first-class LLM provider, following the exact same patterns used by the existing `OpenAIProvider`, `ClaudeProvider`, and `OllamaProvider`.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, with both a global endpoint and a China-region endpoint.

---

## Changes

### `src/llm/core/types.py`
- Adds `ASTRAFLOW = "astraflow"` and `ASTRAFLOW_CN = "astraflow_cn"` to the `ProviderType` enum.

### `src/llm/providers/astraflow.py` *(new file)*
- `AstraflowProvider` — targets the **global** endpoint (`https://api-us-ca.umodelverse.ai/v1`) using `ASTRAFLOW_API_KEY`.
- `AstraflowCNProvider` — targets the **China** endpoint (`https://api.modelverse.cn/v1`) using `ASTRAFLOW_CN_API_KEY`.
- Both extend the OpenAI-compatible client (same `openai.OpenAI` SDK, just a different `base_url`).
- Pre-registered model catalogue includes popular models available on the platform.

### `src/llm/providers/__init__.py`
- Exports `AstraflowProvider` and `AstraflowCNProvider`.

### `src/llm/providers/resolver.py`
- Registers both providers in `_PROVIDER_MAP`.

### `.env.example`
- Documents `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY`.

---

## Usage

```python
import os
os.environ["ASTRAFLOW_API_KEY"] = "sk-..."

from llm.providers import get_provider
from llm.core.types import ProviderType, LLMInput, Message, Role

provider = get_provider(ProviderType.ASTRAFLOW)
response = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="Hello!")]))
print(response.content)
```

Or via environment variable:
```bash
export LLM_PROVIDER=astraflow
export ASTRAFLOW_API_KEY=sk-...
```

---

## References
- Sign up: https://astraflow.ucloud.cn/
- Global API base: `https://api-us-ca.umodelverse.ai/v1`
- China API base:  `https://api.modelverse.cn/v1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Astraflow LLM provider with global and China endpoint options.
  * New optional environment variables for Astraflow API key configuration to enable the new provider functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Astraflow as an OpenAI‑compatible LLM provider with global and China endpoints. Lets users switch to Astraflow and use its model catalog with the existing chat API.

- **New Features**
  - Added `AstraflowProvider` (global `https://api-us-ca.umodelverse.ai/v1`) and `AstraflowCNProvider` (China `https://api.modelverse.cn/v1`) built on `openai`; default model `gpt-4o-mini`.
  - Introduced `ProviderType.ASTRAFLOW` and `ProviderType.ASTRAFLOW_CN`; wired into `_PROVIDER_MAP` and exported from `llm.providers`.
  - Seeded model catalog (e.g., GPT‑4o, Claude 3.5, DeepSeek, Gemini 2.0, Llama 3.3) with tool/vision support and usage mapping; documented `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` in `.env.example`.

- **Migration**
  - Set `ASTRAFLOW_API_KEY` (global) or `ASTRAFLOW_CN_API_KEY` (China).
  - Select `astraflow` or `astraflow_cn` via `ProviderType` or `LLM_PROVIDER`.

<sup>Written for commit cdccea9d5bb3a01e655c54ecbe17356285d4e9ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

