### PR TITLE
docs: sync zh-cn rc1 release heading

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -81,6 +81,15 @@
 
 ## 最新动态
 
+### v2.0.0-rc.1 — 表面同步、运营工作流与 ECC 2.0 Alpha（2026年4月）
+
+* **公共表面已与真实仓库同步** —— 元数据、目录数量、插件清单以及安装文档现在都与实际开源表面保持一致。
+* **运营与外向型工作流扩展** —— `brand-voice`、`social-graph-ranker`、`customer-billing-ops`、`google-workspace-ops` 等运营型 skill 已纳入同一系统。
+* **媒体与发布工具补齐** —— `manim-video`、`remotion-video-creation` 以及社媒发布能力让技术讲解和发布流程直接在同一仓库内完成。
+* **框架与产品表面继续扩展** —— `nestjs-patterns`、更完整的 Codex/OpenCode 安装表面，以及跨 harness 打包改进，让仓库不再局限于 Claude Code。
+* **ECC 2.0 alpha 已进入仓库** —— `ecc2/` 下的 Rust 控制层现已可在本地构建，并提供 `dashboard`、`start`、`sessions`、`status`、`stop`、`resume` 与 `daemon` 命令。
+* **生态加固持续推进** —— AgentShield、ECC Tools 成本控制、计费门户工作与网站刷新仍围绕核心插件持续交付。
+
 ### v1.9.0 — 选择性安装与语言扩展 (2026年3月)
 
 * **选择性安装架构** — 基于清单的安装流程，使用 `install-plan.js` 和 `install-apply.js` 进行针对性组件安装。状态存储跟踪已安装内容并支持增量更新。

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -178,6 +178,14 @@ test('README.zh-CN.md latest release heading matches package.json', () => {
   );
 });
 
+test('docs/zh-CN/README.md latest release heading matches package.json', () => {
+  const source = fs.readFileSync(zhCnReadmePath, 'utf8');
+  assert.ok(
+    source.includes(`### v${expectedVersion} `),
+    'Expected docs/zh-CN/README.md to advertise the current release heading',
+  );
+});
+
 // ── Claude plugin manifest ────────────────────────────────────────────────────
 console.log('\n=== .claude-plugin/plugin.json ===\n');
 


### PR DESCRIPTION
## Summary

- add the missing `v2.0.0-rc.1` latest-release section to `docs/zh-CN/README.md`
- extend manifest/version regression coverage so the localized README heading stays aligned with `package.json`

## Test plan

- `node tests/plugin-manifest.test.js`
- `node tests/docs/ecc2-release-surface.test.js`
- `git diff --check`
- `npm run lint`
- `npm test` (2150/2150)

## Scope

Core ECC 2.0 release-surface cleanup only. No external contributor PR scope touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing v2.0.0-rc.1 latest-release heading to the Chinese README and introduces a regression test to keep it in sync with `package.json`.

- **Bug Fixes**
  - Added the missing v2.0.0-rc.1 latest-release section to docs/zh-CN/README.md.
  - Extended tests to assert the zh-CN README heading includes the current version from `package.json` to prevent drift.

<sup>Written for commit 19b465fc7b1a0ba76436740c9912d1382c59b11d. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1645?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Chinese changelog for v2.0.0-rc.1 documenting repository synchronization improvements, expanded operations workflows, new media and video creation capabilities, enhanced framework installation support, and a new Rust control layer with CLI commands.

* **Tests**
  * Added validation to ensure Chinese documentation version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->