### PR TITLE
fix(code-reviewer): suppress false-positive findings (#1486)

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -27,6 +27,50 @@ When invoked:
 - **Consolidate** similar issues (e.g., "5 functions missing error handling" not 5 separate findings)
 - **Prioritize** issues that could cause bugs, security vulnerabilities, or data loss
 
+### Pre-Report Gate
+
+Before you write a finding, answer **all four** questions. If any answer is "no" or "unsure", downgrade severity or drop the finding.
+
+1. **Can I cite the exact line?** — Name the file and line range. Vague findings ("somewhere in the auth layer") are not actionable and must be dropped.
+2. **Can I describe the concrete failure mode?** — "What input, in what state, causes what bad outcome?" If you cannot name the trigger, you are pattern-matching, not reviewing.
+3. **Have I read the surrounding context?** — Check callers, imports, and tests. Many apparent issues are already handled one frame up or guarded by a type.
+4. **Is the severity I am about to assign defensible?** — A missing JSDoc is never HIGH. A single `any` in a test fixture is never CRITICAL. Severity inflation erodes trust faster than missed findings.
+
+### HIGH / CRITICAL Require Proof
+
+For any finding tagged HIGH or CRITICAL, include:
+
+- The exact snippet and line number
+- The specific failure scenario (input, state, outcome)
+- Why existing guards (types, validation, framework defaults) do **not** catch it
+
+If you cannot produce all three, demote to MEDIUM or drop.
+
+### It Is Acceptable — And Expected — To Return Zero Findings
+
+A clean review is a valid review. Do **not** manufacture findings to justify the invocation. If the diff is small, well-typed, tested, and follows the project's patterns, the correct output is a summary with zero rows and verdict `APPROVE`.
+
+Manufactured findings (filler nits, speculative "consider using X", hypothetical edge cases without a trigger) are the primary failure mode of LLM reviewers and directly undermine this agent's usefulness.
+
+## Common False Positives — Skip These
+
+Patterns that LLM reviewers commonly mis-flag. **Skip** unless you have evidence specific to this codebase:
+
+- **"Consider adding error handling"** on a call whose error path is handled by the caller or framework (Express error middleware, React error boundaries, top-level `try/catch`, Promise chains with `.catch` upstream).
+- **"Missing input validation"** when the function is internal and its callers already validate (trace at least one caller before flagging).
+- **"Magic number"** for well-known constants: `200`, `404`, `1000` (ms), `60`, `24`, `1024`, array index `0`/`-1`, HTTP status codes, and single-use local constants whose meaning is obvious from the variable name.
+- **"Function too long"** for exhaustive `switch` statements, configuration objects, test tables, or generated code — length is not complexity.
+- **"Missing JSDoc"** on single-purpose internal helpers whose name and signature are self-describing.
+- **"Prefer `const` over `let`"** when the variable is reassigned — read the whole function before flagging.
+- **"Possible null dereference"** when the preceding line narrows the type or an `if`-guard is in scope — trace type flow, don't pattern-match on `?.`.
+- **"N+1 query"** on fixed-cardinality loops (e.g. iterating a 4-element enum) or on paths already using `DataLoader`/batching.
+- **"Missing await"** on fire-and-forget calls that are intentionally detached (logging, metrics, background queue pushes) — check for a comment or `void` prefix before flagging.
+- **"Should use TypeScript"** / **"Should have types"** in a JavaScript-only file — match the project's existing language, do not suggest a stack change.
+- **"Hardcoded value"** for values in test fixtures, example code, or documentation snippets — tests *should* have hardcoded expectations.
+- **Security theater**: flagging `Math.random()` in a non-cryptographic context (animation, jitter, sampling), or `eval`/`Function` in a plugin system that is explicitly a code-loading surface.
+
+When tempted to flag one of the above, ask: **"Would a senior engineer on this team actually change this in review?"** If no, skip.
+
 ## Review Checklist
 
 ### Security (CRITICAL)
@@ -206,9 +250,11 @@ Verdict: WARNING — 2 HIGH issues should be resolved before merge.
 
 ## Approval Criteria
 
-- **Approve**: No CRITICAL or HIGH issues
+- **Approve**: No CRITICAL or HIGH issues (including clean reviews with zero findings — this is a valid, expected outcome)
 - **Warning**: HIGH issues only (can merge with caution)
 - **Block**: CRITICAL issues found — must fix before merge
+
+Do **not** withhold approval to appear rigorous. If the diff is clean, approve it.
 
 ## Project-Specific Guidelines
 

--- a/tests/ci/code-reviewer-false-positive-guard.test.js
+++ b/tests/ci/code-reviewer-false-positive-guard.test.js
@@ -25,10 +25,12 @@ const requiredHeadings = [
 ];
 
 const requiredPatterns = [
-  // Pre-report gate must force the reviewer to cite lines and describe
-  // concrete failure modes before writing a finding.
+  // Pre-report gate must force the reviewer to cite lines, describe
+  // concrete failure modes, and check surrounding context before writing a
+  // finding. All four gate questions must stay locked in.
   /Can I cite the exact line/i,
   /concrete failure mode/i,
+  /Have I read the surrounding context/i,
   /Severity inflation/i,
 
   // HIGH/CRITICAL must carry proof.
@@ -63,10 +65,12 @@ function test(name, fn) {
   }
 }
 
+function read() {
+  return fs.readFileSync(reviewerPath, 'utf8');
+}
+
 function run() {
   console.log('\n=== Testing code-reviewer false-positive guardrails ===\n');
-
-  const source = fs.readFileSync(reviewerPath, 'utf8');
 
   let passed = 0;
   let failed = 0;
@@ -74,6 +78,7 @@ function run() {
   for (const heading of requiredHeadings) {
     if (
       test(`code-reviewer.md contains heading: ${heading}`, () => {
+        const source = read();
         assert.ok(source.includes(heading), `code-reviewer.md missing required heading "${heading}"`);
       })
     )
@@ -84,6 +89,7 @@ function run() {
   for (const pattern of requiredPatterns) {
     if (
       test(`code-reviewer.md matches ${pattern}`, () => {
+        const source = read();
         assert.ok(pattern.test(source), `code-reviewer.md missing required pattern ${pattern}`);
       })
     )
@@ -95,6 +101,7 @@ function run() {
   // quantitative bar, not just prose heuristics.
   if (
     test('code-reviewer.md retains the >80% confidence threshold', () => {
+      const source = read();
       assert.ok(/>\s*80%\s*confident/i.test(source), 'code-reviewer.md missing >80% confidence threshold');
     })
   )

--- a/tests/ci/code-reviewer-false-positive-guard.test.js
+++ b/tests/ci/code-reviewer-false-positive-guard.test.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Validate that agents/code-reviewer.md carries the anti-false-positive
+ * guardrails that address issue #1486.
+ *
+ * Prior versions of the agent flagged many HIGH-severity findings on
+ * well-formed diffs (see issue #1486). These guardrails force the agent
+ * to justify every finding, enumerate common LLM-reviewer false positives,
+ * and make clear that a zero-finding review is a valid outcome.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const reviewerPath = path.join(repoRoot, 'agents', 'code-reviewer.md');
+
+const requiredHeadings = [
+  '## Confidence-Based Filtering',
+  '### Pre-Report Gate',
+  '### HIGH / CRITICAL Require Proof',
+  '### It Is Acceptable — And Expected — To Return Zero Findings',
+  '## Common False Positives — Skip These'
+];
+
+const requiredPatterns = [
+  // Pre-report gate must force the reviewer to cite lines and describe
+  // concrete failure modes before writing a finding.
+  /Can I cite the exact line/i,
+  /concrete failure mode/i,
+  /Severity inflation/i,
+
+  // HIGH/CRITICAL must carry proof.
+  /exact snippet and line number/i,
+  /specific failure scenario/i,
+  /demote to MEDIUM or drop/i,
+
+  // Zero findings must be an explicitly valid outcome.
+  /clean review is a valid review/i,
+  /Manufactured findings/i,
+
+  // Enumerated false-positive patterns from issue #1486.
+  /Common False Positives/i,
+  /Consider adding error handling/i,
+  /Missing input validation/i,
+  /Magic number/i,
+  /Would a senior engineer on this team actually change this in review/i,
+
+  // Approval must not be withheld to appear rigorous.
+  /Do \*\*not\*\* withhold approval to appear rigorous/i
+];
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function run() {
+  console.log('\n=== Testing code-reviewer false-positive guardrails ===\n');
+
+  const source = fs.readFileSync(reviewerPath, 'utf8');
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const heading of requiredHeadings) {
+    if (
+      test(`code-reviewer.md contains heading: ${heading}`, () => {
+        assert.ok(source.includes(heading), `code-reviewer.md missing required heading "${heading}"`);
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
+  for (const pattern of requiredPatterns) {
+    if (
+      test(`code-reviewer.md matches ${pattern}`, () => {
+        assert.ok(pattern.test(source), `code-reviewer.md missing required pattern ${pattern}`);
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
+  // The 80% confidence floor must survive so that the agent still has a
+  // quantitative bar, not just prose heuristics.
+  if (
+    test('code-reviewer.md retains the >80% confidence threshold', () => {
+      assert.ok(/>\s*80%\s*confident/i.test(source), 'code-reviewer.md missing >80% confidence threshold');
+    })
+  )
+    passed++;
+  else failed++;
+
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
## Summary

Closes #1486.

Issue #1486 reports that the `code-reviewer` agent flags many parts of
well-formed code as HIGH priority, and that most of those findings are
false positives — "it acts like it has to flag something every time it's
called, even though there is nothing."

The agent already had a short "Confidence-Based Filtering" section, but
in practice it was too weak to stop an LLM reviewer from manufacturing
findings to justify its invocation. This PR hardens that contract.

## What changed

**`agents/code-reviewer.md`**

1. **Pre-Report Gate (new).** Four questions the agent must answer
   before writing *any* finding: can I cite the exact line, can I
   describe the concrete failure mode, have I read the surrounding
   context, is the severity I am about to assign defensible? If any
   answer is "unsure", the finding is downgraded or dropped.

2. **HIGH / CRITICAL require proof (new).** Every HIGH/CRITICAL finding
   must carry the exact snippet, the specific failure scenario
   (input, state, outcome), and a rationale for why existing guards
   (types, validation, framework defaults) do not already catch it.
   No proof, no HIGH/CRITICAL — demote to MEDIUM or drop.

3. **Zero findings is a valid outcome (new).** An explicit statement
   that a clean review with verdict APPROVE is expected on small,
   well-typed, tested diffs. Manufactured findings are called out as
   the primary LLM-reviewer failure mode.

4. **Common False Positives — Skip These (new).** A concrete
   enumerated checklist of patterns LLM reviewers habitually
   mis-flag: over-eager error-handling nits when the caller already
   handles errors, magic-number flags on HTTP status codes and
   obvious constants, N+1 claims on fixed-cardinality loops,
   language-stack suggestions in a JS-only file, hardcoded values
   in test fixtures, `Math.random()` in non-crypto contexts, etc.

5. **Approval guidance tightened.** The Approval Criteria now
   explicitly instructs the agent not to withhold approval to
   appear rigorous.

**`tests/ci/code-reviewer-false-positive-guard.test.js` (new)**

A CI test that reads `agents/code-reviewer.md` and asserts the
guardrails above are present — required headings, required prose
patterns, and the surviving >80% confidence floor. This locks the
anti-false-positive contract in place so future edits cannot silently
regress it. Follows the same structure as
`tests/ci/agent-instruction-safety.test.js`.

## Test plan

- [x] `node tests/ci/code-reviewer-false-positive-guard.test.js` — 20/20 pass
- [x] `node tests/run-all.js` — 2220/2220 pass (was 2200 before; 20 new asserts)
- [x] `npx markdownlint-cli agents/code-reviewer.md` — clean
- [x] `npx eslint tests/ci/code-reviewer-false-positive-guard.test.js` — clean

## Scope

- Only `agents/code-reviewer.md` is modified; no other agents, hooks,
  or runtime code is touched.
- No frontmatter changes (name/description/tools/model preserved).
- The existing >80% confidence threshold, severity taxonomy, checklist
  sections, and output format are preserved — this is additive
  guidance, not a rewrite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a Pre-Report Gate with four qualification questions and a >80% confidence threshold.
  * Tightened HIGH/CRITICAL findings to require concrete proof artifacts or demotion/drop.
  * Explicitly approves zero-finding reviews and lists common false-positive patterns to skip; advises against withholding approval for showmanship.

* **Tests**
  * Added CI validation to assert the guideline content and enforcement checks are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->