### PR TITLE
fix: harden agent instruction surfaces

### DIFF
--- a/.agents/skills/frontend-patterns/SKILL.md
+++ b/.agents/skills/frontend-patterns/SKILL.md
@@ -17,6 +17,12 @@ Modern frontend patterns for React, Next.js, and performant user interfaces.
 - Handling client-side routing and navigation
 - Building accessible, responsive UI patterns
 
+## Privacy and Data Boundaries
+
+Frontend examples should use synthetic or domain-generic data. Do not collect, log, persist, or display credentials, access tokens, SSNs, health data, payment details, private emails, phone numbers, or other sensitive personal data unless the user explicitly requests a scoped implementation with appropriate validation, redaction, and access controls.
+
+Avoid adding analytics, tracking pixels, third-party scripts, or external data sinks without explicit approval. When handling user data, prefer least-privilege APIs, client-side redaction before logging, and server-side validation for every boundary.
+
 ## Component Patterns
 
 ### Composition Over Inheritance

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -60,6 +60,12 @@ The sync script (`scripts/sync-ecc-to-codex.sh`) uses a Node-based TOML parser t
 - **`--update-mcp`** — explicitly replaces all ECC-managed servers with the latest recommended config (safely removes subtables like `[mcp_servers.supabase.env]`).
 - **User config is always preserved** — custom servers, args, env vars, and credentials outside ECC-managed sections are never touched.
 
+## External Action Boundaries
+
+Treat networked tools as read-only by default. Search, inspect, and draft freely within the user's requested scope, but require explicit user approval before posting, publishing, pushing, merging, opening paid jobs, dispatching remote agents, changing third-party resources, or modifying credentials.
+
+When approval is ambiguous, produce a local plan or draft artifact instead of taking the external action. Preserve user config and private state unless the user specifically asks for a scoped change.
+
 ## Multi-Agent Support
 
 Codex now supports multi-agent workflows behind the experimental `features.multi_agent` flag.

--- a/.kiro/skills/search-first/SKILL.md
+++ b/.kiro/skills/search-first/SKILL.md
@@ -21,6 +21,12 @@ Use this skill when:
 - The user asks "add X functionality" and you're about to write code
 - Before creating a new utility, helper, or abstraction
 
+## Scope and Approval Rules
+
+Default to read-only research: inspect the repo, package metadata, docs, and public examples before recommending a dependency or integration. Do not install packages, configure MCP servers, publish artifacts, open PRs, or make external write actions from this skill unless the user has explicitly approved that action in the current task.
+
+When a candidate requires credentials, paid services, network writes, or project-wide config changes, return a recommendation and approval checkpoint instead of applying it directly.
+
 ## Workflow
 
 ```

--- a/.kiro/skills/search-first/SKILL.md
+++ b/.kiro/skills/search-first/SKILL.md
@@ -51,9 +51,9 @@ When a candidate requires credentials, paid services, network writes, or project
 │     │ as-is   │  │  /Wrap   │  │  Custom  │  │
 │     └─────────┘  └──────────┘  └─────────┘  │
 ├─────────────────────────────────────────────┤
-│  5. IMPLEMENT                               │
-│     Install package / Configure MCP /       │
-│     Write minimal custom code               │
+│  5. APPROVAL CHECKPOINT / IMPLEMENT         │
+│     Recommend package / MCP / custom code   │
+│     Apply only after explicit approval      │
 └─────────────────────────────────────────────┘
 ```
 
@@ -61,10 +61,10 @@ When a candidate requires credentials, paid services, network writes, or project
 
 | Signal | Action |
 |--------|--------|
-| Exact match, well-maintained, MIT/Apache | **Adopt** — install and use directly |
-| Partial match, good foundation | **Extend** — install + write thin wrapper |
-| Multiple weak matches | **Compose** — combine 2-3 small packages |
-| Nothing suitable found | **Build** — write custom, but informed by research |
+| Exact match, well-maintained, MIT/Apache | **Adopt** — recommend the package and request approval before install or config changes |
+| Partial match, good foundation | **Extend** — recommend the package plus a thin wrapper, then wait for approval before applying |
+| Multiple weak matches | **Compose** — propose 2-3 small packages and the integration plan before installing anything |
+| Nothing suitable found | **Build** — explain why custom code is warranted, then implement only within the approved task scope |
 
 ## How to Use
 
