### PR TITLE
fix(ci): validate plugin catalog counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ everything-claude-code/
 |   |-- plugin.json         # Plugin metadata and component paths
 |   |-- marketplace.json    # Marketplace catalog for /plugin marketplace add
 |
-|-- agents/           # 36 specialized subagents for delegation
+|-- agents/           # 48 specialized subagents for delegation
 |   |-- planner.md           # Feature implementation planning
 |   |-- architect.md         # System design decisions
 |   |-- tdd-guide.md         # Test-driven development

--- a/scripts/ci/catalog.js
+++ b/scripts/ci/catalog.js
@@ -21,6 +21,8 @@ const AGENTS_PATH = path.join(ROOT, 'AGENTS.md');
 const README_ZH_CN_PATH = path.join(ROOT, 'README.zh-CN.md');
 const DOCS_ZH_CN_README_PATH = path.join(ROOT, 'docs', 'zh-CN', 'README.md');
 const DOCS_ZH_CN_AGENTS_PATH = path.join(ROOT, 'docs', 'zh-CN', 'AGENTS.md');
+const PLUGIN_JSON_PATH = path.join(ROOT, '.claude-plugin', 'plugin.json');
+const MARKETPLACE_JSON_PATH = path.join(ROOT, '.claude-plugin', 'marketplace.json');
 const WRITE_MODE = process.argv.includes('--write');
 
 const OUTPUT_MODE = process.argv.includes('--md')
@@ -346,6 +348,57 @@ function parseZhAgentsDocExpectations(agentsContent) {
   return expectations;
 }
 
+
+function parseCatalogDescriptionExpectations(content, source, getDescription) {
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error(`${source} is not valid JSON: ${error.message}`);
+  }
+
+  const description = getDescription(parsed);
+  if (typeof description !== 'string') {
+    throw new Error(`${source} is missing the catalog count description`);
+  }
+
+  const match = description.match(/(\d+)\s+agents,\s+(\d+)\s+skills,\s+(\d+)\s+legacy command shims?/i);
+  if (!match) {
+    throw new Error(`${source} is missing the catalog count description`);
+  }
+
+  return [
+    { category: 'agents', mode: 'exact', expected: Number(match[1]), source },
+    { category: 'skills', mode: 'exact', expected: Number(match[2]), source },
+    { category: 'commands', mode: 'exact', expected: Number(match[3]), source },
+  ];
+}
+
+function syncCatalogDescription(content, catalog, source, getDescription, setDescription) {
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error(`${source} is not valid JSON: ${error.message}`);
+  }
+
+  const description = getDescription(parsed);
+  if (typeof description !== 'string') {
+    throw new Error(`${source} is missing the catalog count description`);
+  }
+
+  const nextDescription = replaceOrThrow(
+    description,
+    /(\d+)(\s+agents,\s+)(\d+)(\s+skills,\s+)(\d+)(\s+legacy command shims?)/i,
+    (_, __, agentsSuffix, ___, skillsSuffix, ____, commandsSuffix) =>
+      `${catalog.agents.count}${agentsSuffix}${catalog.skills.count}${skillsSuffix}${catalog.commands.count}${commandsSuffix}`,
+    source
+  );
+
+  setDescription(parsed, nextDescription);
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
 function evaluateExpectations(catalog, expectations) {
   return expectations.map(expectation => {
     const actual = catalog[expectation.category].count;
@@ -547,6 +600,8 @@ function createDocumentSpecs(paths = {}) {
     zhRootReadmePath = README_ZH_CN_PATH,
     zhDocsReadmePath = DOCS_ZH_CN_README_PATH,
     zhDocsAgentsPath = DOCS_ZH_CN_AGENTS_PATH,
+    pluginJsonPath = PLUGIN_JSON_PATH,
+    marketplaceJsonPath = MARKETPLACE_JSON_PATH,
   } = paths;
 
   return [
@@ -575,6 +630,36 @@ function createDocumentSpecs(paths = {}) {
       parseExpectations: parseZhAgentsDocExpectations,
       syncContent: syncZhAgents,
     },
+    {
+      filePath: pluginJsonPath,
+      parseExpectations: content => parseCatalogDescriptionExpectations(
+        content,
+        '.claude-plugin/plugin.json description',
+        parsed => parsed.description
+      ),
+      syncContent: (content, catalog) => syncCatalogDescription(
+        content,
+        catalog,
+        '.claude-plugin/plugin.json description',
+        parsed => parsed.description,
+        (parsed, description) => { parsed.description = description; }
+      ),
+    },
+    {
+      filePath: marketplaceJsonPath,
+      parseExpectations: content => parseCatalogDescriptionExpectations(
+        content,
+        '.claude-plugin/marketplace.json plugin description',
+        parsed => parsed.plugins?.[0]?.description
+      ),
+      syncContent: (content, catalog) => syncCatalogDescription(
+        content,
+        catalog,
+        '.claude-plugin/marketplace.json plugin description',
+        parsed => parsed.plugins?.[0]?.description,
+        (parsed, description) => { parsed.plugins[0].description = description; }
+      ),
+    },
   ];
 }
 
@@ -585,6 +670,8 @@ function createDocumentSpecsForRoot(root) {
     zhRootReadmePath: path.join(root, 'README.zh-CN.md'),
     zhDocsReadmePath: path.join(root, 'docs', 'zh-CN', 'README.md'),
     zhDocsAgentsPath: path.join(root, 'docs', 'zh-CN', 'AGENTS.md'),
+    pluginJsonPath: path.join(root, '.claude-plugin', 'plugin.json'),
+    marketplaceJsonPath: path.join(root, '.claude-plugin', 'marketplace.json'),
   });
 }
 
