### PR TITLE
feat: add loop-status exit-code mode

### DIFF
--- a/commands/loop-status.md
+++ b/commands/loop-status.md
@@ -40,6 +40,8 @@ tool calls that have no matching `tool_result`.
   directly.
 - `ecc loop-status --bash-timeout-seconds 1800` adjusts the stale Bash
   threshold.
+- `ecc loop-status --exit-code` exits `2` when stale loop or tool signals are
+  found, or `1` when transcripts cannot be scanned.
 - `ecc loop-status --watch` refreshes status until interrupted.
 - `ecc loop-status --watch --watch-count 3` emits a bounded watch stream for
   scripts and handoffs.

--- a/commands/loop-status.md
+++ b/commands/loop-status.md
@@ -42,6 +42,8 @@ tool calls that have no matching `tool_result`.
   threshold.
 - `ecc loop-status --exit-code` exits `2` when stale loop or tool signals are
   found, or `1` when transcripts cannot be scanned.
+- `--exit-code` with `--watch` requires `--watch-count` so watchdog scripts do
+  not wait forever for a process exit.
 - `ecc loop-status --watch` refreshes status until interrupted.
 - `ecc loop-status --watch --watch-count 3 --exit-code` refreshes a bounded
   number of times, then exits with the highest status seen.

--- a/commands/loop-status.md
+++ b/commands/loop-status.md
@@ -43,6 +43,8 @@ tool calls that have no matching `tool_result`.
 - `ecc loop-status --exit-code` exits `2` when stale loop or tool signals are
   found, or `1` when transcripts cannot be scanned.
 - `ecc loop-status --watch` refreshes status until interrupted.