@@ -141,8 +141,8 @@ Combine for progressive discovery:
 Need: Check markdown files for broken links
 Search: npm "markdown dead link checker"
 Found: textlint-rule-no-dead-link (score: 9/10)
-Action: ADOPT — npm install textlint-rule-no-dead-link
-Result: Zero custom code, battle-tested solution
+Action: ADOPT — recommend `textlint-rule-no-dead-link` and ask before installing it
+Result: Zero custom code if approved, battle-tested solution
 ```
 
 ### Example 2: "Add HTTP client wrapper"
@@ -150,8 +150,8 @@ Result: Zero custom code, battle-tested solution
 Need: Resilient HTTP client with retries and timeout handling
 Search: npm "http client retry", PyPI "httpx retry"
 Found: got (Node) with retry plugin, httpx (Python) with built-in retry
-Action: ADOPT — use got/httpx directly with retry config
-Result: Zero custom code, production-proven libraries
+Action: ADOPT — recommend `got`/`httpx` directly with retry config and ask before changing dependencies
+Result: Zero custom code if approved, production-proven libraries
 ```
 
 ### Example 3: "Add config file linter"
@@ -159,8 +159,8 @@ Result: Zero custom code, production-proven libraries
 Need: Validate project config files against a schema
 Search: npm "config linter schema", "json schema validator cli"
 Found: ajv-cli (score: 8/10)
