### PR TITLE
fix: clarify configure-ecc skill copy roots

### DIFF
--- a/docs/ja-JP/skills/configure-ecc/SKILL.md
+++ b/docs/ja-JP/skills/configure-ecc/SKILL.md
@@ -130,9 +130,20 @@ Options:
 
 ### 2c: インストールの実行
 
-選択された各スキルについて、スキルディレクトリ全体をコピーします：
+選択された各スキルについて、正しいソースルートからスキルディレクトリ全体をコピーします：
+
 ```bash
-cp -r $ECC_ROOT/skills/<skill-name> $TARGET/skills/
+# ステップ 2a で選択したコアスキルは .agents/skills/ 配下にあります
+cp -R "$ECC_ROOT/.agents/skills/<skill-name>" "$TARGET/skills/"
+
+# ステップ 2b/2c で選択したニッチスキルは skills/ 配下にあります
+cp -R "$ECC_ROOT/skills/<skill-name>" "$TARGET/skills/"
+```
+
+glob で取得したソースディレクトリを処理するときは、trailing slash 付きのソースをそのまま `cp` に渡さないでください。宛先名にディレクトリ名を明示します：
+
+```bash
+cp -R "${src%/}" "$TARGET/skills/$(basename "${src%/}")"
 ```
 
 注: `continuous-learning` と `continuous-learning-v2` には追加ファイル（config.json、フック、スクリプト）があります — SKILL.md だけでなく、ディレクトリ全体がコピーされることを確認してください。

--- a/docs/ja-JP/skills/configure-ecc/SKILL.md
+++ b/docs/ja-JP/skills/configure-ecc/SKILL.md
@@ -133,10 +133,10 @@ Options:
 選択された各スキルについて、正しいソースルートからスキルディレクトリ全体をコピーします：
 
 ```bash
-# ステップ 2a で選択したコアスキルは .agents/skills/ 配下にあります
+# コアスキルは .agents/skills/ 配下にあります
 cp -R "$ECC_ROOT/.agents/skills/<skill-name>" "$TARGET/skills/"
 
-# ステップ 2b/2c で選択したニッチスキルは skills/ 配下にあります
+# ニッチスキルは skills/ 配下にあります
 cp -R "$ECC_ROOT/skills/<skill-name>" "$TARGET/skills/"
 ```
 

--- a/docs/zh-CN/skills/configure-ecc/SKILL.md
+++ b/docs/zh-CN/skills/configure-ecc/SKILL.md
@@ -199,10 +199,20 @@ mkdir -p $TARGET/skills $TARGET/rules
 
 ### 2d: 执行安装
 
-对于每个选定的技能，复制整个技能目录：
+对于每个选定的技能，请从正确的源目录复制整个技能目录：
 
 ```bash
-cp -r $ECC_ROOT/skills/<skill-name> $TARGET/skills/
+# 步骤 2a 选中的核心技能位于 .agents/skills/
+cp -R "$ECC_ROOT/.agents/skills/<skill-name>" "$TARGET/skills/"
+
+# 步骤 2b/2c 选中的细分技能位于 skills/
+cp -R "$ECC_ROOT/skills/<skill-name>" "$TARGET/skills/"
+```
+
+遍历 glob 得到的源目录时，不要把带 trailing slash 的源路径直接传给 `cp`。显式使用目录名作为目标名：
+
+```bash
+cp -R "${src%/}" "$TARGET/skills/$(basename "${src%/}")"
 ```
 
 注意：`continuous-learning` 和 `continuous-learning-v2` 有额外的文件（config.json、钩子、脚本）——确保复制整个目录，而不仅仅是 SKILL.md。

--- a/docs/zh-CN/skills/configure-ecc/SKILL.md
+++ b/docs/zh-CN/skills/configure-ecc/SKILL.md
@@ -202,10 +202,10 @@ mkdir -p $TARGET/skills $TARGET/rules
 对于每个选定的技能，请从正确的源目录复制整个技能目录：
 
 ```bash
-# 步骤 2a 选中的核心技能位于 .agents/skills/
+# 核心技能位于 .agents/skills/
 cp -R "$ECC_ROOT/.agents/skills/<skill-name>" "$TARGET/skills/"
 
-# 步骤 2b/2c 选中的细分技能位于 skills/
+# 细分技能位于 skills/
 cp -R "$ECC_ROOT/skills/<skill-name>" "$TARGET/skills/"
 ```
 

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -195,9 +195,20 @@ For each selected category, print the full list of skills below and ask the user
 
 ### 2d: Execute Installation
 