+- `ecc loop-status --watch --watch-count 3 --exit-code` refreshes a bounded
+  number of times, then exits with the highest status seen.
 - `ecc loop-status --watch --watch-count 3` emits a bounded watch stream for
   scripts and handoffs.
 

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -24,6 +24,7 @@ function usage() {
     '  --bash-timeout-seconds <n>     Age before a pending Bash call is stale (default: 1800)',
     '  --wake-grace-multiplier <n>    ScheduleWakeup grace multiplier (default: 2)',
     '  --now <time>                   Override current time (ISO, epoch ms, or "now")',
+    '  --exit-code                    Exit 2 on attention signals, 1 on scan errors',
     '  --watch                        Refresh status until interrupted',
     '  --watch-count <n>              Stop after n watch refreshes',
     '  --watch-interval-seconds <n>   Seconds between watch refreshes (default: 5)',
@@ -62,6 +63,7 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   const options = {
     bashTimeoutSeconds: DEFAULT_BASH_TIMEOUT_SECONDS,
+    exitCode: false,
     home: null,
     json: false,
     limit: DEFAULT_LIMIT,
@@ -99,6 +101,8 @@ function parseArgs(argv) {
     } else if (arg === '--now') {
       options.now = readValue(args, index, arg);
       index += 1;
+    } else if (arg === '--exit-code') {
+      options.exitCode = true;
     } else if (arg === '--watch') {
       options.watch = true;
     } else if (arg === '--watch-count') {
@@ -119,6 +123,7 @@ function normalizeOptions(options = {}) {
   return {
     ...options,
     bashTimeoutSeconds: options.bashTimeoutSeconds ?? DEFAULT_BASH_TIMEOUT_SECONDS,
+    exitCode: Boolean(options.exitCode),
     limit: options.limit ?? DEFAULT_LIMIT,
     transcriptPaths: options.transcriptPaths || [],
     watch: Boolean(options.watch),
@@ -606,15 +611,28 @@ function writeStatus(payload, options) {
   }
 }
 
+function getStatusExitCode(payload) {
+  if (payload.sessions.some(session => session.state === 'attention')) {
+    return 2;
+  }
+  if (payload.errors.length > 0) {
+    return 1;
+  }
+  return 0;
+}
+
 async function runWatch(options) {
   const normalizedOptions = normalizeOptions(options);
   let iteration = 0;
+  let exitCode = 0;
 
   while (normalizedOptions.watchCount === null || iteration < normalizedOptions.watchCount) {
     if (iteration > 0 && !normalizedOptions.json) {
       console.log('');
     }
-    writeStatus(buildStatus(normalizedOptions), normalizedOptions);
+    const payload = buildStatus(normalizedOptions);
+    writeStatus(payload, normalizedOptions);
+    exitCode = Math.max(exitCode, getStatusExitCode(payload));
     iteration += 1;
 
     if (normalizedOptions.watchCount !== null && iteration >= normalizedOptions.watchCount) {
@@ -623,6 +641,8 @@ async function runWatch(options) {
 
     await sleep(normalizedOptions.watchIntervalSeconds * 1000);
   }
+
+  return exitCode;
 }
 
 async function main() {
@@ -633,11 +653,18 @@ async function main() {
   }
 
   if (options.watch) {
-    await runWatch(options);
+    const exitCode = await runWatch(options);
+    if (options.exitCode) {
+      process.exitCode = exitCode;
+    }
     return;
   }
 
-  writeStatus(buildStatus(options), options);
+  const payload = buildStatus(options);
+  writeStatus(payload, options);
+  if (options.exitCode) {
+    process.exitCode = getStatusExitCode(payload);
+  }
 }
 
 if (require.main === module) {
@@ -652,6 +679,7 @@ module.exports = {
   buildStatus,
   extractToolResultIds,
   extractToolUses,
+  getStatusExitCode,
   parseArgs,
   runWatch,
 };

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -116,6 +116,10 @@ function parseArgs(argv) {
     }
   }
 
+  if (options.exitCode && options.watch && options.watchCount === null) {
+    throw new Error('--exit-code with --watch requires --watch-count so the process can exit');
+  }
+
   return options;
 }
 

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -9,7 +9,7 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'loop-status.js');
-const { analyzeTranscript, buildStatus, parseArgs } = require('../../scripts/loop-status');
+const { analyzeTranscript, buildStatus, getStatusExitCode, parseArgs } = require('../../scripts/loop-status');
 const NOW = '2026-04-30T10:00:00.000Z';
 
 function run(args = [], options = {}) {
@@ -400,6 +400,7 @@ function runTests() {
     const options = parseArgs([
       'node',
       'scripts/loop-status.js',
+      '--exit-code',
       '--watch',
       '--watch-count',
       '2',
@@ -407,9 +408,49 @@ function runTests() {
       '0.01',
     ]);
 
+    assert.strictEqual(options.exitCode, true);
     assert.strictEqual(options.watch, true);
     assert.strictEqual(options.watchCount, 2);
     assert.strictEqual(options.watchIntervalSeconds, 0.01);
+  })) passed++; else failed++;
+
+  if (test('exit-code mode returns 2 when attention signals are present', () => {
+    const homeDir = createTempHome();
+
+    try {
+      writeTranscript(homeDir, '-Users-affoon-project-exit-code', 'session-exit-code.jsonl', [
+        toolUse('2026-04-30T09:10:00.000Z', 'session-exit-code', 'toolu_exit_bash', 'Bash', {
+          command: 'pytest tests/integration/test_pipeline.py',
+        }),
+      ]);
+
+      const result = run(['--home', homeDir, '--now', NOW, '--json', '--exit-code']);
+
+      assert.strictEqual(result.code, 2, result.stderr);
+      const payload = parsePayload(result.stdout);
+      assert.strictEqual(payload.sessions[0].state, 'attention');
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('exit-code mode returns 1 for scan errors without attention signals', () => {
+    const missingTranscript = path.join(os.tmpdir(), 'ecc-loop-status-missing.jsonl');
+    const result = run(['--transcript', missingTranscript, '--now', NOW, '--json', '--exit-code']);
+
+    assert.strictEqual(result.code, 1, result.stderr);
+    const payload = parsePayload(result.stdout);
+    assert.strictEqual(payload.sessions.length, 0);
+    assert.strictEqual(payload.errors.length, 1);
+  })) passed++; else failed++;
+
+  if (test('getStatusExitCode prioritizes attention signals over scan errors', () => {
+    const payload = {
+      errors: [{ message: 'unreadable' }],
+      sessions: [{ state: 'attention' }],
+    };
+
+    assert.strictEqual(getStatusExitCode(payload), 2);
   })) passed++; else failed++;
 
   if (test('watch mode emits repeated JSON status frames', () => {
@@ -443,6 +484,39 @@ function runTests() {
       assert.strictEqual(frames[1].schemaVersion, 'ecc.loop-status.v1');
       assert.strictEqual(frames[0].sessions[0].sessionId, 'session-watch');
       assert.strictEqual(frames[1].sessions[0].sessionId, 'session-watch');
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('watch mode honors exit-code after bounded refreshes', () => {
+    const homeDir = createTempHome();
+
+    try {
+      writeTranscript(homeDir, '-Users-affoon-project-watch-exit', 'session-watch-exit.jsonl', [
+        toolUse('2026-04-30T09:00:00.000Z', 'session-watch-exit', 'toolu_watch_exit', 'ScheduleWakeup', {
+          delaySeconds: 300,
+          reason: 'Loop checkpoint',
+        }),
+      ]);
+
+      const result = run([
+        '--home',
+        homeDir,
+        '--now',
+        NOW,
+        '--json',
+        '--watch',
+        '--watch-count',
+        '1',
+        '--watch-interval-seconds',
+        '0.01',
+        '--exit-code',
+      ]);
+
+      assert.strictEqual(result.code, 2, result.stderr);
+      const frame = JSON.parse(result.stdout.trim());
+      assert.strictEqual(frame.sessions[0].state, 'attention');
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -435,13 +435,18 @@ function runTests() {
   })) passed++; else failed++;
 
   if (test('exit-code mode returns 1 for scan errors without attention signals', () => {
-    const missingTranscript = path.join(os.tmpdir(), 'ecc-loop-status-missing.jsonl');
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-loop-status-missing-'));
+    const missingTranscript = path.join(tempDir, 'missing.jsonl');
     const result = run(['--transcript', missingTranscript, '--now', NOW, '--json', '--exit-code']);
 
-    assert.strictEqual(result.code, 1, result.stderr);
-    const payload = parsePayload(result.stdout);
-    assert.strictEqual(payload.sessions.length, 0);
-    assert.strictEqual(payload.errors.length, 1);
+    try {
+      assert.strictEqual(result.code, 1, result.stderr);
+      const payload = parsePayload(result.stdout);
+      assert.strictEqual(payload.sessions.length, 0);
+      assert.strictEqual(payload.errors.length, 1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   if (test('exit-code mode rejects unbounded watch mode', () => {

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -444,6 +444,13 @@ function runTests() {
     assert.strictEqual(payload.errors.length, 1);
   })) passed++; else failed++;
 
+  if (test('exit-code mode rejects unbounded watch mode', () => {
+    const result = run(['--watch', '--exit-code']);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /--exit-code with --watch requires --watch-count/);
+  })) passed++; else failed++;
+
   if (test('getStatusExitCode prioritizes attention signals over scan errors', () => {
     const payload = {
       errors: [{ message: 'unreadable' }],


### PR DESCRIPTION
## Summary
- add `ecc loop-status --exit-code` for watchdog scripts
- return `2` when stale loop/tool attention signals are present and `1` for scan errors without attention signals
- preserve default zero-exit behavior unless the flag is provided, including watch mode

Refs #1577

## Validation
- node tests/scripts/loop-status.test.js
- node tests/scripts/ecc.test.js
- git diff --check
- npm run lint
- npm test (2193/2193 passing)

## Notes
- This does not claim to patch Claude Code runtime internals. It makes ECC transcript diagnostics usable from cron/systemd/watchdog wrappers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--exit-code` to loop-status: sets process exit codes (2 for attention/stale signals, 1 for transcript scan errors, 0 otherwise). In bounded watch mode the command exits after the specified refreshes and returns the highest observed status.

* **Documentation**
  * Updated command docs and help to describe `--exit-code`, exit code meanings, and interaction with watch/bounded watch.

* **Tests**
  * Added tests covering `--exit-code` behavior, attention priority, and validation that bounded watch requires a watch count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->