### PR TITLE
docs(strategic-compact): fix hook command path in SKILL.md

### DIFF
--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -46,11 +46,11 @@ Add to your `~/.claude/settings.json`:
     "PreToolUse": [
       {
         "matcher": "Edit",
-        "hooks": [{ "type": "command", "command": "node ~/.claude/skills/strategic-compact/suggest-compact.js" }]
+        "hooks": [{ "type": "command", "command": "node ~/.claude/scripts/hooks/suggest-compact.js" }]
       },
       {
         "matcher": "Write",
-        "hooks": [{ "type": "command", "command": "node ~/.claude/skills/strategic-compact/suggest-compact.js" }]
+        "hooks": [{ "type": "command", "command": "node ~/.claude/scripts/hooks/suggest-compact.js" }]
       }
     ]
   }


### PR DESCRIPTION
## What Changed

Updated the `Hook Setup` example in `skills/strategic-compact/SKILL.md` to reference the current script location.

Before:
```json
"command": "node ~/.claude/skills/strategic-compact/suggest-compact.js"
```

After:
```json
"command": "node ~/.claude/scripts/hooks/suggest-compact.js"
```

## Why This Change

Closes #1675.

The documented path does not exist in the current repo layout. The cross-platform Node.js implementation ships at `scripts/hooks/suggest-compact.js` (the old `skills/strategic-compact/suggest-compact.sh` shell variant is superseded). Anyone who copy-pasted the documented config hit a broken hook command — the PreToolUse hook would silently fail to locate the script.

Cross-checked against:
- `hooks/hooks.json` — already uses `scripts/hooks/suggest-compact.js`
- `docs/ko-KR/skills/strategic-compact/SKILL.md` — already uses `scripts/hooks/suggest-compact.js`
- `tests/hooks/suggest-compact.test.js` — tests target `scripts/hooks/suggest-compact.js`

## Testing Done

- `node tests/run-all.js` -> **2200/2200 pass**
- `node scripts/ci/validate-skills.js` -> 182 skill directories validated
- `node scripts/ci/validate-agents.js` -> 48 agents validated
- `node scripts/ci/validate-commands.js` -> 68 commands validated
- `node scripts/ci/validate-hooks.js` -> 26 hook matchers validated
- `node scripts/ci/check-unicode-safety.js` -> pass
- `node scripts/ci/catalog.js --text` -> counts match
- `npx markdownlint-cli "skills/**/*.md" --ignore node_modules` -> clean

## Type of Change

- [x] Documentation update (corrects a broken path in a user-facing hook setup example)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Security & Quality Checklist

- [x] Follows the repo's conventional-commit / file-layout conventions
- [x] Tested locally against the full CI gate (`node tests/run-all.js`)
- [x] No sensitive information added
- [x] Description clearly explains the behavior change
- [x] Surgical diff (2 lines, 1 file) — minimal blast radius
- [x] No API, no runtime code path, no validator schema affected

## Documentation

- `skills/strategic-compact/SKILL.md` updated inline.
- Translated mirrors (`docs/zh-CN`, `docs/ja-JP`, `docs/zh-TW`) were intentionally left untouched — they lag the English source and are synced via separate `docs/sync-*-v1.10` PRs. `docs/ko-KR` already uses the correct path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hook command path in `skills/strategic-compact/SKILL.md` so the PreToolUse examples point to `~/.claude/scripts/hooks/suggest-compact.js` instead of the outdated location. Addresses #1675 by aligning docs with the current layout so copy-pasted configs work and the hook runs.

<sup>Written for commit 456154e727b37c9edfbb1fd553d2f5e3fe5ba9f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples to show the correct script paths for hook setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->