### PR TITLE
docs(continuous-learning): mark v1 as deprecated; route to v2

### DIFF
--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -1,9 +1,23 @@
 ---
 name: continuous-learning
-description: Automatically extract reusable patterns from Claude Code sessions and save them as learned skills for future use.
+description: "[DEPRECATED — use continuous-learning-v2] Legacy v1 stop-hook skill extractor. v2 is a strict superset (instinct-based, project-scoped, hook-reliable). Do not invoke v1; route all 'continuous learning' / 'session learning' / 'pattern extraction' requests to continuous-learning-v2."
 ---
 
-# Continuous Learning Skill
+# Continuous Learning Skill — DEPRECATED
+
+> **DEPRECATED 2026-04-28.** Use `continuous-learning-v2` instead. v2 is a strict superset:
+> stop-hook → PreToolUse/PostToolUse (100% reliable observation), full skills → atomic
+> instincts with confidence scoring, no scope → project-scoped + global with promotion.
+> See v2's "What's New in v2 (vs v1)" table for the full delta.
+>
+> Kept for archival reference. The `name` and `description` above route the skill picker
+> away from v1, and the body below remains in case any existing consumer still relies on
+> the v1 trigger surface. Maintainers may choose to delete this file entirely if backward
+> compatibility is no longer needed.
+
+---
+
+## Original v1 Documentation (archival)
 
 Automatically evaluates Claude Code sessions on end to extract reusable patterns that can be saved as learned skills.
 


### PR DESCRIPTION
## Summary

Marks the v1 \`continuous-learning\` skill as deprecated and steers the skill picker toward \`continuous-learning-v2\` (which already ships in this same marketplace).

## Why

\`continuous-learning-v2/SKILL.md\` already documents itself as superseding v1 — see its \"What's New in v2 (vs v1)\" table. v2 is a strict superset:

| Feature | v1 | v2 |
|---------|----|----|
| Observation | Stop hook (can miss abnormal session end) | PreToolUse/PostToolUse (100% reliable) |
| Analysis | Main context | Background agent (Haiku) |
| Granularity | Full skills | Atomic \"instincts\" |
| Confidence | None | 0.3-0.9 weighted |
| Evolution | Direct to skill | Instincts → cluster → skill/command/agent |
| Sharing | None | Export/import instincts |
| Scope (v2.1) | N/A | Project-scoped + global + promotion |

Today the skill picker can pick either v1 or v2 based on description keyword overlap. Without an explicit deprecation marker on v1, downstream agents (including Claude itself) often select v1 when the user is asking for what v2 actually solves.

## What changed

- \`skills/continuous-learning/SKILL.md\` frontmatter \`description\` is prefixed with \`[DEPRECATED — use continuous-learning-v2]\` and re-targets v1 traffic to v2 explicitly.
- Body opens with a deprecation banner explaining the v1 → v2 delta in one paragraph.
- Original v1 documentation is preserved below the banner, marked as archival.

No code or behavior changes. Pure docs/routing.

## Notes for reviewer

- I took the conservative path (shadow the trigger surface, keep the file). If you'd rather delete \`skills/continuous-learning/\` entirely now that v2 is the canonical entry, happy to switch this PR to that. Both are valid.
- The deprecation date in the banner is 2026-04-28 (today); feel free to adjust to your preferred convention.

## Test plan

- [x] \`SKILL.md\` frontmatter still parses (\`name\`, \`description\` fields valid).
- [x] No edits to \`skills/continuous-learning-v2/\` — that path remains canonical.
- [ ] Manual: a session that asks for \"continuous learning\" / \"session pattern extraction\" should now route to v2 rather than v1.

🤖 Authored against the upstream branch from a downstream user who actively uses both skills daily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Continuous-learning v1 skill marked as deprecated.
  * Users directed to migrate to continuous-learning v2.
  * Legacy documentation retained for existing consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->