### PR TITLE
fix: refine gateguard destructive git detection

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -39,7 +39,7 @@ const MAX_CHECKED_ENTRIES = 500;
 const MAX_SESSION_KEYS = 50;
 const ROUTINE_BASH_SESSION_KEY = '__bash_session__';
 
-const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f|drop\s+table|delete\s+from|truncate|git\s+push\s+--force|dd\s+if=)\b/i;
+const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f|drop\s+table|delete\s+from|truncate|git\s+push\s+--force(?!-with-lease)|git\s+commit\s+--amend|dd\s+if=)\b/i;
 
 // --- State management (per-session, atomic writes, bounded) ---
 

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -223,6 +223,62 @@ function runTests() {
 
   // --- Test 5: denies first routine Bash, allows second ---
   clearState();
+  if (test('allows safe git push --force-with-lease without destructive gate', () => {
+    writeState({
+      checked: ['__bash_session__'],
+      last_active: Date.now()
+    });
+
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'git push --force-with-lease origin feature-branch' }
+    };
+    const result = runBashHook(input);
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    if (output.hookSpecificOutput) {
+      assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny',
+        'safe lease-protected force push should not be denied');
+    } else {
+      assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+    }
+  })) passed++; else failed++;
+
+  // --- Test 6: gates amend as destructive Bash ---
+  clearState();
+  if (test('denies git commit --amend as destructive Bash', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'git commit --amend --no-edit' }
+    };
+    const result = runBashHook(input);
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('rollback'));
+  })) passed++; else failed++;
+
+  // --- Test 7: still gates plain force push as destructive Bash ---
+  clearState();
+  if (test('denies plain git push --force as destructive Bash', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'git push --force origin feature-branch' }
+    };
+    const result = runBashHook(input);
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('rollback'));
+  })) passed++; else failed++;
+
+  // --- Test 8: denies first routine Bash, allows second ---
+  clearState();
   if (test('denies first routine Bash, allows second', () => {
     const input = {
       tool_name: 'Bash',


### PR DESCRIPTION
## Summary
- Allow `git push --force-with-lease` after the routine Bash gate instead of treating it as destructive `--force`.
- Gate `git commit --amend` as destructive Git history mutation requiring explicit rollback-confirming intent.
- Add regression coverage for lease-protected force push, amend, and plain force push behavior.

## Validation
- `node tests/hooks/gateguard-fact-force.test.js` (`32/32`)
- `node scripts/ci/validate-hooks.js`
- `npx eslint scripts/hooks/gateguard-fact-force.js tests/hooks/gateguard-fact-force.test.js`
- `node tests/hooks/hooks.test.js` (`222/222`)
- `git diff --check`
- `npm run lint`
- `npm test` (`2052/2052`)

Closes #1586


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines gateguard’s destructive Git detection to allow `git push --force-with-lease` while gating `git commit --amend` as a destructive action. Prevents false positives and tightens protection around history rewrites.

- **Bug Fixes**
  - Update destructive Bash regex to exclude `git push --force-with-lease` and include `git commit --amend`; keep `git push --force` blocked.
  - Add regression tests covering lease-protected push, amend, and plain force push.

<sup>Written for commit ac8d5617c38a085747f8b7c984ab7763b4761112. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1630?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of destructive git operations to correctly allow `git push --force-with-lease` while continuing to protect against other destructive commands.
  * Extended protection to include `git commit --amend` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->