### PR TITLE
fix(opencode-plugin): replace shell probes with file-only fs checks

### DIFF
--- a/.opencode/plugins/ecc-hooks.ts
+++ b/.opencode/plugins/ecc-hooks.ts
@@ -43,6 +43,14 @@ export const ECCHooksPlugin: ECCHooksPluginFn = async ({
     return path.join(worktreePath, p)
   }
 
+  function hasRegularFile(relativePath: string): boolean {
+    try {
+      return fs.statSync(path.join(worktreePath, relativePath)).isFile()
+    } catch {
+      return false
+    }
+  }
+
   const pendingToolChanges = new Map<string, { path: string; type: "added" | "modified" }>()
   let writeCounter = 0
 
@@ -276,8 +284,7 @@ export const ECCHooksPlugin: ECCHooksPluginFn = async ({
 
       // Check for project-specific context files
       try {
-        const hasClaudeMd = await $`test -f ${worktree}/CLAUDE.md && echo "yes"`.text()
-        if (hasClaudeMd.trim() === "yes") {
+        if (hasRegularFile("CLAUDE.md")) {
           log("info", "[ECC] Found CLAUDE.md - loading project context")
         }
       } catch {
@@ -412,9 +419,10 @@ export const ECCHooksPlugin: ECCHooksPluginFn = async ({
       }
       for (const [lockfile, pm] of Object.entries(lockfiles)) {
         try {
-          await $`test -f ${worktree}/${lockfile}`
-          env.PACKAGE_MANAGER = pm
-          break
+          if (hasRegularFile(lockfile)) {
+            env.PACKAGE_MANAGER = pm
+            break
+          }
         } catch {
           // Not found, try next
         }
@@ -431,8 +439,9 @@ export const ECCHooksPlugin: ECCHooksPluginFn = async ({
       const detected: string[] = []
       for (const [file, lang] of Object.entries(langDetectors)) {
         try {
-          await $`test -f ${worktree}/${file}`
-          detected.push(lang)
+          if (hasRegularFile(file)) {
+            detected.push(lang)
+          }
         } catch {
           // Not found
         }

--- a/tests/opencode/ecc-hooks-file-probes.test.js
+++ b/tests/opencode/ecc-hooks-file-probes.test.js
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for OpenCode ECC file probes.
+ *
+ * Run with: node tests/opencode/ecc-hooks-file-probes.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { pathToFileURL } = require('url');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const opencodeRoot = path.join(repoRoot, '.opencode');
+const distPluginPath = path.join(opencodeRoot, 'dist', 'plugins', 'ecc-hooks.js');
+
+let passed = 0;
+let failed = 0;
+
+function asyncTest(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      console.log(`  ✓ ${name}`);
+      return true;
+    })
+    .catch((err) => {
+      console.log(`  ✗ ${name}`);
+      console.log(`    Error: ${err.message}`);
+      return false;
+    });
+}
+
+function createTestDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-opencode-file-probes-'));
+}
+
+function cleanupTestDir(testDir) {
+  fs.rmSync(testDir, { recursive: true, force: true });
+}
+
+function buildOpencodePlugin() {
+  const result = process.platform === 'win32'
+    ? spawnSync('cmd.exe', ['/d', '/s', '/c', 'npm run build'], {
+        cwd: opencodeRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    : spawnSync('npm', ['run', 'build'], {
+        cwd: opencodeRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `OpenCode plugin build failed: ${(result.stderr || result.stdout || '').trim()}`
+    );
+  }
+}
+
+async function loadPlugin() {
+  buildOpencodePlugin();
+  const moduleUrl = `${pathToFileURL(distPluginPath).href}?t=${Date.now()}`;
+  return import(moduleUrl);
+}
+
+function createPluginInput(worktreePath, logs) {
+  return {
+    client: {
+      app: {
+        log: ({ body }) => {
+          logs.push(body);
+          return Promise.resolve();
+        },
+      },
+    },
+    $: () => {
+      throw new Error('shell execution should not be required for file probes');
+    },
+    directory: worktreePath,
+    worktree: worktreePath,
+  };
+}
+
+async function runTests() {
+  console.log('\n=== Testing OpenCode ECC file probes ===\n');
+
+  const { ECCHooksPlugin } = await loadPlugin();
+
+  if (await asyncTest('session.created ignores CLAUDE.md directories', async () => {
+    const testDir = createTestDir();
+    try {
+      fs.mkdirSync(path.join(testDir, 'CLAUDE.md'));
+
+      const logs = [];
+      const hooks = await ECCHooksPlugin(createPluginInput(testDir, logs));
+      await hooks['session.created']();
+
+      assert.ok(
+        !logs.some((entry) => String(entry?.message || '').includes('Found CLAUDE.md')),
+        'directory named CLAUDE.md should not be treated as a project context file'
+      );
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++; else failed++;
+
+  if (await asyncTest('shell.env ignores directories masquerading as lockfiles and markers', async () => {
+    const testDir = createTestDir();
+    try {
+      fs.mkdirSync(path.join(testDir, 'pnpm-lock.yaml'));
+      fs.mkdirSync(path.join(testDir, 'tsconfig.json'));
+
+      const logs = [];
+      const hooks = await ECCHooksPlugin(createPluginInput(testDir, logs));
+      const env = await hooks['shell.env']();
+
+      assert.ok(!('PACKAGE_MANAGER' in env), 'lockfile directory should not set PACKAGE_MANAGER');
+      assert.ok(!('DETECTED_LANGUAGES' in env), 'marker directory should not set DETECTED_LANGUAGES');
+      assert.ok(!('PRIMARY_LANGUAGE' in env), 'marker directory should not set PRIMARY_LANGUAGE');
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++; else failed++;
+
+  if (await asyncTest('shell.env still detects regular files', async () => {
+    const testDir = createTestDir();
+    try {
+      fs.writeFileSync(path.join(testDir, 'pnpm-lock.yaml'), 'lockfile');
+      fs.writeFileSync(path.join(testDir, 'tsconfig.json'), '{}');
+
+      const logs = [];
+      const hooks = await ECCHooksPlugin(createPluginInput(testDir, logs));
+      const env = await hooks['shell.env']();
+
+      assert.strictEqual(env.PACKAGE_MANAGER, 'pnpm');
+      assert.strictEqual(env.PRIMARY_LANGUAGE, 'typescript');
+      assert.strictEqual(env.DETECTED_LANGUAGES, 'typescript');
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+runTests().catch((err) => {
+  console.log(`\nFatal: ${err.message}`);
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed + 1}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What Changed

- replaced shell-based file probes in the OpenCode ECC plugin with file-only Node filesystem checks
- added a small regression test covering `CLAUDE.md`, lockfile, and language-marker detection
- kept the change focused to the OpenCode plugin probing path

Files in scope:

- `.opencode/plugins/ecc-hooks.ts`
- `tests/opencode/ecc-hooks-file-probes.test.js`

## Why This Change

On Windows, using ECC as an OpenCode plugin can repeatedly emit:

```text
bun: command not found: test
```

Based on real process-level A/B testing, this behavior appears to come from the ECC plugin's shell-based file probes rather than from the OpenCode core shell path itself.

The previous implementation used shell probes such as:

```ts
await $`test -f ${worktree}/${lockfile}`
await $`test -f ${worktree}/${file}`
await $`test -f ${worktree}/CLAUDE.md && echo "yes"`
```

This PR removes those shell probes and replaces them with `fs.statSync(...).isFile()` checks via a small helper. That keeps the cross-platform behavior while preserving the original `test -f` semantics that only regular files should count.

Closes #1576.
