### PR TITLE
fix(ci): flag SKILL.md frontmatter defects in validate-skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ Short version:
 - [ ] Links to related skills
 - [ ] No sensitive data (API keys, tokens, paths)
 - [ ] Frontmatter declares `name:` matching the directory name
-- [ ] Frontmatter `description:` is an inline string or folded (`>`) scalar — not a literal block (`|` / `|-`), which preserves internal newlines and breaks flat-table renderers
+- [ ] Frontmatter `description:` is an inline string or folded (`>`) scalar — not a literal block (`|`, `|-`, or `|+`), which preserves internal newlines and breaks flat-table renderers
 
 ### Example Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,8 @@ Short version:
 - [ ] Tested with Claude Code
 - [ ] Links to related skills
 - [ ] No sensitive data (API keys, tokens, paths)
+- [ ] Frontmatter declares `name:` matching the directory name
+- [ ] Frontmatter `description:` is an inline string or folded (`>`) scalar — not a literal block (`|` / `|-`), which preserves internal newlines and breaks flat-table renderers
 
 ### Example Skills
 

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -43,7 +43,7 @@ const STRICT = process.argv.includes('--strict') || process.env.CI_STRICT_SKILLS
 function extractFrontmatter(content) {
   // Strip BOM if present (UTF-8 BOM: U+FEFF).
   const clean = content.replace(/^\uFEFF/, '');
-  const match = clean.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const match = clean.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return { present: false, lines: [] };
   return {
     present: true,
@@ -87,8 +87,13 @@ function inspectFrontmatter(lines) {
 
     const key = match[1];
     const rawValue = match[2];
-    // Strip unquoted trailing comment for value/indicator inspection.
-    const valueNoComment = rawValue.replace(/\s+#.*$/, '').trim();
+    // Strip unquoted comments for value/indicator inspection. Handles both
+    // trailing comments (`foo: bar # note`) and comment-only values
+    // (`foo: # todo`) so the latter is treated as empty.
+    const valueNoComment = rawValue
+      .replace(/^\s*#.*$/, '')
+      .replace(/\s+#.*$/, '')
+      .trim();
     values[key] = valueNoComment;
 
     // Detect literal / folded block-scalar indicators. Accept chomp
@@ -104,6 +109,59 @@ function inspectFrontmatter(lines) {
   }
 
   return { values, descriptionIndicator };
+}
+
+/**
+ * Validate a single skill directory.
+ *
+ * Returns `{ fatal }` where `fatal` indicates a structural error that
+ * should be surfaced via `console.error` and abort CI (missing/empty
+ * SKILL.md). Frontmatter findings are routed through
+ * `reportFrontmatterFinding`, which owns the WARN/ERROR decision based
+ * on strict mode.
+ *
+ * @param {string} dir
+ * @param {string} skillsDir
+ * @param {(msg: string) => void} reportFrontmatterFinding
+ * @returns {{fatal: boolean}}
+ */
+function validateSkillDir(dir, skillsDir, reportFrontmatterFinding) {
+  const skillMd = path.join(skillsDir, dir, 'SKILL.md');
+  if (!fs.existsSync(skillMd)) {
+    console.error(`ERROR: ${dir}/ - Missing SKILL.md`);
+    return { fatal: true };
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(skillMd, 'utf-8');
+  } catch (err) {
+    console.error(`ERROR: ${dir}/SKILL.md - ${err.message}`);
+    return { fatal: true };
+  }
+  if (content.trim().length === 0) {
+    console.error(`ERROR: ${dir}/SKILL.md - Empty file`);
+    return { fatal: true };
+  }
+
+  const fm = extractFrontmatter(content);
+  if (fm.present) {
+    const { values, descriptionIndicator } = inspectFrontmatter(fm.lines);
+
+    if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
+      reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter missing required field: name`);
+    } else if (values.name === '') {
+      reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter 'name' is empty`);
+    }
+
+    if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
+      reportFrontmatterFinding(
+        `${dir}/SKILL.md - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
+      );
+    }
+  }
+
+  return { fatal: false };
 }
 
 function validateSkills() {
@@ -130,44 +188,11 @@ function validateSkills() {
   };
 
   for (const dir of dirs) {
-    const skillMd = path.join(SKILLS_DIR, dir, 'SKILL.md');
-    if (!fs.existsSync(skillMd)) {
-      console.error(`ERROR: ${dir}/ - Missing SKILL.md`);
+    const { fatal } = validateSkillDir(dir, SKILLS_DIR, reportFrontmatterFinding);
+    if (fatal) {
       hasErrors = true;
       continue;
     }
-
-    let content;
-    try {
-      content = fs.readFileSync(skillMd, 'utf-8');
-    } catch (err) {
-      console.error(`ERROR: ${dir}/SKILL.md - ${err.message}`);
-      hasErrors = true;
-      continue;
-    }
-    if (content.trim().length === 0) {
-      console.error(`ERROR: ${dir}/SKILL.md - Empty file`);
-      hasErrors = true;
-      continue;
-    }
-
-    const fm = extractFrontmatter(content);
-    if (fm.present) {
-      const { values, descriptionIndicator } = inspectFrontmatter(fm.lines);
-
-      if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
-        reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter missing required field: name`);
-      } else if (values.name === '') {
-        reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter 'name' is empty`);
-      }
-
-      if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
-        reportFrontmatterFinding(
-          `${dir}/SKILL.md - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
-        );
-      }
-    }
-
     validCount++;
   }
 

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -1,6 +1,22 @@
 #!/usr/bin/env node
 /**
  * Validate curated skill directories (skills/ in repo).
+ *
+ * Checks:
+ *   1. Each sub-directory of skills/ contains a SKILL.md file.
+ *   2. SKILL.md is non-empty.
+ *   3. SKILL.md frontmatter (if present) declares a `name:` field.
+ *   4. SKILL.md frontmatter `description:` uses an inline scalar — not a
+ *      literal block scalar (`|` / `|-` / `|+`), which preserves internal
+ *      newlines and breaks flat-table renderers keyed off `description`.
+ *
+ * Frontmatter findings default to WARN so CI does not break while
+ * pre-existing data defects are being cleaned up out of band (see #1663).
+ * Pass `--strict` or set `CI_STRICT_SKILLS=1` to promote frontmatter
+ * findings to errors (exit 1).
+ *
+ * Structural findings (missing/empty SKILL.md) are always errors.
+ *
  * Scope: curated only. Learned/imported/evolved roots are out of scope.
  * If skills/ does not exist, exit 0 (no curated skills to validate).
  */
@@ -10,6 +26,80 @@ const path = require('path');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 
+const STRICT = process.argv.includes('--strict')
+  || process.env.CI_STRICT_SKILLS === '1';
+
+/**
+ * Parse the leading YAML frontmatter of a markdown document.
+ *
+ * Returns `{ present, lines }` so callers can inspect raw lines
+ * (needed to detect block-scalar `description:` values).
+ *
+ * Tolerant of UTF-8 BOM and CRLF line endings, matching the other
+ * validators in this directory.
+ *
+ * @param {string} content
+ * @returns {{present: boolean, lines: string[]}}
+ */
+function extractFrontmatter(content) {
+  // Strip BOM if present (UTF-8 BOM: U+FEFF).
+  const clean = content.replace(/^\uFEFF/, "");
+  const match = clean.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return { present: false, lines: [] };
+  return {
+    present: true,
+    lines: match[1].split(/\r?\n/),
+  };
+}
+
+/**
+ * Extract top-level keys and flag block-scalar `description:` values.
+ *
+ * Lines that continue a block scalar (`|` or `>`) are skipped — we only
+ * care about the top-level key set and the raw indicator on the
+ * `description:` line.
+ *
+ * @param {string[]} lines
+ * @returns {{keys: Set<string>, descriptionIndicator: string|null}}
+ */
+function inspectFrontmatter(lines) {
+  const keys = new Set();
+  let descriptionIndicator = null;
+  let inBlockScalar = false;
+  let blockScalarIndent = -1;
+
+  for (const rawLine of lines) {
+    if (inBlockScalar) {
+      // Stay inside the block until a line with indent <= the opener's
+      // indent (or an empty continuation).
+      const leadingSpaces = rawLine.match(/^(\s*)/)[1].length;
+      if (rawLine.trim() === '' || leadingSpaces > blockScalarIndent) {
+        continue;
+      }
+      inBlockScalar = false;
+      blockScalarIndent = -1;
+    }
+
+    const match = rawLine.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+
+    const key = match[1];
+    const rawValue = match[2];
+    keys.add(key);
+
+    // Detect literal / folded block scalar indicators.
+    if (/^[|>][+-]?\s*$/.test(rawValue.trim())) {
+      if (key === 'description') {
+        descriptionIndicator = rawValue.trim();
+      }
+      inBlockScalar = true;
+      blockScalarIndent = rawLine.match(/^(\s*)/)[1].length;
+    }
+  }
+
+  return { keys, descriptionIndicator };
+}
+
 function validateSkills() {
   if (!fs.existsSync(SKILLS_DIR)) {
     console.log('No curated skills directory (skills/), skipping');
@@ -17,9 +107,23 @@ function validateSkills() {
   }
 
   const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
-  const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+  const dirs = entries
+    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+    .map(e => e.name);
+
   let hasErrors = false;
+  let warnCount = 0;
   let validCount = 0;
+
+  const reportFrontmatterFinding = (msg) => {
+    if (STRICT) {
+      console.error(`ERROR: ${msg}`);
+      hasErrors = true;
+    } else {
+      console.warn(`WARN: ${msg}`);
+      warnCount++;
+    }
+  };
 
   for (const dir of dirs) {
     const skillMd = path.join(SKILLS_DIR, dir, 'SKILL.md');
@@ -43,6 +147,25 @@ function validateSkills() {
       continue;
     }
 
+    const fm = extractFrontmatter(content);
+    if (fm.present) {
+      const { keys, descriptionIndicator } = inspectFrontmatter(fm.lines);
+
+      if (!keys.has('name')) {
+        reportFrontmatterFinding(
+          `${dir}/SKILL.md - frontmatter missing required field: name`,
+        );
+      }
+
+      if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
+        reportFrontmatterFinding(
+          `${dir}/SKILL.md - frontmatter description uses literal block scalar ` +
+            `'${descriptionIndicator}' which preserves internal newlines; ` +
+            `use an inline string or folded '>' scalar instead`,
+        );
+      }
+    }
+
     validCount++;
   }
 
@@ -50,7 +173,11 @@ function validateSkills() {
     process.exit(1);
   }
 
-  console.log(`Validated ${validCount} skill directories`);
+  let msg = `Validated ${validCount} skill directories`;
+  if (warnCount > 0) {
+    msg += ` (${warnCount} warning${warnCount === 1 ? '' : 's'})`;
+  }
+  console.log(msg);
 }
 
 validateSkills();

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -26,8 +26,7 @@ const path = require('path');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
 
-const STRICT = process.argv.includes('--strict')
-  || process.env.CI_STRICT_SKILLS === '1';
+const STRICT = process.argv.includes('--strict') || process.env.CI_STRICT_SKILLS === '1';
 
 /**
  * Parse the leading YAML frontmatter of a markdown document.
@@ -43,27 +42,30 @@ const STRICT = process.argv.includes('--strict')
  */
 function extractFrontmatter(content) {
   // Strip BOM if present (UTF-8 BOM: U+FEFF).
-  const clean = content.replace(/^\uFEFF/, "");
+  const clean = content.replace(/^\uFEFF/, '');
   const match = clean.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return { present: false, lines: [] };
   return {
     present: true,
-    lines: match[1].split(/\r?\n/),
+    lines: match[1].split(/\r?\n/)
   };
 }
 
 /**
- * Extract top-level keys and flag block-scalar `description:` values.
+ * Extract top-level keys (with trimmed values) and flag block-scalar
+ * `description:` values.
  *
  * Lines that continue a block scalar (`|` or `>`) are skipped — we only
  * care about the top-level key set and the raw indicator on the
- * `description:` line.
+ * `description:` line. Block-scalar indicators accept YAML chomp and
+ * indent modifiers and trailing comments, e.g. `|`, `|-`, `|+`, `|2`,
+ * `|-2`, `>-  # note`.
  *
  * @param {string[]} lines
- * @returns {{keys: Set<string>, descriptionIndicator: string|null}}
+ * @returns {{values: Record<string,string>, descriptionIndicator: string|null}}
  */
 function inspectFrontmatter(lines) {
-  const keys = new Set();
+  const values = Object.create(null);
   let descriptionIndicator = null;
   let inBlockScalar = false;
   let blockScalarIndent = -1;
@@ -85,19 +87,23 @@ function inspectFrontmatter(lines) {
 
     const key = match[1];
     const rawValue = match[2];
-    keys.add(key);
+    // Strip unquoted trailing comment for value/indicator inspection.
+    const valueNoComment = rawValue.replace(/\s+#.*$/, '').trim();
+    values[key] = valueNoComment;
 
-    // Detect literal / folded block scalar indicators.
-    if (/^[|>][+-]?\s*$/.test(rawValue.trim())) {
+    // Detect literal / folded block-scalar indicators. Accept chomp
+    // modifiers (`-` / `+`) and optional indent-indicator digits in
+    // either order, per YAML 1.2.
+    if (/^[|>](?:[+-]?\d+|\d+[+-]?|[+-])?$/.test(valueNoComment)) {
       if (key === 'description') {
-        descriptionIndicator = rawValue.trim();
+        descriptionIndicator = valueNoComment;
       }
       inBlockScalar = true;
       blockScalarIndent = rawLine.match(/^(\s*)/)[1].length;
     }
   }
 
-  return { keys, descriptionIndicator };
+  return { values, descriptionIndicator };
 }
 
 function validateSkills() {
@@ -107,15 +113,13 @@ function validateSkills() {
   }
 
   const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
-  const dirs = entries
-    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-    .map(e => e.name);
+  const dirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.')).map(e => e.name);
 
   let hasErrors = false;
   let warnCount = 0;
   let validCount = 0;
 
-  const reportFrontmatterFinding = (msg) => {
+  const reportFrontmatterFinding = msg => {
     if (STRICT) {
       console.error(`ERROR: ${msg}`);
       hasErrors = true;
@@ -149,19 +153,17 @@ function validateSkills() {
 
     const fm = extractFrontmatter(content);
     if (fm.present) {
-      const { keys, descriptionIndicator } = inspectFrontmatter(fm.lines);
+      const { values, descriptionIndicator } = inspectFrontmatter(fm.lines);
 
-      if (!keys.has('name')) {
-        reportFrontmatterFinding(
-          `${dir}/SKILL.md - frontmatter missing required field: name`,
-        );
+      if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
+        reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter missing required field: name`);
+      } else if (values.name === '') {
+        reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter 'name' is empty`);
       }
 
       if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
         reportFrontmatterFinding(
-          `${dir}/SKILL.md - frontmatter description uses literal block scalar ` +
-            `'${descriptionIndicator}' which preserves internal newlines; ` +
-            `use an inline string or folded '>' scalar instead`,
+          `${dir}/SKILL.md - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
         );
       }
     }

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -801,6 +801,129 @@ function runTests() {
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 
+  // Run validate-skills.js against a fixture dir, optionally passing
+  // extra argv (e.g. '--strict') so the frontmatter finding suite can
+  // exercise both warn and strict modes.
+  //
+  // Captures stderr on both success and failure (the shared
+  // runSourceViaTempFile helper only surfaces stderr when the child
+  // exits non-zero, which hides WARN lines in the default mode).
+  function runSkillsValidator(testDir, argv = []) {
+    const { spawnSync } = require('child_process');
+    const validatorPath = path.join(validatorsDir, 'validate-skills.js');
+    let source = fs.readFileSync(validatorPath, 'utf8');
+    source = stripShebang(source);
+    source = source.replace(
+      /const SKILLS_DIR = .*?;/,
+      `const SKILLS_DIR = ${JSON.stringify(testDir)};`,
+    );
+    if (argv.length > 0) {
+      const argvPreamble = argv
+        .map(arg => `process.argv.push(${JSON.stringify(arg)});`)
+        .join('\n');
+      source = `${argvPreamble}\n${source}`;
+    }
+    const tmpFile = path.join(repoRoot,
+      `.tmp-validator-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+    try {
+      fs.writeFileSync(tmpFile, source, 'utf8');
+      const r = spawnSync('node', [tmpFile], {
+        encoding: 'utf8',
+        timeout: 10000,
+        cwd: repoRoot,
+      });
+      return {
+        code: typeof r.status === 'number' ? r.status : 1,
+        stdout: r.stdout || '',
+        stderr: r.stderr || '',
+      };
+    } finally {
+      try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore */ }
+    }
+  }
+
+  if (test('warns when frontmatter is missing name (default mode)', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'no-name-skill');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\ndescription: "X"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir);
+    assert.strictEqual(result.code, 0,
+      `Default mode must not fail CI; got stderr: ${result.stderr}`);
+    assert.ok(
+      result.stderr.includes('WARN') && result.stderr.includes('missing required field: name'),
+      `Should warn on missing name; got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('errors when frontmatter is missing name (strict mode)', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'no-name-skill');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\ndescription: "X"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 1, '--strict must fail CI on missing name');
+    assert.ok(result.stderr.includes('missing required field: name'),
+      'Should report missing name');
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('warns on literal block-scalar description (|-)', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'block-desc-skill');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: block-desc-skill\ndescription: |-\n  line one\n  line two\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir);
+    assert.strictEqual(result.code, 0, 'Default mode should not fail CI');
+    assert.ok(
+      result.stderr.includes('WARN') && result.stderr.includes('literal block scalar'),
+      `Should warn on |- description; got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('accepts folded (>) and inline descriptions', () => {
+    const testDir = createTestDir();
+    const folded = path.join(testDir, 'folded-skill');
+    fs.mkdirSync(folded);
+    fs.writeFileSync(path.join(folded, 'SKILL.md'),
+      '---\nname: folded-skill\ndescription: >\n  joined\n  on spaces\norigin: ECC\n---\n# Skill');
+    const inline = path.join(testDir, 'inline-skill');
+    fs.mkdirSync(inline);
+    fs.writeFileSync(path.join(inline, 'SKILL.md'),
+      '---\nname: inline-skill\ndescription: "single line"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 0,
+      `Folded and inline should pass strict; got stderr: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Validated 2'),
+      `Should count both skills; got stdout: ${result.stdout}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('skips hidden directories under skills/', () => {
+    const testDir = createTestDir();
+    // A dot-prefixed directory (e.g. .DS_Store-adjacent junk or legacy
+    // cache) must not count as a skill and must not error.
+    fs.mkdirSync(path.join(testDir, '.cache'));
+    fs.writeFileSync(path.join(testDir, '.cache', 'SKILL.md'), '# ignored');
+    const real = path.join(testDir, 'real-skill');
+    fs.mkdirSync(real);
+    fs.writeFileSync(path.join(real, 'SKILL.md'),
+      '---\nname: real-skill\ndescription: "x"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 0, 'Hidden dirs should be skipped');
+    assert.ok(result.stdout.includes('Validated 1'),
+      `Should only count the non-hidden skill; got stdout: ${result.stdout}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
   // ==========================================
   // validate-commands.js
   // ==========================================

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 
 const validatorsDir = path.join(__dirname, '..', '..', 'scripts', 'ci');
 const repoRoot = path.join(__dirname, '..', '..');
@@ -178,6 +178,48 @@ function runCatalogValidator(overrides = {}) {
   }
 
   return runSourceViaTempFile(source);
+}
+
+// Run validate-skills.js against a fixture dir, optionally passing
+// extra argv (e.g. '--strict') and env overrides (e.g.
+// CI_STRICT_SKILLS=1) so the frontmatter finding suite can exercise
+// both warn and strict modes via argv and env code paths.
+//
+// Captures stderr on both success and failure (the shared
+// runSourceViaTempFile helper only surfaces stderr when the child
+// exits non-zero, which hides WARN lines in the default mode).
+function runSkillsValidator(testDir, argv = [], envOverrides = {}) {
+  const validatorPath = path.join(validatorsDir, 'validate-skills.js');
+  let source = fs.readFileSync(validatorPath, 'utf8');
+  source = stripShebang(source);
+  source = source.replace(
+    /const SKILLS_DIR = .*?;/,
+    `const SKILLS_DIR = ${JSON.stringify(testDir)};`,
+  );
+  if (argv.length > 0) {
+    const argvPreamble = argv
+      .map(arg => `process.argv.push(${JSON.stringify(arg)});`)
+      .join('\n');
+    source = `${argvPreamble}\n${source}`;
+  }
+  const tmpFile = path.join(repoRoot,
+    `.tmp-validator-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+  try {
+    fs.writeFileSync(tmpFile, source, 'utf8');
+    const r = spawnSync('node', [tmpFile], {
+      encoding: 'utf8',
+      timeout: 10000,
+      cwd: repoRoot,
+      env: { ...process.env, ...envOverrides },
+    });
+    return {
+      code: typeof r.status === 'number' ? r.status : 1,
+      stdout: r.stdout || '',
+      stderr: r.stderr || '',
+    };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore */ }
+  }
 }
 
 function writeCatalogFixture(testDir, options = {}) {
@@ -801,48 +843,6 @@ function runTests() {
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 
-  // Run validate-skills.js against a fixture dir, optionally passing
-  // extra argv (e.g. '--strict') so the frontmatter finding suite can
-  // exercise both warn and strict modes.
-  //
-  // Captures stderr on both success and failure (the shared
-  // runSourceViaTempFile helper only surfaces stderr when the child
-  // exits non-zero, which hides WARN lines in the default mode).
-  function runSkillsValidator(testDir, argv = [], envOverrides = {}) {
-    const { spawnSync } = require('child_process');
-    const validatorPath = path.join(validatorsDir, 'validate-skills.js');
-    let source = fs.readFileSync(validatorPath, 'utf8');
-    source = stripShebang(source);
-    source = source.replace(
-      /const SKILLS_DIR = .*?;/,
-      `const SKILLS_DIR = ${JSON.stringify(testDir)};`,
-    );
-    if (argv.length > 0) {
-      const argvPreamble = argv
-        .map(arg => `process.argv.push(${JSON.stringify(arg)});`)
-        .join('\n');
-      source = `${argvPreamble}\n${source}`;
-    }
-    const tmpFile = path.join(repoRoot,
-      `.tmp-validator-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
-    try {
-      fs.writeFileSync(tmpFile, source, 'utf8');
-      const r = spawnSync('node', [tmpFile], {
-        encoding: 'utf8',
-        timeout: 10000,
-        cwd: repoRoot,
-        env: { ...process.env, ...envOverrides },
-      });
-      return {
-        code: typeof r.status === 'number' ? r.status : 1,
-        stdout: r.stdout || '',
-        stderr: r.stderr || '',
-      };
-    } finally {
-      try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore */ }
-    }
-  }
-
   if (test('warns when frontmatter is missing name (default mode)', () => {
     const testDir = createTestDir();
     const skillDir = path.join(testDir, 'no-name-skill');
@@ -982,6 +982,39 @@ function runTests() {
     assert.strictEqual(result.code, 1, 'CI_STRICT_SKILLS=1 must fail CI on missing name');
     assert.ok(result.stderr.includes('missing required field: name'),
       'Should report missing name');
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags comment-only name value as empty (strict)', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'comment-only-name');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: # todo\ndescription: "X"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 1, 'Strict mode must fail CI on empty name');
+    assert.ok(result.stderr.includes("'name' is empty"),
+      `Should report empty name; got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('tolerates ---trailing text outside frontmatter block', () => {
+    // A SKILL.md whose body contains a line starting with '---text'
+    // must not be parsed as frontmatter. Regression guard for
+    // closing-delimiter tightening: the old regex would greedily
+    // match '---trailing'.
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'no-frontmatter-dashes');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '# Skill\n\nSome body text.\n\n---trailing content\nmore body\n');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 0,
+      `Should not flag frontmatter findings when no valid frontmatter exists; got stderr: ${result.stderr}`);
+    assert.ok(!result.stderr.includes('missing required field: name'),
+      'Must not treat ---trailing as a frontmatter closer');
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -210,7 +210,7 @@ function runSkillsValidator(testDir, argv = [], envOverrides = {}) {
       encoding: 'utf8',
       timeout: 10000,
       cwd: repoRoot,
-      env: { ...process.env, ...envOverrides },
+      env: { ...process.env, CI_STRICT_SKILLS: '', ...envOverrides },
     });
     return {
       code: typeof r.status === 'number' ? r.status : 1,

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -808,7 +808,7 @@ function runTests() {
   // Captures stderr on both success and failure (the shared
   // runSourceViaTempFile helper only surfaces stderr when the child
   // exits non-zero, which hides WARN lines in the default mode).
-  function runSkillsValidator(testDir, argv = []) {
+  function runSkillsValidator(testDir, argv = [], envOverrides = {}) {
     const { spawnSync } = require('child_process');
     const validatorPath = path.join(validatorsDir, 'validate-skills.js');
     let source = fs.readFileSync(validatorPath, 'utf8');
@@ -831,6 +831,7 @@ function runTests() {
         encoding: 'utf8',
         timeout: 10000,
         cwd: repoRoot,
+        env: { ...process.env, ...envOverrides },
       });
       return {
         code: typeof r.status === 'number' ? r.status : 1,
@@ -921,6 +922,66 @@ function runTests() {
     assert.strictEqual(result.code, 0, 'Hidden dirs should be skipped');
     assert.ok(result.stdout.includes('Validated 1'),
       `Should only count the non-hidden skill; got stdout: ${result.stdout}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('warns when name: value is empty or whitespace', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'empty-name-skill');
+    fs.mkdirSync(skillDir);
+    // `name:` key present but value is blank.
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname:    \ndescription: "X"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir);
+    assert.strictEqual(result.code, 0,
+      `Default mode must not fail CI; got stderr: ${result.stderr}`);
+    assert.ok(
+      result.stderr.includes('WARN') && result.stderr.includes("'name' is empty"),
+      `Should warn on empty name; got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('warns on literal block-scalar description with |+ chomp', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'keep-desc-skill');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: keep-desc-skill\ndescription: |+\n  line one\n  line two\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir);
+    assert.strictEqual(result.code, 0, 'Default mode should not fail CI');
+    assert.ok(result.stderr.includes('literal block scalar'),
+      `Should warn on |+ description; got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('warns on block-scalar description with indent indicator and trailing comment', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'indent-desc-skill');
+    fs.mkdirSync(skillDir);
+    // `|-2  # note` is still a literal block scalar in YAML 1.2.
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: indent-desc-skill\ndescription: |-2  # trimmed two-space indent\n    line one\n    line two\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir);
+    assert.strictEqual(result.code, 0, 'Default mode should not fail CI');
+    assert.ok(result.stderr.includes('literal block scalar'),
+      `Should warn on |-2 description; got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('honors CI_STRICT_SKILLS=1 env flag', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'no-name-skill-env');
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\ndescription: "X"\norigin: ECC\n---\n# Skill');
+
+    const result = runSkillsValidator(testDir, [], { CI_STRICT_SKILLS: '1' });
+    assert.strictEqual(result.code, 1, 'CI_STRICT_SKILLS=1 must fail CI on missing name');
+    assert.ok(result.stderr.includes('missing required field: name'),
+      'Should report missing name');
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 


### PR DESCRIPTION
## What Changed

Extends `scripts/ci/validate-skills.js` to statically catch the SKILL.md frontmatter defects reported in #1663:

1. `name:` field missing from SKILL.md frontmatter.
2. `description:` using a literal block scalar (`|`, `|-`, `|+`) which preserves internal newlines and breaks flat-table renderers.

Also adds five tests to `tests/ci/validators.test.js` covering both checks in both default and strict modes, and two bullets to the Skill Checklist in `CONTRIBUTING.md`.

## Why This Change

#1663 identifies two specific SKILL.md files whose frontmatter breaks downstream tools that render skills as a flat table keyed off `name` / `description`. PR #1664 fixes the data (the two offending files). This PR is **complementary**: it extends the CI validator so the same class of defect cannot silently reappear as new skills are contributed.

Today the current `validate-skills.js` only checks `SKILL.md` file existence and non-empty content — it does not inspect YAML frontmatter at all. With 182 skill directories and growing, that gap leaves the repo one unnoticed typo away from the renderer regressions #1663 describes.

## How It Behaves

- **Default mode:** frontmatter findings are `WARN`, exit 0. Running against current `main` reports exactly two warnings — the same two files in #1663 — and CI stays green while #1664 proceeds through review.
- **Strict mode (`--strict` or `CI_STRICT_SKILLS=1`):** the same findings become `ERROR`, exit 1. Intended to be flipped on in the workflow file once #1664 (or equivalent) lands.
- **Structural findings** (missing/empty `SKILL.md`) continue to be errors as before.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js` — **2205/2205 pass**)
- [x] Edge cases considered and tested

Specific manual verification:

```
$ node scripts/ci/validate-skills.js
WARN: openclaw-persona-forge/SKILL.md - frontmatter description uses literal block scalar '|-' ...
WARN: skill-stocktake/SKILL.md - frontmatter missing required field: name
Validated 182 skill directories (2 warnings)
# exit 0

$ node scripts/ci/validate-skills.js --strict
ERROR: openclaw-persona-forge/SKILL.md - ...
ERROR: skill-stocktake/SKILL.md - ...
# exit 1
```

Full CI chain (`validate-agents`, `validate-hooks`, `validate-commands`, `validate-skills`, `validate-install-manifests`, `validate-workflow-security`, `validate-rules`, `catalog.js --text`, `check-unicode-safety`) all pass. ESLint on `scripts/**/*.js tests/**/*.js` passes. `markdownlint` on agents/skills/commands/rules passes.

New tests added to `tests/ci/validators.test.js`:

- `warns when frontmatter is missing name (default mode)`
- `errors when frontmatter is missing name (strict mode)`
- `warns on literal block-scalar description (|-)`
- `accepts folded (>) and inline descriptions`
- `skips hidden directories under skills/`

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [x] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (n/a — JS only)
- [x] Pre-commit hooks pass locally
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation (CONTRIBUTING.md Skill Checklist)
- [x] Added comments for complex logic (block-scalar continuation handling)
- [ ] README updated (not needed — internal CI validator)

## Relationship to other PRs

- **Refs #1663** (issue).
- **Complements #1664** (data fix). Does not conflict: this PR does not touch the two SKILL.md files that #1664 edits. When #1664 merges, this validator's warning count on `main` drops from 2 to 0, at which point a one-line workflow edit can flip strict mode on.

## Bespoke parser note

The frontmatter parser here is intentionally tiny and mirrors the style of `scripts/ci/validate-agents.js` (BOM-tolerant, CRLF-tolerant, line-based). I deliberately did not pull in a YAML dependency: the other validators in this directory all use a small bespoke parser, and the checks here only need top-level key presence and the `description:` indicator character.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `scripts/ci/validate-skills.js` to flag SKILL.md frontmatter issues from #1663: require `name:` and forbid literal-block `description:`. Findings are WARN by default; `--strict` or `CI_STRICT_SKILLS=1` makes them ERROR.

- **Bug Fixes**
  - Requires `name:`; flags empty or comment-only values.
  - Rejects literal-block `description:` (`|`, `|+`, `|-`); accepts inline and folded `>`.
  - Detects block-scalar variants with chomp/indent digits and trailing comments.
  - Tightens frontmatter parsing to require newline/EOF after closing `---` (avoids `---text` body matches).
  - Skips hidden subdirectories under `skills/`.
  - Adds focused tests for empty/comment-only `name`, `|+`/`|-2 #` cases, env-based strict mode, and the `---trailing` guard.

<sup>Written for commit 36a1c13914313c58552a8e2e06191871f04dda94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Contribution checklist clarified: skill metadata must have a name matching its directory and use inline or folded description formatting (no literal block scalars).

* **New Features**
  * Validator strict mode treats frontmatter issues as errors, skips hidden skill directories, and reports total validated items plus warning counts; frontmatter parsing tolerates common line endings and BOM.

* **Tests**
  * Expanded coverage for strict vs default behavior, description-format checks, hidden-directory skipping, and frontmatter parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->