### PR TITLE
fix: avoid Cursor nested AGENTS context pollution

### DIFF
--- a/scripts/lib/install-targets/cursor-project.js
+++ b/scripts/lib/install-targets/cursor-project.js
@@ -133,6 +133,12 @@ module.exports = createInstallTargetAdapter({
         destinationPath: path.join(targetRoot, 'mcp.json'),
       });
 
+      if (sourceRelativePath === 'AGENTS.md') {
+        // Cursor treats nested AGENTS.md files as directory context; do not
+        // install ECC's root project identity into a host project's .cursor/.
+        return [];
+      }
+
       if (sourceRelativePath === 'rules') {
         return takeUniqueOperations(createFlatRuleOperations({
           moduleId: module.id,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -172,6 +172,36 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('does not install root AGENTS.md into Cursor nested context', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'cursor',
+      repoRoot,
+      projectRoot,
+      modules: [
+        {
+          id: 'agents-core',
+          paths: ['.agents', 'agents', 'AGENTS.md'],
+        },
+      ],
+    });
+
+    assert.ok(
+      !plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'AGENTS.md'
+      )),
+      'Cursor installs should not copy ECC root AGENTS.md into host project context'
+    );
+    assert.ok(
+      !plan.operations.some(operation => (
+        operation.destinationPath === path.join(projectRoot, '.cursor', 'AGENTS.md')
+      )),
+      'Cursor installs should not create .cursor/AGENTS.md'
+    );
+  })) passed++; else failed++;
+
   if (test('plans cursor platform rule files as .mdc and excludes rule README docs', () => {
     const repoRoot = path.join(__dirname, '..', '..');
     const projectRoot = '/workspace/app';


### PR DESCRIPTION
## Summary
- Stops Cursor target planning from installing ECC's root `AGENTS.md` into host projects as `.cursor/AGENTS.md`.
- Adds a regression covering the #1520 context-pollution path from `agents-core`.
- Leaves Cursor agents, rules, hooks, and MCP planning intact.

Fixes #1520

## Validation
- `node tests/lib/install-targets.test.js` (failed before implementation, passes after)
- `node tests/lib/install-executor.test.js`
- `node tests/lib/install-manifests.test.js`
- `node scripts/ci/validate-install-manifests.js`
- `node tests/scripts/install-plan.test.js`
- `node tests/scripts/install-apply.test.js`
- `git diff --check`
- `npm run lint`
- `npm test` (2058/2058)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop installing the repo’s root `AGENTS.md` into host projects’ `.cursor/` to avoid Cursor nested context pollution in Cursor projects. Keeps agents, rules, hooks, and MCP planning unchanged; fixes #1520.

- **Bug Fixes**
  - Skip copying root `AGENTS.md` in the Cursor install target so it isn’t treated as directory context.
  - Add a regression test to ensure no `.cursor/AGENTS.md` is created.

<sup>Written for commit 10c4e03b6e3825836586af4795bbc1021b2e3760. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1636?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where documentation files were being incorrectly included in the installation process, preventing them from appearing in nested project contexts.

* **Tests**
  * Added unit tests to verify proper file exclusion during installation and prevent regression of this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->