### PR TITLE
test: extend insaits monitor subprocess timeout

### DIFF
--- a/tests/hooks/insaits-security-monitor.test.js
+++ b/tests/hooks/insaits-security-monitor.test.js
@@ -11,6 +11,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'insaits-security-monitor.py');
+const MONITOR_TIMEOUT_MS = 30000;
 
 function createTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'insaits-monitor-'));
@@ -93,10 +94,14 @@ function runMonitor(options = {}) {
     encoding: 'utf8',
     env,
     cwd: tempDir,
-    timeout: 10000,
+    timeout: MONITOR_TIMEOUT_MS,
   });
   result.tempDir = tempDir;
   return result;
+}
+
+function statusError(result) {
+  return result.stderr || result.error?.message || `status ${result.status}`;
 }
 
 function test(name, fn) {
@@ -123,7 +128,7 @@ function runTests() {
       env: { FAKE_INSAITS_MODE: 'clean' },
     });
     try {
-      assert.strictEqual(result.status, 0, result.stderr);
+      assert.strictEqual(result.status, 0, statusError(result));
       assert.strictEqual(result.stdout, '');
 
       const [audit] = readAudit(result.tempDir);
@@ -143,7 +148,7 @@ function runTests() {
       env: { FAKE_INSAITS_MODE: 'critical' },
     });
     try {
-      assert.strictEqual(result.status, 2, result.stderr);
+      assert.strictEqual(result.status, 2, statusError(result));
       assert.ok(result.stdout.includes('SECRET'));
       assert.ok(result.stdout.includes('token-like string detected'));
 
@@ -161,7 +166,7 @@ function runTests() {
       env: { FAKE_INSAITS_MODE: 'medium' },
     });
     try {
-      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.status, 0, statusError(result));
       assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('PROMPT_INJECTION'));
 
@@ -179,7 +184,7 @@ function runTests() {
       env: { FAKE_INSAITS_MODE: 'error', INSAITS_FAIL_MODE: '' },
     });
     try {
-      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.status, 0, statusError(result));
       assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('SDK error'));
     } finally {
@@ -193,7 +198,7 @@ function runTests() {
       env: { FAKE_INSAITS_MODE: 'error', INSAITS_FAIL_MODE: 'closed' },
     });
     try {
-      assert.strictEqual(result.status, 2);
+      assert.strictEqual(result.status, 2, statusError(result));
       assert.ok(result.stdout.includes('InsAIts SDK error (RuntimeError)'));
       assert.ok(result.stdout.includes('blocking execution'));
     } finally {


### PR DESCRIPTION
## Summary\n- raise the InsAIts monitor subprocess test timeout to match slow Windows Node 22/pnpm startup behavior\n- include spawn error details in status assertions so future timeout failures are actionable\n\n## Validation\n- node tests/hooks/insaits-security-monitor.test.js\n- npx eslint tests/hooks/insaits-security-monitor.test.js\n- npm run lint\n- git diff --check -- tests/hooks/insaits-security-monitor.test.js\n- node tests/run-all.js (2005/2005)\n\nMain failure addressed: https://github.com/affaan-m/everything-claude-code/actions/runs/25138232699/job/73681849329

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the InsAIts security monitor test subprocess timeout to 30s to handle slow Windows + Node 22 `pnpm` startup. Adds clearer assertion errors by surfacing stderr or spawn error messages for faster debugging.

<sup>Written for commit 41281d1dd97f04d6db7984416428ab9c43317196. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1622?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended monitor subprocess timeout from 10 to 30 seconds to accommodate longer-running operations.
  * Improved error messaging for monitor subprocess failures with consistent, prioritized error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->