### PR TITLE
docs: align rc1 social launch copy

### DIFF
--- a/docs/business/social-launch-copy.md
+++ b/docs/business/social-launch-copy.md
@@ -1,29 +1,34 @@
 # Social Launch Copy (X + LinkedIn)
 
-Use these templates as launch-ready starting points. Replace placeholders before posting.
+Use these templates as launch-ready starting points. Review channel tone before posting.
 
 ## X Post: Release Announcement
 
 ```text
-ECC v1.8.0 is live.
+ECC v2.0.0-rc.1 is live.
 
-We moved from “config pack” to an agent harness performance system:
-- hook reliability fixes
-- new harness commands
-- cross-tool parity (Claude Code, Cursor, OpenCode, Codex)
+The repo is moving from a Claude Code config pack into a cross-harness operating system for agentic work.
 
-Start here: <repo-link>
+What ships:
+- Hermes setup guide
+- release notes and launch collateral
+- cross-harness architecture docs
+- Hermes import guidance for turning local operator workflows into public ECC skills
+
+Start here: https://github.com/affaan-m/everything-claude-code
+Release notes: https://github.com/affaan-m/everything-claude-code/blob/main/docs/releases/2.0.0-rc.1/release-notes.md
 ```
 
 ## X Post: Proof + Metrics
 
 ```text
-If you evaluate agent tooling, use blended distribution metrics:
-- npm installs (`ecc-universal`, `ecc-agentshield`)
-- GitHub App installs
-- repo adoption (stars/forks/contributors)
+ECC v2.0.0-rc.1 keeps the public surface honest:
+- reusable ECC substrate in repo
+- Hermes documented as the operator shell
+- private workspace state left out
+- release metadata and docs covered by tests
 
-We now track this monthly in-repo for sponsor transparency.
+This is the release-candidate line: public system shape now, deeper local integrations only after sanitization.
 ```
 
 ## X Quote Tweet: Eval Skills Article
@@ -36,7 +41,7 @@ In ECC we turned this into production checks via:
 - /quality-gate
 - Stop-phase session summaries
 
-This is where harness performance compounds over time.
+In v2.0.0-rc.1, that discipline extends to the release surface: docs, manifests, launch copy, and public/private boundaries are test-backed.
 ```
 
 ## X Quote Tweet: Plankton / deslop workflow
@@ -44,19 +49,24 @@ This is where harness performance compounds over time.
 ```text
 This workflow direction is right: optimize the harness, not just prompts.
 
-Our v1.8.0 focus was reliability + parity + measurable quality gates across toolchains.
+ECC v2.0.0-rc.1 pushes that further: reusable skills, thin harness adapters, and Hermes as the operator shell on top.
 ```
 
 ## LinkedIn Post: Partner-Friendly Summary
 
 ```text
-We shipped ECC v1.8.0 with one objective: improve agent harness performance in production.
+ECC v2.0.0-rc.1 is live.
 
-Highlights:
-- more reliable hook lifecycle behavior
-- new harness-level quality commands
-- parity across Claude Code, Cursor, OpenCode, and Codex
-- stronger sponsor-facing metrics tracking
+The practical shift: ECC is no longer just a Claude Code config pack. It is becoming a cross-harness operating system for agentic work.
 
-If your team runs AI coding agents daily, this is designed for operational use.
+This release-candidate surface includes:
+- sanitized Hermes setup documentation
+- release notes and launch collateral
+- cross-harness architecture notes
+- Hermes import guidance for turning local operator patterns into public ECC skills
+
+It does not include private workspace state, credentials, raw local exports, or personal datasets.
+
+Repo: https://github.com/affaan-m/everything-claude-code
+Release notes: https://github.com/affaan-m/everything-claude-code/blob/main/docs/releases/2.0.0-rc.1/release-notes.md
 ```

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -100,6 +100,21 @@ test('release docs do not contain unresolved public-link placeholders', () => {
   assert.deepStrictEqual(offenders, []);
 });
 
+test('business launch copy stays aligned with the rc.1 public surface', () => {
+  const source = read('docs/business/social-launch-copy.md');
+  assert.ok(source.includes('ECC v2.0.0-rc.1'), 'business launch copy should use the rc.1 release');
+  assert.ok(
+    source.includes('https://github.com/affaan-m/everything-claude-code'),
+    'business launch copy should include the public repo URL'
+  );
+  assert.ok(
+    source.includes('docs/releases/2.0.0-rc.1/release-notes.md'),
+    'business launch copy should link to the rc.1 release notes'
+  );
+  assert.ok(!source.includes('<repo-link>'), 'business launch copy should not contain repo placeholders');
+  assert.ok(!source.includes('v1.8.0'), 'business launch copy should not stay pinned to v1.8.0');
+});
+
 test('Hermes setup uses release-candidate wording for the rc.1 surface', () => {
   const source = read('docs/HERMES-SETUP.md');
   assert.ok(source.includes('Public Release Candidate Scope'));

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -108,7 +108,9 @@ test('business launch copy stays aligned with the rc.1 public surface', () => {
     'business launch copy should include the public repo URL'
   );
   assert.ok(
-    source.includes('docs/releases/2.0.0-rc.1/release-notes.md'),
+    source.includes(
+      'https://github.com/affaan-m/everything-claude-code/blob/main/docs/releases/2.0.0-rc.1/release-notes.md'
+    ),
     'business launch copy should link to the rc.1 release notes'
   );
   assert.ok(!source.includes('<repo-link>'), 'business launch copy should not contain repo placeholders');


### PR DESCRIPTION
## Summary
- update business social launch templates from v1.8.0 to the ECC v2.0.0-rc.1 public surface
- replace the unresolved <repo-link> placeholder with canonical repo and rc.1 release-note links
- add release-surface regression coverage for the business launch-copy doc

## Validation
- node tests/docs/ecc2-release-surface.test.js
- node tests/scripts/release.test.js
- node tests/plugin-manifest.test.js
- git diff --check
- npm run lint
- npm test (2149/2149)

## Notes
- Scope is core release-surface cleanup only; no external contributor PR files touched.
- Pre-branch upstream scan completed with git fetch --all --prune and git branch -a.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the business social launch templates with ECC v2.0.0-rc.1 and replaces placeholders with canonical repo and release-note links. Adds a test to keep the launch copy synced with the public release surface.

- **Bug Fixes**
  - Updated docs in `docs/business/social-launch-copy.md` to rc.1, added the public repo URL and `docs/releases/2.0.0-rc.1/release-notes.md`, and refreshed language to reflect Hermes, cross-harness scope, and public/private boundaries.
  - Extended `tests/docs/ecc2-release-surface.test.js` to require rc.1 strings and canonical links, and to forbid `<repo-link>` and any v1.8.0 references.

<sup>Written for commit bf03694729345dc74a2e7e09c668ba2bd54a9785. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1644?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release messaging to announce ECC v2.0.0-rc.1, reframing as a cross-harness operating system centered on Hermes
  * Rewrote social copy (X, LinkedIn) to list shipped guides, architecture docs, Hermes import guidance, and explicit repo + release-notes links
  * Clarified release-candidate scope and public-surface exclusions

* **Tests**
  * Added a documentation regression test to validate the new launch copy, version string, and release links (and reject old placeholders)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->