### PR TITLE
test: harden MCP health HTTP probe fixture

### DIFF
--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -54,6 +54,18 @@ function readState(statePath) {
   return JSON.parse(fs.readFileSync(statePath, 'utf8'));
 }
 
+function readOptionalFile(filePath) {
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '<missing>';
+}
+
+function hookFailureDetails(result, statePath) {
+  return [
+    `exit=${result.code}`,
+    `stderr=${result.stderr.trim() || '<empty>'}`,
+    `state=${readOptionalFile(statePath)}`
+  ].join('; ');
+}
+
 function createCommandConfig(scriptPath) {
   return {
     command: process.execPath,
@@ -132,7 +144,15 @@ function waitForHttpReady(urlString, timeoutMs = 5000) {
     const attempt = () => {
       const req = client.request(urlString, { method: 'GET' }, res => {
         res.resume();
-        resolve();
+        res.once('end', resolve);
+        res.once('error', error => {
+          if (Date.now() >= deadline) {
+            reject(new Error(`Timed out waiting for ${urlString}: ${error.message}`));
+            return;
+          }
+
+          setTimeout(attempt, 25);
+        });
       });
 
       req.setTimeout(250, () => {
@@ -835,26 +855,30 @@ async function runTests() {
 
       writeConfig(configPath, {
         mcpServers: {
-          github: {
+          http400: {
             type: 'http',
             url: `http://127.0.0.1:${port}/mcp`
           }
         }
       });
 
-      const input = { tool_name: 'mcp__github__search_repositories', tool_input: {} };
+      const input = { tool_name: 'mcp__http400__search_repositories', tool_input: {} };
       const result = runHook(input, {
         CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
         ECC_MCP_CONFIG_PATH: configPath,
         ECC_MCP_HEALTH_STATE_PATH: statePath,
-        ECC_MCP_HEALTH_TIMEOUT_MS: '500'
+        ECC_MCP_HEALTH_TIMEOUT_MS: '2000'
       });
 
-      assert.strictEqual(result.code, 0, `Expected HTTP 400 probe to be treated as healthy, got ${result.code}`);
+      assert.strictEqual(
+        result.code,
+        0,
+        `Expected HTTP 400 probe to be treated as healthy: ${hookFailureDetails(result, statePath)}`
+      );
       assert.strictEqual(result.stdout.trim(), JSON.stringify(input), 'Expected original JSON on stdout');
 
       const state = readState(statePath);
-      assert.strictEqual(state.servers.github.status, 'healthy', 'Expected HTTP MCP server to be marked healthy');
+      assert.strictEqual(state.servers.http400.status, 'healthy', 'Expected HTTP MCP server to be marked healthy');
     } finally {
       serverProcess.kill('SIGTERM');
       cleanupTempDir(tempDir);
@@ -910,10 +934,14 @@ async function runTests() {
         CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
         ECC_MCP_CONFIG_PATH: configPath,
         ECC_MCP_HEALTH_STATE_PATH: statePath,
-        ECC_MCP_HEALTH_TIMEOUT_MS: '500'
+        ECC_MCP_HEALTH_TIMEOUT_MS: '2000'
       });
 
-      assert.strictEqual(result.code, 0, `Expected HTTP 401 probe to be treated as healthy, got ${result.code}`);
+      assert.strictEqual(
+        result.code,
+        0,
+        `Expected HTTP 401 probe to be treated as healthy: ${hookFailureDetails(result, statePath)}`
+      );
       assert.strictEqual(result.stdout.trim(), JSON.stringify(input), 'Expected original JSON on stdout');
 
       const state = readState(statePath);


### PR DESCRIPTION
## Summary
- Harden the MCP health HTTP test readiness helper so it waits for the readiness response to fully end before invoking the hook.
- Isolate the HTTP 400 fixture behind a synthetic MCP server name instead of the common `github` server name.
- Increase the HTTP fixture timeout and include hook stderr/state diagnostics when probe expectations fail.

## Context
Post-merge main CI for PR #1630 failed reproducibly only on `windows-latest, Node 18.x, yarn` in `hooks/mcp-health-check.test.js`; the hook already treats HTTP 400 as healthy, so this patch targets test fixture stability and diagnostics.

## Validation
- `node tests/hooks/mcp-health-check.test.js` (`20/20`)
- `node scripts/ci/validate-hooks.js`
- `npx eslint tests/hooks/mcp-health-check.test.js`
- `npm run lint`
- `git diff --check`
- `npm test` (`2052/2052`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the MCP health HTTP probe test on Windows CI by waiting for the readiness response to fully end and adding better failure diagnostics. Reduces flakiness in `hooks/mcp-health-check.test.js` for HTTP 400/401 cases.

- **Bug Fixes**
  - Wait for `end` in `waitForHttpReady` and retry on stream errors until timeout.
  - Use a synthetic `http400` MCP server name and matching tool names; update state assertions.
  - Increase HTTP fixture timeout to 2000ms and include stderr/state in assertion messages.

<sup>Written for commit e6dc55e0303d2d257bed2676b899c2480a46997e. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1632?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved HTTP health check reliability with enhanced timeout handling and error recovery mechanisms.
  * Better diagnostic information for troubleshooting server health issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->