### PR TITLE
feat: write loop-status snapshots

### DIFF
--- a/commands/loop-status.md
+++ b/commands/loop-status.md
@@ -49,12 +49,27 @@ tool calls that have no matching `tool_result`.
   number of times, then exits with the highest status seen.
 - `ecc loop-status --watch --watch-count 3` emits a bounded watch stream for
   scripts and handoffs.
+- `ecc loop-status --watch --write-dir ~/.claude/loops` maintains
+  `index.json` and per-session JSON snapshots for sibling terminals or
+  watchdog scripts.
 
 ## Watch Mode
 
 When `--watch` is present, refresh status periodically. With `--json`, each
 refresh is emitted as one JSON object per line so another terminal or script can
 consume the stream.
+
+## Snapshot Files
+
+Use `--write-dir <dir>` when a separate process needs to inspect loop state
+without waiting for the current Claude session to dequeue `/loop-status`. The
+CLI writes:
+
+- `index.json` with one row per inspected session.
+- `<session-id>.json` with the full status payload for that session.
+
+These files are snapshots of local transcript analysis. They do not control or
+timeout Claude Code runtime tool calls.
 
 ## Arguments
 

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -658,7 +658,7 @@ function writeStatusSnapshots(payload, writeDir) {
   const outputDir = path.resolve(writeDir);
   fs.mkdirSync(outputDir, { recursive: true });
 
-  const usedNames = new Set();
+  const usedNames = new Set(['index.json']);
   const sessions = payload.sessions.map(session => {
     const snapshotPath = getSnapshotPath(outputDir, session, usedNames);
     atomicWriteJson(snapshotPath, {

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -634,12 +634,20 @@ function atomicWriteJson(filePath, payload) {
 
 function getSnapshotPath(outputDir, session, usedNames) {
   const baseName = sanitizeSnapshotName(session.sessionId);
-  let fileName = `${baseName}.json`;
-  if (usedNames.has(fileName)) {
-    fileName = `${baseName}-${hashString(session.transcriptPath || session.sessionId).slice(0, 8)}.json`;
+  const hashSuffix = hashString(session.transcriptPath || session.sessionId).slice(0, 8);
+  let attempt = 0;
+
+  while (attempt < 1000) {
+    const suffix = attempt === 0 ? '' : `-${hashSuffix}${attempt === 1 ? '' : `-${attempt}`}`;
+    const fileName = `${baseName}${suffix}.json`;
+    if (!usedNames.has(fileName)) {
+      usedNames.add(fileName);
+      return path.join(outputDir, fileName);
+    }
+    attempt += 1;
   }
-  usedNames.add(fileName);
-  return path.join(outputDir, fileName);
+
+  throw new Error(`Could not allocate a snapshot filename for session ${session.sessionId}`);
 }
 
 function writeStatusSnapshots(payload, writeDir) {
@@ -685,6 +693,19 @@ function writeStatusSnapshots(payload, writeDir) {
   };
 }
 
+function tryWriteStatusSnapshots(payload, options) {
+  if (!options.writeDir) {
+    return null;
+  }
+
+  try {
+    return writeStatusSnapshots(payload, options.writeDir);
+  } catch (error) {
+    console.error(`[loop-status] WARNING: could not write status snapshots: ${error.message}`);
+    return null;
+  }
+}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -717,7 +738,7 @@ async function runWatch(options) {
       console.log('');
     }
     const payload = buildStatus(normalizedOptions);
-    writeStatusSnapshots(payload, normalizedOptions.writeDir);
+    tryWriteStatusSnapshots(payload, normalizedOptions);
     writeStatus(payload, normalizedOptions);
     exitCode = Math.max(exitCode, getStatusExitCode(payload));
     iteration += 1;
@@ -748,7 +769,7 @@ async function main() {
   }
 
   const payload = buildStatus(options);
-  writeStatusSnapshots(payload, options.writeDir);
+  tryWriteStatusSnapshots(payload, options);
   writeStatus(payload, options);
   if (options.exitCode) {
     process.exitCode = getStatusExitCode(payload);
@@ -770,5 +791,6 @@ module.exports = {
   getStatusExitCode,
   parseArgs,
   runWatch,
+  tryWriteStatusSnapshots,
   writeStatusSnapshots,
 };

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -626,7 +626,12 @@ function sanitizeSnapshotName(value, fallback = 'session') {
     return sanitized;
   }
   if (sanitized && isWindowsReservedBasename(sanitized)) {
-    return `${sanitized}-${hashString(raw).slice(0, 8)}`;
+    const firstDotIndex = sanitized.indexOf('.');
+    const hashSuffix = hashString(raw).slice(0, 8);
+    if (firstDotIndex === -1) {
+      return `${sanitized}-${hashSuffix}`;
+    }
+    return `${sanitized.slice(0, firstDotIndex)}-${hashSuffix}${sanitized.slice(firstDotIndex)}`;
   }
 
   const prefix = sanitized ? sanitized.slice(0, 48).replace(/[._-]+$/g, '') : fallback;

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const crypto = require('crypto');
 
 const DEFAULT_BASH_TIMEOUT_SECONDS = 30 * 60;
 const DEFAULT_LIMIT = 10;
@@ -28,6 +29,7 @@ function usage() {
     '  --watch                        Refresh status until interrupted',
     '  --watch-count <n>              Stop after n watch refreshes',
     '  --watch-interval-seconds <n>   Seconds between watch refreshes (default: 5)',
+    '  --write-dir <dir>              Write index.json and per-session status snapshots',
     '',
     'Examples:',
     '  node scripts/loop-status.js --json',
@@ -74,6 +76,7 @@ function parseArgs(argv) {
     watchCount: null,
     wakeGraceMultiplier: DEFAULT_WAKE_GRACE_MULTIPLIER,
     watchIntervalSeconds: DEFAULT_WATCH_INTERVAL_SECONDS,
+    writeDir: null,
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -111,6 +114,9 @@ function parseArgs(argv) {
     } else if (arg === '--watch-interval-seconds') {
       options.watchIntervalSeconds = readPositiveNumber(readValue(args, index, arg), arg);
       index += 1;
+    } else if (arg === '--write-dir') {
+      options.writeDir = readValue(args, index, arg);
+      index += 1;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -134,6 +140,7 @@ function normalizeOptions(options = {}) {
     watchCount: options.watchCount ?? null,
     wakeGraceMultiplier: options.wakeGraceMultiplier ?? DEFAULT_WAKE_GRACE_MULTIPLIER,
     watchIntervalSeconds: options.watchIntervalSeconds ?? DEFAULT_WATCH_INTERVAL_SECONDS,
+    writeDir: options.writeDir || null,
   };
 }
 
@@ -603,6 +610,81 @@ function formatText(payload) {
   return lines.join('\n');
 }
 
+function hashString(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex');
+}
+
+function sanitizeSnapshotName(value, fallback = 'session') {
+  const raw = String(value || '').trim() || fallback;
+  const sanitized = raw.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, '');
+  if (sanitized && sanitized.length <= 96) {
+    return sanitized;
+  }
+
+  const prefix = sanitized ? sanitized.slice(0, 48).replace(/[._-]+$/g, '') : fallback;
+  return `${prefix || fallback}-${hashString(raw).slice(0, 12)}`;
+}
+
+function atomicWriteJson(filePath, payload) {
+  const data = JSON.stringify(payload, null, 2) + '\n';
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
+  fs.writeFileSync(tempPath, data, 'utf8');
+  fs.renameSync(tempPath, filePath);
+}
+
+function getSnapshotPath(outputDir, session, usedNames) {
+  const baseName = sanitizeSnapshotName(session.sessionId);
+  let fileName = `${baseName}.json`;
+  if (usedNames.has(fileName)) {
+    fileName = `${baseName}-${hashString(session.transcriptPath || session.sessionId).slice(0, 8)}.json`;
+  }
+  usedNames.add(fileName);
+  return path.join(outputDir, fileName);
+}
+
+function writeStatusSnapshots(payload, writeDir) {
+  if (!writeDir) {
+    return null;
+  }
+
+  const outputDir = path.resolve(writeDir);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const usedNames = new Set();
+  const sessions = payload.sessions.map(session => {
+    const snapshotPath = getSnapshotPath(outputDir, session, usedNames);
+    atomicWriteJson(snapshotPath, {
+      generatedAt: payload.generatedAt,
+      schemaVersion: 'ecc.loop-status.session.v1',
+      session,
+    });
+
+    return {
+      lastEventAt: session.lastEventAt,
+      sessionId: session.sessionId,
+      signalTypes: session.signals.map(signal => signal.type),
+      snapshotPath,
+      state: session.state,
+      transcriptPath: session.transcriptPath,
+    };
+  });
+
+  const indexPath = path.join(outputDir, 'index.json');
+  atomicWriteJson(indexPath, {
+    errors: payload.errors,
+    generatedAt: payload.generatedAt,
+    schemaVersion: 'ecc.loop-status.index.v1',
+    sessionCount: payload.sessions.length,
+    sessions,
+    source: payload.source,
+  });
+
+  return {
+    indexPath,
+    sessionCount: payload.sessions.length,
+  };
+}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -635,6 +717,7 @@ async function runWatch(options) {
       console.log('');
     }
     const payload = buildStatus(normalizedOptions);
+    writeStatusSnapshots(payload, normalizedOptions.writeDir);
     writeStatus(payload, normalizedOptions);
     exitCode = Math.max(exitCode, getStatusExitCode(payload));
     iteration += 1;
@@ -665,6 +748,7 @@ async function main() {
   }
 
   const payload = buildStatus(options);
+  writeStatusSnapshots(payload, options.writeDir);
   writeStatus(payload, options);
   if (options.exitCode) {
     process.exitCode = getStatusExitCode(payload);
@@ -686,4 +770,5 @@ module.exports = {
   getStatusExitCode,
   parseArgs,
   runWatch,
+  writeStatusSnapshots,
 };

--- a/scripts/loop-status.js
+++ b/scripts/loop-status.js
@@ -614,11 +614,19 @@ function hashString(value) {
   return crypto.createHash('sha256').update(String(value)).digest('hex');
 }
 
+function isWindowsReservedBasename(value) {
+  const basename = String(value).split('.')[0];
+  return /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(basename);
+}
+
 function sanitizeSnapshotName(value, fallback = 'session') {
   const raw = String(value || '').trim() || fallback;
   const sanitized = raw.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, '');
-  if (sanitized && sanitized.length <= 96) {
+  if (sanitized && sanitized.length <= 96 && !isWindowsReservedBasename(sanitized)) {
     return sanitized;
+  }
+  if (sanitized && isWindowsReservedBasename(sanitized)) {
+    return `${sanitized}-${hashString(raw).slice(0, 8)}`;
   }
 
   const prefix = sanitized ? sanitized.slice(0, 48).replace(/[._-]+$/g, '') : fallback;
@@ -629,7 +637,18 @@ function atomicWriteJson(filePath, payload) {
   const data = JSON.stringify(payload, null, 2) + '\n';
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
   fs.writeFileSync(tempPath, data, 'utf8');
-  fs.renameSync(tempPath, filePath);
+  try {
+    fs.renameSync(tempPath, filePath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch (cleanupError) {
+      if (cleanupError.code !== 'ENOENT') {
+        console.error(`[loop-status] WARNING: could not remove temporary snapshot file ${tempPath}: ${cleanupError.message}`);
+      }
+    }
+    throw error;
+  }
 }
 
 function getSnapshotPath(outputDir, session, usedNames) {

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -594,6 +594,43 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('keeps index.json reserved when session id sanitizes to index', () => {
+    const homeDir = createTempHome();
+    const snapshotDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-loop-status-index-collision-'));
+
+    try {
+      writeTranscript(homeDir, '-Users-affoon-project-index-collision', 'index.jsonl', [
+        assistantMessage('2026-04-30T09:55:00.000Z', 'index', 'Loop checkpoint.'),
+      ]);
+
+      const result = run([
+        '--home',
+        homeDir,
+        '--now',
+        NOW,
+        '--json',
+        '--write-dir',
+        snapshotDir,
+      ]);
+
+      assert.strictEqual(result.code, 0, result.stderr);
+
+      const indexPath = path.join(snapshotDir, 'index.json');
+      const indexPayload = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+      assert.strictEqual(indexPayload.schemaVersion, 'ecc.loop-status.index.v1');
+      assert.strictEqual(indexPayload.sessions.length, 1);
+      assert.strictEqual(indexPayload.sessions[0].sessionId, 'index');
+      assert.notStrictEqual(indexPayload.sessions[0].snapshotPath, indexPath);
+
+      const snapshotPayload = JSON.parse(fs.readFileSync(indexPayload.sessions[0].snapshotPath, 'utf8'));
+      assert.strictEqual(snapshotPayload.schemaVersion, 'ecc.loop-status.session.v1');
+      assert.strictEqual(snapshotPayload.session.sessionId, 'index');
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(snapshotDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('write-dir failures do not suppress normal stdout', () => {
     const homeDir = createTempHome();
 

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -594,6 +594,35 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('write-dir failures do not suppress normal stdout', () => {
+    const homeDir = createTempHome();
+
+    try {
+      const blockedPath = path.join(homeDir, 'snapshot-target-is-a-file');
+      fs.writeFileSync(blockedPath, 'not a directory\n', 'utf8');
+      writeTranscript(homeDir, '-Users-affoon-project-write-error', 'session-write-error.jsonl', [
+        assistantMessage('2026-04-30T09:55:00.000Z', 'session-write-error', 'Loop checkpoint.'),
+      ]);
+
+      const result = run([
+        '--home',
+        homeDir,
+        '--now',
+        NOW,
+        '--json',
+        '--write-dir',
+        blockedPath,
+      ]);
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      const payload = parsePayload(result.stdout);
+      assert.strictEqual(payload.schemaVersion, 'ecc.loop-status.v1');
+      assert.strictEqual(payload.sessions[0].sessionId, 'session-write-error');
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -642,6 +642,9 @@ function runTests() {
       writeTranscript(homeDir, '-Users-affoon-project-windows-name', 'con.jsonl', [
         assistantMessage('2026-04-30T09:55:00.000Z', 'con', 'Loop checkpoint.'),
       ]);
+      writeTranscript(homeDir, '-Users-affoon-project-windows-name', 'con-txt.jsonl', [
+        assistantMessage('2026-04-30T09:56:00.000Z', 'con.txt', 'Loop checkpoint.'),
+      ]);
 
       const result = run([
         '--home',
@@ -657,13 +660,17 @@ function runTests() {
 
       const indexPath = path.join(snapshotDir, 'index.json');
       const indexPayload = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
-      const snapshotName = path.basename(indexPayload.sessions[0].snapshotPath);
-      assert.strictEqual(indexPayload.sessions[0].sessionId, 'con');
-      assert.notStrictEqual(snapshotName.toLowerCase(), 'con.json');
+      assert.strictEqual(indexPayload.sessions.length, 2);
 
-      const snapshotPayload = JSON.parse(fs.readFileSync(indexPayload.sessions[0].snapshotPath, 'utf8'));
-      assert.strictEqual(snapshotPayload.schemaVersion, 'ecc.loop-status.session.v1');
-      assert.strictEqual(snapshotPayload.session.sessionId, 'con');
+      for (const sessionIndex of indexPayload.sessions) {
+        const snapshotName = path.basename(sessionIndex.snapshotPath);
+        assert.notStrictEqual(snapshotName.toLowerCase(), `${sessionIndex.sessionId}.json`);
+        assert.ok(!/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(snapshotName.split('.')[0]));
+
+        const snapshotPayload = JSON.parse(fs.readFileSync(sessionIndex.snapshotPath, 'utf8'));
+        assert.strictEqual(snapshotPayload.schemaVersion, 'ecc.loop-status.session.v1');
+        assert.strictEqual(snapshotPayload.session.sessionId, sessionIndex.sessionId);
+      }
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
       fs.rmSync(snapshotDir, { recursive: true, force: true });

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -6,10 +6,16 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'loop-status.js');
-const { analyzeTranscript, buildStatus, getStatusExitCode, parseArgs } = require('../../scripts/loop-status');
+const {
+  analyzeTranscript,
+  buildStatus,
+  getStatusExitCode,
+  parseArgs,
+  writeStatusSnapshots,
+} = require('../../scripts/loop-status');
 const NOW = '2026-04-30T10:00:00.000Z';
 
 function run(args = [], options = {}) {
@@ -25,25 +31,22 @@ function run(args = [], options = {}) {
     envOverrides.HOME = envOverrides.USERPROFILE;
   }
 
-  try {
-    const stdout = execFileSync('node', [SCRIPT, ...args], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-      cwd: options.cwd || process.cwd(),
-      env: {
-        ...process.env,
-        ...envOverrides,
-      },
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (error) {
-    return {
-      code: error.status || 1,
-      stdout: error.stdout || '',
-      stderr: error.stderr || '',
-    };
-  }
+  const result = spawnSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10000,
+    cwd: options.cwd || process.cwd(),
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
+  });
+
+  return {
+    code: result.status || (result.signal ? 1 : 0),
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
 }
 
 function createTempHome() {
@@ -631,6 +634,77 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('avoids Windows reserved basenames for session snapshots', () => {
+    const homeDir = createTempHome();
+    const snapshotDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-loop-status-windows-name-'));
+
+    try {
+      writeTranscript(homeDir, '-Users-affoon-project-windows-name', 'con.jsonl', [
+        assistantMessage('2026-04-30T09:55:00.000Z', 'con', 'Loop checkpoint.'),
+      ]);
+
+      const result = run([
+        '--home',
+        homeDir,
+        '--now',
+        NOW,
+        '--json',
+        '--write-dir',
+        snapshotDir,
+      ]);
+
+      assert.strictEqual(result.code, 0, result.stderr);
+
+      const indexPath = path.join(snapshotDir, 'index.json');
+      const indexPayload = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+      const snapshotName = path.basename(indexPayload.sessions[0].snapshotPath);
+      assert.strictEqual(indexPayload.sessions[0].sessionId, 'con');
+      assert.notStrictEqual(snapshotName.toLowerCase(), 'con.json');
+
+      const snapshotPayload = JSON.parse(fs.readFileSync(indexPayload.sessions[0].snapshotPath, 'utf8'));
+      assert.strictEqual(snapshotPayload.schemaVersion, 'ecc.loop-status.session.v1');
+      assert.strictEqual(snapshotPayload.session.sessionId, 'con');
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(snapshotDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('cleans temporary snapshot files when atomic rename fails', () => {
+    const snapshotDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-loop-status-rename-failure-'));
+    const originalRenameSync = fs.renameSync;
+
+    try {
+      fs.renameSync = () => {
+        throw new Error('simulated rename failure');
+      };
+
+      assert.throws(() => writeStatusSnapshots({
+        errors: [],
+        generatedAt: NOW,
+        sessions: [
+          {
+            eventCount: 1,
+            lastEventAt: NOW,
+            pendingTools: [],
+            recommendedAction: 'No action needed.',
+            sessionId: 'rename-failure',
+            signals: [],
+            state: 'ok',
+            transcriptPath: path.join(snapshotDir, 'rename-failure.jsonl'),
+          },
+        ],
+        source: {},
+      }, snapshotDir), /simulated rename failure/);
+
+      const tempFiles = fs.readdirSync(snapshotDir).filter(fileName => fileName.endsWith('.tmp'));
+      assert.deepStrictEqual(tempFiles, []);
+    } finally {
+      fs.renameSync = originalRenameSync;
+      fs.rmSync(snapshotDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('write-dir failures do not suppress normal stdout', () => {
     const homeDir = createTempHome();
 
@@ -655,6 +729,7 @@ function runTests() {
       const payload = parsePayload(result.stdout);
       assert.strictEqual(payload.schemaVersion, 'ecc.loop-status.v1');
       assert.strictEqual(payload.sessions[0].sessionId, 'session-write-error');
+      assert.match(result.stderr, /\[loop-status\] WARNING: could not write status snapshots:/);
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }

--- a/tests/scripts/loop-status.test.js
+++ b/tests/scripts/loop-status.test.js
@@ -414,6 +414,17 @@ function runTests() {
     assert.strictEqual(options.watchIntervalSeconds, 0.01);
   })) passed++; else failed++;
 
+  if (test('parses write-dir snapshot option', () => {
+    const options = parseArgs([
+      'node',
+      'scripts/loop-status.js',
+      '--write-dir',
+      '/tmp/ecc-loop-snapshots',
+    ]);
+
+    assert.strictEqual(options.writeDir, '/tmp/ecc-loop-snapshots');
+  })) passed++; else failed++;
+
   if (test('exit-code mode returns 2 when attention signals are present', () => {
     const homeDir = createTempHome();
 
@@ -531,6 +542,55 @@ function runTests() {
       assert.strictEqual(frame.sessions[0].state, 'attention');
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('writes per-session status snapshots and index when write-dir is set', () => {
+    const homeDir = createTempHome();
+    const snapshotDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-loop-status-snapshots-'));
+
+    try {
+      writeTranscript(homeDir, '-Users-affoon-project-snapshot', 'session-snapshot.jsonl', [
+        toolUse('2026-04-30T09:00:00.000Z', 'session-snapshot', 'toolu_snapshot', 'ScheduleWakeup', {
+          delaySeconds: 300,
+          reason: 'Loop checkpoint',
+        }),
+      ]);
+
+      const result = run([
+        '--home',
+        homeDir,
+        '--now',
+        NOW,
+        '--json',
+        '--write-dir',
+        snapshotDir,
+      ]);
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      const stdoutPayload = parsePayload(result.stdout);
+      assert.strictEqual(stdoutPayload.schemaVersion, 'ecc.loop-status.v1');
+
+      const indexPath = path.join(snapshotDir, 'index.json');
+      const snapshotPath = path.join(snapshotDir, 'session-snapshot.json');
+      assert.ok(fs.existsSync(indexPath), 'write-dir should include an index.json file');
+      assert.ok(fs.existsSync(snapshotPath), 'write-dir should include a per-session snapshot');
+
+      const indexPayload = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+      assert.strictEqual(indexPayload.schemaVersion, 'ecc.loop-status.index.v1');
+      assert.strictEqual(indexPayload.sessions.length, 1);
+      assert.strictEqual(indexPayload.sessions[0].sessionId, 'session-snapshot');
+      assert.strictEqual(indexPayload.sessions[0].state, 'attention');
+      assert.strictEqual(indexPayload.sessions[0].snapshotPath, snapshotPath);
+
+      const snapshotPayload = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+      assert.strictEqual(snapshotPayload.schemaVersion, 'ecc.loop-status.session.v1');
+      assert.strictEqual(snapshotPayload.generatedAt, NOW);
+      assert.strictEqual(snapshotPayload.session.sessionId, 'session-snapshot');
+      assert.ok(snapshotPayload.session.signals.some(signal => signal.type === 'schedule_wakeup_overdue'));
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(snapshotDir, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary
- add `ecc loop-status --write-dir <dir>` to write `index.json` plus per-session status snapshots
- keep normal text/JSON stdout behavior unchanged, including watch mode
- document snapshot files as transcript-analysis status, not Claude runtime control

## Validation
- `node tests/scripts/loop-status.test.js` (21/21)
- `node tests/scripts/ecc.test.js` (16/16)
- `node tests/scripts/npm-publish-surface.test.js` (2/2)
- `git diff --check`
- `npm run lint`
- `npm test` (2196/2196)

Refs #1577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to emit an overall index.json and per-session snapshot JSON files during normal and watch-mode runs; snapshot writing is best-effort, atomic, and won’t change exit/status behavior.

* **Documentation**
  * Documented snapshot outputs and contents, filename/reservation rules, and clarified snapshots are local analysis artifacts that do not affect runtime tool behavior.

* **Tests**
  * Added tests covering snapshot generation, filename collision and reserved-name handling, atomic-write cleanup, and graceful warning-on-write-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->