### PR TITLE
fix(hooks): treat HTTP 400 MCP probes as reachable

### DIFF
--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -24,7 +24,7 @@ const DEFAULT_TTL_MS = 2 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_BACKOFF_MS = 30 * 1000;
 const MAX_BACKOFF_MS = 10 * 60 * 1000;
-const HEALTHY_HTTP_CODES = new Set([200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 405]);
+const HEALTHY_HTTP_CODES = new Set([200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 400, 405]);
 const RECONNECT_STATUS_CODES = new Set([401, 403, 429, 503]);
 const FAILURE_PATTERNS = [
   { code: 401, pattern: /\b401\b|unauthori[sz]ed|auth(?:entication)?\s+(?:failed|expired|invalid)/i },

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -6,9 +6,10 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const http = require('http');
 const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 const script = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'mcp-health-check.js');
 
@@ -97,6 +98,17 @@ function runRawHook(rawInput, env = {}) {
     stdout: result.stdout || '',
     stderr: result.stderr || ''
   };
+}
+
+function waitForFile(filePath, timeoutMs = 5000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath, 'utf8');
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
 }
 async function runTests() {
   console.log('\n=== Testing mcp-health-check.js ===\n');
@@ -190,6 +202,64 @@ async function runTests() {
       assert.strictEqual(state.servers.flaky.status, 'unhealthy', 'Expected flaky server to be marked unhealthy');
       assert.ok(state.servers.flaky.nextRetryAt > state.servers.flaky.checkedAt, 'Expected retry backoff to be recorded');
     } finally {
+      cleanupTempDir(tempDir);
+    }
+  })) passed++; else failed++;
+
+  if (await asyncTest('treats HTTP 400 probe responses as healthy reachable servers', async () => {
+    const tempDir = createTempDir();
+    const configPath = path.join(tempDir, 'claude.json');
+    const statePath = path.join(tempDir, 'mcp-health.json');
+    const serverScript = path.join(tempDir, 'http-400-server.js');
+    const portFile = path.join(tempDir, 'server-port.txt');
+    const serverProcess = spawn(process.execPath, [serverScript, portFile], {
+      stdio: 'ignore'
+    });
+
+    try {
+      fs.writeFileSync(
+        serverScript,
+        [
+          "const fs = require('fs');",
+          "const http = require('http');",
+          "const portFile = process.argv[2];",
+          "const server = http.createServer((_req, res) => {",
+          "  res.writeHead(400, { 'Content-Type': 'application/json' });",
+          "  res.end(JSON.stringify({ error: 'invalid MCP request' }));",
+          "});",
+          "server.listen(0, '127.0.0.1', () => {",
+          "  fs.writeFileSync(portFile, String(server.address().port));",
+          "});",
+          "setInterval(() => {}, 1000);"
+        ].join('\n')
+      );
+
+      const port = waitForFile(portFile).trim();
+
+      writeConfig(configPath, {
+        mcpServers: {
+          github: {
+            type: 'http',
+            url: `http://127.0.0.1:${port}/mcp`
+          }
+        }
+      });
+
+      const input = { tool_name: 'mcp__github__search_repositories', tool_input: {} };
+      const result = runHook(input, {
+        CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
+        ECC_MCP_CONFIG_PATH: configPath,
+        ECC_MCP_HEALTH_STATE_PATH: statePath,
+        ECC_MCP_HEALTH_TIMEOUT_MS: '500'
+      });
+
+      assert.strictEqual(result.code, 0, `Expected HTTP 400 probe to be treated as healthy, got ${result.code}`);
+      assert.strictEqual(result.stdout.trim(), JSON.stringify(input), 'Expected original JSON on stdout');
+
+      const state = readState(statePath);
+      assert.strictEqual(state.servers.github.status, 'healthy', 'Expected HTTP MCP server to be marked healthy');
+    } finally {
+      serverProcess.kill('SIGTERM');
       cleanupTempDir(tempDir);
     }
   })) passed++; else failed++;

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -262,6 +262,17 @@ async function runTests() {
     } finally {
       if (serverProcess) {
         serverProcess.kill('SIGTERM');
+        await new Promise(resolve => {
+          let settled = false;
+          const finish = () => {
+            if (settled) return;
+            settled = true;
+            resolve();
+          };
+          serverProcess.once('exit', finish);
+          serverProcess.once('close', finish);
+          setTimeout(finish, 500);
+        });
       }
       cleanupTempDir(tempDir);
     }

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -6,7 +6,6 @@
 
 const assert = require('assert');
 const fs = require('fs');
-const http = require('http');
 const os = require('os');
 const path = require('path');
 const { spawn, spawnSync } = require('child_process');
@@ -212,9 +211,7 @@ async function runTests() {
     const statePath = path.join(tempDir, 'mcp-health.json');
     const serverScript = path.join(tempDir, 'http-400-server.js');
     const portFile = path.join(tempDir, 'server-port.txt');
-    const serverProcess = spawn(process.execPath, [serverScript, portFile], {
-      stdio: 'ignore'
-    });
+    let serverProcess;
 
     try {
       fs.writeFileSync(
@@ -233,6 +230,10 @@ async function runTests() {
           "setInterval(() => {}, 1000);"
         ].join('\n')
       );
+
+      serverProcess = spawn(process.execPath, [serverScript, portFile], {
+        stdio: 'ignore'
+      });
 
       const port = waitForFile(portFile).trim();
 
@@ -259,7 +260,9 @@ async function runTests() {
       const state = readState(statePath);
       assert.strictEqual(state.servers.github.status, 'healthy', 'Expected HTTP MCP server to be marked healthy');
     } finally {
-      serverProcess.kill('SIGTERM');
+      if (serverProcess) {
+        serverProcess.kill('SIGTERM');
+      }
       cleanupTempDir(tempDir);
     }
   })) passed++; else failed++;


### PR DESCRIPTION
## Summary
- treat HTTP 400 MCP probe responses as reachable in the health-check hook
- add regression coverage for HTTP-backed MCP servers that respond with 400 on probe
- fix the new test's server bootstrap ordering so the script is written before the child process is spawned

## Testing
- `node tests/hooks/mcp-health-check.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats HTTP 400 responses from HTTP MCP probes as reachable so HTTP-backed MCP servers aren’t falsely marked unhealthy or put on backoff. Adds regression coverage and stabilizes test server bootstrap and cleanup.

- **Bug Fixes**
  - Added 400 to the healthy HTTP codes in the health-check hook.
  - Tests: added coverage for HTTP 400 probes; write the probe server script before spawn, wait for the port file, and wait for server exit before cleanup to avoid race conditions.

<sup>Written for commit 13d2115b308e08c36edc9f82642dd842ac9d859c. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP 400 responses are now treated as healthy in health checks, avoiding unnecessary reconnections.

* **Tests**
  * Added a test verifying HTTP-based health probing accepts non-standard healthy status codes (including 400) and records healthy state.
  * Improved test synchronization to more reliably validate probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->