### PR TITLE
fix(continuous-learning-v2): collapse SSH/HTTPS remotes to one project ID

### DIFF
--- a/skills/continuous-learning-v2/scripts/detect-project.sh
+++ b/skills/continuous-learning-v2/scripts/detect-project.sh
@@ -56,10 +56,26 @@ export CLV2_OBSERVER_PROMPT_PATTERN
 #   https://user:token@github.com/owner/repo → github.com/owner/repo
 #   ssh://git@github.com/owner/repo.git     → github.com/owner/repo
 #   http://gitea.local:3000/u/r.git         → gitea.local:3000/u/r
+#   /home/user/Repos/MyProject              → /home/user/Repos/MyProject (case preserved)
+#   file:///home/user/Repos/MyProject       → /home/user/Repos/MyProject (case preserved)
 # Empty input → empty output (caller falls back to project_root).
 _clv2_normalize_remote_url() {
   local url="$1"
   [ -z "$url" ] && return 0
+
+  # Decide up-front whether this looks like a network URL or a local
+  # filesystem path. Local paths must keep their original case because
+  # case-sensitive filesystems treat /home/u/Repos and /home/u/repos as
+  # distinct directories — lowercasing them would collide unrelated repos.
+  # `file://` URIs point at local paths too, so they are treated as local.
+  local is_network=0
+  case "$url" in
+    file://*) is_network=0 ;;
+    *://*)    is_network=1 ;;   # http://, https://, ssh://, git://, ...
+    *@*:*)    is_network=1 ;;   # SCP-like:  user@host:path
+    *)        is_network=0 ;;   # bare local path (absolute or relative)
+  esac
+
   # Strip embedded credentials: scheme://user[:pass]@host/... → scheme://host/...
   # Match the same pattern used by the credential-strip step in
   # _clv2_detect_project ([^@]+, not [^@/]+) so this function is safe to call
