### PR TITLE
fix: parse all Claude content blocks

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -64,20 +64,32 @@ class ClaudeProvider(LLMProvider):
 
             response = self.client.messages.create(**params)
 
-            tool_calls = None
-            if response.content and hasattr(response.content[0], "type"):
-                if response.content[0].type == "tool_use":
-                    tool_calls = [
+            text_parts: list[str] = []
+            tool_calls: list[ToolCall] = []
+            for block in response.content or []:
+                block_type = getattr(block, "type", None)
+                if block_type == "text":
+                    text = getattr(block, "text", "")
+                    if text:
+                        text_parts.append(text)
+                elif block_type == "tool_use":
+                    raw_arguments = getattr(block, "input", {})
+                    arguments = (
+                        raw_arguments.copy()
+                        if isinstance(raw_arguments, dict)
+                        else getattr(raw_arguments, "__dict__", {}).copy()
+                    )
+                    tool_calls.append(
                         ToolCall(
-                            id=getattr(response.content[0], "id", ""),
-                            name=getattr(response.content[0], "name", ""),
-                            arguments=getattr(response.content[0].input, "__dict__", {}),
+                            id=getattr(block, "id", ""),
+                            name=getattr(block, "name", ""),
+                            arguments=arguments,
                         )
-                    ]
+                    )
 
             return LLMOutput(
-                content=response.content[0].text if response.content else "",
-                tool_calls=tool_calls,
+                content="".join(text_parts),
+                tool_calls=tool_calls or None,
                 model=response.model,
                 usage={
                     "input_tokens": response.usage.input_tokens,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,10 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "unit: marks fast unit tests")

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from llm.core.types import LLMInput, Message, Role
+from llm.providers.claude import ClaudeProvider
+
+
+class FakeMessages:
+    def __init__(self, response: SimpleNamespace) -> None:
+        self.response = response
+
+    def create(self, **_params: object) -> SimpleNamespace:
+        return self.response
+
+
+class FakeClient:
+    def __init__(self, response: SimpleNamespace) -> None:
+        self.messages = FakeMessages(response)
+        self.api_key = "test-key"
+
+
+def make_provider(response: SimpleNamespace) -> ClaudeProvider:
+    provider = ClaudeProvider(api_key="test-key")
+    provider.client = FakeClient(response)
+    return provider
+
+
+def make_response(content: list[SimpleNamespace], stop_reason: str = "tool_use") -> SimpleNamespace:
+    return SimpleNamespace(
+        content=content,
+        model="claude-test",
+        usage=SimpleNamespace(input_tokens=3, output_tokens=5),
+        stop_reason=stop_reason,
+    )
+
+
+@pytest.mark.unit
+def test_generate_collects_text_and_tool_use_blocks() -> None:
+    provider = make_provider(
+        make_response(
+            [
+                SimpleNamespace(type="text", text="I will search. "),
+                SimpleNamespace(type="tool_use", id="toolu_1", name="search", input={"query": "claude"}),
+                SimpleNamespace(type="text", text="Done."),
+            ]
+        )
+    )
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="Search")]))
+
+    assert output.content == "I will search. Done."
+    assert output.tool_calls is not None
+    assert len(output.tool_calls) == 1
+    assert output.tool_calls[0].id == "toolu_1"
+    assert output.tool_calls[0].name == "search"
+    assert output.tool_calls[0].arguments == {"query": "claude"}
+
+
+@pytest.mark.unit
+def test_generate_collects_multiple_tool_use_blocks() -> None:
+    provider = make_provider(
+        make_response(
+            [
+                SimpleNamespace(type="tool_use", id="toolu_1", name="search", input={"query": "claude"}),
+                SimpleNamespace(
+                    type="tool_use",
+                    id="toolu_2",
+                    name="read",
+                    input=SimpleNamespace(path="README.md"),
+                ),
+            ]
+        )
+    )
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="Use tools")]))
+
+    assert output.content == ""
+    assert [call.id for call in output.tool_calls or []] == ["toolu_1", "toolu_2"]
+    assert (output.tool_calls or [])[1].arguments == {"path": "README.md"}
+
+
+@pytest.mark.unit
+def test_generate_copies_tool_use_dict_arguments() -> None:
+    raw_arguments: dict[str, Any] = {"query": "claude"}
+    provider = make_provider(
+        make_response(
+            [SimpleNamespace(type="tool_use", id="toolu_1", name="search", input=raw_arguments)]
+        )
+    )
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="Use tools")]))
+    raw_arguments["query"] = "mutated"
+
+    assert (output.tool_calls or [])[0].arguments == {"query": "claude"}
+
+
+@pytest.mark.unit
+def test_generate_text_only_has_no_tool_calls() -> None:
+    provider = make_provider(
+        make_response(
+            [SimpleNamespace(type="text", text="Hello.")],
+            stop_reason="end_turn",
+        )
+    )
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="Hi")]))
+
+    assert output.content == "Hello."
+    assert output.tool_calls is None


### PR DESCRIPTION
## Summary
- parse every Claude response content block instead of only inspecting the first one
- preserve text from multiple text blocks and collect all `tool_use` blocks
- add regression coverage for mixed text/tool responses and multiple tool calls

## Tests
- `PYTHONPATH=src pytest -q tests/test_claude_provider.py tests/test_types.py tests/test_resolver.py tests/test_executor.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude provider parsing by iterating every response content block. We now merge all text blocks and collect every `tool_use` call with safe, normalized arguments.

- **Bug Fixes**
  - Iterate all blocks; join text; preserve order of multiple `tool_use`.
  - Coerce `input` (dict or object) to a copied dict to avoid mutation.
  - Return `tool_calls` as `None` when no tools are present.
  - Add unit tests for mixed text/tool replies, multiple tool calls, ordering, and argument copying.

<sup>Written for commit 3c724f2e1d09034efa21666f66876d97a22a32c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude response parsing to aggregate text from all content blocks, correctly extract tool calls, and return no tool calls when none are present; tool-call arguments are safely copied to avoid later mutation.

* **Tests**
  * Added unit tests verifying aggregation of text blocks, extraction and ordering of tool calls, argument copying, and empty-text behavior.

* **Tests**
  * Registered a "unit" pytest marker in test configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->