### PR TITLE
fix: normalize codex skill metadata

### DIFF
--- a/.agents/skills/agent-introspection-debugging/SKILL.md
+++ b/.agents/skills/agent-introspection-debugging/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: agent-introspection-debugging
 description: Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports.
-origin: ECC
 ---
 
 # Agent Introspection Debugging

--- a/.agents/skills/agent-introspection-debugging/agents/openai.yaml
+++ b/.agents/skills/agent-introspection-debugging/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Agent Introspection Debugging"
+  short_description: "Structured self-debugging for AI agent failures"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $agent-introspection-debugging to diagnose and recover from an AI agent failure."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/agent-sort/SKILL.md
+++ b/.agents/skills/agent-sort/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: agent-sort
 description: Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.
-origin: ECC
 ---
 
 # Agent Sort

--- a/.agents/skills/agent-sort/agents/openai.yaml
+++ b/.agents/skills/agent-sort/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Agent Sort"
+  short_description: "Evidence-backed ECC install planning"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $agent-sort to build an evidence-backed ECC install plan."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/api-design/SKILL.md
+++ b/.agents/skills/api-design/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: api-design
 description: REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.
-origin: ECC
 ---
 
 # API Design Patterns

--- a/.agents/skills/api-design/agents/openai.yaml
+++ b/.agents/skills/api-design/agents/openai.yaml
@@ -2,6 +2,6 @@ interface:
   display_name: "API Design"
   short_description: "REST API design patterns and best practices"
   brand_color: "#F97316"
-  default_prompt: "Design REST API: resources, status codes, pagination"
+  default_prompt: "Use $api-design to design production REST API resources and responses."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/article-writing/SKILL.md
+++ b/.agents/skills/article-writing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: article-writing
 description: Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.
-origin: ECC
 ---
 
 # Article Writing

--- a/.agents/skills/article-writing/agents/openai.yaml
+++ b/.agents/skills/article-writing/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Article Writing"
-  short_description: "Write long-form content in a supplied voice without sounding templated"
+  short_description: "Long-form content in a supplied voice"
   brand_color: "#B45309"
-  default_prompt: "Draft a sharp long-form article from these notes and examples"
+  default_prompt: "Use $article-writing to draft polished long-form content in the supplied voice."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/backend-patterns/SKILL.md
+++ b/.agents/skills/backend-patterns/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: backend-patterns
 description: Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes.
-origin: ECC
 ---
 
 # Backend Development Patterns

--- a/.agents/skills/backend-patterns/agents/openai.yaml
+++ b/.agents/skills/backend-patterns/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Backend Patterns"
-  short_description: "API design, database, and server-side patterns"
+  short_description: "API, database, and server-side patterns"
   brand_color: "#F59E0B"
-  default_prompt: "Apply backend patterns: API design, repository, caching"
+  default_prompt: "Use $backend-patterns to apply backend architecture and API patterns."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/brand-voice/SKILL.md
+++ b/.agents/skills/brand-voice/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brand-voice
 description: Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.
-origin: ECC
 ---
 
 # Brand Voice

--- a/.agents/skills/brand-voice/agents/openai.yaml
+++ b/.agents/skills/brand-voice/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Brand Voice"
+  short_description: "Source-derived writing style profiles"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $brand-voice to derive and reuse a source-grounded writing style."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/bun-runtime/SKILL.md
+++ b/.agents/skills/bun-runtime/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: bun-runtime
 description: Bun as runtime, package manager, bundler, and test runner. When to choose Bun vs Node, migration notes, and Vercel support.
-origin: ECC
 ---
 
 # Bun Runtime

--- a/.agents/skills/bun-runtime/agents/openai.yaml
+++ b/.agents/skills/bun-runtime/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Bun Runtime"
-  short_description: "Bun as runtime, package manager, bundler, and test runner"
+  short_description: "Bun runtime, package manager, and test runner"
   brand_color: "#FBF0DF"
