### PR TITLE
fix: add no-hooks minimal install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,34 @@ Most Claude Code users should use exactly one install path:
 
 If you already layered multiple installs and things look duplicated, skip straight to [Reset / Uninstall ECC](#reset--uninstall-ecc).
 
+### Low-context / no-hooks path
+
+If hooks feel too global or you only want ECC's rules, agents, commands, and core workflow skills, skip the plugin and use the minimal manual profile:
+
+```bash
+./install.sh --profile minimal --target claude
+```
+
+```powershell
+.\install.ps1 --profile minimal --target claude
+# or
+npx ecc-install --profile minimal --target claude
+```
+
+This profile intentionally excludes `hooks-runtime`.
+
+If you want the normal core profile but need hooks off, use:
+
+```bash
+./install.sh --profile core --without baseline:hooks --target claude
+```
+
+Add hooks later only if you want runtime enforcement:
+
+```bash
+./install.sh --target claude --modules hooks-runtime
+```
+
 ### Step 1: Install the Plugin (Recommended)
 
 > NOTE: The plugin is convenient, but the OSS installer below is still the most reliable path if your Claude Code build has trouble resolving self-hosted marketplace entries.

--- a/manifests/install-profiles.json
+++ b/manifests/install-profiles.json
@@ -1,6 +1,16 @@
 {
   "version": 1,
   "profiles": {
+    "minimal": {
+      "description": "Low-context Claude Code setup with rules, agents, commands, platform configs, and quality workflow support, but no hook runtime.",
+      "modules": [
+        "rules-core",
+        "agents-core",
+        "commands-core",
+        "platform-configs",
+        "workflow-quality"
+      ]
+    },
     "core": {
       "description": "Minimal harness baseline with commands, hooks, platform configs, and quality workflow support.",
       "modules": [

--- a/tests/lib/install-manifests.test.js
+++ b/tests/lib/install-manifests.test.js
@@ -79,6 +79,7 @@ function runTests() {
 
   if (test('lists install profiles from the real project', () => {
     const profiles = listInstallProfiles();
+    assert.ok(profiles.some(profile => profile.id === 'minimal'), 'Should include minimal profile');
     assert.ok(profiles.some(profile => profile.id === 'core'), 'Should include core profile');
     assert.ok(profiles.some(profile => profile.id === 'full'), 'Should include full profile');
   })) passed++; else failed++;
@@ -210,6 +211,22 @@ function runTests() {
     assert.ok(!plan.skippedModuleIds.includes('workflow-quality'));
     assert.strictEqual(plan.targetAdapterId, 'antigravity-project');
     assert.strictEqual(plan.targetRoot, path.join(projectRoot, '.agent'));
+  })) passed++; else failed++;
+
+  if (test('resolves minimal profile without the hook runtime', () => {
+    const plan = resolveInstallPlan({
+      profileId: 'minimal',
+      target: 'claude',
+      projectRoot: '/workspace/app',
+    });
+
+    assert.deepStrictEqual(
+      plan.selectedModuleIds,
+      ['rules-core', 'agents-core', 'commands-core', 'platform-configs', 'workflow-quality']
+    );
+    assert.ok(!plan.selectedModuleIds.includes('hooks-runtime'),
+      'minimal profile should not install hooks-runtime');
+    assert.ok(plan.operations.length > 0, 'Should include install operations');
   })) passed++; else failed++;
 
   if (test('resolves explicit modules with dependency expansion', () => {

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -271,6 +271,24 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('supports minimal profile dry-runs without hooks through the installer', () => {
+    const homeDir = createTempDir('install-apply-home-');
+    const projectDir = createTempDir('install-apply-project-');
+
+    try {
+      const result = run(['--profile', 'minimal', '--dry-run'], { cwd: projectDir, homeDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(result.stdout.includes('Mode: manifest'));
+      assert.ok(result.stdout.includes('Profile: minimal'));
+      assert.ok(result.stdout.includes('Selected modules: rules-core, agents-core, commands-core, platform-configs, workflow-quality'));
+      assert.ok(!result.stdout.includes('hooks-runtime'));
+      assert.ok(!fs.existsSync(path.join(homeDir, '.claude', 'ecc', 'install-state.json')));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
+  })) passed++; else failed++;
+
   if (test('installs manifest profiles and writes non-legacy install-state', () => {
     const homeDir = createTempDir('install-apply-home-');
     const projectDir = createTempDir('install-apply-project-');

--- a/tests/scripts/install-readme-clarity.test.js
+++ b/tests/scripts/install-readme-clarity.test.js
@@ -70,6 +70,29 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('README documents low-context no-hooks install path', () => {
+    assert.ok(
+      readme.includes('### Low-context / no-hooks path'),
+      'README should surface a low-context no-hooks install option near Quick Start'
+    );
+    assert.ok(
+      readme.includes('./install.sh --profile minimal --target claude'),
+      'README should document the shell minimal profile command'
+    );
+    assert.ok(
+      readme.includes('npx ecc-install --profile minimal --target claude'),
+      'README should document the npx minimal profile command'
+    );
+    assert.ok(
+      readme.includes('--profile core --without baseline:hooks --target claude'),
+      'README should document the hook opt-out path for the core profile'
+    );
+    assert.ok(
+      readme.includes('This profile intentionally excludes `hooks-runtime`.'),
+      'README should state that the minimal profile excludes hooks'
+    );
+  })) passed++; else failed++;
+
   if (test('README explains plugin-path cleanup and rules scoping', () => {
     assert.ok(
       readme.includes('remove the plugin from Claude Code'),


### PR DESCRIPTION
## Summary
- add a minimal install profile for low-context Claude Code installs without hooks-runtime
- document the no-hooks path near Quick Start, including the core profile hook opt-out
- add regression coverage for manifest resolution, README clarity, and installer dry-run output

Fixes #1557.

## Validation
- node tests/lib/install-manifests.test.js
- node tests/scripts/install-readme-clarity.test.js
- node tests/scripts/install-apply.test.js
- node scripts/install-plan.js --profile minimal --target claude --json
- git diff --check
- npm run lint
- npm test (2063/2063)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a minimal install profile for Claude Code that installs rules/agents/commands without `hooks-runtime`, and document the no‑hooks path near Quick Start. Fixes #1557.

- **New Features**
  - New `minimal` profile installs `rules-core`, `agents-core`, `commands-core`, `platform-configs`, `workflow-quality` and excludes `hooks-runtime`.
  - README adds no‑hooks path and core profile hook opt‑out examples for `install.sh`, PowerShell, and `npx ecc-install`.
  - Regression tests cover profile listing and resolution, installer dry‑run output (shows selected modules and omits hooks), and README clarity.

<sup>Written for commit 2ea821644f412e412d60178f52183f594d3727a4. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1639?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added minimal installation profile excluding runtime hooks for lightweight deployments.

* **Documentation**
  * Updated Quick Start guide with alternative installation routes, including options to install without hooks or enable them later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->