@@ -68,17 +84,26 @@ _clv2_normalize_remote_url() {
   # is not allowed by RFC 3986, but being tolerant keeps the function usable
   # in isolation without depending on the caller having pre-stripped.
   url=$(printf '%s' "$url" | sed -E 's|://[^@]+@|://|')
-  # Strip URL scheme (https://, http://, ssh://, git://, ...)
+  # Strip URL scheme (https://, http://, ssh://, git://, file://, ...)
   url=$(printf '%s' "$url" | sed -E 's|^[A-Za-z][A-Za-z0-9+.-]*://||')
   # SCP-like form (after scheme strip this only matches pure SCP URLs):
   #   git@host:path → host/path
   url=$(printf '%s' "$url" | sed -E 's|^[^@/:]+@([^:/]+):|\1/|')
   # Drop trailing .git (and an optional trailing slash)
   url=$(printf '%s' "$url" | sed -E 's|\.git/?$||; s|/+$||')
-  # Lowercase: hostnames are DNS-insensitive and the major Git hosts route
-  # repository paths case-insensitively. Doing this here keeps two clones of
-  # the same repo from drifting into separate hashes due to capitalization.
-  printf '%s' "$url" | tr '[:upper:]' '[:lower:]'
+
+  if [ "$is_network" = "1" ]; then
+    # Lowercase network URLs only. DNS hostnames are case-insensitive, and
+    # the major Git hosts (GitHub, GitLab, Gitea, Bitbucket Cloud) route
+    # repository paths case-insensitively. Lowercasing here keeps two
+    # clones of the same repo from drifting into separate hashes due to
+    # casing differences in the hostname or path.
+    printf '%s' "$url" | tr '[:upper:]' '[:lower:]'
+  else
+    # Local-path / file:// remotes: preserve original case so that
+    # case-sensitive filesystems keep distinct paths distinct.
+    printf '%s' "$url"
+  fi
 }
 
 _clv2_detect_project() {

--- a/skills/continuous-learning-v2/scripts/detect-project.sh
+++ b/skills/continuous-learning-v2/scripts/detect-project.sh
@@ -61,7 +61,13 @@ _clv2_normalize_remote_url() {
   local url="$1"
   [ -z "$url" ] && return 0
   # Strip embedded credentials: scheme://user[:pass]@host/... → scheme://host/...
-  url=$(printf '%s' "$url" | sed -E 's|://[^@/]+@|://|')
+  # Match the same pattern used by the credential-strip step in
+  # _clv2_detect_project ([^@]+, not [^@/]+) so this function is safe to call
+  # on a raw URL whose credential portion contains URL-encoded characters or
+  # any other byte that happens to not be '@'. A literal '/' in the userinfo
+  # is not allowed by RFC 3986, but being tolerant keeps the function usable
+  # in isolation without depending on the caller having pre-stripped.
+  url=$(printf '%s' "$url" | sed -E 's|://[^@]+@|://|')
   # Strip URL scheme (https://, http://, ssh://, git://, ...)
   url=$(printf '%s' "$url" | sed -E 's|^[A-Za-z][A-Za-z0-9+.-]*://||')
   # SCP-like form (after scheme strip this only matches pure SCP URLs):

--- a/skills/continuous-learning-v2/scripts/detect-project.sh
+++ b/skills/continuous-learning-v2/scripts/detect-project.sh
@@ -49,6 +49,32 @@ export CLV2_PYTHON_CMD
 CLV2_OBSERVER_PROMPT_PATTERN='Can you confirm|requires permission|Awaiting (user confirmation|confirmation|approval|permission)|confirm I should proceed|once granted access|grant.*access'
 export CLV2_OBSERVER_PROMPT_PATTERN
 
+# Normalize a git remote URL to a transport-independent canonical form.
+# Examples:
+#   git@github.com:owner/repo.git           → github.com/owner/repo
+#   https://github.com/owner/repo.git       → github.com/owner/repo
+#   https://user:token@github.com/owner/repo → github.com/owner/repo
+#   ssh://git@github.com/owner/repo.git     → github.com/owner/repo
+#   http://gitea.local:3000/u/r.git         → gitea.local:3000/u/r
+# Empty input → empty output (caller falls back to project_root).
+_clv2_normalize_remote_url() {
+  local url="$1"
+  [ -z "$url" ] && return 0
+  # Strip embedded credentials: scheme://user[:pass]@host/... → scheme://host/...
+  url=$(printf '%s' "$url" | sed -E 's|://[^@/]+@|://|')
+  # Strip URL scheme (https://, http://, ssh://, git://, ...)
+  url=$(printf '%s' "$url" | sed -E 's|^[A-Za-z][A-Za-z0-9+.-]*://||')
+  # SCP-like form (after scheme strip this only matches pure SCP URLs):
+  #   git@host:path → host/path
+  url=$(printf '%s' "$url" | sed -E 's|^[^@/:]+@([^:/]+):|\1/|')
+  # Drop trailing .git (and an optional trailing slash)
+  url=$(printf '%s' "$url" | sed -E 's|\.git/?$||; s|/+$||')
+  # Lowercase: hostnames are DNS-insensitive and the major Git hosts route
+  # repository paths case-insensitively. Doing this here keeps two clones of
+  # the same repo from drifting into separate hashes due to capitalization.
+  printf '%s' "$url" | tr '[:upper:]' '[:lower:]'
+}
+
 _clv2_detect_project() {
   local project_root=""
   local project_name=""
@@ -94,15 +120,32 @@ _clv2_detect_project() {
     fi
   fi
 
-  # Compute hash from the original remote URL (legacy, for backward compatibility)
-  local legacy_hash_input="${remote_url:-$project_root}"
+  # Track the original (untouched) remote URL — used as one of the legacy
+  # hash inputs when migrating directories from older versions of this script.
+  local raw_remote_url="$remote_url"
 
   # Strip embedded credentials from remote URL (e.g., https://ghp_xxxx@github.com/...)
   if [ -n "$remote_url" ]; then
     remote_url=$(printf '%s' "$remote_url" | sed -E 's|://[^@]+@|://|')
   fi
 
-  local hash_input="${remote_url:-$project_root}"
+  # Hash input used by the previous version of this script — pre-normalization
+  # but post-credential-stripping. Kept so existing project directories can be
+  # migrated to the normalized hash on first run after this change.
+  local legacy_hash_input="${remote_url:-$project_root}"
+
+  # Normalize the remote URL so transport variants for the same repository
+  # collapse to a single project ID. Without this, a clone over SSH and a
+  # clone over HTTPS of the same repo end up under two different hashes:
+  #   git@github.com:owner/repo.git    → github.com/owner/repo
+  #   https://github.com/owner/repo.git → github.com/owner/repo
+  #   ssh://git@github.com/owner/repo  → github.com/owner/repo
+  local normalized_remote=""
+  if [ -n "$remote_url" ]; then
+    normalized_remote=$(_clv2_normalize_remote_url "$remote_url")
+  fi
+
+  local hash_input="${normalized_remote:-${remote_url:-$project_root}}"
   # Prefer Python for consistent SHA256 behavior across shells/platforms.
   # Pass the value via env var and encode as UTF-8 inside Python so the hash
   # is locale-independent (shells vary between UTF-8 / CP932 / CP1252, which
@@ -122,19 +165,40 @@ print(hashlib.sha256(s.encode("utf-8")).hexdigest()[:12])
                  echo "fallback")
   fi
 
-  # Backward compatibility: if credentials were stripped and the hash changed,
-  # check if a project dir exists under the legacy hash and reuse it
-  if [ "$legacy_hash_input" != "$hash_input" ] && [ -n "$_CLV2_PYTHON_CMD" ]; then
-    local legacy_id=""
-    legacy_id=$(_CLV2_HASH_INPUT="$legacy_hash_input" "$_CLV2_PYTHON_CMD" -c '
+  # Backward compatibility: if a project directory exists under any legacy
+  # hash input but not under the current (normalized) hash, migrate it.
+  # The candidates are tried in order of preference:
+  #   1. credential-stripped, un-normalized URL  (post-credential-strip change)
+  #   2. raw URL                                  (pre-credential-strip)
+  # If two of these collapse to the same hash they are still both attempted —
+  # only the first one whose directory exists wins.
+  if [ -n "$_CLV2_PYTHON_CMD" ] && [ ! -d "${_CLV2_PROJECTS_DIR}/${project_id}" ]; then
+    local legacy_inputs=()
+    [ -n "$legacy_hash_input" ] && [ "$legacy_hash_input" != "$hash_input" ] \
+      && legacy_inputs+=("$legacy_hash_input")
+    [ -n "$raw_remote_url" ] && [ "$raw_remote_url" != "$hash_input" ] \
+      && [ "$raw_remote_url" != "$legacy_hash_input" ] \
+      && legacy_inputs+=("$raw_remote_url")
+
+    local legacy_input legacy_id
+    for legacy_input in "${legacy_inputs[@]}"; do
+      legacy_id=$(_CLV2_HASH_INPUT="$legacy_input" "$_CLV2_PYTHON_CMD" -c '
 import os, hashlib
 s = os.environ["_CLV2_HASH_INPUT"]
 print(hashlib.sha256(s.encode("utf-8")).hexdigest()[:12])
 ' 2>/dev/null)
-    if [ -n "$legacy_id" ] && [ -d "${_CLV2_PROJECTS_DIR}/${legacy_id}" ] && [ ! -d "${_CLV2_PROJECTS_DIR}/${project_id}" ]; then
-      # Migrate legacy directory to new hash
-      mv "${_CLV2_PROJECTS_DIR}/${legacy_id}" "${_CLV2_PROJECTS_DIR}/${project_id}" 2>/dev/null || project_id="$legacy_id"
-    fi
+      if [ -n "$legacy_id" ] && [ "$legacy_id" != "$project_id" ] \
+         && [ -d "${_CLV2_PROJECTS_DIR}/${legacy_id}" ]; then
+        if mv "${_CLV2_PROJECTS_DIR}/${legacy_id}" "${_CLV2_PROJECTS_DIR}/${project_id}" 2>/dev/null; then
+          break
+        else
+          # Migration failed (e.g. permissions) — keep using the legacy id
+          # so we don't lose access to existing data.
+          project_id="$legacy_id"
+          break
+        fi
+      fi
+    done
   fi
 
   # Export results


### PR DESCRIPTION
## Summary

`skills/continuous-learning-v2/scripts/detect-project.sh` derives a project ID by hashing the git remote URL. The hash is taken over the *raw* URL, so the **same repository** ends up under **different project IDs** depending on which transport a particular worktree happens to use:

| Worktree                              | `git remote get-url origin`              | Resulting project ID |
|---------------------------------------|------------------------------------------|----------------------|
| `~/proj/myrepo` (SSH clone)           | `git@github.com:owner/repo.git`          | `664d72…`            |
| `/mnt/work/slot4/myrepo` (HTTPS clone)| `https://github.com/owner/repo.git`      | `83e0e8…`            |

Result: observations, instincts, and evolved artifacts are split across two directories under `~/.claude/homunculus/projects/` for the same repo. `instinct-cli.py projects` lists the same `name` twice, and the `promote` / `evolve` flows operate on whichever directory the current worktree happens to map to. I hit this in the wild — same repo, two clones, two project entries with `0` shared instincts.

## Fix

Normalize the remote URL to a transport-independent canonical form before hashing, so all transports of the same repository collapse to the same project ID:

```
git@github.com:owner/repo.git           -> github.com/owner/repo
https://github.com/owner/repo.git       -> github.com/owner/repo
ssh://git@github.com/owner/repo.git     -> github.com/owner/repo
https://user:token@github.com/owner/repo -> github.com/owner/repo
http://gitea.local:3000/u/r.git         -> gitea.local:3000/u/r
git@github.com:Org/Repo.git             -> github.com/org/repo  (lowercased)
```

The normalizer:
1. Strips embedded credentials (`scheme://user[:pass]@host` → `scheme://host`)
2. Strips the URL scheme (`https://`, `http://`, `ssh://`, `git://`, …)
3. Rewrites SCP-like form (`git@host:path` → `host/path`)
4. Drops a trailing `.git` (and trailing slash)
5. Lowercases — DNS hostnames are case-insensitive, and the major Git hosts (GitHub, GitLab, Gitea, Bitbucket Cloud) route repository paths case-insensitively

## Migration

Existing installs already have project directories created under the pre-normalization hash. The existing legacy-hash recovery branch is extended to try multiple candidates in order:

1. credential-stripped, un-normalized URL (the previous hash basis)
2. raw URL (pre-credential-strip — same fallback the old code already had)

If any of these legacy directories exists and the new normalized directory does not, the legacy directory is `mv`-ed to the new ID. If `mv` fails (e.g. permissions), the script falls back to the legacy ID rather than losing access to existing data — same behavior as the old code.

This handles the **single-legacy-directory** case automatically. The **two-legacy-directories** case (same repo previously seen under both SSH and HTTPS) is left untouched intentionally — automatically merging two `observations.jsonl` files is risky and outside the scope of this fix. Users who hit that case can `cat` + sort `observations.jsonl` manually (which is what I did before submitting this PR).

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Other (skill *script* fix)

## Testing

Manual verification — added a sandboxed test harness and ran it locally:

```bash
# 1. Normalizer unit tests (9 cases, all pass)
git@github.com:error21/ag-orc-core.git           -> github.com/error21/ag-orc-core
https://github.com/error21/ag-orc-core.git       -> github.com/error21/ag-orc-core
https://github.com/error21/ag-orc-core           -> github.com/error21/ag-orc-core
ssh://git@github.com/error21/ag-orc-core.git     -> github.com/error21/ag-orc-core
https://ghp_xxx@github.com/error21/ag-orc-core.git -> github.com/error21/ag-orc-core
http://192.168.68.201:3000/sakuragi/nexus.git    -> 192.168.68.201:3000/sakuragi/nexus
git@github.com:Org/Repo.git                      -> github.com/org/repo
https://gitlab.example.com/group/sub/proj.git/   -> gitlab.example.com/group/sub/proj
(empty)                                          -> (empty)
```

```bash
# 2. End-to-end: two clones of the same repo, different transports
mkrepo "$WORK/ssh-clone"   "git@github.com:error21/demo.git"
mkrepo "$WORK/https-clone" "https://github.com/error21/demo.git"
mkrepo "$WORK/other"       "git@github.com:error21/other-project.git"

ssh_id   = 33ea70b96dd4
https_id = 33ea70b96dd4   # same repo, same ID  ✓
other_id = ac4ce2da5b09   # different repo, different ID  ✓
```

```bash
# 3. Legacy-hash migration: seed a project dir under the old (unnormalized)
#    hash, run detect, verify it gets migrated to the new normalized hash.
seeded legacy_id = 3824b05a8650
after detect:    33ea70b96dd4
PASS: legacy dir migrated to new normalized hash
```

`bash -n` passes; behavior unchanged for repos with no remote (path hash fallback) and for `CLAUDE_PROJECT_DIR`-only invocations (no git lookup at all).

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code (the bug was found via real `instinct-cli.py projects` output; the fix was verified with the harness above)
- [x] No sensitive info
- [x] Clear descriptions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize git remote URLs in `skills/continuous-learning-v2/scripts/detect-project.sh` so SSH/HTTPS/SCP clones of the same repo resolve to one project ID, while preserving case for local-path and `file://` remotes to avoid collisions. Includes safe migration from legacy hashes.

- **Bug Fixes**
  - Added a URL normalizer (strip credentials/scheme, rewrite SCP form, drop `.git`, trim slashes) and hash the canonical result; lowercasing now applies only to network URLs, not local paths or `file://` remotes.
  - Aligned the credential-strip regex in `_clv2_normalize_remote_url` with `_clv2_detect_project` for consistent handling of userinfo edge cases; path-hash fallback and `CLAUDE_PROJECT_DIR` behavior unchanged.

- **Migration**
  - On first run, migrate from legacy IDs derived from (1) credential-stripped URL and (2) raw URL; if `mv` fails, continue using the legacy ID.
  - Does not auto-merge two legacy dirs (e.g., SSH + HTTPS); users can merge artifacts manually if needed.

<sup>Written for commit 32e3c42ea921a7d0e4e443fd69053e023a334d70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced project detection to handle varied remote URL formats consistently, improving identification and tracking.
  * Automatic migration of legacy project configurations to the new normalized format with safe conflict handling and preservation of existing project data and IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->