-  default_prompt: "Use Bun for scripts, install, or run"
+  default_prompt: "Use $bun-runtime to choose and apply Bun runtime workflows."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/claude-api/SKILL.md
+++ b/.agents/skills/claude-api/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: claude-api
 description: Anthropic Claude API patterns for Python and TypeScript. Covers Messages API, streaming, tool use, vision, extended thinking, batches, prompt caching, and Claude Agent SDK. Use when building applications with the Claude API or Anthropic SDKs.
-origin: ECC
 ---
 
 # Claude API

--- a/.agents/skills/claude-api/agents/openai.yaml
+++ b/.agents/skills/claude-api/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Claude API"
-  short_description: "Anthropic Claude API patterns and SDKs"
+  short_description: "Claude API patterns for Python and TypeScript"
   brand_color: "#D97706"
-  default_prompt: "Build applications with the Claude API using Messages, tool use, streaming, and Agent SDK"
+  default_prompt: "Use $claude-api to build with Claude API and Anthropic SDK patterns."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/coding-standards/SKILL.md
+++ b/.agents/skills/coding-standards/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: coding-standards
 description: Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.
-origin: ECC
 ---
 
 # Coding Standards & Best Practices

--- a/.agents/skills/coding-standards/agents/openai.yaml
+++ b/.agents/skills/coding-standards/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Coding Standards"
-  short_description: "Universal coding standards and best practices"
+  short_description: "Cross-project coding conventions and review"
   brand_color: "#3B82F6"
-  default_prompt: "Apply standards: immutability, error handling, type safety"
+  default_prompt: "Use $coding-standards to review code against cross-project standards."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/content-engine/SKILL.md
+++ b/.agents/skills/content-engine/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: content-engine
 description: Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.
-origin: ECC
 ---
 
 # Content Engine

--- a/.agents/skills/content-engine/agents/openai.yaml
+++ b/.agents/skills/content-engine/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Content Engine"
-  short_description: "Turn one idea into platform-native social and content outputs"
+  short_description: "Platform-native content systems and campaigns"
   brand_color: "#DC2626"
-  default_prompt: "Turn this source asset into strong multi-platform content"
+  default_prompt: "Use $content-engine to turn source material into platform-native content."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/crosspost/SKILL.md
+++ b/.agents/skills/crosspost/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: crosspost
 description: Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.
-origin: ECC
 ---
 
 # Crosspost

--- a/.agents/skills/crosspost/agents/openai.yaml
+++ b/.agents/skills/crosspost/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Crosspost"
-  short_description: "Multi-platform content distribution with native adaptation"
+  short_description: "Multi-platform social distribution"
   brand_color: "#EC4899"
-  default_prompt: "Distribute content across X, LinkedIn, Threads, and Bluesky with platform-native adaptation"
+  default_prompt: "Use $crosspost to adapt content for multiple social platforms."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/deep-research/SKILL.md
+++ b/.agents/skills/deep-research/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: deep-research
 description: Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.
-origin: ECC
 ---
 
 # Deep Research

--- a/.agents/skills/deep-research/agents/openai.yaml
+++ b/.agents/skills/deep-research/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Deep Research"
-  short_description: "Multi-source deep research with firecrawl and exa MCPs"
+  short_description: "Multi-source cited research reports"
   brand_color: "#6366F1"
-  default_prompt: "Research the given topic using firecrawl and exa, produce a cited report"
+  default_prompt: "Use $deep-research to produce a cited multi-source research report."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/dmux-workflows/SKILL.md
+++ b/.agents/skills/dmux-workflows/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: dmux-workflows
 description: Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.
-origin: ECC
 ---
 
 # dmux Workflows

--- a/.agents/skills/dmux-workflows/agents/openai.yaml
+++ b/.agents/skills/dmux-workflows/agents/openai.yaml
@@ -2,6 +2,6 @@ interface:
   display_name: "dmux Workflows"
   short_description: "Multi-agent orchestration with dmux"
   brand_color: "#14B8A6"
-  default_prompt: "Orchestrate parallel agent sessions using dmux pane manager"
+  default_prompt: "Use $dmux-workflows to orchestrate parallel agent sessions with dmux."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/documentation-lookup/SKILL.md
+++ b/.agents/skills/documentation-lookup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: documentation-lookup
 description: Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).
