### PR TITLE
docs: close ECC 2.0 rc.1 release policy drift

### DIFF
--- a/docs/HERMES-SETUP.md
+++ b/docs/HERMES-SETUP.md
@@ -83,13 +83,26 @@ These stay local and should be configured per operator:
 ## Suggested Bring-Up Order
 
 0. Run `ecc migrate audit --source ~/.hermes` first to inventory the legacy workspace and see which parts already map onto ECC2.
-0.5. Generate and review artifacts with `ecc migrate plan` / `ecc migrate scaffold`, scaffold reusable legacy skills with `ecc migrate import-skills --output-dir migration-artifacts/skills`, scaffold legacy tool translation templates with `ecc migrate import-tools --output-dir migration-artifacts/tools`, scaffold legacy bridge plugins with `ecc migrate import-plugins --output-dir migration-artifacts/plugins`, preview recurring jobs with `ecc migrate import-schedules --dry-run`, preview gateway dispatch with `ecc migrate import-remote --dry-run`, preview safe env/service context with `ecc migrate import-env --dry-run`, then import sanitized workspace memory with `ecc migrate import-memory`.
-1. Install ECC and verify the baseline harness setup.
+0.5. Plan and scaffold migration artifacts before importing anything:
+   - generate reviewable plans with `ecc migrate plan` and `ecc migrate scaffold`
+   - scaffold reusable legacy skills with `ecc migrate import-skills --output-dir migration-artifacts/skills`
+   - scaffold tool translation templates with `ecc migrate import-tools --output-dir migration-artifacts/tools`
+   - scaffold bridge plugin templates with `ecc migrate import-plugins --output-dir migration-artifacts/plugins`
+   - preview recurring jobs with `ecc migrate import-schedules --dry-run`
+   - preview gateway dispatch with `ecc migrate import-remote --dry-run`
+   - preview safe env/service context with `ecc migrate import-env --dry-run`
+   - import sanitized workspace memory with `ecc migrate import-memory`
+1. Install ECC and verify the baseline harness setup with `node tests/run-all.js`; the expected result is a zero-failure test summary.
 2. Install Hermes and point it at ECC-imported skills.
 3. Register the MCP servers you actually use every day.
 4. Authenticate Google Drive first, then GitHub, then distribution channels.
 5. Start with a small cron surface: readiness check, content accountability, inbox triage, revenue monitor.
 6. Only then add heavier personal workflows like health, relationship graphing, or outbound sequencing.
+
+## Related Docs
+
+- [Hermes/OpenClaw migration guide](HERMES-OPENCLAW-MIGRATION.md)
+- [Cross-harness architecture](architecture/cross-harness.md)
 
 ## Why Hermes x ECC
 

--- a/docs/releases/2.0.0-rc.1/launch-checklist.md
+++ b/docs/releases/2.0.0-rc.1/launch-checklist.md
@@ -10,8 +10,8 @@
 
 ## Release Surface
 
-- confirm package and plugin version policy for `2.0.0-rc.1` (drafted in manifest bump prep)
-- confirm whether `ecc2/Cargo.toml` moves from `0.1.0` to `2.0.0-rc.1`
+- verify package, plugin, marketplace, OpenCode, and agent metadata stays at `2.0.0-rc.1`
+- verify `ecc2/Cargo.toml` stays at `0.1.0` for rc.1; `ecc2/` remains an alpha control-plane scaffold
 - update release metadata in one dedicated release-version PR
 - run the root test suite
 - run `cd ecc2 && cargo test`

--- a/docs/releases/2.0.0-rc.1/release-notes.md
+++ b/docs/releases/2.0.0-rc.1/release-notes.md
@@ -26,7 +26,7 @@ The system now has a clearer shape:
 - cross-harness install surfaces for Claude Code, Codex, OpenCode, Cursor, and related tools
 - Hermes as an optional operator shell for chat, cron, handoffs, and daily work routing
 
-## Preview Boundaries
+## Release Candidate Boundaries
 
 This is a release candidate, not the final GA claim.
 

--- a/docs/tr/CHANGELOG.md
+++ b/docs/tr/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Değişiklik Günlüğü
 
