### PR TITLE
fix(ci): detect unsafe checkouts even when uses: value is quoted

### DIFF
--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -75,7 +75,7 @@ function extractCheckoutSteps(source) {
       startLine: block.startLine,
       text: block.lines.join('\n'),
     }))
-    .filter(block => /uses:\s*actions\/checkout@/m.test(block.text));
+    .filter(block => /uses:\s*['"]?actions\/checkout@/m.test(block.text));
 }
 
 function findViolations(filePath, source) {

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -84,11 +84,21 @@ function run() {
   // Quoted action names (`uses: "actions/checkout@v4"`) are valid YAML and
   // appear in the wild. The original `uses:\s*actions/checkout@` filter
   // skipped quoted forms, letting unsafe `with: ref:` slip past the validator.
-  if (test('detects unsafe checkout when uses: value is quoted', () => {
+  // Cover both double- and single-quoted forms since the regex's ['"]? class
+  // makes them distinct branches.
+  if (test('detects unsafe checkout when uses: value is double-quoted', () => {
     const result = runValidator({
-      'unsafe-quoted.yml': `name: Unsafe\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: "actions/checkout@v4"\n        with:\n          ref: \${{ github.event.pull_request.head.sha }}\n`,
+      'unsafe-double-quoted.yml': `name: Unsafe\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: "actions/checkout@v4"\n        with:\n          ref: \${{ github.event.pull_request.head.sha }}\n`,
     });
-    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on quoted uses:');
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on double-quoted uses:');
+    assert.match(result.stderr, /pull_request\.head\.sha/);
+  })) passed++; else failed++;
+
+  if (test('detects unsafe checkout when uses: value is single-quoted', () => {
+    const result = runValidator({
+      'unsafe-single-quoted.yml': `name: Unsafe\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: 'actions/checkout@v4'\n        with:\n          ref: \${{ github.event.pull_request.head.sha }}\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on single-quoted uses:');
     assert.match(result.stderr, /pull_request\.head\.sha/);
   })) passed++; else failed++;
 

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -81,6 +81,17 @@ function run() {
     assert.match(result.stderr, /pull_request\.head\.sha/);
   })) passed++; else failed++;
 
+  // Quoted action names (`uses: "actions/checkout@v4"`) are valid YAML and
+  // appear in the wild. The original `uses:\s*actions/checkout@` filter
+  // skipped quoted forms, letting unsafe `with: ref:` slip past the validator.
+  if (test('detects unsafe checkout when uses: value is quoted', () => {
+    const result = runValidator({
+      'unsafe-quoted.yml': `name: Unsafe\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: "actions/checkout@v4"\n        with:\n          ref: \${{ github.event.pull_request.head.sha }}\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on quoted uses:');
+    assert.match(result.stderr, /pull_request\.head\.sha/);
+  })) passed++; else failed++;
+
   console.log(`\nPassed: ${passed}`);
   console.log(`Failed: ${failed}`);
 


### PR DESCRIPTION
## Summary

`extractCheckoutSteps` filters step blocks down to ones that invoke `actions/checkout`. The current regex requires the `uses:` value to be unquoted, so any step written as `uses: "actions/checkout@v4"` is silently skipped — including its `with: ref:` and `with: repository:` lines, which is exactly the surface this validator exists to inspect.

Both forms are valid YAML, and quoted values appear in the wild (some style guides quote action names; some YAML formatters add quotes when version strings start with digits). A contributor following such a style — or an attacker who notices the gap — can submit a PR with an unsafe `ref: ${{ github.event.pull_request.head.sha }}` and the validator will pass it.

Same class of issue as the original motivation for this script (#1359), just applied to a step the regex doesn't recognize as a checkout in the first place.

## Change

One-character regex update: allow an optional `'` or `"` before `actions/checkout@`. No behavior change for the unquoted form.

```diff
-    .filter(block => /uses:\s*actions\/checkout@/m.test(block.text));
+    .filter(block => /uses:\s*['"]?actions\/checkout@/m.test(block.text));
```

## Test added

`tests/ci/validate-workflow-security.test.js` gets one new fixture that mirrors the existing `pull_request_target` + `pull_request.head.sha` case but with `uses: "actions/checkout@v4"`. Without the fix this case returns exit 0 (validator silently passes); with the fix it returns non-zero and emits the expected violation.

## Test plan

- [x] `node tests/ci/validate-workflow-security.test.js` — 5/5 pass (was 4/4)
- [x] Existing tests still pass (no regression on unquoted form)
- [x] `node scripts/ci/validate-workflow-security.js` still passes against this repo's actual `.github/workflows/` (7 files clean)

## Related

- Original motivation: #1359
- Found while porting the validator to a downstream Gemini CLI extension ([reference fix in `Jamkris/everything-gemini-code#47`, commit `ce2ca96`](https://github.com/Jamkris/everything-gemini-code/pull/47/commits/ce2ca96)).
- The downstream port also fixes a separate `block-no-verify` false-positive class — filed as a follow-up issue (#1588) rather than bundling here, since it warranted a design discussion before sending a PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CI workflow security validation now correctly recognizes action references wrapped in single or double quotes, ensuring consistent rule enforcement across YAML formats.
* **Tests**
  * Added CI validation tests covering quoted action entries in pull-request workflows to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bypass where the workflow-security validator skipped `actions/checkout` when `uses:` was quoted. Now it detects quoted forms and flags unsafe `ref` values.

- **Bug Fixes**
  - Update regex to allow optional quotes: `/uses:\s*['"]?actions\/checkout@/`.
  - Add tests for both `"actions/checkout@v4"` and `'actions/checkout@v4'` to ensure unsafe refs are caught.

<sup>Written for commit e0ac4c164373259fe0ddb08c9a19d48b460a099c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

