### PR TITLE
fix: add GateGuard recovery escape hatch

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -99,6 +99,9 @@ export ECC_HOOK_PROFILE=standard
 # Disable specific hook IDs (comma-separated)
 export ECC_DISABLED_HOOKS="pre:bash:tmux-reminder,post:edit:typecheck"
 
+# Disable only GateGuard during setup or recovery
+export ECC_GATEGUARD=off
+
 # Cap SessionStart additional context (default: 8000 chars)
 export ECC_SESSION_START_MAX_CHARS=4000
 

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -38,6 +38,8 @@ const READ_HEARTBEAT_MS = 60 * 1000;
 const MAX_CHECKED_ENTRIES = 500;
 const MAX_SESSION_KEYS = 50;
 const ROUTINE_BASH_SESSION_KEY = '__bash_session__';
+const EDIT_WRITE_HOOK_ID = 'pre:edit-write:gateguard-fact-force';
+const BASH_HOOK_ID = 'pre:bash:gateguard-fact-force';
 const ECC_DISABLE_VALUES = new Set(['0', 'false', 'off', 'disabled', 'disable']);
 
 const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f|drop\s+table|delete\s+from|truncate|git\s+push\s+--force(?!-with-lease)|git\s+commit\s+--amend|dd\s+if=)\b/i;
@@ -365,11 +367,12 @@ function routineBashMsg() {
   ].join('\n');
 }
 
-function withRecoveryHint(message) {
+function withRecoveryHint(message, hookIds = [EDIT_WRITE_HOOK_ID]) {
+  const disableTargets = hookIds.map(hookId => `\`${hookId}\``).join(' or ');
   return [
     message,
     '',
-    'Recovery: if GateGuard is blocking setup or repair work, run this session with `ECC_GATEGUARD=off` or add `pre:edit-write:gateguard-fact-force` to `ECC_DISABLED_HOOKS`.'
+    `Recovery: if GateGuard is blocking setup or repair work, run this session with \`ECC_GATEGUARD=off\` or add ${disableTargets} to \`ECC_DISABLED_HOOKS\`.`
   ].join('\n');
 }
 
@@ -377,12 +380,13 @@ function withRecoveryHint(message) {
 
 function denyResult(reason, options = {}) {
   const includeRecoveryHint = options.includeRecoveryHint !== false;
+  const hookIds = Array.isArray(options.hookIds) && options.hookIds.length > 0 ? options.hookIds : [EDIT_WRITE_HOOK_ID];
   return {
     stdout: JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
-        permissionDecisionReason: includeRecoveryHint ? withRecoveryHint(reason) : reason
+        permissionDecisionReason: includeRecoveryHint ? withRecoveryHint(reason, hookIds) : reason
       }
     }),
     exitCode: 0
@@ -471,7 +475,7 @@ function run(rawInput) {
       if (!markChecked(ROUTINE_BASH_SESSION_KEY)) {
         return allowWithStateWarning();
       }
-      return denyResult(routineBashMsg());
+      return denyResult(routineBashMsg(), { hookIds: [BASH_HOOK_ID] });
     }
 
     return rawInput; // allow

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -38,10 +38,24 @@ const READ_HEARTBEAT_MS = 60 * 1000;
 const MAX_CHECKED_ENTRIES = 500;
 const MAX_SESSION_KEYS = 50;
 const ROUTINE_BASH_SESSION_KEY = '__bash_session__';
+const LEGACY_DISABLE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const ECC_DISABLE_VALUES = new Set(['0', 'false', 'off', 'disabled', 'disable']);
 
 const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f|drop\s+table|delete\s+from|truncate|git\s+push\s+--force(?!-with-lease)|git\s+commit\s+--amend|dd\s+if=)\b/i;
 
 // --- State management (per-session, atomic writes, bounded) ---
+
+function normalizeEnvValue(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isGateGuardDisabled() {
+  if (LEGACY_DISABLE_VALUES.has(normalizeEnvValue(process.env.GATEGUARD_DISABLED))) {
+    return true;
+  }
+
+  return ECC_DISABLE_VALUES.has(normalizeEnvValue(process.env.ECC_GATEGUARD));
+}
 
 function sanitizeSessionKey(value) {
   const raw = String(value || '').trim();
@@ -352,6 +366,14 @@ function routineBashMsg() {
   ].join('\n');
 }
 
+function withRecoveryHint(message) {
+  return [
+    message,
+    '',
+    'Recovery: if GateGuard is blocking setup or repair work, run this session with `ECC_GATEGUARD=off` or add `pre:edit-write:gateguard-fact-force` to `ECC_DISABLED_HOOKS`.'
+  ].join('\n');
+}
+
 // --- Deny helper ---
 
 function denyResult(reason) {
@@ -360,7 +382,7 @@ function denyResult(reason) {
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
-        permissionDecisionReason: reason
+        permissionDecisionReason: withRecoveryHint(reason)
       }
     }),
     exitCode: 0
