### PR TITLE
fix: preserve gateguard concurrent state writes

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -129,12 +129,33 @@ function saveState(state) {
   const stateFile = getStateFile();
   let tmpFile = null;
   try {
-    state.last_active = Date.now();
-    state.checked = pruneCheckedEntries(state.checked);
     fs.mkdirSync(STATE_DIR, { recursive: true });
+
+    let mergedChecked = Array.isArray(state.checked) ? state.checked : [];
+    let mergedLastActive = typeof state.last_active === 'number' ? state.last_active : 0;
+
+    try {
+      if (fs.existsSync(stateFile)) {
+        const diskState = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        if (Array.isArray(diskState.checked)) {
+          mergedChecked = Array.from(new Set([...diskState.checked, ...mergedChecked]));
+        }
+        if (typeof diskState.last_active === 'number') {
+          mergedLastActive = Math.max(mergedLastActive, diskState.last_active);
+        }
+      }
+    } catch (_) {
+      /* ignore malformed or transient disk state */
+    }
+
+    const finalState = {
+      checked: pruneCheckedEntries(mergedChecked),
+      last_active: Math.max(mergedLastActive, Date.now())
+    };
+
     // Atomic write: temp file + rename prevents partial reads
-    tmpFile = stateFile + '.tmp.' + process.pid;
-    fs.writeFileSync(tmpFile, JSON.stringify(state, null, 2), 'utf8');
+    tmpFile = `${stateFile}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`;
+    fs.writeFileSync(tmpFile, JSON.stringify(finalState, null, 2), 'utf8');
     try {
       fs.renameSync(tmpFile, stateFile);
     } catch (error) {
@@ -149,6 +170,7 @@ function saveState(state) {
         throw error;
       }
     }
+    tmpFile = null;
   } catch (_) {
     if (tmpFile) {
       try {
@@ -183,7 +205,8 @@ function isChecked(key) {
     const files = fs.readdirSync(STATE_DIR);
     const now = Date.now();
     for (const f of files) {
-      if (!f.startsWith('state-') || !f.endsWith('.json')) continue;
+      const isStateFile = f.startsWith('state-') && (f.endsWith('.json') || f.includes('.json.tmp.'));
+      if (!isStateFile) continue;
       const fp = path.join(STATE_DIR, f);
       try {
         const stat = fs.statSync(fp);

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -752,6 +752,58 @@ function runTests() {
     assert.ok(reason.includes('evil.js'), 'sanitized path should retain visible filename text');
   })) passed++; else failed++;
 
+  // --- Test 28: saveState preserves concurrent disk updates ---
+  clearState();
+  if (test('merges state written by another process during save', () => {
+    const hook = loadDirectHook();
+    const originalMkdirSync = fs.mkdirSync;
+    let injected = false;
+
+    fs.mkdirSync = function patchedMkdirSync(target) {
+      const result = originalMkdirSync.apply(fs, arguments);
+      if (!injected && path.resolve(String(target)) === path.resolve(stateDir)) {
+        injected = true;
+        fs.writeFileSync(stateFile, JSON.stringify({
+          checked: ['/src/concurrent.js'],
+          last_active: Date.now()
+        }), 'utf8');
+      }
+      return result;
+    };
+
+    try {
+      const result = hook.run({
+        tool_name: 'Edit',
+        tool_input: { file_path: '/src/new-edit.js', old_string: 'a', new_string: 'b' }
+      });
+      const output = parseOutput(result.stdout);
+      assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'first edit should still be gated');
+    } finally {
+      fs.mkdirSync = originalMkdirSync;
+    }
+
+    const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.ok(persisted.checked.includes('/src/concurrent.js'), 'concurrent disk entry should be preserved');
+    assert.ok(persisted.checked.includes('/src/new-edit.js'), 'new in-memory entry should be persisted');
+  })) passed++; else failed++;
+
+  // --- Test 29: stale temp files from interrupted writes are pruned ---
+  clearState();
+  if (test('prunes stale state temp files at module load', () => {
+    fs.mkdirSync(stateDir, { recursive: true });
+    const staleTmp = path.join(stateDir, `${path.basename(stateFile)}.tmp.1234.abcd`);
+    const freshState = path.join(stateDir, 'state-fresh-session.json');
+    fs.writeFileSync(staleTmp, '{}', 'utf8');
+    fs.writeFileSync(freshState, '{}', 'utf8');
+    const staleTime = new Date(Date.now() - (61 * 60 * 1000));
+    fs.utimesSync(staleTmp, staleTime, staleTime);
+
+    loadDirectHook();
+
+    assert.ok(!fs.existsSync(staleTmp), 'stale temp state file should be pruned');
+    assert.ok(fs.existsSync(freshState), 'fresh state file should remain');
+  })) passed++; else failed++;
+
   // Cleanup only the temp directory created by this test file.
   try {
     if (fs.existsSync(stateDir)) {


### PR DESCRIPTION
## Summary

Maintainer rescue for the stuck GateGuard state-write fixes in #1442/#1444. Current `main` already has the stable session-key fallback and Windows `EEXIST`/`EPERM` rename fallback; this PR ports the remaining concurrent state-write protection onto current `main`.

## Changes

- Merge current on-disk GateGuard state immediately before writing so a concurrent hook process does not lose another process's checked entries.
- Keep the Windows-safe replace path while using collision-resistant temporary state filenames.
- Prune stale orphan `.tmp` state files left by interrupted writes.
- Add regression coverage for concurrent-save preservation and stale temp cleanup, alongside the new GateGuard edge-path tests already on `main`.

## Validation

- `node tests/hooks/gateguard-fact-force.test.js` -> 29 passed
- `NODE_PATH=/Users/affoon/Documents/GitHub/ECC/everything-claude-code/node_modules node tests/scripts/build-opencode.test.js` -> 3 passed
- `NODE_PATH=/Users/affoon/Documents/GitHub/ECC/everything-claude-code/node_modules npm test` -> 2005 passed, 0 failed

## Contributor PRs

- Replaces the still-conflicting intent from #1442.
- Confirms #1444's core Windows rename/session fallback behavior is already present on current `main`; this PR preserves that behavior while adding the #1442 state merge rescue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects GateGuard state during concurrent writes and cleans up stale temp files. Prevents losing checked entries when multiple hooks save at the same time.

- **Bug Fixes**
  - Merge on-disk state with in-memory state before saving to keep other processes’ checked entries and latest `last_active`.
  - Use collision-resistant temp filenames and keep the Windows-safe rename fallback for `EEXIST`/`EPERM`.
  - Prune stale `.json.tmp.*` state files left by interrupted writes.
  - Add tests for concurrent-save merge and stale temp cleanup.

<sup>Written for commit bbc90bfdc94c9e4aaca2030acc4f075b062b2c26. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1623?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for state persistence behavior under concurrent write conditions and stale file cleanup scenarios.

* **Chores**
  * Enhanced state persistence mechanisms with improved data deduplication, file management, and atomic write reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->