### PR TITLE
fix: remove unsafe exec() in ecc_dashboard.py

### DIFF
--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -8,10 +8,10 @@ import tkinter as tk
 from tkinter import ttk, scrolledtext, messagebox
 import os
 import json
-import subprocess
+
 from typing import Dict, List, Optional
 
-from scripts.lib.ecc_dashboard_runtime import build_terminal_launch, maximize_window
+from scripts.lib.ecc_dashboard_runtime import build_terminal_launch, launch_terminal, maximize_window
 
 # ============================================================================
 # DATA LOADERS - Load ECC data from the project
@@ -794,24 +794,25 @@ Project: github.com/affaan-m/everything-claude-code"""
     def open_terminal(self):
         """Open terminal at project path"""
         path = self.path_entry.get()
-        argv, kwargs = build_terminal_launch(path)
-        subprocess.Popen(argv, **kwargs)
+        launch_terminal(path)
     
     def open_readme(self):
         """Open README in default browser/reader"""
-        import subprocess
-        path = os.path.join(self.path_entry.get(), 'README.md')
+        import webbrowser
+        base = os.path.realpath(self.path_entry.get())
+        path = os.path.join(base, 'README.md')
         if os.path.exists(path):
-            subprocess.Popen(['xdg-open' if os.name != 'nt' else 'start', path])
+            webbrowser.open(path)
         else:
             messagebox.showerror("Error", "README.md not found")
     
     def open_agents(self):
         """Open AGENTS.md"""
-        import subprocess
-        path = os.path.join(self.path_entry.get(), 'AGENTS.md')
+        import webbrowser
+        base = os.path.realpath(self.path_entry.get())
+        path = os.path.join(base, 'AGENTS.md')
         if os.path.exists(path):
-            subprocess.Popen(['xdg-open' if os.name != 'nt' else 'start', path])
+            webbrowser.open(path)
         else:
             messagebox.showerror("Error", "AGENTS.md not found")
     

--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -11,7 +11,10 @@ import json
 
 from typing import Dict, List, Optional
 
-from scripts.lib.ecc_dashboard_runtime import build_terminal_launch, launch_terminal, maximize_window
+from pathlib import Path
+import webbrowser
+
+from scripts.lib.ecc_dashboard_runtime import launch_terminal, maximize_window
 
 # ============================================================================
 # DATA LOADERS - Load ECC data from the project
@@ -793,28 +796,32 @@ Project: github.com/affaan-m/everything-claude-code"""
     
     def open_terminal(self):
         """Open terminal at project path"""
-        path = self.path_entry.get()
-        launch_terminal(path)
+        path = os.path.realpath(self.path_entry.get())
+        try:
+            launch_terminal(path)
+        except Exception as exc:
+            messagebox.showerror("Error", f"Could not open terminal: {exc}")
     
+    def _open_project_doc(self, filename: str) -> None:
+        """Open a project document safely, constrained to the project directory."""
+        base = os.path.realpath(self.path_entry.get())
+        target = os.path.realpath(os.path.join(base, filename))
+        # Boundary check: reject paths that escape the project root
+        if target != base and not target.startswith(base + os.sep):
+            messagebox.showerror("Error", "Access denied: path is outside the project directory")
+            return
+        if os.path.exists(target):
+            webbrowser.open(Path(target).as_uri())
+        else:
+            messagebox.showerror("Error", f"{filename} not found")
+
     def open_readme(self):
         """Open README in default browser/reader"""
-        import webbrowser
-        base = os.path.realpath(self.path_entry.get())
-        path = os.path.join(base, 'README.md')
-        if os.path.exists(path):
-            webbrowser.open(path)
-        else:
-            messagebox.showerror("Error", "README.md not found")
+        self._open_project_doc('README.md')
     
     def open_agents(self):
         """Open AGENTS.md"""