@@ -383,6 +405,11 @@ function run(rawInput) {
   } catch (_) {
     return rawInput; // allow on parse error
   }
+
+  if (isGateGuardDisabled()) {
+    return rawInput;
+  }
+
   activeStateFile = null;
   getStateFile(data);
 

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -38,7 +38,6 @@ const READ_HEARTBEAT_MS = 60 * 1000;
 const MAX_CHECKED_ENTRIES = 500;
 const MAX_SESSION_KEYS = 50;
 const ROUTINE_BASH_SESSION_KEY = '__bash_session__';
-const LEGACY_DISABLE_VALUES = new Set(['1', 'true', 'yes', 'on']);
 const ECC_DISABLE_VALUES = new Set(['0', 'false', 'off', 'disabled', 'disable']);
 
 const DESTRUCTIVE_BASH = /\b(rm\s+-rf|git\s+reset\s+--hard|git\s+checkout\s+--|git\s+clean\s+-f|drop\s+table|delete\s+from|truncate|git\s+push\s+--force(?!-with-lease)|git\s+commit\s+--amend|dd\s+if=)\b/i;
@@ -50,7 +49,7 @@ function normalizeEnvValue(value) {
 }
 
 function isGateGuardDisabled() {
-  if (LEGACY_DISABLE_VALUES.has(normalizeEnvValue(process.env.GATEGUARD_DISABLED))) {
+  if (normalizeEnvValue(process.env.GATEGUARD_DISABLED) === '1') {
     return true;
   }
 
@@ -376,13 +375,14 @@ function withRecoveryHint(message) {
 
 // --- Deny helper ---
 
-function denyResult(reason) {
+function denyResult(reason, options = {}) {
+  const includeRecoveryHint = options.includeRecoveryHint !== false;
   return {
     stdout: JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
-        permissionDecisionReason: withRecoveryHint(reason)
+        permissionDecisionReason: includeRecoveryHint ? withRecoveryHint(reason) : reason
       }
     }),
     exitCode: 0
@@ -462,7 +462,7 @@ function run(rawInput) {
         if (!markChecked(key)) {
           return allowWithStateWarning();
         }
-        return denyResult(destructiveBashMsg());
+        return denyResult(destructiveBashMsg(), { includeRecoveryHint: false });
       }
       return rawInput; // allow retry after facts presented
     }

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -94,6 +94,10 @@ Triggers on: `rm -rf`, `git reset --hard`, `git push --force`, `drop table`, etc
 
 The hook at `scripts/hooks/gateguard-fact-force.js` is included in this plugin. Enable it via hooks.json.
 
+If GateGuard blocks setup or repair work, start the session with
+`ECC_GATEGUARD=off`. For hook-level control, keep using
+`ECC_DISABLED_HOOKS` with the GateGuard hook ID.
+
 ### Option B: Full package with config
 
 ```bash

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -471,7 +471,25 @@ function runTests() {
       'denial reason should mention the existing hook-id disable control');
   })) passed++; else failed++;
 
-  // --- Test 14: destructive Bash denials do not advertise the recovery escape hatch ---
+  // --- Test 14: routine Bash denial messages show the Bash hook escape hatch ---
+  clearState();
+  if (test('routine Bash denials include Bash hook disable id', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' }
+    };
+    const result = runBashHook(input);
+    const output = parseOutput(result.stdout);
+    const reason = output.hookSpecificOutput.permissionDecisionReason;
+
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(reason.includes('pre:bash:gateguard-fact-force'),
+      'routine Bash denial should show the Bash hook ID');
+    assert.ok(!reason.includes('pre:edit-write:gateguard-fact-force'),
+      'routine Bash denial should not show the Edit/Write hook ID as the targeted disable');
+  })) passed++; else failed++;
+
+  // --- Test 15: destructive Bash denials do not advertise the recovery escape hatch ---
   clearState();
   if (test('destructive Bash denials omit recovery escape hatch', () => {
     const input = {
@@ -487,7 +505,7 @@ function runTests() {
       'destructive gate should not advertise disabling GateGuard');
   })) passed++; else failed++;
 
-  // --- Test 15: MultiEdit gates first unchecked file ---
+  // --- Test 16: MultiEdit gates first unchecked file ---
   clearState();
   if (test('denies first MultiEdit with unchecked file', () => {
     const input = {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -408,7 +408,56 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  // --- Test 10: MultiEdit gates first unchecked file ---
+  // --- Test 10: respects direct GateGuard env disable for recovery sessions ---
+  clearState();
+  if (test('respects ECC_GATEGUARD=off without writing gate state', () => {
+    const input = {
+      tool_name: 'Write',
+      tool_input: { file_path: '/src/env-disabled.js', content: 'export const ok = true;' }
+    };
+    const result = runHook(input, { ECC_GATEGUARD: 'off' });
+    const output = parseOutput(result.stdout);
+
+    assert.ok(output, 'should produce valid JSON output');
+    assert.strictEqual(output.tool_name, 'Write', 'disabled gate should pass through raw input');
+    assert.ok(!output.hookSpecificOutput, 'disabled gate should not deny the operation');
+    assert.ok(!fs.existsSync(stateFile), 'disabled gate should not create or mutate gate state');
+  })) passed++; else failed++;
+
+  // --- Test 11: respects legacy GATEGUARD_DISABLED env disable ---
+  clearState();
+  if (test('respects GATEGUARD_DISABLED=1 for Bash recovery', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' }
+    };
+    const result = runBashHook(input, { GATEGUARD_DISABLED: '1' });
+    const output = parseOutput(result.stdout);
+
+    assert.ok(output, 'should produce valid JSON output');
+    assert.strictEqual(output.tool_name, 'Bash', 'disabled gate should pass Bash through raw input');
+    assert.ok(!output.hookSpecificOutput, 'disabled gate should not deny Bash');
+    assert.ok(!fs.existsSync(stateFile), 'disabled gate should not create or mutate gate state');
+  })) passed++; else failed++;
+
+  // --- Test 12: denial messages show an escape hatch ---
+  clearState();
+  if (test('denial messages include direct recovery escape hatch', () => {
+    const input = {
+      tool_name: 'Write',
+      tool_input: { file_path: '/src/recovery-hint.js', content: 'export const ok = true;' }
+    };
+    const result = runHook(input);
+    const output = parseOutput(result.stdout);
+
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('ECC_GATEGUARD=off'),
+      'denial reason should show the direct recovery env toggle');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('ECC_DISABLED_HOOKS'),
+      'denial reason should mention the existing hook-id disable control');
+  })) passed++; else failed++;
+
+  // --- Test 13: MultiEdit gates first unchecked file ---
   clearState();
   if (test('denies first MultiEdit with unchecked file', () => {
     const input = {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -440,7 +440,21 @@ function runTests() {
     assert.ok(!fs.existsSync(stateFile), 'disabled gate should not create or mutate gate state');
   })) passed++; else failed++;
 
-  // --- Test 12: denial messages show an escape hatch ---
+  // --- Test 12: legacy GATEGUARD_DISABLED compatibility is scoped to =1 ---
+  clearState();
+  if (test('does not treat GATEGUARD_DISABLED=true as a disable flag', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' }
+    };
+    const result = runBashHook(input, { GATEGUARD_DISABLED: 'true' });
+    const output = parseOutput(result.stdout);
+
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('current user request'));
+  })) passed++; else failed++;
+
+  // --- Test 13: denial messages show an escape hatch ---
   clearState();
   if (test('denial messages include direct recovery escape hatch', () => {
     const input = {
@@ -457,7 +471,23 @@ function runTests() {
       'denial reason should mention the existing hook-id disable control');
   })) passed++; else failed++;
 
-  // --- Test 13: MultiEdit gates first unchecked file ---
+  // --- Test 14: destructive Bash denials do not advertise the recovery escape hatch ---
+  clearState();
+  if (test('destructive Bash denials omit recovery escape hatch', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /tmp/demo' }
+    };
+    const result = runBashHook(input);
+    const output = parseOutput(result.stdout);
+
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive command detected'));
+    assert.ok(!output.hookSpecificOutput.permissionDecisionReason.includes('ECC_GATEGUARD=off'),
+      'destructive gate should not advertise disabling GateGuard');
+  })) passed++; else failed++;
+
+  // --- Test 15: MultiEdit gates first unchecked file ---
   clearState();
   if (test('denies first MultiEdit with unchecked file', () => {
     const input = {


### PR DESCRIPTION
## Summary
- add a direct `ECC_GATEGUARD=off` escape hatch for setup or repair sessions
- keep compatibility with `GATEGUARD_DISABLED=1`
- show recovery guidance in GateGuard denial messages and docs

Refs #1527. This avoids the external #1548 subagent-bypass scope.

## Validation
- `node tests/hooks/gateguard-fact-force.test.js` (36/36)
- `node tests/hooks/hook-flags.test.js` (55/55)
- `node tests/integration/hooks.test.js` (27/27)
- `git diff --check`
- `npm run lint`
- `npm test` (2194/2194)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime control to bypass GateGuard during setup and recovery.

* **Bug Fixes / Behavior**
  * Improved denial messages to include standardized recovery guidance (omitted for destructive actions).

* **Documentation**
  * Updated docs with instructions for using the new bypass during recovery.

* **Tests**
  * Expanded hook tests to cover bypass and denial-message scenarios and adjusted test ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->