### PR TITLE
fix(hooks): use iTerm2 native escape so notification clicks focus the iTerm tab

### DIFF
--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -120,7 +120,12 @@ function findTerminalTTY() {
       const m = out.match(/^\s*(\d+)\s+(\S+)\s*$/);
       if (!m) return null;
       const [, ppidStr, tty] = m;
-      if (tty && !tty.startsWith('?')) return `/dev/${tty}`;
+      if (tty && !tty.startsWith('?')) {
+        // `ps -o tty=` may emit either "ttys001" or the short form "s001"
+        // depending on macOS version; normalize so the resulting path exists.
+        const name = tty.startsWith('tty') ? tty : `tty${tty}`;
+        return `/dev/${name}`;
+      }
       const ppid = parseInt(ppidStr, 10);
       if (!ppid || ppid <= 1) return null;
       pid = ppid;
@@ -132,21 +137,35 @@ function findTerminalTTY() {
 }
 
 /**
+ * Detect whether the process runs under a terminal multiplexer that would
+ * swallow OSC 9. tmux and screen don't pass OSC 9 through by default, so the
+ * sequence written to their pty never reaches iTerm2 and the user gets no
+ * notification. In that case we skip the iTerm2 fast path and let osascript
+ * handle the notification instead.
+ */
+function isUnderMultiplexer() {
+  if (process.env.TMUX) return true;
+  const term = process.env.TERM || '';
+  return /^screen/.test(term) || /^tmux/.test(term);
+}
+
+/**
  * Send a macOS notification.
  *
- * On iTerm2, prefers the native escape sequence (ESC ] 9 ; <message> BEL)
- * written to the parent terminal's tty. This makes iTerm2 the notification
- * owner, so clicking the notification focuses the exact iTerm2 tab where
- * Claude Code is running. The default osascript path makes Script Editor
- * the owner instead, which causes clicks to launch Script Editor.
+ * On iTerm2 (and not inside tmux/screen), prefers the native escape sequence
+ * (ESC ] 9 ; <message> BEL) written to the parent terminal's tty. This makes
+ * iTerm2 the notification owner, so clicking the notification focuses the
+ * exact iTerm2 tab where Claude Code is running. The default osascript path
+ * makes Script Editor the owner instead, which causes clicks to launch
+ * Script Editor.
  *
- * Falls back to osascript when not running under iTerm2 or when tty
- * discovery fails. AppleScript strings do not support backslash escapes,
- * so we replace double quotes with curly quotes and strip backslashes
- * before embedding.
+ * Falls back to osascript when not running under iTerm2, when tty discovery
+ * fails, or when running inside a multiplexer that would swallow OSC 9.
+ * AppleScript strings do not support backslash escapes, so we replace double
+ * quotes with curly quotes and strip backslashes before embedding.
  */
 function notifyMacOS(title, body) {
-  if (process.env.TERM_PROGRAM === 'iTerm.app') {
+  if (process.env.TERM_PROGRAM === 'iTerm.app' && !isUnderMultiplexer()) {
     try {
       const tty = findTerminalTTY();
       if (tty) {

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -4,8 +4,12 @@
  *
  * Sends a native desktop notification with the task summary when Claude
  * finishes responding.  Supports:
- *   - macOS: osascript (native)
+ *   - macOS: iTerm2 native escape sequence (preferred) or osascript (fallback)
  *   - WSL: PowerShell 7 or Windows PowerShell + BurntToast module
+ *
+ * On macOS under iTerm2, the notification is owned by iTerm2 — clicking it
+ * focuses the iTerm2 tab where Claude Code runs. Outside iTerm2, falls back
+ * to osascript (notification owned by Script Editor; clicks launch it).
  *
  * On WSL, if BurntToast is not installed, logs a tip for installation.
  *
@@ -15,7 +19,7 @@
 
 'use strict';
 
-const { spawnSync } = require('child_process');
+const { spawnSync, execFileSync } = require('child_process');
 const { isMacOS, log } = require('../lib/utils');
 
 const TITLE = 'Claude Code';
@@ -99,13 +103,62 @@ function extractSummary(message) {
 }
 
 /**
- * Send a macOS notification via osascript.
- * AppleScript strings do not support backslash escapes, so we replace
- * double quotes with curly quotes and strip backslashes before embedding.
+ * Walk up the process tree to find an ancestor attached to a real TTY.
+ * Hook subprocesses are detached from a controlling terminal, but the parent
+ * Claude Code process still owns the terminal emulator's tty (e.g. iTerm2 tab).
+ * Returns absolute path like "/dev/ttys017", or null if none found.
+ */
+function findTerminalTTY() {
+  let pid = process.pid;
+  for (let depth = 0; depth < 30; depth += 1) {
+    try {
+      const out = execFileSync('ps', ['-o', 'ppid=,tty=', '-p', String(pid)], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).toString().trim();
+      const m = out.match(/^\s*(\d+)\s+(\S+)\s*$/);
+      if (!m) return null;
+      const [, ppidStr, tty] = m;
+      if (tty && !tty.startsWith('?')) return `/dev/${tty}`;
+      const ppid = parseInt(ppidStr, 10);
+      if (!ppid || ppid <= 1) return null;
+      pid = ppid;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Send a macOS notification.
+ *
+ * On iTerm2, prefers the native escape sequence (ESC ] 9 ; <message> BEL)
+ * written to the parent terminal's tty. This makes iTerm2 the notification
+ * owner, so clicking the notification focuses the exact iTerm2 tab where
+ * Claude Code is running. The default osascript path makes Script Editor
+ * the owner instead, which causes clicks to launch Script Editor.
+ *
+ * Falls back to osascript when not running under iTerm2 or when tty
+ * discovery fails. AppleScript strings do not support backslash escapes,
+ * so we replace double quotes with curly quotes and strip backslashes
+ * before embedding.
  */
 function notifyMacOS(title, body) {
-  const safeBody = body.replace(/\\/g, '').replace(/"/g, '\u201C');
-  const safeTitle = title.replace(/\\/g, '').replace(/"/g, '\u201C');
+  if (process.env.TERM_PROGRAM === 'iTerm.app') {
+    try {
+      const tty = findTerminalTTY();
+      if (tty) {
+        const fs = require('fs');
+        const message = `${title}: ${body}`.replace(/[\x00-\x1f\x7f]/g, ' ');
+        fs.writeFileSync(tty, `\x1b]9;${message}\x07`);
+        return;
+      }
+    } catch (err) {
+      log(`[DesktopNotify] iTerm escape failed, falling back to osascript: ${err.message}`);
+    }
+  }
+  const safeBody = body.replace(/\\/g, '').replace(/"/g, '“');
+  const safeTitle = title.replace(/\\/g, '').replace(/"/g, '“');
   const script = `display notification "${safeBody}" with title "${safeTitle}"`;
   const result = spawnSync('osascript', ['-e', script], { stdio: 'ignore', timeout: 5000 });
   if (result.error || result.status !== 0) {

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -20,6 +20,7 @@
 'use strict';
 
 const { spawnSync, execFileSync } = require('child_process');
+const fs = require('fs');
 const { isMacOS, log } = require('../lib/utils');
 
 const TITLE = 'Claude Code';
@@ -31,7 +32,7 @@ const MAX_BODY_LENGTH = 100;
 let isWSL = false;
 if (process.platform === 'linux') {
   try {
-    isWSL = require('fs').readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
+    isWSL = fs.readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
   } catch {
     isWSL = false;
   }
@@ -114,6 +115,7 @@ function findTerminalTTY() {
     try {
       const out = execFileSync('ps', ['-o', 'ppid=,tty=', '-p', String(pid)], {
         stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 2000,
       }).toString().trim();
       const m = out.match(/^\s*(\d+)\s+(\S+)\s*$/);
       if (!m) return null;
@@ -148,7 +150,8 @@ function notifyMacOS(title, body) {
     try {
       const tty = findTerminalTTY();
       if (tty) {
-        const fs = require('fs');
+        // Strip control chars (incl. ESC/BEL) to prevent escape-sequence injection.
+        // eslint-disable-next-line no-control-regex
         const message = `${title}: ${body}`.replace(/[\x00-\x1f\x7f]/g, ' ');
         fs.writeFileSync(tty, `\x1b]9;${message}\x07`);
         return;

--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -25,6 +25,8 @@ const { isMacOS, log } = require('../lib/utils');
 
 const TITLE = 'Claude Code';
 const MAX_BODY_LENGTH = 100;
+const MAX_TTY_LOOKUP_DEPTH = 30;
+const PS_TIMEOUT_MS = 2000;
 
 /**
  * Memoized WSL detection at module load (avoids repeated /proc/version reads).
@@ -111,11 +113,11 @@ function extractSummary(message) {
  */
 function findTerminalTTY() {
   let pid = process.pid;
-  for (let depth = 0; depth < 30; depth += 1) {
+  for (let depth = 0; depth < MAX_TTY_LOOKUP_DEPTH; depth += 1) {
     try {
       const out = execFileSync('ps', ['-o', 'ppid=,tty=', '-p', String(pid)], {
         stdio: ['ignore', 'pipe', 'ignore'],
-        timeout: 2000,
+        timeout: PS_TIMEOUT_MS,
       }).toString().trim();
       const m = out.match(/^\s*(\d+)\s+(\S+)\s*$/);
       if (!m) return null;


### PR DESCRIPTION
## What Changed

`scripts/hooks/desktop-notify.js` (the `stop:desktop-notify` hook) on macOS now prefers iTerm2's native notification escape sequence (`ESC ] 9 ; <message> BEL`) when running under iTerm2, falling back to `osascript` for Terminal.app and other emulators.

To deliver the escape sequence, the hook walks up the process tree (`ps -o ppid=,tty=`) to find an ancestor attached to a real tty — the hook subprocess itself is detached from a controlling terminal, but its parent Claude Code process owns the iTerm tab tty.

## Why This Change

The current implementation calls `osascript -e 'display notification ...'`. macOS records the notification's owner as the process that posted it, which for `osascript` is **Script Editor**. As a result, clicking a Claude Code completion notification on macOS launches Script Editor instead of returning the user to the iTerm tab where Claude Code is running.

After this change, on iTerm2:

- The notification is owned by **iTerm2**.
- Clicking the notification focuses the **exact iTerm2 tab** where Claude Code is running (because the escape sequence is written to that tab's tty, and iTerm2 binds the resulting macOS notification to that session).
- No external dependencies (no `terminal-notifier`, no AppleScript, no extra processes for the iTerm path — just one tty write).

For non-iTerm2 environments (Terminal.app, Warp, etc.), behavior is unchanged: it still uses `osascript`. WSL/PowerShell path is untouched.

## Reference

iTerm2 documents the escape sequence here:
https://iterm2.com/documentation-escape-codes.html (search for `OSC 9`, "Send Notification").

## Testing Done

- [x] Manual testing completed
  - Reproduced the original bug: clicking a notification launched Script Editor.
  - With the patch, clicking the notification focuses the iTerm2 tab where Claude Code is running.
  - Verified `findTerminalTTY()` correctly walks past the detached hook subprocess and finds the parent's tty (e.g. `/dev/ttys017`).
  - Verified fallback path: with `TERM_PROGRAM=Apple_Terminal`, hook still fires an `osascript` notification (no regression for Terminal.app users).
- [x] Automated tests pass locally (`node tests/hooks/hooks.test.js` — 222/222 passing; full `node tests/run-all.js` shows no new failures attributable to this file).
- [x] Edge cases considered and tested
  - Hook subprocess detached from controlling terminal (`/dev/tty` returns `ENXIO`) → process-tree walk path used.
  - Process-tree walk hits init/no-tty ancestor → returns null → falls back to osascript.
  - Control characters in the message are stripped (`/[\\x00-\\x1f\\x7f]/`) so they cannot break the escape sequence framing.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files unchanged
- [x] No new shell scripts
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format (`fix(hooks): …`)

## Documentation

- [x] Updated the file-level JSDoc comment to describe the new macOS notification behavior and the iTerm2 vs osascript paths.
- [x] Added inline JSDoc on `findTerminalTTY()` and the updated `notifyMacOS()` explaining why the escape-sequence path is preferred and when the osascript fallback is used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS notifications so clicking them focuses the correct iTerm2 tab. On iTerm2, the hook now prefers OSC 9 and falls back to `osascript` in other terminals or when tmux/screen would swallow the escape.

- **Bug Fixes**
  - Use iTerm2’s OSC 9 when `TERM_PROGRAM=iTerm.app` and not inside tmux/screen; write to the parent tab’s tty.
  - Walk the process tree to find a real tty with a 2s timeout; normalize `ps` short TTY names; strip control chars to prevent escape injection.
  - Fall back to `osascript` when not in iTerm2, when tty discovery fails, or under a multiplexer; minor cleanup (hoisted `fs` import, lint note); behavior for Terminal.app/Warp is unchanged.

- **Refactors**
  - Extract `MAX_TTY_LOOKUP_DEPTH` and `PS_TIMEOUT_MS` constants to replace magic numbers.

<sup>Written for commit 97a8b38277bf8e1e972e53bf293be7a498bc9fa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS notifications to prefer native iTerm2 delivery when available (skips tmux/screen), with reliable fallbacks to the standard macOS notification path if native delivery fails. Enhanced parent-process/TTY detection and message sanitization (uses literal curly quotes) for more consistent, clickable notifications across terminal and WSL environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->