### PR TITLE
docs(rules/web/hooks): add --incremental + timeout to tsc hook example

### DIFF
--- a/rules/web/hooks.md
+++ b/rules/web/hooks.md
@@ -44,19 +44,28 @@ Equivalent local commands via `yarn prettier` or `npm exec prettier --` are fine
 
 ### Type Check
 
+Use `--incremental` so re-runs reuse the previous `.tsbuildinfo` (1-3s on unchanged code instead of 30-60s every time). Wrap in `timeout` so a stuck tsc gets reaped by the OS instead of accumulating across edits — this prevents the multi-process buildup that happens when edits fire faster than tsc finishes.
+
 ```json
 {
   "hooks": {
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
-        "command": "pnpm tsc --noEmit --pretty false",
-        "description": "Type-check after frontend edits"
+        "command": "timeout 60 pnpm tsc --noEmit --pretty false --incremental --tsBuildInfoFile node_modules/.cache/tsc-hook.tsbuildinfo",
+        "description": "Type-check after frontend edits (incremental + timeout-capped)"
       }
     ]
   }
 }
 ```
+
+**Why both flags matter:**
+- Without `--incremental`, every edit re-checks the entire program from scratch. On a real Next.js project this stacks fast: edits at 5-10s intervals + 30-60s tsc runs = N concurrent tsc processes.
+- Without `timeout`, a tsc that hangs (transitive dep change, type-checker stuck on a recursive type) never exits and orphans when the parent shell does.
+- `--tsBuildInfoFile` is required because `--noEmit` normally suppresses the buildinfo write; specifying the path explicitly keeps incremental working.
+
+If you're on Windows without GNU coreutils, swap `timeout 60` for a PowerShell wrapper or rely on a Stop/SessionEnd hook to sweep stale tsc processes.
 
 ### CSS Lint
 


### PR DESCRIPTION
## Summary

The recommended `tsc --noEmit` PostToolUse hook in `rules/web/hooks.md` re-checks the entire TypeScript program on every Write/Edit. On a real Next.js project a clean type-check takes 30-60s, but edits typically fire every 5-10s — concurrent tsc processes stack and orphan when the parent shell exits.

I observed 8 stale tsc PIDs accumulated across worktrees on one machine before cleanup, all running the exact command from this doc.

## Changes

```diff
- "command": "pnpm tsc --noEmit --pretty false",
+ "command": "timeout 60 pnpm tsc --noEmit --pretty false --incremental --tsBuildInfoFile node_modules/.cache/tsc-hook.tsbuildinfo",
```

1. **`--incremental` + `--tsBuildInfoFile`** — first run is unchanged; subsequent runs on unchanged code finish in 1-3s by reusing the cached buildinfo. `--tsBuildInfoFile` must be explicit because `--noEmit` normally suppresses the buildinfo write.
2. **`timeout 60` wrapper** — hard backstop so a stuck tsc (transitive dep change, recursive type) gets reaped by the OS instead of orphaning. Linux/macOS/Git Bash all ship GNU coreutils `timeout`.

Adds a rationale paragraph above the snippet and a "Why both flags matter" block below so future readers don't have to rediscover this.

## Test plan

- [ ] Apply hook to a real Next.js repo, edit a TS file 5x in 30s, verify ≤1 tsc process at any time
- [ ] Confirm cached run completes in <5s when no types changed
- [ ] Confirm `timeout 60` reaps a deliberately-hung tsc (e.g. fed an infinite recursive type)
- [ ] Markdown lints clean (`npx markdownlint-cli rules/web/hooks.md`)

Doc-only change. No test/code impact in this repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Type Check hook example to use incremental `tsc` and a 60s timeout to prevent stacked processes and speed up re-runs. Adds `--incremental` with `--tsBuildInfoFile` and wraps the `pnpm tsc --noEmit --pretty false` command with `timeout 60`, plus a short note explaining why both flags are needed.

<sup>Written for commit b2658d1e8f868e9d1dc67660a114645286a46e6e. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1613?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Type Check hook now uses incremental compilation for faster re-checks.
  * Added 60-second timeout to prevent hanging type-check processes.

* **Documentation**
  * Updated documentation explaining incremental compilation benefits and timeout mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->