@@ -689,11 +776,13 @@ module.exports = {
   formatExpectation,
   main,
   parseAgentsDocExpectations,
+  parseCatalogDescriptionExpectations,
   parseReadmeExpectations,
   parseZhAgentsDocExpectations,
   parseZhDocsReadmeExpectations,
   parseZhRootReadmeExpectations,
   runCatalogCheck,
+  syncCatalogDescription,
   syncEnglishAgents,
   syncEnglishReadme,
   syncZhAgents,

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -169,6 +169,8 @@ function runCatalogValidator(overrides = {}) {
     README_ZH_CN_PATH: path.join(repoRoot, 'README.zh-CN.md'),
     DOCS_ZH_CN_README_PATH: path.join(repoRoot, 'docs', 'zh-CN', 'README.md'),
     DOCS_ZH_CN_AGENTS_PATH: path.join(repoRoot, 'docs', 'zh-CN', 'AGENTS.md'),
+    PLUGIN_JSON_PATH: path.join(repoRoot, '.claude-plugin', 'plugin.json'),
+    MARKETPLACE_JSON_PATH: path.join(repoRoot, '.claude-plugin', 'marketplace.json'),
     ...overrides,
   };
 
@@ -183,6 +185,7 @@ function runCatalogValidator(overrides = {}) {
 function writeCatalogFixture(testDir, options = {}) {
   const {
     readmeCounts = { agents: 1, skills: 1, commands: 1 },
+    readmePublicSurfaceCounts = readmeCounts,
     readmeTableCounts = readmeCounts,
     readmeParityCounts = readmeCounts,
     readmeUnrelatedSkillsCount = 16,
@@ -203,6 +206,8 @@ function writeCatalogFixture(testDir, options = {}) {
       'skills/          — 1 个工作流技能和领域知识',
       'commands/        — 1 个斜杠命令',
     ],
+    pluginCounts = { agents: 1, skills: 1, commands: 1 },
+    marketplaceCounts = { agents: 1, skills: 1, commands: 1 },
   } = options;
 
   const readmePath = path.join(testDir, 'README.md');
@@ -210,23 +215,36 @@ function writeCatalogFixture(testDir, options = {}) {
   const zhRootReadmePath = path.join(testDir, 'README.zh-CN.md');
   const zhDocsReadmePath = path.join(testDir, 'docs', 'zh-CN', 'README.md');
   const zhAgentsPath = path.join(testDir, 'docs', 'zh-CN', 'AGENTS.md');
+  const pluginJsonPath = path.join(testDir, '.claude-plugin', 'plugin.json');
+  const marketplaceJsonPath = path.join(testDir, '.claude-plugin', 'marketplace.json');
 
   fs.mkdirSync(path.join(testDir, 'agents'), { recursive: true });
   fs.mkdirSync(path.join(testDir, 'commands'), { recursive: true });
   fs.mkdirSync(path.join(testDir, 'skills', 'demo-skill'), { recursive: true });
   fs.mkdirSync(path.join(testDir, 'docs', 'zh-CN'), { recursive: true });
+  fs.mkdirSync(path.join(testDir, '.claude-plugin'), { recursive: true });
 
   fs.writeFileSync(path.join(testDir, 'agents', 'planner.md'), '---\nmodel: sonnet\ntools: Read\n---\n# Planner');
   fs.writeFileSync(path.join(testDir, 'commands', 'plan.md'), '---\ndescription: Plan\n---\n# Plan');
   fs.writeFileSync(path.join(testDir, 'skills', 'demo-skill', 'SKILL.md'), '---\nname: demo-skill\ndescription: Demo skill\norigin: ECC\n---\n# Demo Skill');
 
-  fs.writeFileSync(readmePath, `Access to ${readmeCounts.agents} agents, ${readmeCounts.skills} skills, and ${readmeCounts.commands} commands.\n| Feature | Claude Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| Agents | PASS: ${readmeTableCounts.agents} agents | Shared | Shared | 1 |\n| Commands | PASS: ${readmeTableCounts.commands} commands | Shared | Shared | 1 |\n| Skills | PASS: ${readmeTableCounts.skills} skills | Shared | Shared | 1 |\n\n| Feature | Count | Format |\n|-----------|-------|---------|\n| Skills | ${readmeUnrelatedSkillsCount} | .agents/skills/ |\n\n## Cross-Tool Feature Parity\n\n| Feature | Claude Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| **Agents** | ${readmeParityCounts.agents} | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |\n| **Commands** | ${readmeParityCounts.commands} | Shared | Instruction-based | 31 |\n| **Skills** | ${readmeParityCounts.skills} | Shared | 10 (native format) | 37 |\n`);
+  fs.writeFileSync(readmePath, `Access to ${readmeCounts.agents} agents, ${readmeCounts.skills} skills, and ${readmeCounts.commands} commands.\n- **Public surface synced to the live repo** — metadata, catalog counts, plugin manifests, and install-facing docs now match the actual OSS surface: ${readmePublicSurfaceCounts.agents} agents, ${readmePublicSurfaceCounts.skills} skills, and ${readmePublicSurfaceCounts.commands} legacy command shims.\n| Feature | Claude Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| Agents | PASS: ${readmeTableCounts.agents} agents | Shared | Shared | 1 |\n| Commands | PASS: ${readmeTableCounts.commands} commands | Shared | Shared | 1 |\n| Skills | PASS: ${readmeTableCounts.skills} skills | Shared | Shared | 1 |\n\n| Feature | Count | Format |\n|-----------|-------|---------|\n| Skills | ${readmeUnrelatedSkillsCount} | .agents/skills/ |\n\n## Cross-Tool Feature Parity\n\n| Feature | Claude Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| **Agents** | ${readmeParityCounts.agents} | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |\n| **Commands** | ${readmeParityCounts.commands} | Shared | Instruction-based | 31 |\n| **Skills** | ${readmeParityCounts.skills} | Shared | 10 (native format) | 37 |\n`);
   fs.writeFileSync(agentsPath, `This is a **production-ready AI coding plugin** providing ${summaryCounts.agents} specialized agents, ${summaryCounts.skills} skills, ${summaryCounts.commands} commands, and automated hook workflows for software development.\n\n\`\`\`\n${structureLines.join('\n')}\n\`\`\`\n`);
   fs.writeFileSync(zhRootReadmePath, `**完成！** 你现在可以使用 ${zhRootReadmeCounts.agents} 个代理、${zhRootReadmeCounts.skills} 个技能和 ${zhRootReadmeCounts.commands} 个命令。\n`);
   fs.writeFileSync(zhDocsReadmePath, `**搞定！** 你现在可以使用 ${zhDocsReadmeCounts.agents} 个智能体、${zhDocsReadmeCounts.skills} 项技能和 ${zhDocsReadmeCounts.commands} 个命令了。\n| 功能特性 | Claude Code | OpenCode | 状态 |\n|---------|-------------|----------|--------|\n| 智能体 | \u2705 ${zhDocsTableCounts.agents} 个 | \u2705 12 个 | **Claude Code 领先** |\n| 命令 | \u2705 ${zhDocsTableCounts.commands} 个 | \u2705 31 个 | **Claude Code 领先** |\n| 技能 | \u2705 ${zhDocsTableCounts.skills} 项 | \u2705 37 项 | **Claude Code 领先** |\n\n| 功能特性 | 数量 | 格式 |\n|-----------|-------|---------|\n| 技能 | ${zhDocsUnrelatedSkillsCount} | .agents/skills/ |\n\n## 跨工具功能对等\n\n| 功能特性 | Claude Code | Cursor IDE | Codex CLI | OpenCode |\n|---------|------------|------------|-----------|----------|\n| **智能体** | ${zhDocsParityCounts.agents} | 共享 (AGENTS.md) | 共享 (AGENTS.md) | 12 |\n| **命令** | ${zhDocsParityCounts.commands} | 共享 | 基于指令 | 31 |\n| **技能** | ${zhDocsParityCounts.skills} | 共享 | 10 (原生格式) | 37 |\n`);
   fs.writeFileSync(zhAgentsPath, `这是一个**生产就绪的 AI 编码插件**，提供 ${zhAgentsSummaryCounts.agents} 个专业代理、${zhAgentsSummaryCounts.skills} 项技能、${zhAgentsSummaryCounts.commands} 条命令以及自动化钩子工作流，用于软件开发。\n\n\`\`\`\n${zhAgentsStructureLines.join('\n')}\n\`\`\`\n`);
+  fs.writeFileSync(pluginJsonPath, JSON.stringify({
+    name: 'everything-claude-code',
+    description: `Battle-tested plugin — ${pluginCounts.agents} agents, ${pluginCounts.skills} skills, ${pluginCounts.commands} legacy command shims`,
+  }, null, 2));
+  fs.writeFileSync(marketplaceJsonPath, JSON.stringify({
+    plugins: [{
+      name: 'everything-claude-code',
+      description: `Marketplace plugin — ${marketplaceCounts.agents} agents, ${marketplaceCounts.skills} skills, ${marketplaceCounts.commands} legacy command shims`,
+    }],
+  }, null, 2));
 
-  return { readmePath, agentsPath, zhRootReadmePath, zhDocsReadmePath, zhAgentsPath };
+  return { readmePath, agentsPath, zhRootReadmePath, zhDocsReadmePath, zhAgentsPath, pluginJsonPath, marketplaceJsonPath };
 }
 
 function runTests() {
@@ -375,8 +393,11 @@ function runTests() {
       zhRootReadmePath,
       zhDocsReadmePath,
       zhAgentsPath,
+      pluginJsonPath,
+      marketplaceJsonPath,
     } = writeCatalogFixture(testDir, {
       readmeCounts: { agents: 99, skills: 99, commands: 99 },
+      readmePublicSurfaceCounts: { agents: 99, skills: 99, commands: 99 },
       readmeTableCounts: { agents: 99, skills: 99, commands: 99 },
       readmeParityCounts: { agents: 99, skills: 99, commands: 99 },
       summaryCounts: { agents: 99, skills: 99, commands: 99 },
@@ -390,6 +411,8 @@ function runTests() {
       zhDocsTableCounts: { agents: 99, skills: 99, commands: 99 },
       zhDocsParityCounts: { agents: 99, skills: 99, commands: 99 },
       zhAgentsSummaryCounts: { agents: 99, skills: 99, commands: 99 },
+      pluginCounts: { agents: 99, skills: 99, commands: 99 },
+      marketplaceCounts: { agents: 99, skills: 99, commands: 99 },
       zhAgentsStructureLines: [
         'agents/          — 99 个专业子代理',
         'skills/          — 99 个工作流技能和领域知识',
@@ -404,10 +427,50 @@ function runTests() {
       README_ZH_CN_PATH: zhRootReadmePath,
       DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
       DOCS_ZH_CN_AGENTS_PATH: zhAgentsPath,
+      PLUGIN_JSON_PATH: pluginJsonPath,
+      MARKETPLACE_JSON_PATH: marketplaceJsonPath,
     });
 
     assert.strictEqual(result.code, 1, 'Should fail when catalog counts drift');
     assert.ok((result.stdout + result.stderr).includes('Documentation count mismatches found:'), 'Should report mismatches');
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('fails when plugin manifest catalog counts drift', () => {
+    const testDir = createTestDir();
+    const {
+      readmePath,
+      agentsPath,
+      zhRootReadmePath,
+      zhDocsReadmePath,
+      zhAgentsPath,
+      pluginJsonPath,
+      marketplaceJsonPath,
+    } = writeCatalogFixture(testDir, {
+      pluginCounts: { agents: 99, skills: 99, commands: 99 },
+      marketplaceCounts: { agents: 99, skills: 99, commands: 99 },
+    });
+
+    const result = runCatalogValidator({
+      ROOT: testDir,
+      README_PATH: readmePath,
+      AGENTS_PATH: agentsPath,
+      README_ZH_CN_PATH: zhRootReadmePath,
+      DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
+      DOCS_ZH_CN_AGENTS_PATH: zhAgentsPath,
+      PLUGIN_JSON_PATH: pluginJsonPath,
+      MARKETPLACE_JSON_PATH: marketplaceJsonPath,
+    });
+
+    assert.strictEqual(result.code, 1, 'Should fail when plugin manifest counts drift');
+    assert.ok(
+      (result.stdout + result.stderr).includes('.claude-plugin/plugin.json description'),
+      'Should report plugin manifest description mismatches'
+    );
+    assert.ok(
+      (result.stdout + result.stderr).includes('.claude-plugin/marketplace.json plugin description'),
+      'Should report marketplace manifest description mismatches'
+    );
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 
@@ -419,6 +482,8 @@ function runTests() {
       zhRootReadmePath,
       zhDocsReadmePath,
       zhAgentsPath,
+      pluginJsonPath,
+      marketplaceJsonPath,
     } = writeCatalogFixture(testDir, {
       readmeCounts: { agents: 1, skills: 1, commands: 1 },
       readmeTableCounts: { agents: 1, skills: 1, commands: 1 },
@@ -433,6 +498,8 @@ function runTests() {
       README_ZH_CN_PATH: zhRootReadmePath,
       DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
       DOCS_ZH_CN_AGENTS_PATH: zhAgentsPath,
+      PLUGIN_JSON_PATH: pluginJsonPath,
+      MARKETPLACE_JSON_PATH: marketplaceJsonPath,
     });
 
     assert.strictEqual(result.code, 1, 'Should fail when README parity table drifts');
@@ -450,6 +517,8 @@ function runTests() {
       agentsPath,
       zhRootReadmePath,
       zhDocsReadmePath,
+      pluginJsonPath,
+      marketplaceJsonPath,
     } = writeCatalogFixture(testDir);
     const missingZhAgentsPath = path.join(testDir, 'docs', 'zh-CN', 'AGENTS.md');
     fs.rmSync(missingZhAgentsPath);
@@ -461,6 +530,8 @@ function runTests() {
       README_ZH_CN_PATH: zhRootReadmePath,
       DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
       DOCS_ZH_CN_AGENTS_PATH: missingZhAgentsPath,
+      PLUGIN_JSON_PATH: pluginJsonPath,
+      MARKETPLACE_JSON_PATH: marketplaceJsonPath,
     });
 
     assert.strictEqual(result.code, 1, 'Should fail when a tracked doc is missing');
@@ -479,8 +550,11 @@ function runTests() {
       zhRootReadmePath,
       zhDocsReadmePath,
       zhAgentsPath,
+      pluginJsonPath,
+      marketplaceJsonPath,
     } = writeCatalogFixture(testDir, {
       readmeCounts: { agents: 9, skills: 9, commands: 9 },
+      readmePublicSurfaceCounts: { agents: 9, skills: 9, commands: 9 },
       readmeTableCounts: { agents: 8, skills: 8, commands: 8 },
       readmeParityCounts: { agents: 7, skills: 7, commands: 7 },
       summaryCounts: { agents: 6, skills: 6, commands: 6 },
@@ -489,6 +563,8 @@ function runTests() {
       zhDocsTableCounts: { agents: 12, skills: 12, commands: 12 },
       zhDocsParityCounts: { agents: 13, skills: 13, commands: 13 },
       zhAgentsSummaryCounts: { agents: 14, skills: 14, commands: 14 },
+      pluginCounts: { agents: 18, skills: 18, commands: 18 },
+      marketplaceCounts: { agents: 19, skills: 19, commands: 19 },
       zhAgentsStructureLines: [
         'agents/          — 15 个专业子代理',
         'skills/          — 16 个工作流技能和领域知识',
@@ -504,6 +580,8 @@ function runTests() {
       README_ZH_CN_PATH: zhRootReadmePath,
       DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
       DOCS_ZH_CN_AGENTS_PATH: zhAgentsPath,
+      PLUGIN_JSON_PATH: pluginJsonPath,
+      MARKETPLACE_JSON_PATH: marketplaceJsonPath,
     });
 
     assert.strictEqual(result.code, 0, `Should sync and pass, got stderr: ${result.stderr}`);
@@ -513,8 +591,11 @@ function runTests() {
     const zhRootReadme = fs.readFileSync(zhRootReadmePath, 'utf8');
     const zhDocsReadme = fs.readFileSync(zhDocsReadmePath, 'utf8');
     const zhAgentsDoc = fs.readFileSync(zhAgentsPath, 'utf8');
+    const pluginJson = fs.readFileSync(pluginJsonPath, 'utf8');
+    const marketplaceJson = fs.readFileSync(marketplaceJsonPath, 'utf8');
 
     assert.ok(readme.includes('Access to 1 agents, 1 skills, and 1 legacy command shims'), 'Should sync README quick-start summary');
+    assert.ok(readme.includes('actual OSS surface: 9 agents, 9 skills, and 9 legacy command shims'), 'Should not rewrite versioned README changelog counts');
     assert.ok(readme.includes('| Agents | PASS: 1 agents |'), 'Should sync README comparison table');
     assert.ok(readme.includes('| Skills | 16 | .agents/skills/ |'), 'Should not rewrite unrelated README tables');
     assert.ok(readme.includes('| **Agents** | 1 | Shared (AGENTS.md) | Shared (AGENTS.md) | 12 |'), 'Should sync README parity table');
@@ -527,6 +608,8 @@ function runTests() {
     assert.ok(zhDocsReadme.includes('| **智能体** | 1 | 共享 (AGENTS.md) | 共享 (AGENTS.md) | 12 |'), 'Should sync docs/zh-CN/README parity table');
     assert.ok(zhAgentsDoc.includes('提供 1 个专业代理、1 项技能、1 条命令'), 'Should sync docs/zh-CN/AGENTS summary');
     assert.ok(zhAgentsDoc.includes('commands/        — 1 个斜杠命令'), 'Should sync docs/zh-CN/AGENTS structure');
+    assert.ok(pluginJson.includes('1 agents, 1 skills, 1 legacy command shims'), 'Should sync plugin manifest catalog description');
+    assert.ok(marketplaceJson.includes('1 agents, 1 skills, 1 legacy command shims'), 'Should sync marketplace plugin catalog description');
 
     cleanupTestDir(testDir);
   })) passed++; else failed++;
@@ -539,6 +622,8 @@ function runTests() {
       zhRootReadmePath,
       zhDocsReadmePath,
       zhAgentsPath,
+      pluginJsonPath,
+      marketplaceJsonPath,
     } = writeCatalogFixture(testDir, {
       structureLines: [
         '  agents/   -   1 specialized subagents   ',
@@ -559,6 +644,8 @@ function runTests() {
       README_ZH_CN_PATH: zhRootReadmePath,
       DOCS_ZH_CN_README_PATH: zhDocsReadmePath,
       DOCS_ZH_CN_AGENTS_PATH: zhAgentsPath,
+      PLUGIN_JSON_PATH: pluginJsonPath,
+      MARKETPLACE_JSON_PATH: marketplaceJsonPath,
     });
 
     assert.strictEqual(result.code, 0, `Should accept formatting variations, got stderr: ${result.stderr}`);


### PR DESCRIPTION
## Summary
- sync install-facing plugin catalog counts to the live repo surface
- teach the catalog validator to check the README public-surface line and plugin manifest descriptions
- add validator fixture coverage so stale manifest counts fail in CI

## Testing
- node scripts/ci/catalog.js --text
- node tests/docs/install-identifiers.test.js
- node tests/ci/validators.test.js (catalog tests pass; unrelated validate-hooks cases fail locally because ajv is not installed)

## Notes
This overlaps the public README count mismatch noted in #1337, but also covers the plugin manifests and the validator gap so the counts cannot drift silently again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now validates and auto-syncs catalog counts across the README and `.claude-plugin` manifests to prevent drift. This keeps install-facing numbers aligned with the live repo surface.

- **Bug Fixes**
  - Validator checks the README public-surface summary and the description fields in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, and syncs them in write mode.
  - Updated counts to 48 agents, 183 skills, and 79 legacy command shims across README examples and manifests.
  - Added tests and fixtures to fail on drift and ensure sync doesn’t rewrite unrelated tables or versioned changelog counts.

<sup>Written for commit ef20d24373749da819ad3d6b255b3e3f9e8d0cb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README metadata reflecting current agent counts.

* **Tests**
  * Enhanced catalog validation to ensure plugin and marketplace manifest descriptions remain synchronized with current counts.
  * Added test coverage for manifest consistency detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->