### PR TITLE
fix: add command metadata frontmatter

### DIFF
--- a/commands/build-fix.md
+++ b/commands/build-fix.md
@@ -1,3 +1,7 @@
+---
+description: Detect the project build system and incrementally fix build/type errors with minimal safe changes.
+---
+
 # Build and Fix
 
 Incrementally fix build and type errors with minimal, safe changes.

--- a/commands/checkpoint.md
+++ b/commands/checkpoint.md
@@ -1,3 +1,7 @@
+---
+description: Create, verify, or list workflow checkpoints after running verification checks.
+---
+
 # Checkpoint Command
 
 Create or verify a checkpoint in your workflow.

--- a/commands/gan-build.md
+++ b/commands/gan-build.md
@@ -1,3 +1,7 @@
+---
+description: Run a generator/evaluator build loop for implementation tasks with bounded iterations and scoring.
+---
+
 Parse the following from $ARGUMENTS:
 1. `brief` — the user's one-line description of what to build
 2. `--max-iterations N` — (optional, default 15) maximum generator-evaluator cycles

--- a/commands/gan-design.md
+++ b/commands/gan-design.md
@@ -1,3 +1,7 @@
+---
+description: Run a generator/evaluator design loop for frontend or visual work with bounded iterations and scoring.
+---
+
 Parse the following from $ARGUMENTS:
 1. `brief` — the user's description of the design to create
 2. `--max-iterations N` — (optional, default 10) maximum design-evaluate cycles

--- a/commands/harness-audit.md
+++ b/commands/harness-audit.md
@@ -1,3 +1,7 @@
+---
+description: Run a deterministic repository harness audit and return a prioritized scorecard.
+---
+
 # Harness Audit Command
 
 Run a deterministic repository harness audit and return a prioritized scorecard.

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,3 +1,7 @@
+---
+description: Extract reusable patterns from the current session and save them as candidate skills or guidance.
+---
+
 # /learn - Extract Reusable Patterns
 
 Analyze the current session and extract any patterns worth saving as skills.

--- a/commands/loop-start.md
+++ b/commands/loop-start.md
@@ -1,3 +1,7 @@
+---
+description: Start a managed autonomous loop pattern with safety defaults and explicit stop conditions.
+---
+
 # Loop Start Command
 
 Start a managed autonomous loop pattern with safety defaults.

--- a/commands/loop-status.md
+++ b/commands/loop-status.md
@@ -1,3 +1,7 @@
+---
+description: Inspect active loop state, progress, failure signals, and recommended intervention.
+---
+
 # Loop Status Command
 
 Inspect active loop state, progress, and failure signals.

--- a/commands/model-route.md
+++ b/commands/model-route.md
@@ -1,3 +1,7 @@
+---
+description: Recommend the best model tier for the current task based on complexity, risk, and budget.
+---
+
 # Model Route Command
 
 Recommend the best model tier for the current task by complexity and budget.

--- a/commands/multi-backend.md
+++ b/commands/multi-backend.md
@@ -1,3 +1,7 @@
+---
+description: Run a backend-focused multi-model workflow for APIs, algorithms, data, and business logic.
+---
+
 # Backend - Backend-Focused Development
 
 Backend-focused workflow (Research → Ideation → Plan → Execute → Optimize → Review), Codex-led.

--- a/commands/multi-execute.md
+++ b/commands/multi-execute.md
@@ -1,3 +1,7 @@
+---
+description: Execute a multi-model implementation plan while preserving Claude as the only filesystem writer.
+---
+
 # Execute - Multi-Model Collaborative Execution
 
 Multi-model collaborative execution - Get prototype from plan → Claude refactors and implements → Multi-model audit and delivery.

--- a/commands/multi-frontend.md
+++ b/commands/multi-frontend.md
@@ -1,3 +1,7 @@
+---
+description: Run a frontend-focused multi-model workflow for components, layouts, animation, and UI polish.
+---
+
 # Frontend - Frontend-Focused Development
 
 Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimize → Review), Gemini-led.

--- a/commands/multi-plan.md
+++ b/commands/multi-plan.md
@@ -1,3 +1,7 @@
+---
+description: Create a multi-model implementation plan without modifying production code.
+---
+
 # Plan - Multi-Model Collaborative Planning
 
 Multi-model collaborative planning - Context retrieval + Dual-model analysis → Generate step-by-step implementation plan.

--- a/commands/multi-workflow.md
+++ b/commands/multi-workflow.md
@@ -1,3 +1,7 @@
+---
+description: Run a full multi-model development workflow with research, planning, execution, optimization, and review.
+---
+
 # Workflow - Multi-Model Collaborative Development
 
 Multi-model collaborative development workflow (Research → Ideation → Plan → Execute → Optimize → Review), with intelligent routing: Frontend → Gemini, Backend → Codex.

--- a/commands/pm2.md
+++ b/commands/pm2.md
@@ -1,3 +1,7 @@
+---
+description: Analyze a project and generate PM2 service commands for detected frontend, backend, or database services.
+---
+
 # PM2 Init
 
 Auto-analyze project and generate PM2 service commands.