-origin: ECC
 ---
 
 # Documentation Lookup (Context7)

--- a/.agents/skills/documentation-lookup/agents/openai.yaml
+++ b/.agents/skills/documentation-lookup/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Documentation Lookup"
-  short_description: "Fetch up-to-date library docs via Context7 MCP"
+  short_description: "Current library docs via Context7"
   brand_color: "#6366F1"
-  default_prompt: "Look up docs for a library or API"
+  default_prompt: "Use $documentation-lookup to fetch current library documentation via Context7."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/e2e-testing/SKILL.md
+++ b/.agents/skills/e2e-testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: e2e-testing
 description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.
-origin: ECC
 ---
 
 # E2E Testing Patterns

--- a/.agents/skills/e2e-testing/agents/openai.yaml
+++ b/.agents/skills/e2e-testing/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "E2E Testing"
-  short_description: "Playwright end-to-end testing"
+  short_description: "Playwright E2E testing patterns"
   brand_color: "#06B6D4"
-  default_prompt: "Generate Playwright E2E tests with Page Object Model"
+  default_prompt: "Use $e2e-testing to design Playwright end-to-end test coverage."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/eval-harness/SKILL.md
+++ b/.agents/skills/eval-harness/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: eval-harness
 description: Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles
-origin: ECC
-tools: Read, Write, Edit, Bash, Grep, Glob
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 
 # Eval Harness Skill

--- a/.agents/skills/eval-harness/agents/openai.yaml
+++ b/.agents/skills/eval-harness/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Eval Harness"
-  short_description: "Eval-driven development with pass/fail criteria"
+  short_description: "Eval-driven development harnesses"
   brand_color: "#EC4899"
-  default_prompt: "Set up eval-driven development with pass/fail criteria"
+  default_prompt: "Use $eval-harness to define eval-driven development checks."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/everything-claude-code/SKILL.md
+++ b/.agents/skills/everything-claude-code/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: everything-claude-code-conventions
+name: everything-claude-code
 description: Development conventions and patterns for everything-claude-code. JavaScript project with conventional commits.
 ---
 

--- a/.agents/skills/everything-claude-code/agents/openai.yaml
+++ b/.agents/skills/everything-claude-code/agents/openai.yaml
@@ -1,6 +1,7 @@
 interface:
   display_name: "Everything Claude Code"
-  short_description: "Repo-specific patterns and workflows for everything-claude-code"
-  default_prompt: "Use the everything-claude-code repo skill to follow existing architecture, testing, and workflow conventions."
+  short_description: "Repo workflows for everything-claude-code"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $everything-claude-code to follow this repository's conventions and workflows."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/exa-search/SKILL.md
+++ b/.agents/skills/exa-search/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exa-search
 description: Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.
-origin: ECC
 ---
 
 # Exa Search

--- a/.agents/skills/exa-search/agents/openai.yaml
+++ b/.agents/skills/exa-search/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Exa Search"
-  short_description: "Neural search via Exa MCP for web, code, and companies"
+  short_description: "Neural search via Exa MCP"
   brand_color: "#8B5CF6"
-  default_prompt: "Search using Exa MCP tools for web content, code, or company research"
+  default_prompt: "Use $exa-search to search web, code, or company data through Exa."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/fal-ai-media/SKILL.md
+++ b/.agents/skills/fal-ai-media/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: fal-ai-media
 description: Unified media generation via fal.ai MCP — image, video, and audio. Covers text-to-image (Nano Banana), text/image-to-video (Seedance, Kling, Veo 3), text-to-speech (CSM-1B), and video-to-audio (ThinkSound). Use when the user wants to generate images, videos, or audio with AI.
-origin: ECC
 ---
 
 # fal.ai Media Generation

--- a/.agents/skills/fal-ai-media/agents/openai.yaml
+++ b/.agents/skills/fal-ai-media/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "fal.ai Media"
-  short_description: "AI image, video, and audio generation via fal.ai"
+  short_description: "AI media generation via fal.ai"
   brand_color: "#F43F5E"
