### PR TITLE
fix: probe stdio MCP servers via .cmd/.exe fallback on Windows

### DIFF
--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -306,96 +306,152 @@ function probeCommandServer(serverName, config) {
       ...(config.env && typeof config.env === 'object' && !Array.isArray(config.env) ? config.env : {})
     };
 
-    let stderr = '';
-    let done = false;
-    let timer = null;
+    // Windows: child_process.spawn does not auto-resolve .cmd/.bat/.exe
+    // shims, so npm-style PATH commands like `npx` (installed as
+    // `npx.cmd`) raise ENOENT under non-shell spawn. Probe candidate
+    // suffixes only on Windows for bare command names without an
+    // extension or path separator. Absolute/relative paths keep
+    // single-candidate ENOENT semantics so existing failure-reason
+    // contracts (and stderr signals like "spawn ... ENOENT") survive.
+    const isPathLike = command && (
+      path.isAbsolute(command)
+      || command.includes('/')
+      || command.includes('\\')
+    );
+    const candidates = process.platform === 'win32'
+      && command
+      && !path.extname(command)
+      && !isPathLike
+        ? [command, command + '.cmd', command + '.exe', command + '.bat']
+        : [command];
 
+    let done = false;
     function finish(result) {
       if (done) return;
       done = true;
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
       resolve(result);
     }
 
-    let child;
-    try {
-      child = spawn(command, args, {
-        env: mergedEnv,
-        cwd: process.cwd(),
-        stdio: ['pipe', 'ignore', 'pipe']
-      });
-    } catch (error) {
-      finish({
-        ok: false,
-        statusCode: null,
-        reason: error.message
-      });
-      return;
-    }
+    function attempt(idx) {
+      const tryCommand = candidates[idx];
+      const isLast = idx + 1 >= candidates.length;
+      let stderr = '';
+      let attemptDone = false;
+      let timer = null;
 
-    child.stderr.on('data', chunk => {
-      if (stderr.length < 4000) {
-        const remaining = 4000 - stderr.length;
-        stderr += String(chunk).slice(0, remaining);
+      function attemptFinish(result) {
+        if (attemptDone) return;
+        attemptDone = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        finish(result);
       }
-    });
 
-    child.on('error', error => {
-      finish({
-        ok: false,
-        statusCode: null,
-        reason: error.message
-      });
-    });
+      function handleEnoent() {
+        attemptDone = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        attempt(idx + 1);
+      }
 
-    child.on('exit', (code, signal) => {
-      finish({
-        ok: false,
-        statusCode: code,
-        reason: stderr.trim() || `process exited before handshake (${signal || code || 'unknown'})`
-      });
-    });
+      // Node 18.20+/20.12+ refuse to spawn .cmd/.bat without `shell: true`
+      // (CVE-2024-27980 mitigation, raises EINVAL). For those candidates
+      // route through the shell so PATH lookup and the cmd interpreter run.
+      const useShell = process.platform === 'win32'
+        && /\.(cmd|bat)$/i.test(tryCommand);
 
-    timer = setTimeout(() => {
-      // A fast-crashing stdio server can finish before the timer callback runs
-      // on a loaded machine. Check the process state again before classifying it
-      // as healthy on timeout.
-      if (child.exitCode !== null || child.signalCode !== null) {
-        finish({
+      let child;
+      try {
+        child = spawn(tryCommand, args, {
+          env: mergedEnv,
+          cwd: process.cwd(),
+          stdio: ['pipe', 'ignore', 'pipe'],
+          shell: useShell
+        });
+      } catch (error) {
+        if ((error.code === 'ENOENT' || error.code === 'EINVAL') && !isLast) {
+          handleEnoent();
+          return;
+        }
+        attemptFinish({
           ok: false,
-          statusCode: child.exitCode,
-          reason: stderr.trim() || `process exited before handshake (${child.signalCode || child.exitCode || 'unknown'})`
+          statusCode: null,
+          reason: error.message
         });
         return;
       }
 
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // ignore
-      }
+      child.stderr.on('data', chunk => {
+        if (stderr.length < 4000) {
+          const remaining = 4000 - stderr.length;
+          stderr += String(chunk).slice(0, remaining);
+        }
+      });
 
-      setTimeout(() => {
+      child.on('error', error => {
+        if ((error.code === 'ENOENT' || error.code === 'EINVAL') && !isLast) {
+          handleEnoent();
+          return;
+        }
+        attemptFinish({
+          ok: false,
+          statusCode: null,
+          reason: error.message
+        });
+      });
+
+      child.on('exit', (code, signal) => {
+        attemptFinish({
+          ok: false,
+          statusCode: code,
+          reason: stderr.trim() || `process exited before handshake (${signal || code || 'unknown'})`
+        });
+      });
+
+      timer = setTimeout(() => {
+        // A fast-crashing stdio server can finish before the timer callback runs
+        // on a loaded machine. Check the process state again before classifying it
+        // as healthy on timeout.
+        if (child.exitCode !== null || child.signalCode !== null) {
+          attemptFinish({
+            ok: false,
+            statusCode: child.exitCode,
+            reason: stderr.trim() || `process exited before handshake (${child.signalCode || child.exitCode || 'unknown'})`
+          });
+          return;
+        }
+
         try {
-          child.kill('SIGKILL');
+          child.kill('SIGTERM');
         } catch {
           // ignore
         }
-      }, 200).unref?.();
 
-      finish({
-        ok: true,
-        statusCode: null,
-        reason: `${serverName} accepted a new stdio process`
-      });
-    }, timeoutMs);
+        setTimeout(() => {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // ignore
+          }
+        }, 200).unref?.();
 
-    if (typeof timer.unref === 'function') {
-      timer.unref();
+        attemptFinish({
+          ok: true,
+          statusCode: null,
+          reason: `${serverName} accepted a new stdio process`
+        });
+      }, timeoutMs);
+
+      if (typeof timer.unref === 'function') {
+        timer.unref();
+      }
     }
+
+    attempt(0);
   });
 }
 

