### PR TITLE
fix: run pre-bash linters through windows wrappers

### DIFF
--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -188,6 +188,54 @@ function validateCommitMessage(command) {
   return { message, issues };
 }
 
+function getPathEnv() {
+  const pathKey = Object.keys(process.env).find(key => key.toLowerCase() === 'path') || 'PATH';
+  return process.env[pathKey] || '';
+}
+
+function isPathLike(command) {
+  return command.includes(path.sep) || (process.platform === 'win32' && /[\\/]/.test(command));
+}
+
+function getExecutableCandidates(command) {
+  if (process.platform !== 'win32' || path.extname(command)) {
+    return [command];
+  }
+
+  const pathExt = process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD';
+  return [command, ...pathExt.split(';').filter(Boolean).map(ext => `${command}${ext.toLowerCase()}`)];
+}
+
+function resolveCommand(command) {
+  if (isPathLike(command)) {
+    return getExecutableCandidates(command).find(candidate => fs.existsSync(candidate)) || null;
+  }
+
+  for (const dir of getPathEnv().split(path.delimiter).filter(Boolean)) {
+    for (const candidate of getExecutableCandidates(path.join(dir, command))) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function runLinterCommand(command, args) {
+  const useShell = process.platform === 'win32' && /\.(?:cmd|bat)$/i.test(command);
+  return spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 30000,
+    shell: useShell
+  });
+}
+
+function commandOutput(result) {
+  return result.stdout || result.stderr || result.error?.message || '';
+}
+
 /**
  * Run linter on staged files
  * @param {string[]} files 
@@ -209,14 +257,10 @@ function runLinter(files) {
     const eslintBin = process.platform === 'win32' ? 'eslint.cmd' : 'eslint';
     const eslintPath = path.join(process.cwd(), 'node_modules', '.bin', eslintBin);
     if (fs.existsSync(eslintPath)) {
-      const result = spawnSync(eslintPath, ['--format', 'compact', ...jsFiles], {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      });
+      const result = runLinterCommand(eslintPath, ['--format', 'compact', ...jsFiles]);
       results.eslint = {
         success: result.status === 0,
-        output: result.stdout || result.stderr
+        output: commandOutput(result)
       };
     }
   }
@@ -224,17 +268,14 @@ function runLinter(files) {
   // Run Pylint if available
   if (pyFiles.length > 0) {
     try {
-      const result = spawnSync('pylint', ['--output-format=text', ...pyFiles], {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      });
-      if (result.error && result.error.code === 'ENOENT') {
+      const pylintPath = resolveCommand('pylint');
+      if (!pylintPath) {
         results.pylint = null;
       } else {
+        const result = runLinterCommand(pylintPath, ['--output-format=text', ...pyFiles]);
         results.pylint = {
           success: result.status === 0,
-          output: result.stdout || result.stderr
+          output: commandOutput(result)
         };
       }
     } catch {
@@ -245,17 +286,14 @@ function runLinter(files) {
   // Run golint if available
   if (goFiles.length > 0) {
     try {
-      const result = spawnSync('golint', goFiles, {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      });
-      if (result.error && result.error.code === 'ENOENT') {
+      const golintPath = resolveCommand('golint');
+      if (!golintPath) {
         results.golint = null;
       } else {
+        const result = runLinterCommand(golintPath, goFiles);
         results.golint = {
           success: !result.stdout || result.stdout.trim() === '',
-          output: result.stdout
+          output: commandOutput(result)
         };
       }
     } catch {

--- a/tests/hooks/pre-bash-commit-quality.test.js
+++ b/tests/hooks/pre-bash-commit-quality.test.js
@@ -274,11 +274,12 @@ if (test('stdin entry point truncates oversized input and preserves pass-through
       filler: 'x'.repeat(1024 * 1024 + 1024)
     }
   });
-  const result = spawnSync('node', [path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-commit-quality.js')], {
+  const result = spawnSync(process.execPath, [path.join(__dirname, '..', '..', 'scripts', 'hooks', 'pre-bash-commit-quality.js')], {
     input: oversized,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 10000
+    timeout: 10000,
+    maxBuffer: 2 * 1024 * 1024
   });
 
   assert.strictEqual(result.status, 0);


### PR DESCRIPTION
## Summary\n- resolve linter commands before running pre-bash commit quality checks\n- run Windows .cmd/.bat wrappers through the Windows shell while keeping direct executables shell-free\n- use process.execPath and an explicit buffer for the oversized stdin hook test\n\n## Validation\n- node tests/hooks/pre-bash-commit-quality.test.js\n- npx eslint scripts/hooks/pre-bash-commit-quality.js tests/hooks/pre-bash-commit-quality.test.js\n- git diff --check -- scripts/hooks/pre-bash-commit-quality.js tests/hooks/pre-bash-commit-quality.test.js\n- npm run lint\n- node tests/run-all.js (1995/1995)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pre-bash commit quality hook so linters run reliably on Windows by resolving commands and correctly invoking `.cmd`/`.bat` wrappers. Also stabilizes the oversized-stdin test.

- **Bug Fixes**
  - Resolve linter commands (`eslint`, `pylint`, `golint`, etc.) via PATH/PATHEXT and explicit paths to avoid ENOENT on Windows.
  - Run Windows `.cmd`/`.bat` wrappers through the shell; run direct executables without a shell for consistent spawning.
  - Unify result handling: shared runner with a 30s timeout and normalized output; oversized-stdin test now uses `process.execPath` and a larger buffer.

<sup>Written for commit 46a30894b800d867f46f63887fb9f8fb602b4919. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1621?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform support for pre-commit quality checks, including better Windows compatibility
  * Enhanced output handling for linting tools to manage large results more effectively
  * More reliable execution of quality check tools across different environments

* **Chores**
  * Strengthened test robustness for quality check execution with improved subprocess handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->