-  default_prompt: "Generate images, videos, or audio using fal.ai models"
+  default_prompt: "Use $fal-ai-media to generate image, video, or audio assets with fal.ai."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with high design quality. Use when the user asks to build web components, pages, or applications and the visual direction matters as much as the code quality.
-origin: ECC
 ---
 
 # Frontend Design

--- a/.agents/skills/frontend-design/agents/openai.yaml
+++ b/.agents/skills/frontend-design/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Frontend Design"
+  short_description: "Production-grade frontend interface design"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $frontend-design to build a distinctive production-grade interface."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/frontend-patterns/SKILL.md
+++ b/.agents/skills/frontend-patterns/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: frontend-patterns
 description: Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices.
-origin: ECC
 ---
 
 # Frontend Development Patterns

--- a/.agents/skills/frontend-patterns/agents/openai.yaml
+++ b/.agents/skills/frontend-patterns/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Frontend Patterns"
-  short_description: "React and Next.js patterns and best practices"
+  short_description: "React and Next.js frontend patterns"
   brand_color: "#8B5CF6"
-  default_prompt: "Apply React/Next.js patterns and best practices"
+  default_prompt: "Use $frontend-patterns to apply React and Next.js frontend patterns."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/frontend-slides/SKILL.md
+++ b/.agents/skills/frontend-slides/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
-origin: ECC
 ---
 
 # Frontend Slides

--- a/.agents/skills/frontend-slides/agents/openai.yaml
+++ b/.agents/skills/frontend-slides/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Frontend Slides"
-  short_description: "Create distinctive HTML slide decks and convert PPTX to web"
+  short_description: "Animation-rich HTML presentation decks"
   brand_color: "#FF6B3D"
-  default_prompt: "Create a viewport-safe HTML presentation with strong visual direction"
+  default_prompt: "Use $frontend-slides to create an animation-rich HTML presentation deck."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/investor-materials/SKILL.md
+++ b/.agents/skills/investor-materials/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: investor-materials
 description: Create and update pitch decks, one-pagers, investor memos, accelerator applications, financial models, and fundraising materials. Use when the user needs investor-facing documents, projections, use-of-funds tables, milestone plans, or materials that must stay internally consistent across multiple fundraising assets.
-origin: ECC
 ---
 
 # Investor Materials

--- a/.agents/skills/investor-materials/agents/openai.yaml
+++ b/.agents/skills/investor-materials/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Investor Materials"
-  short_description: "Create decks, memos, and financial materials from one source of truth"
+  short_description: "Investor decks, memos, and financial materials"
   brand_color: "#7C3AED"
-  default_prompt: "Draft investor materials that stay numerically consistent across assets"
+  default_prompt: "Use $investor-materials to draft consistent investor-facing fundraising assets."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/investor-outreach/SKILL.md
+++ b/.agents/skills/investor-outreach/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: investor-outreach
 description: Draft cold emails, warm intro blurbs, follow-ups, update emails, and investor communications for fundraising. Use when the user wants outreach to angels, VCs, strategic investors, or accelerators and needs concise, personalized, investor-facing messaging.
-origin: ECC
 ---
 
 # Investor Outreach

--- a/.agents/skills/investor-outreach/agents/openai.yaml
+++ b/.agents/skills/investor-outreach/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Investor Outreach"
-  short_description: "Write concise, personalized outreach and follow-ups for fundraising"
+  short_description: "Personalized investor outreach and follow-ups"
   brand_color: "#059669"
-  default_prompt: "Draft a personalized investor outreach email with a clear low-friction ask"
+  default_prompt: "Use $investor-outreach to write concise personalized investor outreach."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/market-research/SKILL.md
+++ b/.agents/skills/market-research/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: market-research
 description: Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.
-origin: ECC
 ---
 
 # Market Research

--- a/.agents/skills/market-research/agents/openai.yaml
+++ b/.agents/skills/market-research/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Market Research"
-  short_description: "Source-attributed market, competitor, and investor research"
+  short_description: "Source-attributed market research"
   brand_color: "#2563EB"
-  default_prompt: "Research this market and summarize the decision-relevant findings"
+  default_prompt: "Use $market-research to research markets with source-attributed findings."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/mcp-server-patterns/SKILL.md
+++ b/.agents/skills/mcp-server-patterns/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mcp-server-patterns
 description: Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API.
