### PR TITLE
fix(suggest-compact): read session_id from stdin JSON for proper isolation

### DIFF
--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -18,14 +18,33 @@ const path = require('path');
 const {
   getTempDir,
   writeFile,
+  readStdinJson,
   log
 } = require('../lib/utils');
 
+async function resolveSessionId() {
+  // Claude Code passes hook input via stdin JSON; session_id is the canonical
+  // field (verified against observations from continuous-learning-v2/observe.sh
+  // which reads the same channel). Fall back to legacy env var, then 'default'.
+  // The stdin read is bounded so the hook stays fast even when invoked outside
+  // a real Claude Code session (e.g. from CI tests).
+  try {
+    const input = await readStdinJson({ timeoutMs: 1000 });
+    if (input && typeof input.session_id === 'string' && input.session_id) {
+      return input.session_id;
+    }
+  } catch {
+    /* fall through to env */
+  }
+  return process.env.CLAUDE_SESSION_ID || 'default';
+}
+
 async function main() {
   // Track tool call count (increment in a temp file)
-  // Use a session-specific counter file based on session ID from environment
-  // or parent PID as fallback
-  const sessionId = (process.env.CLAUDE_SESSION_ID || 'default').replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
+  // Use a session-specific counter file based on session ID from stdin JSON,
+  // legacy env var, or 'default' as fallback
+  const rawSessionId = await resolveSessionId();
+  const sessionId = rawSessionId.replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
   const counterFile = path.join(getTempDir(), `claude-tool-count-${sessionId}`);
   const rawThreshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
   const threshold = Number.isFinite(rawThreshold) && rawThreshold > 0 && rawThreshold <= 10000

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -1034,6 +1034,48 @@ async function runTests() {
     passed++;
   else failed++;
 
+  if (
+    await asyncTest('reads session_id from stdin JSON (Claude Code wire format)', async () => {
+      const sessionId = 'test-stdin-' + Date.now();
+      const stdinJson = JSON.stringify({ session_id: sessionId, tool_name: 'Edit' });
+
+      // No CLAUDE_SESSION_ID env — must come from stdin
+      const result = await runScript(path.join(scriptsDir, 'suggest-compact.js'), stdinJson, {});
+      assert.strictEqual(result.code, 0, `Exit code should be 0, got ${result.code}`);
+
+      const counterFile = path.join(os.tmpdir(), `claude-tool-count-${sessionId}`);
+      assert.ok(fs.existsSync(counterFile), `Counter file should be created from stdin session_id at ${counterFile}`);
+      const count = parseInt(fs.readFileSync(counterFile, 'utf8').trim(), 10);
+      assert.strictEqual(count, 1, `Counter should be 1, got ${count}`);
+
+      fs.unlinkSync(counterFile);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('stdin session_id takes precedence over env CLAUDE_SESSION_ID', async () => {
+      const stdinSession = 'stdin-wins-' + Date.now();
+      const envSession = 'env-loses-' + Date.now();
+      const stdinJson = JSON.stringify({ session_id: stdinSession });
+
+      const result = await runScript(path.join(scriptsDir, 'suggest-compact.js'), stdinJson, {
+        CLAUDE_SESSION_ID: envSession
+      });
+      assert.strictEqual(result.code, 0);
+
+      const stdinCounter = path.join(os.tmpdir(), `claude-tool-count-${stdinSession}`);
+      const envCounter = path.join(os.tmpdir(), `claude-tool-count-${envSession}`);
+      assert.ok(fs.existsSync(stdinCounter), 'Stdin session counter must exist');
+      assert.ok(!fs.existsSync(envCounter), 'Env session counter must NOT exist when stdin provides session_id');
+
+      fs.unlinkSync(stdinCounter);
+    })
+  )
+    passed++;
+  else failed++;
+
   // evaluate-session.js tests
   console.log('\nevaluate-session.js:');
 


### PR DESCRIPTION
## Summary

The `suggest-compact` PreToolUse hook tracks per-session tool-call counts in a temp file named `claude-tool-count-${sessionId}`. Today it sources `sessionId` from `process.env.CLAUDE_SESSION_ID`, but Claude Code does not export that variable — it delivers hook input via **stdin JSON** where the canonical field is `session_id`. As a result, every session collapsed onto the single fallback file `claude-tool-count-default`, and the counter accumulated across sessions indefinitely.

This PR makes the hook read `session_id` from stdin JSON (the same channel `skills/continuous-learning-v2/hooks/observe.sh` already consumes — confirmed by inspecting real `observations.jsonl` records that contain a true UUID under the `"session"` key). The legacy env var path is preserved as a fallback so existing tests and ad-hoc CLI invocations keep working.

## Symptoms in practice

In a real installation, `/var/folders/.../T/claude-tool-count-default` accumulated to **2103** across all sessions before the fix landed. Concrete consequences:

- The `count === threshold` first-time suggestion stopped firing forever after the first global session crossed the threshold.
- Only the modulo branch (every 25 calls past threshold) still triggered, and it fired against shared global state rather than per-session.

## Evidence the wire format is `session_id` over stdin

`skills/continuous-learning-v2/hooks/observe.sh` line 180:

```python
session_id = data.get("session_id", "unknown")
```

…where `data = json.loads(stdin)`. The resulting `observations.jsonl` records contain real UUIDs:

```json
{"session": "560cdfcc-51da-4947-85c1-79df57f2c96a", "tool": "Agent", ...}
```

So the canonical channel is unambiguously stdin JSON with field name `session_id`.

## Change

`scripts/hooks/suggest-compact.js`:

```diff
 const {
   getTempDir,
   writeFile,
+  readStdinJson,
   log
 } = require('../lib/utils');

+async function resolveSessionId() {
+  try {
+    const input = await readStdinJson({ timeoutMs: 1000 });
+    if (input && typeof input.session_id === 'string' && input.session_id) {
+      return input.session_id;
+    }
+  } catch {
+    /* fall through to env */
+  }
+  return process.env.CLAUDE_SESSION_ID || 'default';
+}
+
 async function main() {
-  const sessionId = (process.env.CLAUDE_SESSION_ID || 'default')
-    .replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
+  const rawSessionId = await resolveSessionId();
+  const sessionId = rawSessionId.replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
```

`readStdinJson` already exists in `scripts/lib/utils.js` and is used by other hooks. The 1000ms timeout keeps the hook fast even when invoked from CI / ad-hoc tests where stdin may stay open.

## Test plan

`tests/hooks/hooks.test.js`:

- All 13 existing `suggest-compact.js` tests still pass (they cover the env-var fallback path).
- Two new tests added:
  - `reads session_id from stdin JSON (Claude Code wire format)` — sets only stdin, asserts the per-session counter file is created.
  - `stdin session_id takes precedence over env CLAUDE_SESSION_ID` — sets both, asserts the stdin-named counter file exists and the env-named one does not.
- Total suite: **224 / 224 passing** (was 222 before this PR).

## Backwards compatibility

- Hooks invoked with empty stdin and only `CLAUDE_SESSION_ID` env set: still write to `claude-tool-count-${env}` (env fallback path).
- Hooks invoked with neither: still write to `claude-tool-count-default` (final fallback).
- Hooks invoked with malformed stdin: `readStdinJson` resolves to `{}`, falls through to env then default. Hook continues without crashing.

## Out of scope (potential follow-ups)

- The 2103-count `claude-tool-count-default` file from before the fix will linger until the OS cleans `/tmp` or the user removes it. Not cleaned up here to avoid touching unrelated state.
- The hook could additionally use `transcript_path` (also delivered via stdin) to extract a stable session shortId, but `session_id` is sufficient for isolation and matches the observer hook's contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `suggest-compact` hook to read `session_id` from stdin JSON so tool-call counts are tracked per session, not globally. Keeps `CLAUDE_SESSION_ID` as a fallback for compatibility.

- **Bug Fixes**
  - Read `session_id` via `readStdinJson` (1s timeout), sanitize, and use for `claude-tool-count-${sessionId}`; fall back to `CLAUDE_SESSION_ID` then `default`.
  - Resolves all sessions collapsing into `claude-tool-count-default`, which stopped the first-threshold suggestion from firing.

<sup>Written for commit 5a7bb2dac839bd4df01e8dd7ffcf6714fa794200. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1631?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session identifiers can now be provided through direct input, with automatic fallback to environment variable configuration, maintaining full backward compatibility while offering enhanced setup flexibility.

* **Tests**
  * Added test coverage for input-based session configuration and validation of configuration priority when multiple sources are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->