### PR TITLE
fix: retry observer wait after SIGUSR1

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -83,6 +83,28 @@ exit_if_idle_without_sessions() {
   fi
 }
 
+wait_for_claude_analysis() {
+  local child_pid="$1"
+  local wait_status=0
+
+  while true; do
+    wait "$child_pid"
+    wait_status=$?
+
+    if [ "$wait_status" -eq 0 ]; then
+      return 0
+    fi
+
+    # SIGUSR1 can interrupt wait while the Claude child is still running.
+    # Re-wait in that case so a signal is not logged as a false child failure.
+    if kill -0 "$child_pid" 2>/dev/null; then
+      continue
+    fi
+
+    return "$wait_status"
+  done
+}
+
 analyze_observations() {
   if [ ! -f "$OBSERVATIONS_FILE" ]; then
     return
@@ -217,7 +239,7 @@ PROMPT
   ) &
   watchdog_pid=$!
 
-  wait "$claude_pid"
+  wait_for_claude_analysis "$claude_pid"
   exit_code=$?
   kill "$watchdog_pid" 2>/dev/null || true
   rm -f "$analysis_file"

--- a/tests/hooks/observer-memory.test.js
+++ b/tests/hooks/observer-memory.test.js
@@ -205,6 +205,63 @@ test('prompt references analysis_file not full OBSERVATIONS_FILE', () => {
   assert.ok(promptSection.includes('${analysis_relpath}'), 'Prompt should point Claude at the sampled analysis file (via relative path), not the full observations file');
 });
 
+test('observer-loop wait helper retries SIGUSR1-interrupted waits while claude child is alive', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const content = fs.readFileSync(observerLoopPath, 'utf8');
+  const helperMatch = content.match(/wait_for_claude_analysis\(\) \{[\s\S]*?\n\}/);
+  assert.ok(helperMatch, 'observer-loop.sh should define wait_for_claude_analysis helper');
+
+  const script = [
+    'set +e',
+    helperMatch[0],
+    'trap ":" USR1',
+    '( sleep 0.35; exit 0 ) &',
+    'claude_child=$!',
+    '( sleep 0.05; kill -USR1 $$ ) &',
+    'signaler=$!',
+    'wait_for_claude_analysis "$claude_child"',
+    'status=$?',
+    'wait "$signaler" 2>/dev/null || true',
+    'exit "$status"'
+  ].join('\n');
+
+  const result = spawnSync('bash', ['-c', script], {
+    encoding: 'utf8',
+    timeout: 5000
+  });
+
+  assert.strictEqual(result.status, 0, `interrupted wait should return child exit 0, got ${result.status}; stderr: ${result.stderr}`);
+});
+
+test('observer-loop wait helper preserves real nonzero claude exits', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const content = fs.readFileSync(observerLoopPath, 'utf8');
+  const helperMatch = content.match(/wait_for_claude_analysis\(\) \{[\s\S]*?\n\}/);
+  assert.ok(helperMatch, 'observer-loop.sh should define wait_for_claude_analysis helper');
+
+  const script = [
+    'set +e',
+    helperMatch[0],
+    '( sleep 0.05; exit 7 ) &',
+    'claude_child=$!',
+    'wait_for_claude_analysis "$claude_child"',
+    'exit "$?"'
+  ].join('\n');
+
+  const result = spawnSync('bash', ['-c', script], {
+    encoding: 'utf8',
+    timeout: 5000
+  });
+
+  assert.strictEqual(result.status, 7, `real child failure should be preserved, got ${result.status}; stderr: ${result.stderr}`);
+});
+
 // ──────────────────────────────────────────────────────
 // Test group 5: Signal counter file simulation
 // ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1598 by making the continuous-learning-v2 observer distinguish a SIGUSR1-interrupted shell `wait` from an actual Claude child-process failure.

- Adds `wait_for_claude_analysis` in `observer-loop.sh`.
- Re-waits when `wait "$claude_pid"` returns nonzero but the Claude child is still alive.
- Preserves the existing failure log for real nonzero Claude exits.
- Adds regression coverage for the interrupted-wait path and real child failure path.

## Verification

- `node tests/hooks/observer-memory.test.js`
- `node tests/hooks/hooks.test.js`
- `NODE_PATH=/Users/affoon/Documents/GitHub/ECC/everything-claude-code/node_modules node scripts/ci/validate-hooks.js`

## Notes

The fresh worktree did not have local `node_modules`; `validate-hooks.js` requires `ajv`, so validation was run with `NODE_PATH` pointed at the already-installed dependency tree in the main checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent false Claude failure logs by retrying SIGUSR1-interrupted waits in the continuous-learning-v2 observer. Stops unnecessary restarts while the child is still running.

- **Bug Fixes**
  - Added `wait_for_claude_analysis` to re-wait if `wait` is interrupted and the child PID is alive; replaced the direct `wait` in `observer-loop.sh`.
  - Preserve real non-zero Claude exits and log them as failures.
  - Added tests for SIGUSR1-interrupted waits and real non-zero exit paths.

<sup>Written for commit fd95cf6b29231b8dc58c4faac5db04e441c1729d. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1606?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess wait behavior to correctly handle interrupt signals and reliably propagate the child process's real exit status.

* **Tests**
  * Added runtime tests covering interrupted wait scenarios and preservation of exact exit codes to ensure robust subprocess handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->