### PR TITLE
fix: disable Claude plugin bundled MCPs

### DIFF
--- a/.claude-plugin/PLUGIN_SCHEMA_NOTES.md
+++ b/.claude-plugin/PLUGIN_SCHEMA_NOTES.md
@@ -132,6 +132,26 @@ The test `plugin.json does NOT have explicit hooks declaration` in `tests/hooks/
 
 ---
 
+## The `mcpServers` Field: Keep the Empty Opt-Out
+
+ECC keeps `.mcp.json` at the repository root for Codex plugin installs and manual MCP setup.
+Claude Code also auto-discovers plugin-root `.mcp.json` files by convention, which would bundle the same MCP servers into Claude plugin installs.
+
+Keep this field in `.claude-plugin/plugin.json`:
+
+```json
+{
+  "mcpServers": {}
+}
+```
+
+This explicit empty object prevents Claude plugin installs from auto-loading ECC's root MCP definitions.
+Without the opt-out, strict OpenAI-compatible gateways can reject plugin MCP tool names such as `mcp__plugin_everything-claude-code_github__create_pull_request_review` because they exceed 64 characters.
+
+Users who want the bundled MCP servers should configure them manually from `.mcp.json` or `mcp-configs/mcp-servers.json`.
+
+---
+
 ## Known Anti-Patterns
 
 These look correct but are rejected:
@@ -142,6 +162,7 @@ These look correct but are rejected:
 * Relying on inferred paths
 * Assuming marketplace behavior matches local validation
 * **Adding `"hooks": "./hooks/hooks.json"`** - auto-loaded by convention, causes duplicate error
+* Removing `"mcpServers": {}` - re-enables root `.mcp.json` auto-discovery for Claude plugin installs and can produce overlong MCP tool names
 
 Avoid cleverness. Be explicit.
 
@@ -170,7 +191,8 @@ Before submitting changes that touch `plugin.json`:
 1. Ensure all component fields are arrays
 2. Include a `version`
 3. Do NOT add `agents` or `hooks` fields (both are auto-loaded by convention)
-4. Run:
+4. Preserve `"mcpServers": {}` unless you are intentionally changing Claude plugin MCP bundling behavior
+5. Run:
 
 ```bash
 claude plugin validate .claude-plugin/plugin.json

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,6 +22,7 @@
     "automation",
     "best-practices"
   ],
+  "mcpServers": {},
   "skills": ["./skills/"],
   "commands": ["./commands/"]
 }

--- a/README.md
+++ b/README.md
@@ -829,6 +829,8 @@ Windows note: the Claude config directory is `%USERPROFILE%\\.claude`, not `~/cl
 
 #### Configure MCPs
 
+Claude plugin installs intentionally do not auto-enable ECC's bundled MCP server definitions. This avoids overlong plugin MCP tool names on strict third-party gateways while keeping manual MCP setup available.
+
 Copy desired MCP server definitions from `mcp-configs/mcp-servers.json` into your official Claude Code config in `~/.claude/settings.json`, or into a project-scoped `.mcp.json` if you want repo-local MCP access.
 
 If you already run your own copies of ECC-bundled MCPs, set:

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -5,7 +5,7 @@
   "required": ["name"],
   "properties": {
     "name": { "type": "string" },
-    "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$" },
     "description": { "type": "string" },
     "author": {
       "oneOf": [
@@ -30,6 +30,22 @@
     "skills": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "commands": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "mcpServers": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        {
+          "type": "object"
+        }
+      ]
     },
     "features": {
       "type": "object",

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -217,6 +217,24 @@ test('claude plugin.json commands is an array', () => {
   assert.ok(Array.isArray(claudePlugin.commands), 'Expected commands to be an array');
 });
 
+test('claude plugin.json disables bundled MCP servers for provider tool-name compatibility', () => {
+  const reportedOverlongToolName = `mcp__plugin_${claudePlugin.name}_github__create_pull_request_review`;
+
+  assert.ok(
+    reportedOverlongToolName.length > 64,
+    'Expected the reported GitHub MCP tool name to exceed strict provider limits without the MCP opt-out',
+  );
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(claudePlugin, 'mcpServers'),
+    'Expected mcpServers to be explicitly declared so Claude Code does not auto-load root .mcp.json',
+  );
+  assert.deepStrictEqual(
+    claudePlugin.mcpServers,
+    {},
+    'Claude plugin installs must not auto-bundle root MCP servers; document/manual MCP install remains supported',
+  );
+});
+
 test('claude plugin.json does NOT have explicit hooks declaration', () => {
   assert.ok(
     !('hooks' in claudePlugin),


### PR DESCRIPTION
## Summary
- add an explicit empty Claude plugin mcpServers object so Claude plugin installs do not auto-bundle the repo-root .mcp.json
- keep the repo-root .mcp.json available for Codex plugin installs and manual MCP setup
- add a regression for the reported over-64 GitHub MCP tool name and document the opt-out

Fixes #1516.
Fixes #1553.

## Validation
- node tests/plugin-manifest.test.js
- node tests/docs/install-identifiers.test.js
- claude plugin validate .
- claude plugin validate .claude-plugin/plugin.json (passes with existing command frontmatter warnings)
- git diff --check
- npm run lint
- npm test (2059/2059)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable auto-bundling of repo MCP servers in Claude plugin installs by setting `"mcpServers": {}` in `.claude-plugin/plugin.json`, preventing overlong MCP tool names on strict gateways while keeping manual MCP setup available.

- **Bug Fixes**
  - Opt out of root `.mcp.json` auto-discovery via `"mcpServers": {}` in the Claude plugin manifest.
  - Extend `schemas/plugin.schema.json` to support `mcpServers` (string | string[] | object) and allow SemVer pre-release in `version`.
  - Document the opt-out and risks in `.claude-plugin/PLUGIN_SCHEMA_NOTES.md` and `README.md`.
  - Add tests to enforce the empty `mcpServers`, guard the >64-char GitHub MCP tool name case, and confirm `commands` is an array.

- **Migration**
  - No action needed. To enable MCPs, copy from `mcp-configs/mcp-servers.json` or root `.mcp.json` into `~/.claude/settings.json` or a project `.mcp.json`.

<sup>Written for commit b1c0bdd235e2261140fbe850723cfad66dfc8022. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1637?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP server configuration behavior to prevent auto-loading of bundled MCP servers, protecting against gateway rejections due to long tool names.

* **New Features**
  * Added support for `mcpServers` configuration field in plugin manifest.
  * Extended version format to support prerelease and build identifiers (e.g., `1.0.0-beta`).
  * Added `commands` configuration field support.

* **Tests**
  * Added validation tests for plugin manifest structure and MCP configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->