### PR TITLE
fix(hooks): bypass gateguard friction gates inside subagent invocations (#1548)

### DIFF
--- a/docs/fixes/HOOK-FIX-20260421-ADDENDUM.md
+++ b/docs/fixes/HOOK-FIX-20260421-ADDENDUM.md
@@ -87,9 +87,9 @@ hook command が `"C:\Program Files\Git\bin\bash.exe" "C:\Users\...\wrapper.sh"`
 ### 回避策
 
 第1トークンを bash.exe のフルパス＋スペース付きパスにしないこと：
-1. ✅ `bash` （PATH 解決の単一トークン）— 夜fix / hooks.json パターン
-2. ✅ `.sh` 直接パス（Claude Code の .sh ハンドリングに依存）— 朝fix
-3. ❌ `"C:\Program Files\Git\bin\bash.exe" "<path>"` — 1トークン目が quoted で空白込み
+1. PASS: `bash` （PATH 解決の単一トークン）— 夜fix / hooks.json パターン
+2. PASS: `.sh` 直接パス（Claude Code の .sh ハンドリングに依存）— 朝fix
+3. FAIL: `"C:\Program Files\Git\bin\bash.exe" "<path>"` — 1トークン目が quoted で空白込み
 
 ## 結論
 

--- a/docs/fixes/HOOK-FIX-20260421-ADDENDUM.md
+++ b/docs/fixes/HOOK-FIX-20260421-ADDENDUM.md
@@ -86,6 +86,14 @@ hook command が `"C:\Program Files\Git\bin\bash.exe" "C:\Users\...\wrapper.sh"`
 
 ### 回避策
 
+<!--
+  Note: this list originally used check-mark (U+2705) and
+  cross-mark (U+274C) emoji, but the repo-wide check-unicode-safety
+  CI rejects those codepoints. PR #1567 (gateguard subagent fix)
+  was blocked by these pre-existing violations, so they are
+  replaced with plain-text PASS/FAIL to unblock CI. Not a content
+  change - semantics are identical.
+-->
 第1トークンを bash.exe のフルパス＋スペース付きパスにしないこと：
 1. PASS: `bash` （PATH 解決の単一トークン）— 夜fix / hooks.json パターン
 2. PASS: `.sh` 直接パス（Claude Code の .sh ハンドリングに依存）— 朝fix

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -328,19 +328,38 @@ function routineBashMsg() {
 
 // --- Subagent detection ---
 //
-// Claude Code's hook payload includes `parent_tool_use_id` for tool calls
-// spawned inside a Task/Agent subagent. Top-level tool calls have no such
-// parent. When a subagent is present, the main session has already satisfied
-// the fact-forcing gate for the user's request — re-gating every subagent
-// produces pure friction (see #1548) without adding any safety value.
-// Destructive Bash remains gated even in subagent context (safety gate,
-// not a friction gate).
+// Claude Code's hook payload carries `agent_id` (with `agent_type`) when the
+// hook fires from within a Task/Agent subagent. Per the documented hook
+// schema: "Present only when the hook fires from within a subagent (e.g.,
+// a tool called by an AgentTool worker). Absent for the main thread, even
+// in --agent sessions. Use this field (not agent_type) to distinguish
+// subagent calls from main-thread calls." The rest of this repo already
+// keys off `agent_id` for the same purpose (see
+// skills/continuous-learning-v2/hooks/observe.sh and tests/hooks/hooks.test.js).
+//
+// Some internal Claude Code stream events carry `parent_tool_use_id`
+// instead. We check it as a defensive fallback in case a future hook
+// payload surfaces that field, but the canonical documented signal is
+// `agent_id`.
+//
+// When a subagent is detected, the main session has already satisfied the
+// first-touch fact-forcing gate for the user's request, so re-gating
+// Edit/Write/MultiEdit on the subagent's first touch of each file produces
+// pure friction (see #1548) without adding safety value. Bash (both
+// routine AND destructive) stays gated in subagent context: the routine-
+// Bash gate is the containment net for destructive commands that slip
+// past the narrow DESTRUCTIVE_BASH regex (rm -f, mkfs, curl|sh, etc.).
 
 function isSubagentInvocation(data) {
   if (!data || typeof data !== 'object') {
     return false;
   }
-  const candidates = [data.parent_tool_use_id, data.parentToolUseId];
+  const candidates = [
+    data.agent_id,
+    data.agentId,
+    data.parent_tool_use_id,
+    data.parentToolUseId
+  ];
   for (const candidate of candidates) {
     if (typeof candidate === 'string' && candidate.trim()) {
       return true;
@@ -384,18 +403,25 @@ function run(rawInput) {
 
   // Subagents (Task/Agent tool) inherit the user's instruction from the parent
   // session, which has already satisfied the fact-forcing gate. Bypass the
-  // friction gates for subagent invocations (see #1548). Destructive Bash is
-  // still gated below as a safety check, regardless of subagent context.
+  // first-touch file gates (Edit/Write/MultiEdit) for subagents (see #1548).
+  // Bash stays fully gated in subagent context: the DESTRUCTIVE_BASH regex
+  // is narrow, so the routine-Bash gate is the containment net for commands
+  // like `rm -f`, `mkfs`, `curl | sh`, `chmod -R 777 /`, redirects to /etc,
+  // etc. that would otherwise get unlimited silent passes in a subagent.
   const inSubagent = isSubagentInvocation(data);
 
   if (toolName === 'Edit' || toolName === 'Write') {
-    if (inSubagent) {
-      return rawInput; // allow — parent session already gated
-    }
-
     const filePath = toolInput.file_path || '';
+    // Settings-file writes are handled by other validators, not this
+    // fact-forcing gate. Keep this pass-through at the top — running it
+    // before the subagent bypass preserves the exact same control-flow
+    // shape the top-level path already had.
     if (!filePath || isClaudeSettingsPath(filePath)) {
       return rawInput; // allow
+    }
+
+    if (inSubagent) {
+      return rawInput; // allow — parent session already gated
     }
 
     if (!isChecked(filePath)) {
@@ -439,10 +465,8 @@ function run(rawInput) {
       return rawInput; // allow retry after facts presented
     }
 
-    if (inSubagent) {
-      return rawInput; // allow — parent session already gated the routine-bash intent
-    }
-
+    // Note: no subagent bypass for routine Bash. See comment above —
+    // DESTRUCTIVE_BASH is narrow and routine-Bash is the containment net.
     if (!isChecked(ROUTINE_BASH_SESSION_KEY)) {
       markChecked(ROUTINE_BASH_SESSION_KEY);
       return denyResult(routineBashMsg());

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -326,6 +326,29 @@ function routineBashMsg() {
   ].join('\n');
 }
 
+// --- Subagent detection ---
+//
+// Claude Code's hook payload includes `parent_tool_use_id` for tool calls
+// spawned inside a Task/Agent subagent. Top-level tool calls have no such
+// parent. When a subagent is present, the main session has already satisfied
+// the fact-forcing gate for the user's request — re-gating every subagent
+// produces pure friction (see #1548) without adding any safety value.
+// Destructive Bash remains gated even in subagent context (safety gate,
+// not a friction gate).
+
+function isSubagentInvocation(data) {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const candidates = [data.parent_tool_use_id, data.parentToolUseId];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // --- Deny helper ---
 
 function denyResult(reason) {
@@ -359,7 +382,17 @@ function run(rawInput) {
   const TOOL_MAP = { edit: 'Edit', write: 'Write', multiedit: 'MultiEdit', bash: 'Bash' };
   const toolName = TOOL_MAP[rawToolName.toLowerCase()] || rawToolName;
 
+  // Subagents (Task/Agent tool) inherit the user's instruction from the parent
+  // session, which has already satisfied the fact-forcing gate. Bypass the
+  // friction gates for subagent invocations (see #1548). Destructive Bash is
+  // still gated below as a safety check, regardless of subagent context.
+  const inSubagent = isSubagentInvocation(data);
+
   if (toolName === 'Edit' || toolName === 'Write') {
+    if (inSubagent) {
+      return rawInput; // allow — parent session already gated
+    }
+
     const filePath = toolInput.file_path || '';
     if (!filePath || isClaudeSettingsPath(filePath)) {
       return rawInput; // allow
@@ -374,6 +407,10 @@ function run(rawInput) {
   }
 
   if (toolName === 'MultiEdit') {
+    if (inSubagent) {
+      return rawInput; // allow — parent session already gated
+    }
+
     const edits = toolInput.edits || [];
     for (const edit of edits) {
       const filePath = edit.file_path || '';
@@ -392,13 +429,18 @@ function run(rawInput) {
     }
 
     if (DESTRUCTIVE_BASH.test(command)) {
-      // Gate destructive commands on first attempt; allow retry after facts presented
+      // Gate destructive commands on first attempt; allow retry after facts presented.
+      // Safety gate: applies in both top-level and subagent contexts.
       const key = '__destructive__' + crypto.createHash('sha256').update(command).digest('hex').slice(0, 16);
       if (!isChecked(key)) {
         markChecked(key);
         return denyResult(destructiveBashMsg());
       }
       return rawInput; // allow retry after facts presented
+    }
+
+    if (inSubagent) {
+      return rawInput; // allow — parent session already gated the routine-bash intent
     }
 
     if (!isChecked(ROUTINE_BASH_SESSION_KEY)) {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -528,153 +528,6 @@ function runTests() {
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('current instruction'));
   })) passed++; else failed++;
 
-  // --- Tests 20-25: subagent context bypasses friction gates (issue #1548) ---
-  //
-  // Subagent invocations (Task/Agent tool) carry `parent_tool_use_id` in the
-  // hook payload. The main session has already satisfied the fact-forcing gate
-  // for the user's request, so re-gating every subagent tool call is pure
-  // friction — especially on Linux where subagents can end up with a different
-  // session_id and therefore a fresh, empty state file. Friction gates
-  // (routine Bash, Edit/Write/MultiEdit first-touch) bypass in subagent
-  // context; destructive Bash remains gated as a safety check.
-
-  // --- Test 20: subagent routine Bash is not gated even with a fresh session_id ---
-  clearState();
-  if (test('allows subagent routine Bash without gating (parent_tool_use_id set)', () => {
-    const input = {
-      tool_name: 'Bash',
-      tool_input: { command: 'pwd' },
-      session_id: 'subagent-fresh-session',
-      parent_tool_use_id: 'toolu_parent_01'
-    };
-    const result = runBashHook(input, {
-      CLAUDE_SESSION_ID: '',
-      ECC_SESSION_ID: '',
-    });
-    assert.strictEqual(result.code, 0, 'exit code should be 0');
-    const output = parseOutput(result.stdout);
-    assert.ok(output, 'should produce valid JSON output');
-    if (output.hookSpecificOutput) {
-      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
-        'subagent routine Bash must not be gated');
-    } else {
-      assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
-    }
-  })) passed++; else failed++;
-
-  // --- Test 21: subagent destructive Bash is STILL gated (safety gate) ---
-  clearState();
-  if (test('gates subagent destructive Bash for safety (parent_tool_use_id set)', () => {
-    const input = {
-      tool_name: 'Bash',
-      tool_input: { command: 'rm -rf /tmp/demo-path' },
-      session_id: 'subagent-fresh-session',
-      parent_tool_use_id: 'toolu_parent_02'
-    };
-    const result = runBashHook(input, {
-      CLAUDE_SESSION_ID: '',
-      ECC_SESSION_ID: '',
-    });
-    const output = parseOutput(result.stdout);
-    assert.ok(output, 'should produce JSON output');
-    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
-      'destructive Bash must still be gated in subagent context');
-    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
-  })) passed++; else failed++;
-
-  // --- Test 22: subagent Edit is not gated ---
-  clearState();
-  if (test('allows subagent Edit without gating (parent_tool_use_id set)', () => {
-    const input = {
-      tool_name: 'Edit',
-      tool_input: { file_path: '/src/subagent-touched.js', old_string: 'a', new_string: 'b' },
-      session_id: 'subagent-fresh-session',
-      parent_tool_use_id: 'toolu_parent_03'
-    };
-    const result = runHook(input, {
-      CLAUDE_SESSION_ID: '',
-      ECC_SESSION_ID: '',
-    });
-    const output = parseOutput(result.stdout);
-    assert.ok(output, 'should produce valid JSON output');
-    if (output.hookSpecificOutput) {
-      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
-        'subagent Edit must not be gated');
-    } else {
-      assert.strictEqual(output.tool_name, 'Edit', 'pass-through should preserve input');
-    }
-  })) passed++; else failed++;
-
-  // --- Test 23: subagent MultiEdit is not gated ---
-  clearState();
-  if (test('allows subagent MultiEdit without gating (parent_tool_use_id set)', () => {
-    const input = {
-      tool_name: 'MultiEdit',
-      tool_input: {
-        edits: [
-          { file_path: '/src/subagent-multi-a.js', old_string: 'a', new_string: 'b' },
-          { file_path: '/src/subagent-multi-b.js', old_string: 'c', new_string: 'd' }
-        ]
-      },
-      session_id: 'subagent-fresh-session',
-      parent_tool_use_id: 'toolu_parent_04'
-    };
-    const result = runHook(input, {
-      CLAUDE_SESSION_ID: '',
-      ECC_SESSION_ID: '',
-    });
-    const output = parseOutput(result.stdout);
-    assert.ok(output, 'should produce valid JSON output');
-    if (output.hookSpecificOutput) {
-      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
-        'subagent MultiEdit must not be gated');
-    } else {
-      assert.strictEqual(output.tool_name, 'MultiEdit', 'pass-through should preserve input');
-    }
-  })) passed++; else failed++;
-
-  // --- Test 24: camelCase parentToolUseId variant is honored ---
-  clearState();
-  if (test('honors camelCase parentToolUseId variant', () => {
-    const input = {
-      tool_name: 'Bash',
-      tool_input: { command: 'uptime' },
-      session_id: 'subagent-fresh-session',
-      parentToolUseId: 'toolu_parent_camel'
-    };
-    const result = runBashHook(input, {
-      CLAUDE_SESSION_ID: '',
-      ECC_SESSION_ID: '',
-    });
-    const output = parseOutput(result.stdout);
-    assert.ok(output, 'should produce valid JSON output');
-    if (output.hookSpecificOutput) {
-      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
-        'camelCase parentToolUseId should also bypass the routine-Bash gate');
-    } else {
-      assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
-    }
-  })) passed++; else failed++;
-
-  // --- Test 25: empty-string parent_tool_use_id does NOT mark as subagent ---
-  clearState();
-  if (test('empty parent_tool_use_id does not bypass routine Bash gate', () => {
-    const input = {
-      tool_name: 'Bash',
-      tool_input: { command: 'pwd' },
-      session_id: 'top-level-fresh',
-      parent_tool_use_id: ''
-    };
-    const result = runBashHook(input, {
-      CLAUDE_SESSION_ID: '',
-      ECC_SESSION_ID: '',
-    });
-    const output = parseOutput(result.stdout);
-    assert.ok(output, 'should produce JSON output');
-    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
-      'empty parent_tool_use_id must not be treated as subagent context');
-  })) passed++; else failed++;
-
   // --- Test 19: long raw session IDs hash instead of collapsing to project fallback ---
   clearState();
   if (test('uses a stable hash for long raw session ids', () => {
@@ -707,6 +560,302 @@ function runTests() {
     } else {
       assert.strictEqual(secondOutput.tool_name, 'Bash');
     }
+  })) passed++; else failed++;
+
+  // --- Tests 20-30: subagent context bypasses first-touch file gates (issue #1548) ---
+  //
+  // Background: Claude Code's PreToolUse hook payload carries `agent_id`
+  // (with `agent_type`) when the hook fires from inside a Task/Agent
+  // subagent. The documented schema says: "Present only when the hook fires
+  // from within a subagent... Use this field (not agent_type) to distinguish
+  // subagent calls from main-thread calls." On Linux, subagents frequently
+  // get a different session_id than the parent, producing a fresh empty
+  // state file and re-triggering the first-touch gate for every subagent
+  // call.
+  //
+  // These tests verify the subagent detection logic via strict A/B asserts:
+  // the SAME input without the subagent marker is denied (gate fires), and
+  // WITH the marker is allowed (bypass fires). This proves the bypass path
+  // is being exercised rather than, e.g., a pass-through earlier in the
+  // control flow.
+  //
+  // Tests also verify:
+  //   - Bash stays fully gated in subagent context (routine-Bash is the
+  //     containment net for destructive commands the narrow DESTRUCTIVE_BASH
+  //     regex misses: `rm -f`, `mkfs`, `curl | sh`, etc.)
+  //   - Non-string subagent markers (numbers, null) are ignored
+  //   - Two sequential subagent Edit calls on different files both pass
+  //     (reproduces the #1548 scenario)
+
+  function runBashWithFreshSession(extra = {}) {
+    return runBashHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'pwd' },
+      session_id: 'subagent-fresh-session',
+      ...extra,
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+  }
+
+  function runEditWithFreshSession(filePath, extra = {}) {
+    return runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: filePath, old_string: 'a', new_string: 'b' },
+      session_id: 'subagent-fresh-session',
+      ...extra,
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+  }
+
+  // --- Test 20: A/B — top-level Edit denies; subagent Edit (agent_id) allows ---
+  clearState();
+  if (test('A/B: same Edit input denies at top level, allows with agent_id', () => {
+    // A: no subagent marker → must deny (first-touch gate fires)
+    clearState();
+    const topLevel = runEditWithFreshSession('/src/ab-edit.js');
+    const topOut = parseOutput(topLevel.stdout);
+    assert.ok(topOut, 'top-level should produce JSON output');
+    assert.strictEqual(topOut.hookSpecificOutput.permissionDecision, 'deny',
+      'same Edit must be denied without subagent marker (first-touch gate)');
+
+    // B: with agent_id → must allow (subagent bypass fires)
+    clearState();
+    const subagent = runEditWithFreshSession('/src/ab-edit.js', { agent_id: 'agent-abc-123' });
+    const subOut = parseOutput(subagent.stdout);
+    assert.ok(subOut, 'subagent should produce JSON output');
+    assert.ok(
+      !subOut.hookSpecificOutput || subOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'same Edit must pass through in subagent context (agent_id set)'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 21: A/B — top-level Write denies; subagent Write (agent_id) allows ---
+  clearState();
+  if (test('A/B: same Write input denies at top level, allows with agent_id', () => {
+    clearState();
+    const topLevel = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: '/src/ab-write.js', content: 'x' },
+      session_id: 'subagent-fresh-session',
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+    const topOut = parseOutput(topLevel.stdout);
+    assert.ok(topOut, 'top-level should produce JSON output');
+    assert.strictEqual(topOut.hookSpecificOutput.permissionDecision, 'deny',
+      'same Write must be denied without subagent marker');
+
+    clearState();
+    const subagent = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: '/src/ab-write.js', content: 'x' },
+      session_id: 'subagent-fresh-session',
+      agent_id: 'agent-abc-123',
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+    const subOut = parseOutput(subagent.stdout);
+    assert.ok(subOut, 'subagent should produce JSON output');
+    assert.ok(
+      !subOut.hookSpecificOutput || subOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'same Write must pass through in subagent context'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 22: A/B — top-level MultiEdit denies; subagent MultiEdit allows ---
+  clearState();
+  if (test('A/B: same MultiEdit input denies at top level, allows with agent_id', () => {
+    const edits = [
+      { file_path: '/src/ab-multi-a.js', old_string: 'a', new_string: 'b' },
+      { file_path: '/src/ab-multi-b.js', old_string: 'c', new_string: 'd' }
+    ];
+
+    clearState();
+    const topLevel = runHook({
+      tool_name: 'MultiEdit',
+      tool_input: { edits },
+      session_id: 'subagent-fresh-session',
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+    const topOut = parseOutput(topLevel.stdout);
+    assert.ok(topOut, 'top-level should produce JSON output');
+    assert.strictEqual(topOut.hookSpecificOutput.permissionDecision, 'deny',
+      'same MultiEdit must be denied without subagent marker');
+
+    clearState();
+    const subagent = runHook({
+      tool_name: 'MultiEdit',
+      tool_input: { edits },
+      session_id: 'subagent-fresh-session',
+      agent_id: 'agent-abc-123',
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+    const subOut = parseOutput(subagent.stdout);
+    assert.ok(subOut, 'subagent should produce JSON output');
+    assert.ok(
+      !subOut.hookSpecificOutput || subOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'same MultiEdit must pass through in subagent context'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 23: routine Bash stays gated in subagent context (safety containment) ---
+  clearState();
+  if (test('routine Bash is STILL gated in subagent context (containment for narrow DESTRUCTIVE_BASH regex)', () => {
+    const result = runBashWithFreshSession({ agent_id: 'agent-abc-123' });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+      'routine Bash must remain gated in subagents to catch rm -f, mkfs, curl|sh, etc.');
+  })) passed++; else failed++;
+
+  // --- Test 24: destructive Bash remains gated in subagent context ---
+  clearState();
+  if (test('destructive Bash (rm -rf) is gated in subagent context', () => {
+    const result = runBashHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /tmp/demo-path' },
+      session_id: 'subagent-fresh-session',
+      agent_id: 'agent-abc-123',
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+      'destructive Bash must be denied in subagent context');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'),
+      'deny reason should name the Destructive gate');
+  })) passed++; else failed++;
+
+  // --- Test 25: parent_tool_use_id is honored as a fallback marker ---
+  clearState();
+  if (test('parent_tool_use_id is honored as a fallback subagent marker for Edit', () => {
+    clearState();
+    const topLevel = runEditWithFreshSession('/src/fallback-edit.js');
+    const topOut = parseOutput(topLevel.stdout);
+    assert.strictEqual(topOut.hookSpecificOutput.permissionDecision, 'deny',
+      'top-level edit should deny');
+
+    clearState();
+    const subagent = runEditWithFreshSession('/src/fallback-edit.js', {
+      parent_tool_use_id: 'toolu_parent_01'
+    });
+    const subOut = parseOutput(subagent.stdout);
+    assert.ok(
+      !subOut.hookSpecificOutput || subOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'parent_tool_use_id fallback should allow the subagent Edit'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 26: camelCase variants (agentId, parentToolUseId) are honored ---
+  clearState();
+  if (test('camelCase subagent markers are honored (agentId, parentToolUseId)', () => {
+    clearState();
+    const a = runEditWithFreshSession('/src/camel-agent.js', { agentId: 'agent-camel' });
+    const aOut = parseOutput(a.stdout);
+    assert.ok(
+      !aOut.hookSpecificOutput || aOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'camelCase agentId should allow subagent Edit'
+    );
+
+    clearState();
+    const b = runEditWithFreshSession('/src/camel-parent.js', { parentToolUseId: 'toolu_camel' });
+    const bOut = parseOutput(b.stdout);
+    assert.ok(
+      !bOut.hookSpecificOutput || bOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'camelCase parentToolUseId should allow subagent Edit'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 27: empty-string and non-string markers do NOT mark as subagent ---
+  clearState();
+  if (test('empty/non-string subagent markers do not trigger bypass', () => {
+    // Empty string agent_id: must still deny the first-touch gate.
+    clearState();
+    const empty = runEditWithFreshSession('/src/empty-marker.js', { agent_id: '' });
+    const emptyOut = parseOutput(empty.stdout);
+    assert.strictEqual(emptyOut.hookSpecificOutput.permissionDecision, 'deny',
+      'empty-string agent_id must not be treated as a subagent marker');
+
+    // Numeric agent_id: also must not trigger bypass.
+    clearState();
+    const numeric = runEditWithFreshSession('/src/numeric-marker.js', { agent_id: 12345 });
+    const numericOut = parseOutput(numeric.stdout);
+    assert.strictEqual(numericOut.hookSpecificOutput.permissionDecision, 'deny',
+      'non-string (numeric) agent_id must not be treated as a subagent marker');
+
+    // Null agent_id: ditto.
+    clearState();
+    const nullMarker = runEditWithFreshSession('/src/null-marker.js', { agent_id: null });
+    const nullOut = parseOutput(nullMarker.stdout);
+    assert.strictEqual(nullOut.hookSpecificOutput.permissionDecision, 'deny',
+      'null agent_id must not be treated as a subagent marker');
+
+    // Whitespace-only agent_id: ditto.
+    clearState();
+    const wsMarker = runEditWithFreshSession('/src/ws-marker.js', { agent_id: '   ' });
+    const wsOut = parseOutput(wsMarker.stdout);
+    assert.strictEqual(wsOut.hookSpecificOutput.permissionDecision, 'deny',
+      'whitespace-only agent_id must not be treated as a subagent marker');
+  })) passed++; else failed++;
+
+  // --- Test 28: #1548 reproduction — two sequential subagent Edits on different files ---
+  // The classic #1548 trace: a subagent invoked with a fresh session_id touches
+  // file A (would normally be denied by first-touch gate on fresh state), then
+  // touches file B. Without the bypass both would deny. With the bypass both
+  // must pass through.
+  clearState();
+  if (test('two sequential subagent Edits on different files both pass (repro #1548)', () => {
+    clearState();
+    const first = runEditWithFreshSession('/src/seq-file-a.js', { agent_id: 'agent-sequential' });
+    const firstOut = parseOutput(first.stdout);
+    assert.ok(firstOut, 'first call should produce JSON');
+    assert.ok(
+      !firstOut.hookSpecificOutput || firstOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'first subagent Edit must pass through'
+    );
+
+    const second = runEditWithFreshSession('/src/seq-file-b.js', { agent_id: 'agent-sequential' });
+    const secondOut = parseOutput(second.stdout);
+    assert.ok(secondOut, 'second call should produce JSON');
+    assert.ok(
+      !secondOut.hookSpecificOutput || secondOut.hookSpecificOutput.permissionDecision !== 'deny',
+      'second subagent Edit on a different file must also pass through (no residual gating)'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 29: subagent MultiEdit mixing settings path + regular file passes ---
+  // The Edit/Write branch runs `isClaudeSettingsPath` before the subagent
+  // bypass so settings-path handling is unaffected. MultiEdit takes the
+  // subagent short-circuit as-is. Verify both.
+  clearState();
+  if (test('subagent MultiEdit with settings path + regular file is allowed', () => {
+    const result = runHook({
+      tool_name: 'MultiEdit',
+      tool_input: {
+        edits: [
+          { file_path: '/some/.claude/settings.json', old_string: '{}', new_string: '{"k":1}' },
+          { file_path: '/src/multi-settings-regular.js', old_string: 'a', new_string: 'b' }
+        ]
+      },
+      session_id: 'subagent-fresh-session',
+      agent_id: 'agent-multi-settings'
+    }, { CLAUDE_SESSION_ID: '', ECC_SESSION_ID: '' });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.ok(
+      !output.hookSpecificOutput || output.hookSpecificOutput.permissionDecision !== 'deny',
+      'subagent MultiEdit mixing settings + regular file should pass'
+    );
+  })) passed++; else failed++;
+
+  // --- Test 30: top-level Edit to .claude/settings.json path passes through unchanged ---
+  // Safety-preservation test: the settings-path short-circuit must still fire
+  // BEFORE the subagent check at the top of Edit/Write, so other validators
+  // continue to own that file. This test just asserts the pre-existing
+  // behavior is unchanged by the refactor.
+  clearState();
+  if (test('top-level Edit to .claude/settings.json passes (unchanged)', () => {
+    const result = runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: '/home/u/.claude/settings.json', old_string: '{}', new_string: '{"k":1}' }
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.ok(
+      !output.hookSpecificOutput || output.hookSpecificOutput.permissionDecision !== 'deny',
+      'Edit to Claude settings path should always pass through'
+    );
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -528,6 +528,153 @@ function runTests() {
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('current instruction'));
   })) passed++; else failed++;
 
+  // --- Tests 20-25: subagent context bypasses friction gates (issue #1548) ---
+  //
+  // Subagent invocations (Task/Agent tool) carry `parent_tool_use_id` in the
+  // hook payload. The main session has already satisfied the fact-forcing gate
+  // for the user's request, so re-gating every subagent tool call is pure
+  // friction — especially on Linux where subagents can end up with a different
+  // session_id and therefore a fresh, empty state file. Friction gates
+  // (routine Bash, Edit/Write/MultiEdit first-touch) bypass in subagent
+  // context; destructive Bash remains gated as a safety check.
+
+  // --- Test 20: subagent routine Bash is not gated even with a fresh session_id ---
+  clearState();
+  if (test('allows subagent routine Bash without gating (parent_tool_use_id set)', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'pwd' },
+      session_id: 'subagent-fresh-session',
+      parent_tool_use_id: 'toolu_parent_01'
+    };
+    const result = runBashHook(input, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+    });
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    if (output.hookSpecificOutput) {
+      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+        'subagent routine Bash must not be gated');
+    } else {
+      assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+    }
+  })) passed++; else failed++;
+
+  // --- Test 21: subagent destructive Bash is STILL gated (safety gate) ---
+  clearState();
+  if (test('gates subagent destructive Bash for safety (parent_tool_use_id set)', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /tmp/demo-path' },
+      session_id: 'subagent-fresh-session',
+      parent_tool_use_id: 'toolu_parent_02'
+    };
+    const result = runBashHook(input, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+      'destructive Bash must still be gated in subagent context');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+  })) passed++; else failed++;
+
+  // --- Test 22: subagent Edit is not gated ---
+  clearState();
+  if (test('allows subagent Edit without gating (parent_tool_use_id set)', () => {
+    const input = {
+      tool_name: 'Edit',
+      tool_input: { file_path: '/src/subagent-touched.js', old_string: 'a', new_string: 'b' },
+      session_id: 'subagent-fresh-session',
+      parent_tool_use_id: 'toolu_parent_03'
+    };
+    const result = runHook(input, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    if (output.hookSpecificOutput) {
+      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+        'subagent Edit must not be gated');
+    } else {
+      assert.strictEqual(output.tool_name, 'Edit', 'pass-through should preserve input');
+    }
+  })) passed++; else failed++;
+
+  // --- Test 23: subagent MultiEdit is not gated ---
+  clearState();
+  if (test('allows subagent MultiEdit without gating (parent_tool_use_id set)', () => {
+    const input = {
+      tool_name: 'MultiEdit',
+      tool_input: {
+        edits: [
+          { file_path: '/src/subagent-multi-a.js', old_string: 'a', new_string: 'b' },
+          { file_path: '/src/subagent-multi-b.js', old_string: 'c', new_string: 'd' }
+        ]
+      },
+      session_id: 'subagent-fresh-session',
+      parent_tool_use_id: 'toolu_parent_04'
+    };
+    const result = runHook(input, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    if (output.hookSpecificOutput) {
+      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+        'subagent MultiEdit must not be gated');
+    } else {
+      assert.strictEqual(output.tool_name, 'MultiEdit', 'pass-through should preserve input');
+    }
+  })) passed++; else failed++;
+
+  // --- Test 24: camelCase parentToolUseId variant is honored ---
+  clearState();
+  if (test('honors camelCase parentToolUseId variant', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'uptime' },
+      session_id: 'subagent-fresh-session',
+      parentToolUseId: 'toolu_parent_camel'
+    };
+    const result = runBashHook(input, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    if (output.hookSpecificOutput) {
+      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+        'camelCase parentToolUseId should also bypass the routine-Bash gate');
+    } else {
+      assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+    }
+  })) passed++; else failed++;
+
+  // --- Test 25: empty-string parent_tool_use_id does NOT mark as subagent ---
+  clearState();
+  if (test('empty parent_tool_use_id does not bypass routine Bash gate', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'pwd' },
+      session_id: 'top-level-fresh',
+      parent_tool_use_id: ''
+    };
+    const result = runBashHook(input, {
+      CLAUDE_SESSION_ID: '',
+      ECC_SESSION_ID: '',
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+      'empty parent_tool_use_id must not be treated as subagent context');
+  })) passed++; else failed++;
+
   // --- Test 19: long raw session IDs hash instead of collapsing to project fallback ---
   clearState();
   if (test('uses a stable hash for long raw session ids', () => {


### PR DESCRIPTION
## Summary

Fixes #1548. GateGuard's fact-forcing gate re-fires for every subagent
(Task/Agent tool) call because subagents frequently get a different
`session_id` than the parent on Linux, producing a fresh empty state file.
Users report being blocked on the first Bash call of every subagent and
have to disable gateguard entirely via `ECC_DISABLED_HOOKS` as a workaround.

Claude Code's hook payload carries `parent_tool_use_id` for tool calls
spawned inside a subagent. When that field is present, the parent session
has already satisfied the fact-forcing gate for the user's instruction, so
re-gating the subagent adds friction with no safety value.

## Change

- New helper `isSubagentInvocation(data)` — checks for non-empty
  `parent_tool_use_id` (or camelCase `parentToolUseId`).
- Bypasses the Edit / Write / MultiEdit first-touch gates for subagents.
- Bypasses the routine first-Bash gate for subagents.
- **Keeps the destructive-Bash gate active for subagents.** Commands
  matching the `DESTRUCTIVE_BASH` regex still require facts — safety gate,
  not friction gate.

## Tests

6 new cases in `tests/hooks/gateguard-fact-force.test.js`:

- Subagent routine Bash allowed with fresh `session_id` + `parent_tool_use_id`
- Subagent destructive Bash still gated
- Subagent Edit allowed
- Subagent MultiEdit allowed
- camelCase `parentToolUseId` variant honored
- Empty-string `parent_tool_use_id` must NOT be treated as subagent

Result: 25/25 gateguard tests pass, full suite 1882/1882.

## Test plan

- [x] Reproduce #1548: subagent Bash denied on first call with fresh session_id
- [x] With fix: subagent Bash passes through
- [x] Top-level first Bash still gated (no regression)
- [x] Subagent `rm -rf …` still gated (safety preserved)
- [x] `npm test` suite green (1882/1882)
- [x] `npx eslint` clean on changed files

Closes #1548

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents GateGuard from re-gating subagent tool calls by detecting subagent context and bypassing first-touch file gates, fixing first-call blocks in #1548. Bypass applies to file tools only; Bash stays gated for safety.

- **Bug Fixes**
  - Detect subagents via `agent_id`/`agentId`, with fallback to `parent_tool_use_id`/`parentToolUseId`.
  - Bypass first-touch gates for `Edit`, `Write`, and `MultiEdit` in subagents; `Bash` (routine and destructive) remains gated, with `DESTRUCTIVE_BASH` still enforced.
  - Preserve `.claude/settings.json` pass-through by running that check before the subagent bypass.
  - Add strict A/B tests for subagent behavior; annotate PASS/FAIL emoji replacement in `docs/fixes/HOOK-FIX-20260421-ADDENDUM.md` to satisfy unicode-safety CI.

<sup>Written for commit d3b1621a9f8c44296488cf04219463b07db11513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Subagent-detected operations now bypass routine file-operation friction checks while preserving destructive-action safeguards for shell commands.

* **Tests**
  * Added tests covering subagent detection (multiple marker variants), invalid-marker rejection, multi-file and sequential subagent scenarios, and continued gating for destructive Bash commands.

* **Documentation**
  * Updated workaround guidance text; replaced emoji status indicators with plain PASS/FAIL and clarified Bash outcome notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->