-Action: ADOPT + EXTEND — install ajv-cli, write project-specific schema
-Result: 1 package + 1 schema file, no custom validation logic
+Action: ADOPT + EXTEND — recommend `ajv-cli` plus a project-specific schema, then wait for approval before install/write
+Result: 1 package + 1 schema file if approved, no custom validation logic
 ```
 
 ## Anti-Patterns

--- a/skills/autonomous-agent-harness/SKILL.md
+++ b/skills/autonomous-agent-harness/SKILL.md
@@ -8,6 +8,12 @@ origin: ECC
 
 Turn Claude Code into a persistent, self-directing agent system using only native features and MCP servers.
 
+## Consent and Safety Boundaries
+
+Autonomous operation must be explicitly requested and scoped by the user. Do not create schedules, dispatch remote agents, write persistent memory, use computer control, post externally, modify third-party resources, or act on private communications unless the user has approved that capability and the target workspace for the current setup.
+
+Prefer dry-run plans and local queue files before enabling recurring or event-driven actions. Keep credentials, private workspace exports, personal datasets, and account-specific automations out of reusable ECC artifacts.
+
 ## When to Activate
 
 - User wants an agent that runs continuously or on a schedule

--- a/skills/defi-amm-security/SKILL.md
+++ b/skills/defi-amm-security/SKILL.md
@@ -20,6 +20,12 @@ Critical vulnerability patterns and hardened implementations for Solidity AMM co
 
 Use this as a checklist-plus-pattern library. Review every user entrypoint against the categories below and prefer the hardened examples over hand-rolled variants.
 
+## Execution Safety
+
+The shell commands in this skill are local audit examples. Run them only in a trusted checkout or disposable sandbox, and do not splice untrusted contract names, paths, RPC URLs, private keys, or user-supplied flags into shell commands. Ask before installing tools or running long fuzzing/static-analysis jobs that may consume significant local or paid resources.
+
+Never include secrets, private keys, seed phrases, API tokens, or mainnet signing credentials in command examples, logs, or reports.
+
 ## Examples
 
 ### Reentrancy: enforce CEI order

--- a/tests/ci/agent-instruction-safety.test.js
+++ b/tests/ci/agent-instruction-safety.test.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Validate safety guardrails on agent-facing instruction artifacts.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const guardrails = [
+  {
+    path: '.codex/AGENTS.md',
+    heading: '## External Action Boundaries',
+    requiredPatterns: [
+      /read-only by default/i,
+      /explicit user approval/i,
+      /posting, publishing, pushing, merging/i,
+    ],
+  },
+  {
+    path: '.kiro/skills/search-first/SKILL.md',
+    heading: '## Scope and Approval Rules',
+    requiredPatterns: [
+      /Default to read-only research/i,
+      /Do not install packages/i,
+      /approval checkpoint/i,
+    ],
+  },
+  {
+    path: 'skills/autonomous-agent-harness/SKILL.md',
+    heading: '## Consent and Safety Boundaries',
+    requiredPatterns: [
+      /explicitly requested and scoped/i,
+      /Do not create schedules/i,
+      /Prefer dry-run plans/i,
+    ],
+  },
+  {
+    path: 'skills/defi-amm-security/SKILL.md',
+    heading: '## Execution Safety',
+    requiredPatterns: [
+      /local audit examples/i,
+      /trusted checkout or disposable sandbox/i,
+      /private keys, seed phrases/i,
+    ],
+  },
+  {
+    path: '.agents/skills/frontend-patterns/SKILL.md',
+    heading: '## Privacy and Data Boundaries',
+    requiredPatterns: [
+      /synthetic or domain-generic data/i,
+      /Do not collect, log, persist, or display/i,
+      /analytics, tracking pixels/i,
+    ],
+  },
+];
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function run() {
+  console.log('\n=== Testing agent instruction safety guardrails ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('flagged instruction artifacts keep scoped safety sections', () => {
+    for (const guardrail of guardrails) {
+      const source = read(guardrail.path);
+      assert.ok(source.includes(guardrail.heading), `${guardrail.path} missing ${guardrail.heading}`);
+      for (const pattern of guardrail.requiredPatterns) {
+        assert.ok(pattern.test(source), `${guardrail.path} missing ${pattern}`);
+      }
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();

--- a/tests/ci/agent-instruction-safety.test.js
+++ b/tests/ci/agent-instruction-safety.test.js
@@ -79,15 +79,15 @@ function run() {
   let passed = 0;
   let failed = 0;
 
-  if (test('flagged instruction artifacts keep scoped safety sections', () => {
-    for (const guardrail of guardrails) {
+  for (const guardrail of guardrails) {
+    if (test(`${guardrail.path} keeps scoped safety guardrails`, () => {
       const source = read(guardrail.path);
       assert.ok(source.includes(guardrail.heading), `${guardrail.path} missing ${guardrail.heading}`);
       for (const pattern of guardrail.requiredPatterns) {
         assert.ok(pattern.test(source), `${guardrail.path} missing ${pattern}`);
       }
-    }
-  })) passed++; else failed++;
+    })) passed++; else failed++;
+  }
 
   console.log(`\nPassed: ${passed}`);
   console.log(`Failed: ${failed}`);


### PR DESCRIPTION
## Summary
- add explicit approval/scope boundaries to the five instruction artifacts flagged in #1612
- clarify read-only defaults for search, Codex networked tools, autonomous operation, audit commands, and frontend data handling
- add a CI regression test that keeps these safety sections present

Closes #1612

## Validation
- node tests/ci/agent-instruction-safety.test.js
- git diff --check
- npm run lint
- npm test (2185/2185 passing)

## Coordination
- TEST-WRITER notified before merge consideration; no merge until CI and coordination are clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened safety and security guidance across skills and frontend examples: require synthetic/domain‑generic data, forbid exposing sensitive credentials/personal data, discourage unapproved third‑party scripts, and enforce least‑privilege, client‑side redaction, and server validation.
  * Added scope and approval rules making research/read‑only the default, introducing explicit approval checkpoints, preferring dry‑runs/plans, and restricting autonomous/operational side effects until approved.

* **Tests**
  * Added CI checks to validate presence of agent instruction safety guardrails in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->