-For each selected skill, copy the entire skill directory:
+For each selected skill, copy the entire skill directory from the correct source root:
+
 ```bash
-cp -r $ECC_ROOT/skills/<skill-name> $TARGET/skills/
+# Core skills selected from Step 2a live under .agents/skills/
+cp -R "$ECC_ROOT/.agents/skills/<skill-name>" "$TARGET/skills/"
+
+# Niche skills selected from Step 2b/2c live under skills/
+cp -R "$ECC_ROOT/skills/<skill-name>" "$TARGET/skills/"
+```
+
+When iterating over globbed source directories, never pass a trailing-slash source directly to `cp`. Use the directory path as the destination name explicitly:
+
+```bash
+cp -R "${src%/}" "$TARGET/skills/$(basename "${src%/}")"
 ```
 
 Note: `continuous-learning` and `continuous-learning-v2` have extra files (config.json, hooks, scripts) — ensure the entire directory is copied, not just SKILL.md.

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -198,10 +198,10 @@ For each selected category, print the full list of skills below and ask the user
 For each selected skill, copy the entire skill directory from the correct source root:
 
 ```bash
-# Core skills selected from Step 2a live under .agents/skills/
+# Core skills live under .agents/skills/
 cp -R "$ECC_ROOT/.agents/skills/<skill-name>" "$TARGET/skills/"
 
-# Niche skills selected from Step 2b/2c live under skills/
+# Niche skills live under skills/
 cp -R "$ECC_ROOT/skills/<skill-name>" "$TARGET/skills/"
 ```
 

--- a/tests/docs/configure-ecc-install-paths.test.js
+++ b/tests/docs/configure-ecc-install-paths.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const configureEccDocs = [
+  'skills/configure-ecc/SKILL.md',
+  'docs/zh-CN/skills/configure-ecc/SKILL.md',
+  'docs/ja-JP/skills/configure-ecc/SKILL.md',
+];
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+console.log('\n=== Testing configure-ecc install path guidance ===\n');
+
+for (const relativePath of configureEccDocs) {
+  const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+  test(`${relativePath} separates core and niche skill source roots`, () => {
+    assert.ok(
+      content.includes('$ECC_ROOT/.agents/skills/<skill-name>'),
+      'Expected configure-ecc to document the core skill source root'
+    );
+    assert.ok(
+      content.includes('$ECC_ROOT/skills/<skill-name>'),
+      'Expected configure-ecc to document the niche skill source root'
+    );
+  });
+
+  test(`${relativePath} documents defensive copy form for trailing slash sources`, () => {
+    assert.ok(
+      content.includes('${src%/}'),
+      'Expected configure-ecc to strip trailing slash before copying'
+    );
+    assert.ok(
+      content.includes('$(basename "${src%/}")'),
+      'Expected configure-ecc to preserve the skill directory name explicitly'
+    );
+  });
+}
+
+if (failed > 0) {
+  console.log(`\nFailed: ${failed}`);
+  process.exit(1);
+}
+
+console.log(`\nPassed: ${passed}`);

--- a/tests/docs/configure-ecc-install-paths.test.js
+++ b/tests/docs/configure-ecc-install-paths.test.js
@@ -27,12 +27,16 @@ function test(name, fn) {
   }
 }
 
+function readConfigureEccDoc(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
 console.log('\n=== Testing configure-ecc install path guidance ===\n');
 
 for (const relativePath of configureEccDocs) {
-  const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
-
   test(`${relativePath} separates core and niche skill source roots`, () => {
+    const content = readConfigureEccDoc(relativePath);
+
     assert.ok(
       content.includes('$ECC_ROOT/.agents/skills/<skill-name>'),
       'Expected configure-ecc to document the core skill source root'
@@ -44,6 +48,8 @@ for (const relativePath of configureEccDocs) {
   });
 
   test(`${relativePath} documents defensive copy form for trailing slash sources`, () => {
+    const content = readConfigureEccDoc(relativePath);
+
     assert.ok(
       content.includes('${src%/}'),
       'Expected configure-ecc to strip trailing slash before copying'


### PR DESCRIPTION
## Summary
- Clarifies configure-ecc install guidance so core skills copy from `$ECC_ROOT/.agents/skills/<skill-name>` and niche skills copy from `$ECC_ROOT/skills/<skill-name>`.
- Documents defensive `cp -R "${src%/}" "$TARGET/skills/$(basename "${src%/}")"` handling for globbed source directories.
- Adds regression coverage for English, zh-CN, and ja-JP configure-ecc docs.

Fixes #1483

## Validation
- `node tests/docs/configure-ecc-install-paths.test.js`
- `node tests/docs/install-identifiers.test.js`
- `node tests/plugin-manifest.test.js`
- `git diff --check`
- `npm run lint`
- `npm test` (2071/2071)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies configure-ecc install steps so skills copy from the right roots and adds a safe `cp` pattern for globbed sources. Fixes #1483 and adds a regression test that fails clearly if docs are missing.

- **Bug Fixes**
  - Document correct copy paths: core under `$ECC_ROOT/.agents/skills/<skill-name>`, niche under `$ECC_ROOT/skills/<skill-name>`.
  - Add defensive copy example to avoid trailing-slash issues: `cp -R "${src%/}" "$TARGET/skills/$(basename "${src%/}")"`.
  - Update `SKILL.md` in English, `zh-CN`, and `ja-JP`; add `tests/docs/configure-ecc-install-paths.test.js` to assert both roots and the safe copy form, with clean failures when a locale doc is missing.

<sup>Written for commit 3438e7a2849192fbfaf4a6aa54eefb60ef0b53a8. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1641?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified skill installation: separate source paths for core vs. niche skills and safer copy behavior to avoid trailing-slash issues.
  * Updated installation guides in English, Japanese, and Chinese for clearer, more reliable steps.

* **Tests**
  * Added docs verification tests to ensure installation guidance is consistent across localized documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->