-origin: ECC
 ---
 
 # MCP Server Patterns

--- a/.agents/skills/mcp-server-patterns/agents/openai.yaml
+++ b/.agents/skills/mcp-server-patterns/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "MCP Server Patterns"
+  short_description: "MCP server tools, resources, and prompts"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $mcp-server-patterns to build MCP tools, resources, and prompts."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/nextjs-turbopack/SKILL.md
+++ b/.agents/skills/nextjs-turbopack/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: nextjs-turbopack
 description: Next.js 16+ and Turbopack — incremental bundling, FS caching, dev speed, and when to use Turbopack vs webpack.
-origin: ECC
 ---
 
 # Next.js and Turbopack

--- a/.agents/skills/nextjs-turbopack/agents/openai.yaml
+++ b/.agents/skills/nextjs-turbopack/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Next.js Turbopack"
-  short_description: "Next.js 16+ and Turbopack dev bundler"
+  short_description: "Next.js and Turbopack workflow guidance"
   brand_color: "#000000"
-  default_prompt: "Next.js dev, Turbopack, or bundle optimization"
+  default_prompt: "Use $nextjs-turbopack to work through Next.js and Turbopack decisions."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/product-capability/SKILL.md
+++ b/.agents/skills/product-capability/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: product-capability
 description: Translate PRD intent, roadmap asks, or product discussions into an implementation-ready capability plan that exposes constraints, invariants, interfaces, and unresolved decisions before multi-service work starts. Use when the user needs an ECC-native PRD-to-SRS lane instead of vague planning prose.
-origin: ECC
 ---
 
 # Product Capability

--- a/.agents/skills/product-capability/agents/openai.yaml
+++ b/.agents/skills/product-capability/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Product Capability"
+  short_description: "Implementation-ready product capability plans"
+  brand_color: "#0EA5E9"
+  default_prompt: "Use $product-capability to turn product intent into an implementation plan."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: security-review
 description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
-origin: ECC
 ---
 
 # Security Review Skill

--- a/.agents/skills/security-review/agents/openai.yaml
+++ b/.agents/skills/security-review/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Security Review"
-  short_description: "Comprehensive security checklist and vulnerability detection"
+  short_description: "Security checklist and vulnerability review"
   brand_color: "#EF4444"
-  default_prompt: "Run security checklist: secrets, input validation, injection prevention"
+  default_prompt: "Use $security-review to review sensitive code with the security checklist."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/strategic-compact/SKILL.md
+++ b/.agents/skills/strategic-compact/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: strategic-compact
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction.
-origin: ECC
 ---
 
 # Strategic Compact Skill

--- a/.agents/skills/strategic-compact/agents/openai.yaml
+++ b/.agents/skills/strategic-compact/agents/openai.yaml
@@ -2,6 +2,6 @@ interface:
   display_name: "Strategic Compact"
   short_description: "Context management via strategic compaction"
   brand_color: "#14B8A6"
-  default_prompt: "Suggest task boundary compaction for context management"
+  default_prompt: "Use $strategic-compact to choose a useful context compaction boundary."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/tdd-workflow/SKILL.md
+++ b/.agents/skills/tdd-workflow/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tdd-workflow
 description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
-origin: ECC
 ---
 
 # Test-Driven Development Workflow

--- a/.agents/skills/tdd-workflow/agents/openai.yaml
+++ b/.agents/skills/tdd-workflow/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "TDD Workflow"
-  short_description: "Test-driven development with 80%+ coverage"
+  short_description: "Test-driven development with coverage gates"
   brand_color: "#22C55E"
-  default_prompt: "Follow TDD: write tests first, implement, verify 80%+ coverage"
+  default_prompt: "Use $tdd-workflow to drive the change with tests before implementation."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/verification-loop/SKILL.md
+++ b/.agents/skills/verification-loop/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: verification-loop
 description: "A comprehensive verification system for Claude Code sessions."
-origin: ECC
 ---
 
 # Verification Loop Skill

