### PR TITLE
docs(tr): sync outdated Quick Start sections with English README

### DIFF
--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -120,13 +120,25 @@ Bu repository yalnızca ham kodu içerir. Rehberler her şeyi açıklıyor.
 
 ### Adım 1: Plugin'i Kurun
 
+> NOTE: Plugin rahat bir yoldur, ancak Claude Code sürümünüz kendi host ettiğimiz marketplace girişlerini çözmekte zorlanıyorsa, aşağıdaki OSS installer hâlâ en güvenilir yoldur.
+
 ```bash
 # Marketplace ekle
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
 
 # Plugin'i kur
-/plugin install everything-claude-code
+/plugin install everything-claude-code@everything-claude-code
 ```
+
+### İsimlendirme + Geçiş Notu
+
+ECC'nin artık üç ayrı kamuya açık tanımlayıcısı var ve bunlar birbirinin yerine kullanılamaz:
+
+- GitHub kaynak deposu: `affaan-m/everything-claude-code`
+- Claude marketplace/plugin tanımlayıcısı: `everything-claude-code@everything-claude-code`
+- npm paketi: `ecc-universal`
+
+Bu kasıtlı bir tercih. Anthropic marketplace/plugin kurulumları kanonik plugin tanımlayıcısını anahtar olarak kullanıyor; bu yüzden ECC, listeleme adı, `/plugin install`, `/plugin list` ve depo dokümanlarını tek bir kamuya açık kurulum yüzeyi olan `everything-claude-code@everything-claude-code` etrafında standart hale getirdi. Eski paylaşımlarda kısa lakap hâlâ görünebilir; o kısaltma artık kullanılmıyor. Ayrıca npm paketi `ecc-universal` olarak kaldı; bu nedenle npm kurulumu ile marketplace kurulumu bilerek farklı isimler kullanıyor.
 
 ### Adım 2: Rule'ları Kurun (Gerekli)
 
@@ -163,6 +175,9 @@ Manuel kurulum talimatları için `rules/` klasöründeki README'ye bakın.
 ### Adım 3: Kullanmaya Başlayın
 
 ```bash
+# Asıl iş akışı yüzeyi skill'lerdir.
+# ECC commands/ dizininden taşınırken mevcut slash komut adları da çalışmaya devam eder.
+
 # Bir command deneyin (plugin kurulumu namespace'li form kullanır)
 /ecc:plan "Kullanıcı kimlik doğrulaması ekle"
 
@@ -173,7 +188,38 @@ Manuel kurulum talimatları için `rules/` klasöründeki README'ye bakın.
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-**Bu kadar!** Artık 28 agent, 116 skill ve 59 command'a erişiminiz var.
+**Bu kadar!** Artık 48 agent, 183 skill ve 79 legacy command shim'ine erişiminiz var.
+
+### Dashboard GUI
+
+ECC bileşenlerini görsel olarak keşfetmek için masaüstü dashboard'u başlatın:
+
+```bash
+npm run dashboard
+# veya
+python3 ./ecc_dashboard.py
+```
+
+**Özellikler:**
+- Sekmeli arayüz: Agents, Skills, Commands, Rules, Settings
+- Koyu/Açık tema geçişi
+- Yazı tipi özelleştirme (aile & boyut)
+- Başlıkta ve görev çubuğunda proje logosu
+- Tüm bileşenler arasında arama/filtreleme
+
+### Multi-model command'ları ek kurulum gerektirir
+
+> WARNING: `multi-*` command'ları yukarıdaki temel plugin/rule kurulumuna **dahil değildir**.
+>
+> `/multi-plan`, `/multi-execute`, `/multi-backend`, `/multi-frontend` ve `/multi-workflow` komutlarını kullanmak için `ccg-workflow` runtime'ını da kurmanız gerekir.
+>
+> `npx ccg-workflow` ile başlatın.
+>
+> Bu runtime, söz konusu komutların beklediği harici bağımlılıkları sağlar:
+> - `~/.claude/bin/codeagent-wrapper`
+> - `~/.claude/.ccg/prompts/*`
+>
+> `ccg-workflow` olmadan bu `multi-*` command'ları düzgün çalışmaz.
 
 ---
 


### PR DESCRIPTION
## Summary

Brings the Turkish `docs/tr/README.md` Quick Start into alignment with the current English README by inserting missing sections while preserving existing Turkish wording.

> **Note:** This is an **AI-assisted translation**. Native-speaker review welcome — especially the 'İsimlendirme + Geçiş Notu' paragraph and terminology choices around *marketplace*, *namespace*, and *runtime*.

## What changed

**Quick Start**
- Step 1: updated `/plugin install everything-claude-code` → `/plugin install everything-claude-code@everything-claude-code`, plus NOTE about plugin vs OSS installer
- New subsection: **İsimlendirme + Geçiş Notu** — explains the three public identifiers (repo / marketplace-plugin / npm)
- Step 3: component counts updated `28 agent / 116 skill / 59 command` → `48 agent / 183 skill / 79 legacy command shim`, plus skills-first framing
- New subsection: **Dashboard GUI** (Tkinter)
- New subsection: **Multi-model command'ları ek kurulum gerektirir** — `ccg-workflow` runtime warning

**What's New** was already up-to-date with v1.10.0 and v1.9.0 entries — not touched.

## Scope intentionally limited

Existing Turkish paragraphs preserved verbatim. No restructuring of working sections. Larger English-only sections (Cursor/Codex/OpenCode/Cross-Tool Feature Parity/Background/Community Projects) left for follow-up PRs.

## Test plan

- [x] Markdown renders on GitHub preview
- [x] Relative links resolve from `docs/tr/`
- [x] No existing Turkish sentences reworded
- [x] Diff is +48 / -2 lines, additive
- [ ] Native-speaker terminology review (welcome from community)

## Related

- Companion PRs: #1560 (ko-KR), #1561 (ja-JP), #1562 (zh-CN), #1563 (zh-TW)
- Context issue: #1549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation instructions with clarified marketplace identifier.
  * Added guidance on plugin identifiers and legacy alias transition.
  * Updated available functionality and feature information.
  * Documented optional dashboard UI support.
  * Added installation requirements for multi-command runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `docs/tr/README.md` Quick Start to match the English README. Adds missing sections (naming/migration, Dashboard GUI, multi‑model runtime), fixes the plugin install command, and refreshes component counts.

- **New Features**
  - Added "İsimlendirme + Geçiş Notu" clarifying identifiers: `affaan-m/everything-claude-code`, `everything-claude-code@everything-claude-code`, `ecc-universal`.
  - Added Dashboard GUI instructions (`npm run dashboard` or `python3 ./ecc_dashboard.py`).
  - Updated Step 3 with skills‑first guidance and new counts (48 agents, 183 skills, 79 legacy command shims).

- **Migration**
  - Use namespaced install: `/plugin install everything-claude-code@everything-claude-code` (fallback to OSS installer if marketplace resolve fails).
  - `multi-*` commands require `ccg-workflow` (`npx ccg-workflow`) to provide `~/.claude/bin/codeagent-wrapper` and `~/.claude/.ccg/prompts/*`.

<sup>Written for commit d470a267852153d37953f6b9384de0ff09db54ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