+## 2.0.0-rc.1 - 2026-04-28
+
+### Öne Çıkanlar
+
+- Hermes operatör hikayesi için genel ECC 2.0 sürüm adayı yüzeyi eklendi.
+- ECC, Claude Code, Codex, Cursor, OpenCode ve Gemini genelinde yeniden kullanılabilir cross-harness altyapı olarak belgelendi.
+- Özel operatör state'i yayımlamak yerine sanitize edilmiş Hermes import becerisi eklendi.
+
+### Sürüm Yüzeyi
+
+- Paket, plugin, marketplace, OpenCode, ajan ve README metadataları `2.0.0-rc.1` olarak güncellendi.
+- Sürüm notları, sosyal taslaklar, launch checklist, handoff notları ve demo prompt'ları `docs/releases/2.0.0-rc.1/` altında toplandı.
+- ECC/Hermes sınırı için `docs/architecture/cross-harness.md` ve regresyon kapsamı eklendi.
+- `ecc2/` sürümlemesi bağımsız tutuldu; release engineering aksi karar vermedikçe alpha control-plane scaffold olarak kalır.
+
+### Notlar
+
+- Bu bir sürüm adayıdır; tam ECC 2.0 control-plane yol haritası için GA iddiası değildir.
+- Ön sürüm npm yayımları, release engineering aksi karar vermedikçe `next` dist-tag kullanmalıdır.
+
+## 1.10.0 - 2026-04-05
+
+### Öne Çıkanlar
+
+- Genel repo yüzeyi birkaç haftalık OSS büyümesi ve backlog merge'lerinden sonra canlı repo ile senkronize edildi.
+- Operatör iş akışı hattı voice, graph-ranking, billing, workspace ve outbound becerileriyle genişletildi.
+- Medya üretim hattı Manim ve Remotion odaklı launch araçlarıyla genişletildi.
+- ECC 2.0 alpha control-plane binary artık `ecc2/` üzerinden yerelde build ediliyor ve ilk kullanılabilir CLI/TUI yüzeyini sunuyor.
+
+### Sürüm Yüzeyi
+
+- Plugin, marketplace, Codex, OpenCode ve ajan metadataları `1.10.0` olarak güncellendi.
+- Yayınlanan sayımlar canlı OSS yüzeyine eşitlendi: 38 ajan, 156 beceri, 72 komut.
+- Üst seviye install dokümanları ve marketplace açıklamaları mevcut repo durumuyla eşitlendi.
+
+### Notlar
+
+- Claude plugin'i platform seviyesindeki rules dağıtım kısıtlarıyla sınırlı kalır; selective install / OSS yolu hâlâ en güvenilir tam kurulum yoludur.
+- Bu sürüm bir repo-yüzeyi düzeltmesi ve ekosistem senkronizasyonudur; tam ECC 2.0 yol haritasının tamamlandığı iddiası değildir.
+
 ## 1.9.0 - 2026-03-20
 
 ### Öne Çıkanlar

--- a/docs/zh-CN/CHANGELOG.md
+++ b/docs/zh-CN/CHANGELOG.md
@@ -1,5 +1,45 @@
 # 更新日志
 
+## 2.0.0-rc.1 - 2026-04-28
+
+### 亮点
+
+* 为 Hermes 操作员叙事新增公开的 ECC 2.0 release candidate 表面。
+* 将 ECC 明确记录为跨 Claude Code、Codex、Cursor、OpenCode 和 Gemini 的可复用 cross-harness 基础层。
+* 新增经过清理的 Hermes import 技能表面，而不是发布私有操作员状态。
+
+### 发布表面
+
+* 将 package、plugin、marketplace、OpenCode、agent 和 README 元数据更新为 `2.0.0-rc.1`。
+* 在 `docs/releases/2.0.0-rc.1/` 下集中发布说明、社交草稿、发布清单、交接说明和演示提示词。
+* 新增 `docs/architecture/cross-harness.md`，并补充 ECC/Hermes 边界的回归覆盖。
+* `ecc2/` 版本保持独立；除非 release engineering 另有决定，它仍是 alpha control-plane scaffold。
+
+### 备注
+
+* 这是 release candidate，不是完整 ECC 2.0 control-plane 路线图的 GA 声明。
+* 预发布 npm 发布应使用 `next` dist-tag，除非 release engineering 明确选择其他策略。
+
+## 1.10.0 - 2026-04-05
+
+### 亮点
+
+* 在数周 OSS 增长和 backlog 合并后，公开发布表面已同步到当前仓库状态。
+* 操作员工作流扩展了 voice、graph-ranking、billing、workspace 和 outbound 技能。
+* 媒体生成工作流扩展了 Manim 和 Remotion 优先的发布工具。
+* ECC 2.0 alpha control-plane binary 现在可从 `ecc2/` 本地构建，并提供首个可用的 CLI/TUI 表面。
+
+### 发布表面
+
+* 将 plugin、marketplace、Codex、OpenCode 和 agent 元数据更新为 `1.10.0`。
+* 将公开计数同步到当前 OSS 表面：38 个代理、156 个技能、72 个命令。
+* 刷新顶层安装文档和 marketplace 描述，使其匹配当前仓库状态。
+
+### 备注
+
+* Claude plugin 仍受平台级 rules 分发限制影响；selective install / OSS 路径仍是最可靠的完整安装方式。
+* 这是仓库表面校正和生态同步版本，不表示完整 ECC 2.0 路线图已经完成。
+
 ## 1.9.0 - 2026-03-20
 
 ### 亮点

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -106,10 +106,40 @@ test('Hermes setup uses release-candidate wording for the rc.1 surface', () => {
   assert.ok(!source.includes('Public Preview Scope'));
 });
 