--- a/.agents/skills/verification-loop/agents/openai.yaml
+++ b/.agents/skills/verification-loop/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Verification Loop"
-  short_description: "Build, test, lint, typecheck verification"
+  short_description: "Build, test, lint, and typecheck verification"
   brand_color: "#10B981"
-  default_prompt: "Run verification: build, test, lint, typecheck, security"
+  default_prompt: "Use $verification-loop to run build, test, lint, and typecheck verification."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/video-editing/SKILL.md
+++ b/.agents/skills/video-editing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: video-editing
 description: AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.
-origin: ECC
 ---
 
 # Video Editing

--- a/.agents/skills/video-editing/agents/openai.yaml
+++ b/.agents/skills/video-editing/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Video Editing"
-  short_description: "AI-assisted video editing for real footage"
+  short_description: "AI-assisted editing for real footage"
   brand_color: "#EF4444"
-  default_prompt: "Edit video using AI-assisted pipeline: organize, cut, compose, generate assets, polish"
+  default_prompt: "Use $video-editing to plan an AI-assisted edit for real footage."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/x-api/SKILL.md
+++ b/.agents/skills/x-api/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: x-api
 description: X/Twitter API integration for posting tweets, threads, reading timelines, search, and analytics. Covers OAuth auth patterns, rate limits, and platform-native content posting. Use when the user wants to interact with X programmatically.
-origin: ECC
 ---
 
 # X API

--- a/.agents/skills/x-api/agents/openai.yaml
+++ b/.agents/skills/x-api/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "X API"
-  short_description: "X/Twitter API integration for posting, threads, and analytics"
+  short_description: "X API posting, timelines, and analytics"
   brand_color: "#000000"
-  default_prompt: "Use X API to post tweets, threads, or retrieve timeline and search data"
+  default_prompt: "Use $x-api to build X API posting, timeline, or analytics workflows."
 policy:
   allow_implicit_invocation: true

