### PR TITLE
fix: make /plan work without planner agent

### DIFF
--- a/commands/plan.md
+++ b/commands/plan.md
@@ -4,7 +4,9 @@ description: Restate requirements, assess risks, and create step-by-step impleme
 
 # Plan Command
 
-This command invokes the **planner** agent to create a comprehensive implementation plan before writing any code.
+This command creates a comprehensive implementation plan before writing any code.
+
+Run inline by default. Do not call the Task tool or any subagent by default. This keeps `/plan` usable from plugin installs that ship commands without agent files.
 
 ## What This Command Does
 
@@ -24,7 +26,7 @@ Use `/plan` when:
 
 ## How It Works
 
-The planner agent will:
+The assistant will:
 
 1. **Analyze the request** and restate requirements in clear terms
 2. **Break down into phases** with specific, actionable steps
@@ -38,7 +40,7 @@ The planner agent will:
 ```
 User: /plan I need to add real-time notifications when markets resolve
 
-Agent (planner):
+Assistant:
 # Implementation Plan: Real-Time Market Resolution Notifications
 
 ## Requirements Restatement
@@ -93,7 +95,7 @@ Agent (planner):
 
 ## Important Notes
 
-**CRITICAL**: The planner agent will **NOT** write any code until you explicitly confirm the plan with "yes" or "proceed" or similar affirmative response.
+**CRITICAL**: This command will **NOT** write any code until you explicitly confirm the plan with "yes" or "proceed" or similar affirmative response.
 
 If you want changes, respond with:
 - "modify: [your changes]"
@@ -109,9 +111,11 @@ After planning:
 
 > **Need deeper planning?** Use `/prp-plan` for artifact-producing planning with PRD integration, codebase analysis, and pattern extraction. Use `/prp-implement` to execute those plans with rigorous validation loops.
 
-## Related Agents
+## Optional Planner Agent
 
-This command invokes the `planner` agent provided by ECC.
+ECC also provides a `planner` agent for manual installs that include agent files. Use it only when the local runtime already exposes that subagent and the user explicitly asks you to delegate planning.
+
+If the `planner` subagent is unavailable, continue planning inline instead of surfacing an "Agent type 'planner' not found" error.
 
 For manual installs, the source file lives at:
 `agents/planner.md`

--- a/tests/commands/plan-command.test.js
+++ b/tests/commands/plan-command.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const planCommandPath = path.join(repoRoot, 'commands', 'plan.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+function readPlanCommand() {
+  return fs.readFileSync(planCommandPath, 'utf8');
+}
+
+console.log('\n=== Testing /plan command prompt ===\n');
+
+test('/plan runs inline by default without requiring planner agent installation', () => {
+  const source = readPlanCommand();
+
+  assert.ok(
+    source.includes('Do not call the Task tool or any subagent by default'),
+    'Expected /plan to avoid default subagent delegation',
+  );
+  assert.ok(
+    source.includes('If the `planner` subagent is unavailable'),
+    'Expected /plan to define a planner-unavailable fallback',
+  );
+  assert.ok(
+    !source.includes('This command invokes the **planner** agent'),
+    'Expected /plan not to claim unconditional planner invocation',
+  );
+  assert.ok(
+    !source.includes('The planner agent will:'),
+    'Expected /plan to describe inline behavior, not mandatory agent behavior',
+  );
+  assert.ok(
+    !source.includes('Agent (planner):'),
+    'Expected /plan examples not to imply the planner agent is required',
+  );
+});
+
+test('/plan preserves the explicit confirmation gate before code edits', () => {
+  const source = readPlanCommand();
+
+  assert.ok(
+    source.includes('WAIT for user CONFIRM before touching any code'),
+    'Expected frontmatter to preserve the no-code-before-confirmation rule',
+  );
+  assert.ok(
+    source.includes('WAITING FOR CONFIRMATION'),
+    'Expected example output to preserve the confirmation handoff',
+  );
+  assert.ok(
+    source.includes('will **NOT** write any code until you explicitly confirm'),
+    'Expected important notes to preserve the confirmation contract',
+  );
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- make `/plan` run inline by default instead of requiring the `planner` subagent
- keep `planner` as an optional manual-install companion with a missing-agent fallback
- add regression coverage for the inline/default prompt contract and confirmation gate

## Validation
- `node tests/commands/plan-command.test.js`
- `node scripts/ci/validate-commands.js`
- `git diff --check`
- `npm run lint`
- `npm test` (2052/2052)

Closes #1601

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `/plan` inline by default so it works without the `planner` subagent. Addresses #1601.

- **Bug Fixes**
  - Default to inline planning; no Task tool or subagent calls by default.
  - Fallback to inline if `planner` isn’t installed; avoids “Agent type 'planner' not found”.
  - Updated `commands/plan.md` to reflect assistant-first behavior and keep the confirmation gate; added `tests/commands/plan-command.test.js` to assert inline default, fallback text, and the confirmation contract.

<sup>Written for commit 671d1a21d14dcf6bb4ff25b6e453d27e4a602f76. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1629?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `/plan` command documentation to clarify inline execution is the default behavior, with optional planner delegation available for manual installs.

* **Tests**
  * Added validation tests to ensure `/plan` command executes inline by default and preserves user confirmation gates before making code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->