+test('Hermes setup cross-links adjacent migration and architecture docs', () => {
+  const source = read('docs/HERMES-SETUP.md');
+  assert.ok(source.includes('HERMES-OPENCLAW-MIGRATION.md'));
+  assert.ok(source.includes('architecture/cross-harness.md'));
+  assert.ok(source.includes('Plan and scaffold migration artifacts'));
+  assert.ok(!source.includes('0.5. Generate and review artifacts with `ecc migrate plan` /'));
+});
+
 test('release docs preserve the ECC/Hermes boundary', () => {
   const releaseNotes = read('docs/releases/2.0.0-rc.1/release-notes.md');
   assert.ok(releaseNotes.includes('ECC is the reusable substrate'));
   assert.ok(releaseNotes.includes('Hermes as the operator shell'));
+});
+
+test('release docs use release-candidate wording consistently', () => {
+  const releaseNotes = read('docs/releases/2.0.0-rc.1/release-notes.md');
+  assert.ok(releaseNotes.includes('## Release Candidate Boundaries'));
+  assert.ok(!releaseNotes.includes('## Preview Boundaries'));
+});
+
+test('launch checklist records the ecc2 alpha version policy', () => {
+  const cargoToml = read('ecc2/Cargo.toml');
+  const launchChecklist = read('docs/releases/2.0.0-rc.1/launch-checklist.md');
+  assert.ok(cargoToml.includes('version = "0.1.0"'));
+  assert.ok(launchChecklist.includes('`ecc2/Cargo.toml` stays at `0.1.0`'));
+  assert.ok(!launchChecklist.includes('confirm whether `ecc2/Cargo.toml` moves'));
+});
+
+test('localized changelogs include rc.1 and 1.10.0 release entries', () => {
+  for (const relativePath of ['docs/tr/CHANGELOG.md', 'docs/zh-CN/CHANGELOG.md']) {
+    const source = read(relativePath);
+    assert.ok(source.includes('## 2.0.0-rc.1 - 2026-04-28'), `${relativePath} missing rc.1 entry`);
+    assert.ok(source.includes('## 1.10.0 - 2026-04-05'), `${relativePath} missing 1.10.0 entry`);
+  }
 });
 
 if (failed > 0) {


### PR DESCRIPTION
## Summary

- record that `ecc2/Cargo.toml` stays independently versioned at `0.1.0` for rc.1
- replace lingering preview-boundary wording with release-candidate wording
- add Hermes setup cross-links and split the migration bring-up step into reviewable commands
- backfill Turkish and Simplified Chinese changelog entries for `1.10.0` and `2.0.0-rc.1`
- extend the release-surface regression test to lock those decisions

## Test plan

- `node tests/docs/ecc2-release-surface.test.js`
- `npx eslint tests/docs/ecc2-release-surface.test.js`
- `npx markdownlint docs/HERMES-SETUP.md docs/releases/2.0.0-rc.1/release-notes.md docs/releases/2.0.0-rc.1/launch-checklist.md docs/tr/CHANGELOG.md docs/zh-CN/CHANGELOG.md`
- `git diff --check -- docs/HERMES-SETUP.md docs/releases/2.0.0-rc.1/release-notes.md docs/releases/2.0.0-rc.1/launch-checklist.md docs/tr/CHANGELOG.md docs/zh-CN/CHANGELOG.md tests/docs/ecc2-release-surface.test.js`
- `npm run lint`
- `node tests/run-all.js` (2020/2020)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns ECC 2.0 rc.1 docs and tests with the release policy: keep `ecc2/Cargo.toml` at `0.1.0`, switch to release-candidate wording, and clarify Hermes setup and migration steps. Adds Turkish and Simplified Chinese changelog entries and locks these decisions with a regression test.

- **Bug Fixes**
  - Document `ecc2/Cargo.toml` stays at `0.1.0` for rc.1; `ecc2/` remains an alpha control‑plane scaffold.
  - Replace “Preview” with “Release Candidate” wording in `2.0.0-rc.1` notes.
  - Improve `docs/HERMES-SETUP.md`: split plan/scaffold steps into clear commands, add cross‑links to `HERMES-OPENCLAW-MIGRATION.md` and `architecture/cross-harness.md`, and add a baseline harness check.
  - Backfill `docs/tr/CHANGELOG.md` and `docs/zh-CN/CHANGELOG.md` for `1.10.0` and `2.0.0-rc.1`.
  - Extend `tests/docs/ecc2-release-surface.test.js` to assert version policy, wording, cross‑links, and localized changelog entries.

<sup>Written for commit 7b134d01ef26230cac5447408e505a6bf41d5b9f. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1624?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Hermes migration setup guide with clearer step-by-step checklist
  * Updated 2.0.0-rc.1 release documentation with explicit version pinning details
  * Added 2.0.0-rc.1 and 1.10.0 changelog entries
  * Expanded changelog in Turkish and Chinese languages

* **Tests**
  * Added validation tests for documentation consistency and release surface requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->