--- a/tests/ci/codex-skill-surface.test.js
+++ b/tests/ci/codex-skill-surface.test.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Validate the Codex-facing .agents/skills surface.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const CODEX_SKILLS_DIR = path.join(REPO_ROOT, '.agents', 'skills');
+const ALLOWED_FRONTMATTER_KEYS = new Set([
+  'allowed-tools',
+  'description',
+  'license',
+  'metadata',
+  'name',
+]);
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function listSkillDirs() {
+  return fs.readdirSync(CODEX_SKILLS_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort();
+}
+
+function parseFrontmatter(skillName) {
+  const skillPath = path.join(CODEX_SKILLS_DIR, skillName, 'SKILL.md');
+  const content = fs.readFileSync(skillPath, 'utf8');
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  assert.ok(match, `${skillName}/SKILL.md is missing frontmatter`);
+
+  const frontmatter = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const topLevelKey = line.match(/^([A-Za-z0-9_-]+):/);
+    if (topLevelKey) {
+      frontmatter[topLevelKey[1]] = line.slice(topLevelKey[1].length + 1).trim();
+    }
+  }
+  return frontmatter;
+}
+
+function parseQuotedYamlValue(source, key) {
+  const match = source.match(new RegExp(`^\\s{2}${key}:\\s*(.+?)\\s*$`, 'm'));
+  if (!match) return '';
+
+  const raw = match[1].trim();
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+function run() {
+  console.log('\n=== Testing Codex skill surface ===\n');
+
+  let passed = 0;
+  let failed = 0;
+  const skillDirs = listSkillDirs();
+
+  if (test('Codex skill directory is populated', () => {
+    assert.ok(skillDirs.length > 0, 'Expected at least one .agents/skills entry');
+  })) passed++; else failed++;
+
+  if (test('SKILL.md frontmatter matches Codex validator expectations', () => {
+    for (const skillDir of skillDirs) {
+      const frontmatter = parseFrontmatter(skillDir);
+      const keys = Object.keys(frontmatter).sort();
+      const unexpected = keys.filter(key => !ALLOWED_FRONTMATTER_KEYS.has(key));
+      assert.deepStrictEqual(unexpected, [], `${skillDir}/SKILL.md has unsupported keys`);
+      assert.strictEqual(frontmatter.name, skillDir, `${skillDir}/SKILL.md name must match folder`);
+      assert.ok(frontmatter.description, `${skillDir}/SKILL.md needs a description`);
+    }
+  })) passed++; else failed++;
+
+  if (test('agents/openai.yaml exists and names the skill in default_prompt', () => {
+    for (const skillDir of skillDirs) {
+      const metadataPath = path.join(CODEX_SKILLS_DIR, skillDir, 'agents', 'openai.yaml');
+      assert.ok(fs.existsSync(metadataPath), `${skillDir} is missing agents/openai.yaml`);
+
+      const metadata = fs.readFileSync(metadataPath, 'utf8');
+      const displayName = parseQuotedYamlValue(metadata, 'display_name');
+      const shortDescription = parseQuotedYamlValue(metadata, 'short_description');
+      const defaultPrompt = parseQuotedYamlValue(metadata, 'default_prompt');
+
+      assert.ok(displayName, `${skillDir}/agents/openai.yaml needs display_name`);
+      assert.ok(shortDescription, `${skillDir}/agents/openai.yaml needs short_description`);
+      assert.ok(defaultPrompt, `${skillDir}/agents/openai.yaml needs default_prompt`);
+      assert.ok(
+        shortDescription.length >= 25 && shortDescription.length <= 64,
+        `${skillDir}/agents/openai.yaml short_description must be 25-64 characters`
+      );
+      assert.ok(
+        defaultPrompt.includes(`$${skillDir}`),
+        `${skillDir}/agents/openai.yaml default_prompt must mention $${skillDir}`
+      );
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
## Summary

Fixes #1587 by normalizing the Codex-facing `.agents/skills` surface:

- Removes unsupported `origin` frontmatter from Codex skill copies.
- Converts `eval-harness` from `tools:` to Codex-supported `allowed-tools:`.
- Aligns `.agents/skills/everything-claude-code/SKILL.md` frontmatter name with its folder.
- Adds missing `agents/openai.yaml` metadata for 6 Codex skills.
- Normalizes OpenAI metadata so every `default_prompt` explicitly mentions `$skill-name` and every `short_description` stays within 25-64 characters.
- Adds a CI regression test for the Codex skill surface contract.

## Verification

- `node tests/ci/codex-skill-surface.test.js`
- `node scripts/ci/validate-agents.js`
- `node scripts/ci/validate-commands.js`
- `node scripts/ci/validate-rules.js`
- `node scripts/ci/validate-skills.js`
- `node scripts/ci/validate-hooks.js`
- `node scripts/ci/validate-install-manifests.js`
- `node scripts/ci/validate-no-personal-paths.js`
- `npm run catalog:check`
- `node tests/run-all.js` (1885 passed, 0 failed)

## Known Existing Blocker

`npm test` currently stops before the suite on an unrelated unicode-safety violation in `docs/fixes/HOOK-FIX-20260421-ADDENDUM.md`:

- line 90: emoji `U+2705`
- line 91: emoji `U+2705`
- line 92: emoji `U+274C`

That file is not touched by this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the Codex-facing `.agents/skills` metadata to match validator expectations and prevent ingestion errors. Fixes #1587 and adds a CI check to lock the contract.

- **Bug Fixes**
  - Removed unsupported `origin` frontmatter across skills.
  - Changed `eval-harness` frontmatter from `tools:` to `allowed-tools:`.
  - Aligned `SKILL.md` name with its folder for `everything-claude-code`.
  - Added missing `agents/openai.yaml` for 6 skills and normalized metadata: each `default_prompt` references `$skill-name` and each `short_description` is 25–64 chars.

<sup>Written for commit d89f8d895dde93ec5e6a88f5c41cd789511c70fb. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1605?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added implicit invocation support and visual branding to multiple agent skills.

* **Documentation**
  * Standardized skill descriptions and default prompts across 30+ agent skills for improved consistency and clarity.

* **Tests**
  * Added CI validation to enforce skill configuration contracts and metadata requirements.

* **Chores**
  * Cleaned up and normalized skill metadata structure across the agent skills directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->