### PR TITLE
docs: add Bring Your AI to Community Ecosystem Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,7 @@ These are not bundled with ECC and are not audited by this repo, but they are wo
 - [claude-seo](https://github.com/AgriciDaniel/claude-seo) — SEO-focused skill and agent collection
 - [claude-ads](https://github.com/AgriciDaniel/claude-ads) — Ad-audit and paid-growth workflow collection
 - [claude-cybersecurity](https://github.com/AgriciDaniel/claude-cybersecurity) — Security-oriented skill and agent collection
-- [Bring Your AI](https://bringyour.ai/claude-code-to-codex) — Local-first Claude Code to Codex migration tool with Codex import audit and AGENTS.md vs. CLAUDE.md guides.
+- [Bring Your AI](https://bringyour.ai/claude-code-to-codex) — Local-first Claude Code to Codex migration tool with [Codex import auditing checklist](https://bringyour.ai/codex-import-checklist) and [AGENTS.md vs. CLAUDE.md behavior comparison](https://bringyour.ai/agents-md-claude-md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ These are not bundled with ECC and are not audited by this repo, but they are wo
 - [claude-seo](https://github.com/AgriciDaniel/claude-seo) — SEO-focused skill and agent collection
 - [claude-ads](https://github.com/AgriciDaniel/claude-ads) — Ad-audit and paid-growth workflow collection
 - [claude-cybersecurity](https://github.com/AgriciDaniel/claude-cybersecurity) — Security-oriented skill and agent collection
+- [Bring Your AI](https://bringyour.ai/claude-code-to-codex) — Local-first Claude Code to Codex migration tool with Codex import audit and AGENTS.md vs. CLAUDE.md guides.
 
 ---
 


### PR DESCRIPTION
Adds one `Community Ecosystem Notes` entry for Bring Your AI.

It is a local-first Claude Code -> Codex migration tool, plus two concrete guides on Codex import auditing and `AGENTS.md` vs. `CLAUDE.md` behavior. It sits outside ECC, but it is directly relevant to users moving harness state across Claude Code and Codex without uploading private harness files.

Links:
- https://bringyour.ai/claude-code-to-codex
- https://bringyour.ai/codex-import-checklist
- https://bringyour.ai/agents-md-claude-md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added “Bring Your AI” to Community Ecosystem Notes as a local-first Claude Code → Codex migration tool. Includes links to the tool, a Codex import audit checklist, and an `AGENTS.md` vs `CLAUDE.md` behavior comparison to help move harness state without uploading private files.

<sup>Written for commit 5bfa955a976e05e84a938104433011f539314012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Community Ecosystem Notes entry linking to "Bring Your AI" with a detailed migration guide for moving Claude Code to Codex, a local-first tool workflow, an import-auditing checklist, and a behavioral comparison between the two approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->