### PR TITLE
docs(pt-BR): sync outdated Quick Start sections with English README

### DIFF
--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -119,6 +119,8 @@ Comece em menos de 2 minutos:
 
 ### Passo 1: Instalar o Plugin
 
+> NOTE: O plugin é conveniente, mas se sua build do Claude Code tiver dificuldade para resolver entradas de marketplace auto-hospedadas, o instalador OSS abaixo ainda é o caminho mais confiável.
+
 ```bash
 # Adicionar marketplace
 /plugin marketplace add https://github.com/affaan-m/everything-claude-code
@@ -126,6 +128,16 @@ Comece em menos de 2 minutos:
 # Instalar plugin
 /plugin install everything-claude-code@everything-claude-code
 ```
+
+### Observação sobre Nomenclatura + Migração
+
+O ECC agora possui três identificadores públicos e eles não são intercambiáveis:
+
+- Repositório fonte no GitHub: `affaan-m/everything-claude-code`
+- Identificador de marketplace/plugin do Claude: `everything-claude-code@everything-claude-code`
+- Pacote npm: `ecc-universal`
+
+Isso é intencional. As instalações de marketplace/plugin da Anthropic são indexadas por um identificador canônico de plugin, portanto o ECC padronizou o nome da listagem, `/plugin install`, `/plugin list` e a documentação do repositório em uma única superfície pública de instalação: `everything-claude-code@everything-claude-code`. Publicações antigas ainda podem mostrar o apelido curto anterior; essa abreviação está descontinuada. Separadamente, o pacote npm permaneceu como `ecc-universal`, então instalações via npm e via marketplace intencionalmente usam nomes diferentes.
 
 ### Passo 2: Instalar as Regras (Obrigatório)
 
@@ -160,6 +172,9 @@ npx ecc-install typescript
 ### Passo 3: Começar a Usar
 
 ```bash
+# Skills são a superfície principal de workflow.
+# Os nomes de slash commands existentes continuam funcionando enquanto o ECC migra de commands/.
+
 # Experimente um comando (a instalação do plugin usa forma com namespace)
 /ecc:plan "Adicionar autenticação de usuário"
 
@@ -170,7 +185,38 @@ npx ecc-install typescript
 /plugin list everything-claude-code@everything-claude-code
 ```
 
-**Pronto!** Você agora tem acesso a 28 agentes, 116 skills e 59 comandos.
+**Pronto!** Você agora tem acesso a 48 agentes, 183 skills e 79 legacy command shims.
+
+### Dashboard GUI
+
+Inicie o dashboard desktop para explorar visualmente os componentes do ECC:
+
+```bash
+npm run dashboard
+# ou
+python3 ./ecc_dashboard.py
+```
+
+**Recursos:**
+- Interface com abas: Agents, Skills, Commands, Rules, Settings
+- Alternância de tema claro/escuro
+- Personalização de fonte (família & tamanho)
+- Logo do projeto no cabeçalho e na barra de tarefas
+- Busca/filtro em todos os componentes
+
+### Comandos multi-modelo exigem configuração adicional
+
+> WARNING: Os comandos `multi-*` **não** estão incluídos na instalação básica de plugin/regras acima.
+>
+> Para usar `/multi-plan`, `/multi-execute`, `/multi-backend`, `/multi-frontend` e `/multi-workflow`, você também precisa instalar o runtime `ccg-workflow`.
+>
+> Inicialize com `npx ccg-workflow`.
+>
+> Esse runtime fornece as dependências externas que esses comandos esperam:
+> - `~/.claude/bin/codeagent-wrapper`
+> - `~/.claude/.ccg/prompts/*`
+>
+> Sem `ccg-workflow`, esses comandos `multi-*` não funcionarão corretamente.
 
 ---
 


### PR DESCRIPTION
## Summary

Brings the Brazilian Portuguese `docs/pt-BR/README.md` Quick Start into alignment with the current English README by inserting missing sections while preserving existing Portuguese wording.

> **Note:** This is an **AI-assisted translation**. Native-speaker review welcome — especially the 'Observação sobre Nomenclatura + Migração' paragraph and terminology choices around *marketplace*, *namespace*, and *runtime*.

## What changed

**Quick Start**
- Step 1: added NOTE about plugin vs OSS installer path
- New subsection: **Observação sobre Nomenclatura + Migração** — explains the three public identifiers (repo / marketplace-plugin / npm)
- Step 3: component counts updated `28 agentes / 116 skills / 59 comandos` → `48 agentes / 183 skills / 79 legacy command shims`, plus skills-first framing
- New subsection: **Dashboard GUI** (Tkinter)
- New subsection: **Comandos multi-modelo exigem configuração adicional** — `ccg-workflow` runtime warning

**What's New** was already up-to-date with v1.10.0/v1.9.0/v1.8.0 entries, and Step 1 command was already namespaced — not touched.

## Scope intentionally limited

Existing Portuguese paragraphs preserved verbatim. No restructuring of working sections. Larger English-only sections (Cursor/Codex/OpenCode/Cross-Tool Feature Parity/Background/Community Projects) left for follow-up PRs.

## Test plan

- [x] Markdown renders on GitHub preview
- [x] Relative links resolve from `docs/pt-BR/`
- [x] No existing Portuguese sentences reworded
- [x] Diff is +47 / -1 lines, additive
- [ ] Native-speaker terminology review (welcome from community)

## Related

- Companion PRs: #1560 (ko-KR), #1561 (ja-JP), #1562 (zh-CN), #1563 (zh-TW), #1564 (tr)
- Context issue: #1549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated Portuguese documentation with installation guidance**, including clarifications on identifier usage across platforms and deprecation notices.
* **Added Dashboard GUI section** documenting launch commands and available capabilities.
* **Updated Getting Started section** emphasizing primary workflow surface and command compatibility during migration.
* **Documented command availability** and runtime requirements for extended functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the Brazilian Portuguese Quick Start with the English README by adding missing sections, updating counts, and clarifying installation paths and runtime requirements.

- **New Features**
  - Added "Dashboard GUI" instructions (`npm run dashboard`, `python3 ./ecc_dashboard.py`).
  - Updated Step 3 with skills-first guidance and new counts: 48 agents, 183 skills, 79 legacy command shims.
  - Added a NOTE on plugin vs OSS installer when marketplace resolution fails.

- **Migration**
  - Added naming/migration note on the three public identifiers: repo `affaan-m/everything-claude-code`, plugin `everything-claude-code@everything-claude-code`, npm `ecc-universal`.
  - Clarified that `multi-*` commands require the `ccg-workflow` runtime and aren’t included in the base plugin install.

<sup>Written for commit 34b5ca60c2397cb8f1eddaef4ee6b47d1de464c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