-        import webbrowser
-        base = os.path.realpath(self.path_entry.get())
-        path = os.path.join(base, 'AGENTS.md')
-        if os.path.exists(path):
-            webbrowser.open(path)
-        else:
-            messagebox.showerror("Error", "AGENTS.md not found")
+        self._open_project_doc('AGENTS.md')
     
     def refresh_data(self):
         """Refresh all data"""

--- a/scripts/lib/ecc_dashboard_runtime.py
+++ b/scripts/lib/ecc_dashboard_runtime.py
@@ -45,7 +45,7 @@ def build_terminal_launch(
     if resolved_os_name == 'nt':
         creationflags = getattr(subprocess, 'CREATE_NEW_CONSOLE', 0)
         return (
-            ['cmd.exe', '/k', 'cd', '/d', path],
+            ['cmd.exe'],
             {
                 'cwd': path,
                 'creationflags': creationflags,
@@ -62,6 +62,15 @@ def build_terminal_launch(
 
 
 def launch_terminal(path: str) -> None:
-    """Open a terminal at the given path."""
-    argv, kwargs = build_terminal_launch(path)
-    subprocess.Popen(argv, **kwargs)  # nosec B603
+    """Open a terminal at the given path.
+
+    Canonicalizes *path* and verifies it is an existing directory before
+    spawning the process so callers cannot supply traversal sequences.
+    Raises ValueError for invalid paths; raises OSError when the terminal
+    executable cannot be found.
+    """
+    canonical = os.path.realpath(path)
+    if not os.path.isdir(canonical):
+        raise ValueError(f"Path is not a valid directory: {canonical!r}")
+    argv, kwargs = build_terminal_launch(canonical)
+    subprocess.Popen(argv, **kwargs)  # noqa: S603 – list argv, no shell=True, path validated above

--- a/scripts/lib/ecc_dashboard_runtime.py
+++ b/scripts/lib/ecc_dashboard_runtime.py
@@ -59,3 +59,9 @@ def build_terminal_launch(
         ['x-terminal-emulator', '-e', 'bash', '-lc', 'cd -- "$1"; exec bash', 'bash', path],
         {},
     )
+
+
+def launch_terminal(path: str) -> None:
+    """Open a terminal at the given path."""
+    argv, kwargs = build_terminal_launch(path)
+    subprocess.Popen(argv, **kwargs)  # nosec B603


### PR DESCRIPTION
## Summary
Fix high severity security issue in `ecc_dashboard.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `ecc_dashboard.py:805` |

**Description**: The dashboard opens files using the operating system's default file handler (xdg-open on Linux, start on Windows) with a path variable at lines 805 and 814. If this path is derived from user input, a UI file picker, or an external configuration without canonicalization and boundary checking, an attacker can supply a path containing '../' sequences to traverse outside the intended directory and open arbitrary files on the filesystem. On systems where xdg-open has handlers registered for certain file types (e.g., .desktop files on Linux, .bat files on Windows), this could escalate from information disclosure to code execution.

## Changes
- `ecc_dashboard.py`
- `scripts/lib/ecc_dashboard_runtime.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe file-open and terminal launch paths in the dashboard to fix V-003 (path traversal/possible code execution). Added safe helpers that canonicalize paths and block traversal for README/AGENTS links.

- **Bug Fixes**
  - Replaced direct `subprocess.Popen` with `launch_terminal(path)` in `ecc_dashboard.py`; new helper validates `realpath`, requires an existing directory, and `build_terminal_launch` now starts `cmd.exe` with `cwd` on Windows.
  - README/AGENTS use `_open_project_doc()` with `realpath` boundary checks and `webbrowser.open(Path(...).as_uri())`; removed `xdg-open`/`start` and show errors when files are missing.

<sup>Written for commit 99fccd8233607480d501588424b22bbbd876c397. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1608?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved terminal launching and document-opening logic for more reliable behavior and path normalization.
  * Consolidated project document opening to ensure targets are resolved within the selected project directory.

* **Bug Fixes**
  * Better user-facing error reporting when opening terminals or project documents fails, reducing silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->