--- a/commands/quality-gate.md
+++ b/commands/quality-gate.md
@@ -1,3 +1,7 @@
+---
+description: Run the ECC quality pipeline for a file or project scope and report remediation steps.
+---
+
 # Quality Gate Command
 
 Run the ECC quality pipeline on demand for a file or project scope.

--- a/commands/refactor-clean.md
+++ b/commands/refactor-clean.md
@@ -1,3 +1,7 @@
+---
+description: Safely identify and remove dead code with verification after each change.
+---
+
 # Refactor Clean
 
 Safely identify and remove dead code with test verification at every step.

--- a/commands/test-coverage.md
+++ b/commands/test-coverage.md
@@ -1,3 +1,7 @@
+---
+description: Analyze coverage, identify gaps, and generate missing tests toward the target threshold.
+---
+
 # Test Coverage
 
 Analyze test coverage, identify gaps, and generate missing tests to reach 80%+ coverage.

--- a/commands/update-codemaps.md
+++ b/commands/update-codemaps.md
@@ -1,3 +1,7 @@
+---
+description: Scan project structure and generate token-lean architecture codemaps.
+---
+
 # Update Codemaps
 
 Analyze the codebase structure and generate token-lean architecture documentation.

--- a/commands/update-docs.md
+++ b/commands/update-docs.md
@@ -1,3 +1,7 @@
+---
+description: Sync documentation from source-of-truth files such as scripts, schemas, routes, and exports.
+---
+
 # Update Documentation
 
 Sync documentation with the codebase, generating from source-of-truth files.

--- a/tests/commands/command-frontmatter.test.js
+++ b/tests/commands/command-frontmatter.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const commandsDir = path.join(repoRoot, 'commands');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+function getCommandFiles() {
+  return fs.readdirSync(commandsDir)
+    .filter(fileName => fileName.endsWith('.md'))
+    .sort();
+}
+
+function parseFrontmatter(content) {
+  if (!content.startsWith('---\n')) {
+    return null;
+  }
+
+  const endIndex = content.indexOf('\n---', 4);
+  if (endIndex === -1) {
+    return null;
+  }
+
+  return content.slice(4, endIndex);
+}
+
+console.log('\n=== Testing command frontmatter metadata ===\n');
+
+for (const fileName of getCommandFiles()) {
+  test(`${fileName} declares command metadata frontmatter`, () => {
+    const content = fs.readFileSync(path.join(commandsDir, fileName), 'utf8');
+    const frontmatter = parseFrontmatter(content);
+
+    assert.ok(frontmatter, 'Expected command file to start with YAML frontmatter');
+    assert.ok(
+      /^description:\s*\S/m.test(frontmatter),
+      'Expected command frontmatter to include a non-empty description'
+    );
+  });
+}
+
+if (failed > 0) {
+  console.log(`\nFailed: ${failed}`);
+  process.exit(1);
+}
+
+console.log(`\nPassed: ${passed}`);

--- a/tests/commands/command-frontmatter.test.js
+++ b/tests/commands/command-frontmatter.test.js
@@ -29,19 +29,16 @@ function getCommandFiles() {
 }
 
 function parseFrontmatter(content) {
-  if (!content.startsWith('---\n')) {
-    return null;
-  }
-
-  const endIndex = content.indexOf('\n---', 4);
-  if (endIndex === -1) {
-    return null;
-  }
-
-  return content.slice(4, endIndex);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  return match ? match[1] : null;
 }
 
 console.log('\n=== Testing command frontmatter metadata ===\n');
+
+test('frontmatter parser accepts LF and CRLF line endings', () => {
+  assert.strictEqual(parseFrontmatter('---\ndescription: ok\n---\n# Title'), 'description: ok');
+  assert.strictEqual(parseFrontmatter('---\r\ndescription: ok\r\n---\r\n# Title'), 'description: ok');
+});
 
 for (const fileName of getCommandFiles()) {
   test(`${fileName} declares command metadata frontmatter`, () => {


### PR DESCRIPTION
## Summary
- add YAML `description` frontmatter to the 20 maintained command docs that were missing command metadata
- add a regression test requiring every shipped `commands/*.md` file to start with frontmatter and expose a non-empty description
- harden the Claude Desktop/plugin command discovery surface called out in #1476 without changing command behavior

Refs #1476

## Validation
- `node tests/commands/command-frontmatter.test.js`
- `node tests/ci/agent-yaml-surface.test.js`
- `node scripts/ci/validate-commands.js`
- `node tests/ci/validators.test.js`
- `node tests/plugin-manifest.test.js`
- `git diff --check`
- `npm run lint`
- `npm test` (2147/2147 passing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add YAML `description` frontmatter to 20 command docs and enforce it with a validation test (supports LF/CRLF) to improve command discovery for Claude Desktop/plugins; addresses #1476 with no behavior changes.

- **Bug Fixes**
  - Added `description` frontmatter to maintained `commands/*.md` files.
  - Added regression test requiring frontmatter with a non-empty `description`, accepting both LF and CRLF line endings.
  - Hardens Desktop/plugin command discovery per #1476.

<sup>Written for commit 0da6bef191b69673e74711957d29b0359743afe2. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1643?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured front-matter descriptions to command documentation for improved rendering and discoverability.

* **Tests**
  * Introduced a validation test that ensures every command document includes a non-empty description front-matter, improving documentation consistency and CI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->