### PR TITLE
fix: derive clv2 hook phase from event env

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -12,8 +12,20 @@
 
 set -e
 
-# Hook phase from CLI argument: "pre" (PreToolUse) or "post" (PostToolUse)
-HOOK_PHASE="${1:-post}"
+# Hook phase from CLI argument: "pre" (PreToolUse) or "post" (PostToolUse).
+# Manual settings.json installs can call this script without the plugin
+# wrapper's positional phase argument, but Claude Code still exposes the hook
+# event name in CLAUDE_HOOK_EVENT_NAME.  Fall back to that env var before
+# defaulting to post so manually registered PreToolUse hooks are recorded as
+# tool_start instead of being silently misclassified as tool_complete.
+HOOK_PHASE="${1:-}"
+if [ -z "$HOOK_PHASE" ]; then
+  case "${CLAUDE_HOOK_EVENT_NAME:-}" in
+    PreToolUse|pretooluse|pre_tool_use|pre) HOOK_PHASE="pre" ;;
+    PostToolUse|posttooluse|post_tool_use|post) HOOK_PHASE="post" ;;
+    *) HOOK_PHASE="post" ;;
+  esac
+fi
 
 # ─────────────────────────────────────────────
 # Read stdin first (before project detection)

--- a/tests/hooks/observe-subdirectory-detection.test.js
+++ b/tests/hooks/observe-subdirectory-detection.test.js
@@ -86,7 +86,7 @@ function gitInit(dir) {
   assert.strictEqual(commitResult.status, 0, commitResult.stderr);
 }
 
-function runObserve({ homeDir, cwd }) {
+function runObserve({ homeDir, cwd, args = ['post'], extraEnv = {} }) {
   const payload = JSON.stringify({
     tool_name: 'Read',
     tool_input: { file_path: 'README.md' },
@@ -95,7 +95,7 @@ function runObserve({ homeDir, cwd }) {
     cwd,
   });
 
-  return spawnSync('bash', [observeShPath, 'post'], {
+  return spawnSync('bash', [observeShPath, ...args], {
     cwd: repoRoot,
     encoding: 'utf8',
     input: payload,
@@ -107,6 +107,7 @@ function runObserve({ homeDir, cwd }) {
       CLAUDE_CODE_ENTRYPOINT: 'cli',
       ECC_HOOK_PROFILE: 'standard',
       ECC_SKIP_OBSERVE: '0',
+      ...extraEnv,
     },
   });
 }
@@ -210,6 +211,40 @@ test('observe.sh writes project metadata for the git root when cwd is a subdirec
 
     const observationsPath = path.join(projectDir, 'observations.jsonl');
     assert.ok(fs.existsSync(observationsPath), 'observe.sh should append an observation');
+  } finally {
+    cleanupDir(testRoot);
+  }
+});
+
+
+test('observe.sh falls back to CLAUDE_HOOK_EVENT_NAME when no phase argument is passed', () => {
+  const testRoot = createTempDir();
+
+  try {
+    const homeDir = path.join(testRoot, 'home');
+    const repoDir = path.join(testRoot, 'repo');
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(repoDir, { recursive: true });
+    gitInit(repoDir);
+
+    const result = runObserve({
+      homeDir,
+      cwd: repoDir,
+      args: [],
+      extraEnv: { CLAUDE_HOOK_EVENT_NAME: 'PreToolUse' },
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+
+    const { projectDir } = readSingleProjectMetadata(homeDir);
+    const observationsPath = path.join(projectDir, 'observations.jsonl');
+    const observation = JSON.parse(fs.readFileSync(observationsPath, 'utf8').trim());
+    assert.strictEqual(
+      observation.event,
+      'tool_start',
+      'manual PreToolUse installs without argv should record tool_start'
+    );
+    assert.ok(Object.prototype.hasOwnProperty.call(observation, 'input'));
+    assert.ok(!Object.prototype.hasOwnProperty.call(observation, 'output'));
   } finally {
     cleanupDir(testRoot);
   }


### PR DESCRIPTION
## Summary
- derive the CLV2 observe hook phase from `CLAUDE_HOOK_EVENT_NAME` when manual installs call `observe.sh` without a positional `pre`/`post` argument
- keep the existing positional argument path unchanged for plugin-managed installs
- add a regression test that runs the real hook without arguments and verifies `PreToolUse` records `tool_start`

## Testing
- `node tests/hooks/observe-subdirectory-detection.test.js`
- `node tests/docs/continuous-learning-v2-docs.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the observe hook to correctly determine event phases from environment variables, ensuring pre-hooks are properly classified as tool_start events instead of being misidentified.

* **Tests**
  * Added test coverage for hook phase detection when invoked without explicit arguments, validating fallback behavior with environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infer the CLV2 observe hook phase from `CLAUDE_HOOK_EVENT_NAME` when `observe.sh` is called without a `pre`/`post` argument. This fixes manual installs misclassifying PreToolUse events as tool_complete.

- **Bug Fixes**
  - Fallback to `CLAUDE_HOOK_EVENT_NAME` when no phase arg is provided (map PreToolUse→pre, PostToolUse→post; default to post).
  - Preserve existing behavior when a positional phase arg is passed.
  - Add a regression test verifying manual PreToolUse without argv records `tool_start` (input present, no output).

<sup>Written for commit 31367bf2aa7cbebb4c7252084b83da892ac4c9e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