--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -313,13 +313,17 @@ function probeCommandServer(serverName, config) {
     // extension or path separator. Absolute/relative paths keep
     // single-candidate ENOENT semantics so existing failure-reason
     // contracts (and stderr signals like "spawn ... ENOENT") survive.
-    const isPathLike = command && (
+    // Guard against non-string command values so misconfigured input
+    // surfaces through finish(...) instead of throwing in path.extname
+    // before spawn's try/catch can catch it.
+    const commandIsString = typeof command === 'string' && command.length > 0;
+    const isPathLike = commandIsString && (
       path.isAbsolute(command)
       || command.includes('/')
       || command.includes('\\')
     );
     const candidates = process.platform === 'win32'
-      && command
+      && commandIsString
       && !path.extname(command)
       && !isPathLike
         ? [command, command + '.cmd', command + '.exe', command + '.bat']
@@ -361,7 +365,12 @@ function probeCommandServer(serverName, config) {
       // Node 18.20+/20.12+ refuse to spawn .cmd/.bat without `shell: true`
       // (CVE-2024-27980 mitigation, raises EINVAL). For those candidates
       // route through the shell so PATH lookup and the cmd interpreter run.
+      // Caveat: under shell mode args are joined and forwarded through
+      // `cmd.exe /d /s /c`; values containing %, ^, &, |, <, >, ", ) may
+      // be subject to Windows quoting heuristics. MCP server configs
+      // should keep args free of unescaped shell metacharacters.
       const useShell = process.platform === 'win32'
+        && typeof tryCommand === 'string'
         && /\.(cmd|bat)$/i.test(tryCommand);
 
       let child;
@@ -425,10 +434,25 @@ function probeCommandServer(serverName, config) {
           return;
         }
 
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          // ignore
+        if (useShell && child.pid) {
+          // shell: true wraps the candidate in cmd.exe; child.kill()
+          // terminates cmd but leaves grandchildren (e.g. node spawned
+          // from a .cmd shim) orphaned. taskkill /T /F walks the
+          // process tree so health probes do not leak processes.
+          try {
+            spawnSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], {
+              stdio: 'ignore',
+              windowsHide: true
+            });
+          } catch {
+            // ignore; SIGKILL safety net below still runs
+          }
+        } else {
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            // ignore
+          }
         }
 
         setTimeout(() => {

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -952,6 +952,65 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  // Windows-only: child_process.spawn cannot resolve .cmd/.bat shims for
+  // bare PATH commands without an extension, and Node 18.20+/20.12+ refuse
+  // to spawn .cmd targets without `shell: true` (CVE-2024-27980). The
+  // probe must retry bare command names with platform extensions and route
+  // .cmd/.bat through the shell, otherwise tools like `npx` (installed as
+  // `npx.cmd`) are misclassified as unhealthy on first use. Path-like
+  // commands keep single-candidate ENOENT semantics.
+  if (process.platform === 'win32') {
+    if (await asyncTest('windows: probes bare PATH commands via .cmd fallback', async () => {
+      const tempDir = createTempDir();
+      const binDir = path.join(tempDir, 'bin');
+      const configPath = path.join(tempDir, 'claude.json');
+      const statePath = path.join(tempDir, 'mcp-health.json');
+
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(binDir, 'winfallback.cmd'),
+        ['@echo off', 'node -e "setInterval(()=>{},1000)"', ''].join('\r\n')
+      );
+
+      try {
+        writeConfig(configPath, {
+          mcpServers: {
+            winfallback: {
+              command: 'winfallback',
+              args: []
+            }
+          }
+        });
+
+        const input = { tool_name: 'mcp__winfallback__list', tool_input: {} };
+        const result = runHook(input, {
+          CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
+          ECC_MCP_CONFIG_PATH: configPath,
+          ECC_MCP_HEALTH_STATE_PATH: statePath,
+          ECC_MCP_HEALTH_TIMEOUT_MS: '500',
+          PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`
+        });
+
+        assert.strictEqual(
+          result.code,
+          0,
+          `Expected bare command to be probed via .cmd fallback: ${hookFailureDetails(result, statePath)}`
+        );
+
+        const state = readState(statePath);
+        assert.strictEqual(
+          state.servers.winfallback.status,
+          'healthy',
+          'Expected bare command to be marked healthy via .cmd fallback'
+        );
+      } finally {
+        cleanupTempDir(tempDir);
+      }
+    })) passed++; else failed++;
+  } else {
+    console.log('  - skipped: windows: probes bare PATH commands via .cmd fallback (non-Windows)');
+  }
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What Changed

  `probeCommandServer` in `scripts/hooks/mcp-health-check.js` now retries the configured stdio command with platform extension candidates on Windows when the bare command name has no extension and is not a path. The probe walks `[command, command.cmd, command.exe, command.bat]` in order and only falls
  through on `ENOENT` / `EINVAL`. `.cmd` / `.bat` candidates are dispatched with `shell: true` so the cmd interpreter (and `PATH` lookup) runs them. Path-like commands (absolute / relative) keep single-candidate ENOENT semantics, so the existing `/ENOENT|spawn/i` failure-reason contract in
  `tests/hooks/mcp-health-check.test.js` is preserved.

  A new Windows-only test `windows: probes bare PATH commands via .cmd fallback` exercises the fallback by writing a `.cmd` shim into a temp dir, prepending it to `PATH`, and asserting the bare command is marked `healthy`. Non-Windows runs print a `- skipped` line and do not touch the pass/fail counts.

  ## Why This Change

  On Windows, `child_process.spawn('npx', …)` raises `ENOENT` because npm-style binaries install as `npx.cmd` and `spawn` does not auto-resolve `.cmd` / `.bat` shims. Worse, since the CVE-2024-27980 mitigation in Node 18.20+ / 20.12+, spawning a `.cmd` target without `shell: true` raises `spawn EINVAL`.
  The combination meant the MCPHealthCheck hook flagged every `npx`-launched stdio MCP (Playwright, Memory, GitHub, Context7, Sequential Thinking, …) as unhealthy on first probe and started blocking their tool calls (`[MCPHealthCheck] <server> is unavailable (spawn npx ENOENT). Blocking <tool> so Claude
  can fall back to non-MCP tools.`), even though Claude Code itself had connected the servers fine.

  This change makes the preflight probe match how the real MCP client launches stdio servers on Windows, eliminating the false-positive block.

  ## Testing Done

  - [x] Manual testing completed
  - [x] Automated tests pass locally (`node tests/run-all.js`)
  - [x] Edge cases considered and tested

  Local results on Windows 11 / Node 24.15.0:
  - `node tests/hooks/mcp-health-check.test.js`: 21 / 21 passed (including new Windows fallback case).
  - `node tests/run-all.js`: 2171 / 2174 passed. The 3 failing tests are pre-existing on `upstream/main` in `scripts/ecc-dashboard.test.js` (`build_terminal_launch …`, `maximize_window …`) and unrelated to this PR — verified by stashing the patch and re-running.
  - `npx eslint scripts/hooks/mcp-health-check.js tests/hooks/mcp-health-check.test.js`: clean.
  - `node scripts/ci/validate-hooks.js`: `Validated 26 hook matchers`.
  - End-to-end: cleared `~/.claude/mcp-health-cache.json`, re-invoked `mcp__playwright__browser_navigate https://example.com`, hook now writes `status: healthy` and the tool call succeeds (previously blocked with `spawn npx ENOENT`).

  ## Type of Change

  - [x] `fix:` Bug fix
  - [ ] `feat:` New feature
  - [ ] `refactor:` Code refactoring
  - [ ] `docs:` Documentation
  - [ ] `test:` Tests
  - [ ] `chore:` Maintenance/tooling
  - [ ] `ci:` CI/CD changes

  ## Security & Quality Checklist

  - [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
  - [x] JSON files validate cleanly
  - [x] Shell scripts pass shellcheck (if applicable) — no shell scripts touched
  - [x] Pre-commit hooks pass locally (if configured)
  - [x] No sensitive data exposed in logs or output
  - [x] Follows conventional commits format

  ## Documentation

  - [x] Updated relevant documentation — inline rationale added in code comments; no user-facing doc changed since the hook is internal
  - [x] Added comments for complex logic
  - [x] README updated (if needed) — n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows stdio MCP health checks by probing bare PATH commands with .cmd/.exe/.bat fallbacks. Hardens the probe to avoid EINVAL errors and orphaned processes, preventing false failures (e.g., `npx`) that blocked MCP tools.

- **Bug Fixes**
  - Retry `[command, command.cmd, command.exe, command.bat]` for bare PATH commands; fall back on ENOENT/EINVAL.
  - Use `shell: true` for `.cmd`/`.bat` and kill the process tree with `taskkill /T` on timeout to prevent leaks.
  - Keep path-like commands single-attempt; add a type guard to surface misconfig errors cleanly.

<sup>Written for commit e8f968ea573f75bacbad16915d9131c00db27487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable command resolution on Windows with executable-extension fallbacks and per-attempt timeouts.
  * Improved probe termination/cleanup on Windows to avoid orphaned subprocesses and ensure accurate health reporting.

* **Tests**
  * Added a Windows-only test verifying fallback behavior for bare path commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->