### PR TITLE
fix(SKILL.md): add missing `name` (skill-stocktake) + collapse multi-line description (openclaw-persona-forge)

### DIFF
--- a/docs/zh-CN/skills/skill-stocktake/SKILL.md
+++ b/docs/zh-CN/skills/skill-stocktake/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: skill-stocktake
 description: "用于审计Claude技能和命令的质量。支持快速扫描（仅变更技能）和全面盘点模式，采用顺序子代理批量评估。"
 origin: ECC
 ---

--- a/skills/openclaw-persona-forge/SKILL.md
+++ b/skills/openclaw-persona-forge/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: openclaw-persona-forge
-description: |-
-  为 OpenClaw AI Agent 锻造完整的龙虾灵魂方案。根据用户偏好或随机抽卡，
-  输出身份定位、灵魂描述(SOUL.md)、角色化底线规则、名字和头像生图提示词。
-  如当前环境提供已审核的生图 skill，可自动生成统一风格头像图片。
-  当用户需要创建、设计或定制 OpenClaw 龙虾灵魂时使用。
-  不适用于：微调已有 SOUL.md、非 OpenClaw 平台的角色设计、纯工具型无性格 Agent。
-  触发词：龙虾灵魂、虾魂、OpenClaw 灵魂、养虾灵魂、龙虾角色、龙虾定位、
-  龙虾剧本杀角色、龙虾游戏角色、龙虾 NPC、龙虾性格、龙虾背景故事、
-  lobster soul、lobster character、抽卡、随机龙虾、龙虾 SOUL、gacha。
+description: "为 OpenClaw AI Agent 锻造完整的龙虾灵魂方案。根据用户偏好或随机抽卡， 输出身份定位、灵魂描述(SOUL.md)、角色化底线规则、名字和头像生图提示词。 如当前环境提供已审核的生图 skill，可自动生成统一风格头像图片。 当用户需要创建、设计或定制 OpenClaw 龙虾灵魂时使用。 不适用于：微调已有 SOUL.md、非 OpenClaw 平台的角色设计、纯工具型无性格 Agent。 触发词：龙虾灵魂、虾魂、OpenClaw 灵魂、养虾灵魂、龙虾角色、龙虾定位、 龙虾剧本杀角色、龙虾游戏角色、龙虾 NPC、龙虾性格、龙虾背景故事、 lobster soul、lobster character、抽卡、随机龙虾、龙虾 SOUL、gacha。"
 origin: community
 ---
 

--- a/skills/skill-stocktake/SKILL.md
+++ b/skills/skill-stocktake/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: skill-stocktake
 description: "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation."
 origin: ECC
 ---


### PR DESCRIPTION
Refs #1663.

Smaller scope than the linked issue first suggested — after re-checking with `yaml.safe_load`, the `description: >` folded scalars throughout the repo parse to clean single-line strings (with one trailing `\n` that's the consumer's job to strip). So this PR only touches the genuinely broken cases:

## 1. `name:` added where it was missing

- `skills/skill-stocktake/SKILL.md`
- `docs/zh-CN/skills/skill-stocktake/SKILL.md`

Both had `description:` and `origin:` but no `name:` field. Anthropic's SKILL.md spec treats `name` as required, and several downstream tools key off it directly. Set to `skill-stocktake` to match the directory name.

## 2. `description: |-` collapsed to single-line double-quoted string

- `skills/openclaw-persona-forge/SKILL.md`

The literal block scalar form preserved internal newlines in the parsed value, which broke flat-table rendering. Collapsed the lines to a single sentence-joined string. Content unchanged — just whitespace.

## Why not the other 26 paths from the issue

`description: >` (folded) is valid YAML that produces a single-line string when parsed. The trailing `\n` artifact is on the renderer side, not on this repo.

## Test plan

- [x] `yaml.safe_load` on each modified frontmatter returns a dict with `name` and a single-line `description`.
- [x] No body content changed; only frontmatter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SKILL.md frontmatter by adding the required name for `skill-stocktake` (EN and zh-CN) and collapsing `openclaw-persona-forge` description to a single line so table renderers don’t break. Addresses the parsing/rendering concerns noted in #1663; other folded descriptions are valid and unchanged.

- **Bug Fixes**
  - Added `name: skill-stocktake` to `skills/skill-stocktake/SKILL.md` and `docs/zh-CN/skills/skill-stocktake/SKILL.md`.
  - Converted `skills/openclaw-persona-forge/SKILL.md` description to a single-line string.
  - No body content changes; frontmatter only.

<sup>Written for commit 447bad23e3cccb1de69120bbea01bc7e1284449c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added skill identifiers to documentation metadata for improved categorization and reference.
  * Reformatted skill documentation descriptions for consistency across files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->