### PR TITLE
skills: portfolio curation — dedup, slim, drift-prone markers

### DIFF
--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -398,112 +398,20 @@ Accept: application/vnd.myapp.v2+json
 
 ## Implementation Patterns
 
-### TypeScript (Next.js API Route)
-
-```typescript
-import { z } from "zod";
-import { NextRequest, NextResponse } from "next/server";
-
-const createUserSchema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1).max(100),
-});
-
-export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const parsed = createUserSchema.safeParse(body);
-
-  if (!parsed.success) {
-    return NextResponse.json({
-      error: {
-        code: "validation_error",
-        message: "Request validation failed",
-        details: parsed.error.issues.map(i => ({
-          field: i.path.join("."),
-          message: i.message,
-          code: i.code,
-        })),
-      },
-    }, { status: 422 });
-  }
-
-  const user = await createUser(parsed.data);
-
-  return NextResponse.json(
-    { data: user },
-    {
-      status: 201,
-      headers: { Location: `/api/v1/users/${user.id}` },
-    },
-  );
-}
-```
-
-### Python (Django REST Framework)
-
-```python
-from rest_framework import serializers, viewsets, status
-from rest_framework.response import Response
-
-class CreateUserSerializer(serializers.Serializer):
-    email = serializers.EmailField()
-    name = serializers.CharField(max_length=100)
-
-class UserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = ["id", "email", "name", "created_at"]
-
-class UserViewSet(viewsets.ModelViewSet):
-    serializer_class = UserSerializer
-    permission_classes = [IsAuthenticated]
-
-    def get_serializer_class(self):
-        if self.action == "create":
-            return CreateUserSerializer
-        return UserSerializer
-
-    def create(self, request):
-        serializer = CreateUserSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        user = UserService.create(**serializer.validated_data)
-        return Response(
-            {"data": UserSerializer(user).data},
-            status=status.HTTP_201_CREATED,
-            headers={"Location": f"/api/v1/users/{user.id}"},
-        )
-```
-
-### Go (net/http)
-
-```go
-func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
-    var req CreateUserRequest
-    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-        writeError(w, http.StatusBadRequest, "invalid_json", "Invalid request body")
-        return
-    }
-
-    if err := req.Validate(); err != nil {
-        writeError(w, http.StatusUnprocessableEntity, "validation_error", err.Error())
-        return
-    }
-
-    user, err := h.service.Create(r.Context(), req)
-    if err != nil {
-        switch {
-        case errors.Is(err, domain.ErrEmailTaken):
-            writeError(w, http.StatusConflict, "email_taken", "Email already registered")
-        default:
-            writeError(w, http.StatusInternalServerError, "internal_error", "Internal error")
-        }
-        return
-    }
-
-    w.Header().Set("Location", fmt.Sprintf("/api/v1/users/%s", user.ID))
-    writeJSON(w, http.StatusCreated, map[string]any{"data": user})
-}
-```
+> Per-stack handler/serializer code (Next.js routes, DRF viewsets,
+> Spring controllers, Laravel controllers, Go `net/http`, etc.) lives
+> in the per-stack skills:
+>
+> - `frontend-patterns` / `backend-patterns` (Node / Next.js)
+> - `django-patterns` / `django-security`
+> - `springboot-patterns` / `springboot-security`
+> - `laravel-patterns` / `laravel-security`
+> - `golang-patterns`
+>
+> This skill stays language-agnostic — it defines the **contract**
+> (URLs, methods, status codes, envelopes, pagination, versioning),
+> not the wiring. When implementing, read both: this skill for
+> WHAT, the per-stack skill for HOW.
 
 ## API Design Checklist
 

--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -18,22 +18,12 @@ Backend architecture patterns and best practices for scalable server-side applic
 - Structuring error handling and validation for APIs
 - Building middleware (auth, logging, rate limiting)
 
-## API Design Patterns
+## Server Architecture Patterns
 
-### RESTful API Structure
-
-```typescript
-// PASS: Resource-based URLs
-GET    /api/markets                 # List resources
-GET    /api/markets/:id             # Get single resource
-POST   /api/markets                 # Create resource
-PUT    /api/markets/:id             # Replace resource
-PATCH  /api/markets/:id             # Update resource
-DELETE /api/markets/:id             # Delete resource
-
-// PASS: Query parameters for filtering, sorting, pagination
-GET /api/markets?status=active&sort=volume&limit=20&offset=0
-```
+> HTTP contract design (URLs, status codes, response envelopes,
+> pagination, versioning) lives in **`/api-design`**. This skill
+> covers the layers behind the contract: data access, business
+> logic, and request-pipeline plumbing.
 
 ### Repository Pattern
 
@@ -345,136 +335,23 @@ const data = await fetchWithRetry(() => fetchFromAPI())
 
 ## Authentication & Authorization
 
-### JWT Token Validation
-
-```typescript
-import jwt from 'jsonwebtoken'
-
-interface JWTPayload {
-  userId: string
-  email: string
-  role: 'admin' | 'user'
-}
-
-export function verifyToken(token: string): JWTPayload {
-  try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET!) as JWTPayload
-    return payload
-  } catch (error) {
-    throw new ApiError(401, 'Invalid token')
-  }
-}
-
-export async function requireAuth(request: Request) {
-  const token = request.headers.get('authorization')?.replace('Bearer ', '')
-
-  if (!token) {
-    throw new ApiError(401, 'Missing authorization token')
-  }
-
-  return verifyToken(token)
-}
-
-// Usage in API route
-export async function GET(request: Request) {
-  const user = await requireAuth(request)
-
-  const data = await getDataForUser(user.userId)
-
-  return NextResponse.json({ success: true, data })
-}
-```
-
-### Role-Based Access Control
-
-```typescript
-type Permission = 'read' | 'write' | 'delete' | 'admin'
-
-interface User {
-  id: string
-  role: 'admin' | 'moderator' | 'user'
-}
-
-const rolePermissions: Record<User['role'], Permission[]> = {
-  admin: ['read', 'write', 'delete', 'admin'],
-  moderator: ['read', 'write', 'delete'],
-  user: ['read', 'write']
-}
-
-export function hasPermission(user: User, permission: Permission): boolean {
-  return rolePermissions[user.role].includes(permission)
-}
-
-export function requirePermission(permission: Permission) {
-  return (handler: (request: Request, user: User) => Promise<Response>) => {
-    return async (request: Request) => {
-      const user = await requireAuth(request)
-
-      if (!hasPermission(user, permission)) {
-        throw new ApiError(403, 'Insufficient permissions')
-      }
-
-      return handler(request, user)
-    }
-  }
-}
-
-// Usage - HOF wraps the handler
-export const DELETE = requirePermission('delete')(
-  async (request: Request, user: User) => {
-    // Handler receives authenticated user with verified permission
-    return new Response('Deleted', { status: 200 })
-  }
-)
-```
+> Moved out — token validation, RBAC / scope checks, session
+> management, and the security threat model live in
+> **`/security-review`** plus the per-stack security skills
+> (`django-security`, `springboot-security`, `laravel-security`,
+> `perl-security`).
 
 ## Rate Limiting
 
-### Simple In-Memory Rate Limiter
-
-```typescript
-class RateLimiter {
-  private requests = new Map<string, number[]>()
-
-  async checkLimit(
-    identifier: string,
-    maxRequests: number,
-    windowMs: number
-  ): Promise<boolean> {
-    const now = Date.now()
-    const requests = this.requests.get(identifier) || []
-
-    // Remove old requests outside window
-    const recentRequests = requests.filter(time => now - time < windowMs)
-
-    if (recentRequests.length >= maxRequests) {
-      return false  // Rate limit exceeded
-    }
-
-    // Add current request
-    recentRequests.push(now)
-    this.requests.set(identifier, recentRequests)
-
-    return true
-  }
-}
-
-const limiter = new RateLimiter()
-
-export async function GET(request: Request) {
-  const ip = request.headers.get('x-forwarded-for') || 'unknown'
-
-  const allowed = await limiter.checkLimit(ip, 100, 60000)  // 100 req/min
-
-  if (!allowed) {
-    return NextResponse.json({
-      error: 'Rate limit exceeded'
-    }, { status: 429 })
-  }
-
-  // Continue with request
-}
-```
+> Moved out — rate-limiter design (sliding window, token bucket,
+> shared store on serverless) is part of the HTTP contract and lives
+> in **`/api-design`**. The same skill covers `Retry-After` headers,
+> user-id-vs-IP keying, and `trust proxy` configuration behind a
+> load balancer.
+>
+> The naïve in-memory limiter previously shown here was unsafe in
+> any multi-instance deployment and has been removed to avoid
+> copy-paste regressions.
 
 ## Background Jobs & Queues
 

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -256,79 +256,10 @@ setCount(count + 1)  // Can be stale in async scenarios
 
 ## API Design Standards
 
-### REST API Conventions
-
-```
-GET    /api/markets              # List all markets
-GET    /api/markets/:id          # Get specific market
-POST   /api/markets              # Create new market
-PUT    /api/markets/:id          # Update market (full)
-PATCH  /api/markets/:id          # Update market (partial)
-DELETE /api/markets/:id          # Delete market
-
-# Query parameters for filtering
-GET /api/markets?status=active&limit=10&offset=0
-```
-
-### Response Format
-
-```typescript
-// PASS: GOOD: Consistent response structure
-interface ApiResponse<T> {
-  success: boolean
-  data?: T
-  error?: string
-  meta?: {
-    total: number
-    page: number
-    limit: number
-  }
-}
-
-// Success response
-return NextResponse.json({
-  success: true,
-  data: markets,
-  meta: { total: 100, page: 1, limit: 10 }
-})
-
-// Error response
-return NextResponse.json({
-  success: false,
-  error: 'Invalid request'
-}, { status: 400 })
-```
-
-### Input Validation
-
-```typescript
-import { z } from 'zod'
-
-// PASS: GOOD: Schema validation
-const CreateMarketSchema = z.object({
-  name: z.string().min(1).max(200),
-  description: z.string().min(1).max(2000),
-  endDate: z.string().datetime(),
-  categories: z.array(z.string()).min(1)
-})
-
-export async function POST(request: Request) {
-  const body = await request.json()
-
-  try {
-    const validated = CreateMarketSchema.parse(body)
-    // Proceed with validated data
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json({
-        success: false,
-        error: 'Validation failed',
-        details: error.errors
-      }, { status: 400 })
-    }
-  }
-}
-```
+> Moved out — HTTP contract concerns (REST conventions, response
+> envelopes, status codes, input validation at the boundary,
+> versioning, pagination, rate limiting) belong to **`/api-design`**.
+> Use that skill when designing or reviewing an HTTP surface.
 
 ## File Organization
 
@@ -459,34 +390,11 @@ const { data } = await supabase
 
 ## Testing Standards
 
-### Test Structure (AAA Pattern)
-
-```typescript
-test('calculates similarity correctly', () => {
-  // Arrange
-  const vector1 = [1, 0, 0]
-  const vector2 = [0, 1, 0]
-
-  // Act
-  const similarity = calculateCosineSimilarity(vector1, vector2)
-
-  // Assert
-  expect(similarity).toBe(0)
-})
-```
-
-### Test Naming
-
-```typescript
-// PASS: GOOD: Descriptive test names
-test('returns empty array when no markets match query', () => { })
-test('throws error when OpenAI API key is missing', () => { })
-test('falls back to substring search when Redis unavailable', () => { })
-
-// FAIL: BAD: Vague test names
-test('works', () => { })
-test('test search', () => { })
-```
+> Moved out — TDD discipline (RED/GREEN/REFACTOR), test structure,
+> coverage gates, and per-language test patterns belong to
+> **`/tdd-workflow`** plus the per-language testing skills
+> (`python-testing`, `golang-testing`, `kotlin-testing`,
+> `rust-testing`, `cpp-testing`, `perl-testing`).
 
 ## Code Smell Detection
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -8,6 +8,14 @@ origin: ECC
 
 Produce thorough, cited research reports from multiple web sources using firecrawl and exa MCP tools.
 
+> ⚠️ **Drift-prone skill.** Depends on TWO external MCPs (firecrawl
+> + exa) plus their evolving tool surfaces. Before invoking, verify
+> both MCPs are connected (the session's available-tools list shows
+> their entries) and the specific tool names still match. If either
+> is missing, ask the user to install it — do not silently degrade
+> to single-source research and present it as multi-source. See
+> [`~/.claude/rules/drift-proof.md`](~/.claude/rules/drift-proof.md).
+
 ## When to Activate
 
 - User asks to research any topic in depth

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -8,6 +8,15 @@ origin: ECC
 
 Neural search for web content, code, companies, and people via the Exa MCP server.
 
+> ⚠️ **Drift-prone skill.** This skill depends on the Exa MCP server
+> being installed and the specific tool names it exposes (`mcp__exa__*`).
+> Before invoking, verify the MCP is connected (the session's
+> available-tools list shows the Exa entries) and the requested tool
+> name still matches Exa's current surface. If the MCP is
+> unavailable, ask the user to install it rather than silently
+> falling through to generic web search. See
+> [`~/.claude/rules/drift-proof.md`](~/.claude/rules/drift-proof.md).
+
 ## When to Activate
 
 - User needs current web information or news

--- a/skills/fal-ai-media/SKILL.md
+++ b/skills/fal-ai-media/SKILL.md
@@ -8,6 +8,15 @@ origin: ECC
 
 Generate images, videos, and audio using fal.ai models via MCP.
 
+> ⚠️ **Drift-prone skill.** fal.ai's model catalog rotates quickly:
+> the specific model IDs cited below (Nano Banana, Seedance, Kling,
+> Veo 3, CSM-1B, ThinkSound) may have new versions, been deprecated,
+> or been replaced by newer entrants. Before quoting a model ID or
+> price, verify against fal.ai's current catalog (`mcp__fal__list_*`
+> tool, the fal.ai dashboard, or `WebFetch` of the model page).
+> Verify the fal MCP is connected before invoking. See
+> [`~/.claude/rules/drift-proof.md`](~/.claude/rules/drift-proof.md).
+
 ## When to Activate
 
 - User wants to generate images from text prompts

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -30,6 +30,11 @@ Use this skill when:
 
 ## Step 0 — Tool availability preflight
 
+> Guidance for the agent to follow inline at the top of the workflow,
+> not an executable pre-script. Skip a row if the tool is obviously
+> unneeded for the current task (e.g. don't shell out to `npm` if the
+> project is pure Python).
+
 Don't assume — check first. Each search channel has its own
 prerequisites; degrading gracefully is better than silently skipping.
 

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -1,48 +1,84 @@
 ---
 name: search-first
-description: Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.
+description: "Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Includes a tool-availability preflight so the skill degrades gracefully when expected MCPs (Context7, Exa) or CLIs (gh, package managers) aren't installed."
 origin: ECC
 ---
 
 # /search-first — Research Before You Code
 
-Systematizes the "search for existing solutions before implementing" workflow.
+Systematizes the "search for existing solutions before implementing"
+workflow. Sound default for any non-trivial new feature.
+
+> ⚠️ **Drift-prone skill.** The "Search Shortcuts by Category"
+> section names specific packages (`ruff`, `httpx`, `zod`, etc.) —
+> those are illustrative examples at write time, **not** a maintained
+> directory. Before recommending one, verify it is still published
+> and healthy (`npm view <pkg> version` / `pip show <pkg>` + a quick
+> deprecation / last-publish check). The workflow itself
+> (need analysis → parallel search → evaluate → decide) is stable;
+> the example list is not. See
+> [`~/.claude/rules/drift-proof.md`](~/.claude/rules/drift-proof.md).
 
 ## Trigger
 
 Use this skill when:
+
 - Starting a new feature that likely has existing solutions
 - Adding a dependency or integration
 - The user asks "add X functionality" and you're about to write code
 - Before creating a new utility, helper, or abstraction
 
+## Step 0 — Tool availability preflight
+
+Don't assume — check first. Each search channel has its own
+prerequisites; degrading gracefully is better than silently skipping.
+
+| Channel | Check | If missing |
+|---------|-------|------------|
+| Repo grep | `git rev-parse --is-inside-work-tree` | not in a git repo → use `find` / direct read |
+| Package registries | `npm --version` / `pip --version` / `cargo --version` for the project's stack | tell the user which manager is missing |
+| GitHub code/repo search | `gh auth status` | ask user to `gh auth login` rather than skipping silently |
+| Library docs | Look for the Context7 MCP in the session's available-tools list | fall back to `WebFetch` of the official docs site |
+| Neural web search | Look for Exa MCP entries (`mcp__exa__*`) | fall back to `WebSearch` |
+| Skills directory | `ls ~/.claude/skills/` (always available) | n/a |
+
+If an expected channel is unavailable, **say so** rather than acting
+as if you searched it. "I checked npm and the repo; Context7 isn't
+connected so I couldn't verify the latest API surface" is honest;
+silently skipping is not.
+
 ## Workflow
 
 ```
 ┌─────────────────────────────────────────────┐
-│  1. NEED ANALYSIS                           │
-│     Define what functionality is needed      │
-│     Identify language/framework constraints  │
+│  0. TOOL PREFLIGHT (above)                  │
 ├─────────────────────────────────────────────┤
-│  2. PARALLEL SEARCH (researcher agent)      │
+│  1. NEED ANALYSIS                           │
+│     Define what functionality is needed     │
+│     Identify language / framework / license │
+│     constraints                             │
+├─────────────────────────────────────────────┤
+│  2. PARALLEL SEARCH (Agent tool)            │
 │     ┌──────────┐ ┌──────────┐ ┌──────────┐  │
-│     │  npm /   │ │  MCP /   │ │  GitHub / │  │
-│     │  PyPI    │ │  Skills  │ │  Web      │  │
+│     │  npm /   │ │  MCP /   │ │  GitHub /│  │
+│     │  PyPI /  │ │  Skills  │ │  Web     │  │
+│     │  cargo   │ │          │ │          │  │
 │     └──────────┘ └──────────┘ └──────────┘  │
 ├─────────────────────────────────────────────┤
 │  3. EVALUATE                                │
-│     Score candidates (functionality, maint, │
-│     community, docs, license, deps)         │
+│     Score candidates: functionality, last   │
+│     release date, weekly downloads, open    │
+│     issues, license, transitive deps        │
 ├─────────────────────────────────────────────┤
 │  4. DECIDE                                  │
-│     ┌─────────┐  ┌──────────┐  ┌─────────┐  │
-│     │  Adopt  │  │  Extend  │  │  Build   │  │
-│     │ as-is   │  │  /Wrap   │  │  Custom  │  │
-│     └─────────┘  └──────────┘  └─────────┘  │
+│     ┌─────────┐ ┌──────────┐ ┌─────────┐    │
+│     │  Adopt  │ │  Extend  │ │  Build  │    │
+│     │  as-is  │ │  / Wrap  │ │  Custom │    │
+│     └─────────┘ └──────────┘ └─────────┘    │
 ├─────────────────────────────────────────────┤
 │  5. IMPLEMENT                               │
-│     Install package / Configure MCP /       │
-│     Write minimal custom code               │
+│     Install / configure / write minimal     │
+│     glue code                               │
 └─────────────────────────────────────────────┘
 ```
 
@@ -50,112 +86,157 @@ Use this skill when:
 
 | Signal | Action |
 |--------|--------|
-| Exact match, well-maintained, MIT/Apache | **Adopt** — install and use directly |
-| Partial match, good foundation | **Extend** — install + write thin wrapper |
-| Multiple weak matches | **Compose** — combine 2-3 small packages |
-| Nothing suitable found | **Build** — write custom, but informed by research |
+| Exact match, well-maintained, MIT/Apache, recent release | **Adopt** — install and use directly |
+| Partial match, good foundation, healthy maintainership | **Extend** — install + write thin wrapper |
+| Multiple weak matches, each covering ~30-40% | **Compose** — combine 2-3 small packages |
+| Nothing suitable, OR all candidates abandoned/insecure | **Build** — write custom, but informed by what you found and didn't find |
 
 ## How to Use
 
 ### Quick Mode (inline)
 
-Before writing a utility or adding functionality, mentally run through:
+Before writing a utility or adding functionality, walk:
 
-0. Does this already exist in the repo? → `rg` through relevant modules/tests first
-1. Is this a common problem? → Search npm/PyPI
-2. Is there an MCP for this? → Check `~/.claude/settings.json` and search
-3. Is there a skill for this? → Check `~/.claude/skills/`
-4. Is there a GitHub implementation/template? → Run GitHub code search for maintained OSS before writing net-new code
+0. **Repo first.** Does this already exist in the codebase?
+   `rg`/`grep` through relevant modules and tests before assuming
+   greenfield.
+1. **Common problem?** Search the project's package registry (npm,
+   PyPI, crates.io, Maven Central, etc., matching the stack).
+2. **MCP exists?** Check the session's available-tools list and
+   `~/.claude/settings.json` for an MCP that already provides the
+   capability.
+3. **Skill exists?** `ls ~/.claude/skills/` — there may be a
+   ready-made workflow.
+4. **OSS implementation?** GitHub code/repo search for a
+   maintained reference.
 
-### Full Mode (agent)
+### Full Mode (Agent tool)
 
-For non-trivial functionality, launch the researcher agent:
+For non-trivial functionality, delegate to a research agent so the
+side searches don't bloat the main context:
 
 ```
-Task(subagent_type="general-purpose", prompt="
-  Research existing tools for: [DESCRIPTION]
-  Language/framework: [LANG]
-  Constraints: [ANY]
+Agent({
+  subagent_type: "general-purpose",  // or "Explore" for code-only lookups
+  description: "Research existing tools for <feature>",
+  prompt: `
+    Research existing tools for: <DESCRIPTION>
+    Language / framework: <LANG>
+    Constraints: <license, runtime, footprint, etc>
 
-  Search: npm/PyPI, MCP servers, Claude Code skills, GitHub
-  Return: Structured comparison with recommendation
-")
+    Search channels (use whichever are available; report which were skipped):
+      - <project's package registry>
+      - MCP servers (Context7 for docs, Exa for neural search)
+      - ~/.claude/skills/ for matching workflows
+      - GitHub code/repo search (via gh)
+    Return: structured comparison of top 3 candidates (name, version,
+    last release, weekly downloads, license, fit), plus a one-line
+    recommendation (adopt / extend / compose / build).
+  `,
+})
 ```
+
+The agent name is `Agent`, not `Task`; `Task` was the legacy harness
+name and is no longer the canonical tool. If the harness exposes
+neither, the prompt above can be sent inline as Quick Mode.
 
 ## Search Shortcuts by Category
 
-### Development Tooling
-- Linting → `eslint`, `ruff`, `textlint`, `markdownlint`
-- Formatting → `prettier`, `black`, `gofmt`
-- Testing → `jest`, `pytest`, `go test`
-- Pre-commit → `husky`, `lint-staged`, `pre-commit`
+> Illustrative — verify currency before quoting.
 
-### AI/LLM Integration
-- Claude SDK → Context7 for latest docs
-- Prompt management → Check MCP servers
-- Document processing → `unstructured`, `pdfplumber`, `mammoth`
+### Development tooling
+
+- Linting → `eslint`, `ruff`, `golangci-lint`, `clippy`
+- Formatting → `prettier`, `black`, `gofmt`, `rustfmt`
+- Testing → `jest` / `vitest`, `pytest`, `go test`, `cargo test`
+- Pre-commit → `husky`, `lefthook`, `pre-commit`
+
+### AI / LLM integration
+
+- Anthropic SDK → see `claude-api` skill (drift-prone — verify
+  current model IDs against the session's system prompt)
+- Library docs → Context7 MCP (verify it's installed first)
+- Document parsing → `unstructured`, `pdfplumber`, `mammoth`,
+  `tika-python`
 
 ### Data & APIs
-- HTTP clients → `httpx` (Python), `ky`/`got` (Node)
-- Validation → `zod` (TS), `pydantic` (Python)
-- Database → Check for MCP servers first
 
-### Content & Publishing
-- Markdown processing → `remark`, `unified`, `markdown-it`
-- Image optimization → `sharp`, `imagemin`
+- HTTP clients → `httpx` (Python), `ky` / `undici` (Node)
+- Schema validation → `zod` / `valibot` (TS), `pydantic` (Python),
+  `validator` (Go)
+- Database access → check for an MCP first (Postgres, ClickHouse,
+  etc. all have ones)
 
-## Integration Points
+### Content & publishing
 
-### With planner agent
-The planner should invoke researcher before Phase 1 (Architecture Review):
-- Researcher identifies available tools
-- Planner incorporates them into the implementation plan
-- Avoids "reinventing the wheel" in the plan
+- Markdown → `remark` / `unified`, `markdown-it`
+- Image processing → `sharp`, `imagemin`
+- Video → see `videodb`, `remotion-video-creation`, `manim-video`
+  skills before reaching for ffmpeg directly
 
-### With architect agent
-The architect should consult researcher for:
-- Technology stack decisions
-- Integration pattern discovery
-- Existing reference architectures
+## Integration points
 
-### With iterative-retrieval skill
-Combine for progressive discovery:
-- Cycle 1: Broad search (npm, PyPI, MCP)
-- Cycle 2: Evaluate top candidates in detail
-- Cycle 3: Test compatibility with project constraints
+- **With `planner` agent**: planner runs research before Phase 1
+  architecture review; researcher's output becomes the
+  "available tools" section of the plan. Avoids reinventing the
+  wheel inside the plan itself.
+- **With `architect` agent**: architect consults research output
+  for tech-stack decisions and reference-architecture lookup.
+- **With `iterative-retrieval` skill**: cycle 1 = broad search,
+  cycle 2 = top-3 deep dive, cycle 3 = compatibility check against
+  the project's actual constraints.
 
 ## Examples
 
-### Example 1: "Add dead link checking"
+### "Add dead-link checking for markdown"
+
 ```
-Need: Check markdown files for broken links
-Search: npm "markdown dead link checker"
-Found: textlint-rule-no-dead-link (score: 9/10)
-Action: ADOPT — npm install textlint-rule-no-dead-link
-Result: Zero custom code, battle-tested solution
+Need:    Verify HTTP links inside .md files
+Stack:   Node monorepo
+Search:  npm registry "markdown link checker"
+Found:   markdown-link-check (active, MIT)
+         lychee (Rust binary, faster but adds toolchain)
+Verify:  npm view markdown-link-check version  →  recent
+Action:  ADOPT — npm install -D markdown-link-check
+Result:  Zero custom code; 1 npm script.
 ```
 
-### Example 2: "Add HTTP client wrapper"
+### "Add HTTP client with retry"
+
 ```
-Need: Resilient HTTP client with retries and timeout handling
-Search: npm "http client retry", PyPI "httpx retry"
-Found: got (Node) with retry plugin, httpx (Python) with built-in retry
-Action: ADOPT — use got/httpx directly with retry config
-Result: Zero custom code, production-proven libraries
+Need:    Resilient HTTP client (timeout, exponential backoff)
+Stack:   Python service
+Search:  PyPI "httpx retry"
+Found:   httpx (built-in transport-level retry via Transport)
+         tenacity (general-purpose retry decorator)
+Verify:  pip show httpx  →  recent; well-maintained
+Action:  ADOPT — httpx Transport + retries=3
+Result:  No wrapper layer; standard library-style usage.
 ```
 
-### Example 3: "Add config file linter"
+### "Add config-file schema validation"
+
 ```
-Need: Validate project config files against a schema
-Search: npm "config linter schema", "json schema validator cli"
-Found: ajv-cli (score: 8/10)
-Action: ADOPT + EXTEND — install ajv-cli, write project-specific schema
-Result: 1 package + 1 schema file, no custom validation logic
+Need:    Validate YAML config against a schema, in CI
+Stack:   any
+Search:  npm "json schema cli", PyPI "yaml schema cli"
+Found:   ajv-cli (Node, JSON Schema Draft-07/2019/2020)
+         check-jsonschema (Python, supports YAML/TOML/JSON)
+Verify:  both have releases in the last 6 months
+Action:  ADOPT (one) + write project schema
+Result:  1 dependency + 1 schema file; no custom validator.
 ```
 
-## Anti-Patterns
+## Anti-patterns
 
-- **Jumping to code**: Writing a utility without checking if one exists
-- **Ignoring MCP**: Not checking if an MCP server already provides the capability
-- **Over-customizing**: Wrapping a library so heavily it loses its benefits
-- **Dependency bloat**: Installing a massive package for one small feature
+- **Jumping to code.** Writing a utility without checking if one
+  already exists in registry / skills / repo.
+- **Ignoring MCPs.** Not checking whether a connected MCP server
+  already exposes the capability before reaching for an SDK.
+- **Over-wrapping.** Building so much glue around a library that you
+  inherit its bugs and lose its updates.
+- **Dependency bloat.** Pulling a 5MB package for one helper that
+  could be 10 lines.
+- **Silent skipping.** Reporting "I searched and found nothing"
+  when one of the search channels was actually unavailable.
+  Always say which channels you used and which you couldn't.

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: security-review
-description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
+description: "Universal security checklist for code review — secrets, input validation, injection prevention, auth, XSS/CSRF, rate limiting, sensitive data, and dependency hygiene. Language and framework agnostic; defers framework-specific wiring (Next.js middleware, Supabase RLS, Spring Security, Django middleware) to the dedicated per-stack security skills. Use when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment / sensitive-data features."
 origin: ECC
 ---
 
-# Security Review Skill
+# Security Review
 
-This skill ensures all code follows security best practices and identifies potential vulnerabilities.
+Universal pre-merge checklist. Per-framework specifics live in
+dedicated skills (`django-security`, `springboot-security`,
+`laravel-security`, `perl-security`, etc.) — this skill is the
+language-agnostic spine.
 
 ## When to Activate
 
@@ -18,478 +21,358 @@ This skill ensures all code follows security best practices and identifies poten
 - Storing or transmitting sensitive data
 - Integrating third-party APIs
 
+## Severity legend
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| CRITICAL | Vuln or data-loss risk | **BLOCK** merge until fixed |
+| HIGH | Bug or significant quality issue | Fix before merge |
+| MEDIUM | Maintainability / best-practice gap | Fix when reasonable |
+| LOW | Style / minor suggestion | Optional |
+
 ## Security Checklist
 
 ### 1. Secrets Management
 
-#### FAIL: NEVER Do This
-```typescript
-const apiKey = "sk-proj-xxxxx"  // Hardcoded secret
-const dbPassword = "password123" // In source code
-```
+**Principle**: secrets live in environment variables (or a secret
+manager), never in source. Validate they exist at startup; fail fast
+if missing.
 
-#### PASS: ALWAYS Do This
 ```typescript
+// ❌ never
+const apiKey = "sk-proj-xxxxx"
+
+// ✅ always
 const apiKey = process.env.OPENAI_API_KEY
-const dbUrl = process.env.DATABASE_URL
-
-// Verify secrets exist
-if (!apiKey) {
-  throw new Error('OPENAI_API_KEY not configured')
-}
+if (!apiKey) throw new Error("OPENAI_API_KEY not configured")
 ```
 
-#### Verification Steps
+```python
+import os
+api_key = os.environ["OPENAI_API_KEY"]  # KeyError at startup if missing
+```
+
+Verify:
 - [ ] No hardcoded API keys, tokens, or passwords
-- [ ] All secrets in environment variables
-- [ ] `.env.local` in .gitignore
-- [ ] No secrets in git history
-- [ ] Production secrets in hosting platform (Vercel, Railway)
+- [ ] All secrets in env vars or a secret manager
+- [ ] `.env*` files in `.gitignore`
+- [ ] No secrets in git history (`git log -p` audit if uncertain)
+- [ ] Production secrets stored in the hosting platform's vault
 
 ### 2. Input Validation
 
-#### Always Validate User Input
+**Principle**: validate at the system boundary using a declarative
+schema. Reject early; never trust shape.
+
 ```typescript
 import { z } from 'zod'
-
-// Define validation schema
-const CreateUserSchema = z.object({
+const CreateUser = z.object({
   email: z.string().email(),
   name: z.string().min(1).max(100),
-  age: z.number().int().min(0).max(150)
+  age: z.number().int().min(0).max(150),
 })
-
-// Validate before processing
-export async function createUser(input: unknown) {
-  try {
-    const validated = CreateUserSchema.parse(input)
-    return await db.users.create(validated)
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return { success: false, errors: error.errors }
-    }
-    throw error
-  }
-}
+const validated = CreateUser.parse(input)  // throws ZodError on bad shape
 ```
 
-#### File Upload Validation
-```typescript
-function validateFileUpload(file: File) {
-  // Size check (5MB max)
-  const maxSize = 5 * 1024 * 1024
-  if (file.size > maxSize) {
-    throw new Error('File too large (max 5MB)')
-  }
-
-  // Type check
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif']
-  if (!allowedTypes.includes(file.type)) {
-    throw new Error('Invalid file type')
-  }
-
-  // Extension check
-  const allowedExtensions = ['.jpg', '.jpeg', '.png', '.gif']
-  const extension = file.name.toLowerCase().match(/\.[^.]+$/)?.[0]
-  if (!extension || !allowedExtensions.includes(extension)) {
-    throw new Error('Invalid file extension')
-  }
-
-  return true
-}
+```python
+from pydantic import BaseModel, EmailStr, conint, constr
+class CreateUser(BaseModel):
+    email: EmailStr
+    name: constr(min_length=1, max_length=100)
+    age: conint(ge=0, le=150) | None = None
 ```
 
-#### Verification Steps
+**File uploads** must validate three orthogonal things:
+- Size (e.g. 5 MB cap)
+- MIME type (whitelist, not blacklist)
+- Extension (whitelist) — and never trust the client-reported type
+  alone; sniff content for sensitive flows
+
+Verify:
 - [ ] All user inputs validated with schemas
-- [ ] File uploads restricted (size, type, extension)
-- [ ] No direct use of user input in queries
-- [ ] Whitelist validation (not blacklist)
-- [ ] Error messages don't leak sensitive info
+- [ ] File uploads bounded (size, type, extension)
+- [ ] Whitelist validation, not blacklist
+- [ ] Error messages don't leak internal structure
 
-### 3. SQL Injection Prevention
+### 3. Injection Prevention (SQL / NoSQL / Command)
 
-#### FAIL: NEVER Concatenate SQL
-```typescript
-// DANGEROUS - SQL Injection vulnerability
-const query = `SELECT * FROM users WHERE email = '${userEmail}'`
-await db.query(query)
+**Principle**: parameterize. Never concatenate untrusted strings into
+queries or shell commands.
+
+```python
+# ❌ string concat
+cur.execute(f"SELECT * FROM users WHERE email = '{user_email}'")
+
+# ✅ parameterized
+cur.execute("SELECT * FROM users WHERE email = %s", (user_email,))
 ```
 
-#### PASS: ALWAYS Use Parameterized Queries
 ```typescript
-// Safe - parameterized query
-const { data } = await supabase
-  .from('users')
-  .select('*')
-  .eq('email', userEmail)
+// ❌ template string into query
+db.query(`SELECT * FROM users WHERE email = '${email}'`)
 
-// Or with raw SQL
-await db.query(
-  'SELECT * FROM users WHERE email = $1',
-  [userEmail]
-)
+// ✅ ORM / parameterized
+db.query("SELECT * FROM users WHERE email = $1", [email])
 ```
 
-#### Verification Steps
-- [ ] All database queries use parameterized queries
-- [ ] No string concatenation in SQL
-- [ ] ORM/query builder used correctly
-- [ ] Supabase queries properly sanitized
+For shell exec: prefer language-native APIs (Python `subprocess` with
+`shell=False` and a list arg, Node `execFile` not `exec`). If shell
+is unavoidable, escape via the language's shell-quote helper — never
+hand-roll quoting.
+
+Verify:
+- [ ] All DB queries parameterized
+- [ ] No string concatenation in SQL or shell exec
+- [ ] ORM / query builder used correctly (no raw escape hatches with
+      user input)
 
 ### 4. Authentication & Authorization
 
-#### JWT Token Handling
-```typescript
-// FAIL: WRONG: localStorage (vulnerable to XSS)
-localStorage.setItem('token', token)
+**Principle**: tokens in `httpOnly`, `Secure`, `SameSite=Strict` (or
+`Lax` for top-level navigations) cookies — never `localStorage`,
+which is XSS-readable. Authorize *every* sensitive operation
+server-side; never trust the client's claim.
 
-// PASS: CORRECT: httpOnly cookies
-res.setHeader('Set-Cookie',
-  `token=${token}; HttpOnly; Secure; SameSite=Strict; Max-Age=3600`)
+```python
+# ✅ verify role on the server before the action
+if requester.role != "admin":
+    return forbidden()
+db.users.delete(target_user_id)
 ```
 
-#### Authorization Checks
-```typescript
-export async function deleteUser(userId: string, requesterId: string) {
-  // ALWAYS verify authorization first
-  const requester = await db.users.findUnique({
-    where: { id: requesterId }
-  })
+For row-level access control, prefer database-enforced policies
+(Postgres RLS, Supabase RLS, FGAC) over application-layer checks.
+See per-stack security skills for the wiring.
 
-  if (requester.role !== 'admin') {
-    return NextResponse.json(
-      { error: 'Unauthorized' },
-      { status: 403 }
-    )
-  }
-
-  // Proceed with deletion
-  await db.users.delete({ where: { id: userId } })
-}
-```
-
-#### Row Level Security (Supabase)
-```sql
--- Enable RLS on all tables
-ALTER TABLE users ENABLE ROW LEVEL SECURITY;
-
--- Users can only view their own data
-CREATE POLICY "Users view own data"
-  ON users FOR SELECT
-  USING (auth.uid() = id);
-
--- Users can only update their own data
-CREATE POLICY "Users update own data"
-  ON users FOR UPDATE
-  USING (auth.uid() = id);
-```
-
-#### Verification Steps
-- [ ] Tokens stored in httpOnly cookies (not localStorage)
-- [ ] Authorization checks before sensitive operations
-- [ ] Row Level Security enabled in Supabase
-- [ ] Role-based access control implemented
-- [ ] Session management secure
+Verify:
+- [ ] Auth tokens in httpOnly cookies (not localStorage)
+- [ ] Authorization checks on every sensitive endpoint
+- [ ] Role / scope checks before destructive operations
+- [ ] Session lifetime is bounded; idle timeout configured
+- [ ] Password reset flows are rate-limited and use single-use tokens
 
 ### 5. XSS Prevention
 
-#### Sanitize HTML
+**Principle**: encode output by default; sanitize when rendering
+user-provided HTML; restrict what scripts can execute via CSP.
+
 ```typescript
 import DOMPurify from 'isomorphic-dompurify'
-
-// ALWAYS sanitize user-provided HTML
-function renderUserContent(html: string) {
-  const clean = DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'p'],
-    ALLOWED_ATTR: []
-  })
-  return <div dangerouslySetInnerHTML={{ __html: clean }} />
-}
+const safe = DOMPurify.sanitize(userHtml, {
+  ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'p'],
+  ALLOWED_ATTR: [],
+})
 ```
 
 #### Content Security Policy
-```typescript
-// next.config.js
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: `
-      default-src 'self';
-      script-src 'self' 'unsafe-eval' 'unsafe-inline';
-      style-src 'self' 'unsafe-inline';
-      img-src 'self' data: https:;
-      font-src 'self';
-      connect-src 'self' https://api.example.com;
-    `.replace(/\s{2,}/g, ' ').trim()
-  }
-]
+
+Use a per-request nonce. **Do NOT default to `'unsafe-inline'` or
+`'unsafe-eval'`** — they neutralize CSP's main purpose.
+
+```
+default-src 'self';
+script-src  'self' 'nonce-<RANDOM>' 'strict-dynamic';
+style-src   'self' 'nonce-<RANDOM>';
+img-src     'self' data: https:;
+font-src    'self';
+connect-src 'self' https://api.example.com;
+frame-ancestors 'none';
+base-uri 'self';
+form-action 'self';
 ```
 
-#### Verification Steps
+Wire the nonce in your framework's middleware/template layer:
+- **Next.js**: `middleware.ts` sets `Content-Security-Policy` and
+  exposes the nonce via `headers()` for `next/script`.
+- **Django**: `django-csp` middleware + `{% csp_nonce %}` template tag.
+- **Spring**: `WebSecurityConfigurerAdapter` + `HeaderWriter`.
+- **Laravel**: middleware that injects nonce into Blade templates.
+
+When you legitimately need `'unsafe-inline'` / `'unsafe-eval'` (legacy
+analytics, dev-only HMR), scope it as narrowly as possible and treat
+it as tech debt with a removal plan — not a default.
+
+Verify:
 - [ ] User-provided HTML sanitized
-- [ ] CSP headers configured
-- [ ] No unvalidated dynamic content rendering
-- [ ] React's built-in XSS protection used
+- [ ] CSP configured; no blanket `'unsafe-inline'` / `'unsafe-eval'`
+- [ ] Templating engine auto-escapes by default; no
+      `dangerouslySetInnerHTML` / `\| safe` without explicit review
 
 ### 6. CSRF Protection
 
-#### CSRF Tokens
-```typescript
-import { csrf } from '@/lib/csrf'
+**Principle**: state-changing requests must require either a
+synchronizer token, the double-submit cookie pattern, or
+`SameSite=Strict` cookies + same-origin checks.
 
-export async function POST(request: Request) {
-  const token = request.headers.get('X-CSRF-Token')
-
-  if (!csrf.verify(token)) {
-    return NextResponse.json(
-      { error: 'Invalid CSRF token' },
-      { status: 403 }
-    )
-  }
-
-  // Process request
-}
+```
+Cookie:        session=...; HttpOnly; Secure; SameSite=Strict
+Request header: X-CSRF-Token: <token from server-rendered form/page>
 ```
 
-#### SameSite Cookies
-```typescript
-res.setHeader('Set-Cookie',
-  `session=${sessionId}; HttpOnly; Secure; SameSite=Strict`)
-```
+Most modern frameworks have built-in CSRF middleware (Django
+`CsrfViewMiddleware`, Rails `protect_from_forgery`, Laravel's
+`VerifyCsrfToken`, Spring Security `csrf()`). Use them; don't
+reinvent.
 
-#### Verification Steps
-- [ ] CSRF tokens on state-changing operations
-- [ ] SameSite=Strict on all cookies
-- [ ] Double-submit cookie pattern implemented
+Verify:
+- [ ] CSRF protection enabled on all state-changing endpoints
+- [ ] `SameSite=Strict` (or `Lax`) on session cookies
+- [ ] Cross-site `POST`s without a token are rejected
 
 ### 7. Rate Limiting
 
-#### API Rate Limiting
-```typescript
-import rateLimit from 'express-rate-limit'
+**Principle**: bound abuse on every endpoint, especially auth
+(login / signup / password reset) and expensive operations (search,
+AI calls, file processing). In multi-instance / serverless
+deployments, **in-memory limiters do not work** — each replica has
+its own counter. Use a shared store (Redis, DynamoDB, Upstash).
 
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // 100 requests per window
-  message: 'Too many requests'
-})
-
-// Apply to routes
-app.use('/api/', limiter)
+```
+Key by authenticated user-id when available; fall back to IP.
+IP alone is bypassable behind shared NATs and trivial via IPv6 rotation.
+On rejection, return 429 with a `Retry-After` header.
 ```
 
-#### Expensive Operations
-```typescript
-// Aggressive rate limiting for searches
-const searchLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 10, // 10 requests per minute
-  message: 'Too many search requests'
-})
+Common patterns:
+- Sliding window (`@upstash/ratelimit`, `redis-rate-limit`)
+- Token bucket (Cloudflare Workers, Envoy)
+- Stack-native middleware (Django Ratelimit, Laravel `RateLimiter`,
+  Spring's `bucket4j-spring-boot-starter`)
 
-app.use('/api/search', searchLimiter)
-```
-
-#### Verification Steps
-- [ ] Rate limiting on all API endpoints
-- [ ] Stricter limits on expensive operations
-- [ ] IP-based rate limiting
-- [ ] User-based rate limiting (authenticated)
+Verify:
+- [ ] Rate limits on all public endpoints
+- [ ] Stricter limits on auth + expensive ops
+- [ ] Shared store used in serverless / multi-instance deployments
+- [ ] User-id-based key when authenticated; IP fallback otherwise
+- [ ] `Retry-After` header on 429s
+- [ ] `trust proxy` configured correctly behind a load balancer
+      (otherwise everyone shares the LB's IP)
 
 ### 8. Sensitive Data Exposure
 
-#### Logging
-```typescript
-// FAIL: WRONG: Logging sensitive data
-console.log('User login:', { email, password })
-console.log('Payment:', { cardNumber, cvv })
+**Principle**: never log secrets or PII; user-facing errors are
+generic; detailed errors only on the server side.
 
-// PASS: CORRECT: Redact sensitive data
-console.log('User login:', { email, userId })
-console.log('Payment:', { last4: card.last4, userId })
+```typescript
+// ❌ leaks credentials
+logger.info("login", { email, password })
+// ✅ identifiers only
+logger.info("login", { email, userId })
 ```
 
-#### Error Messages
-```typescript
-// FAIL: WRONG: Exposing internal details
-catch (error) {
-  return NextResponse.json(
-    { error: error.message, stack: error.stack },
-    { status: 500 }
-  )
-}
-
-// PASS: CORRECT: Generic error messages
-catch (error) {
-  console.error('Internal error:', error)
-  return NextResponse.json(
-    { error: 'An error occurred. Please try again.' },
-    { status: 500 }
-  )
-}
+```python
+# ❌ leaks card data
+logger.info("payment", extra={"card": card_number})
+# ✅ only what's safe
+logger.info("payment", extra={"last4": card.last4, "userId": user.id})
 ```
 
-#### Verification Steps
-- [ ] No passwords, tokens, or secrets in logs
-- [ ] Error messages generic for users
-- [ ] Detailed errors only in server logs
-- [ ] No stack traces exposed to users
+For errors:
 
-### 9. Blockchain Security (Solana)
-
-#### Wallet Verification
 ```typescript
-import { verify } from '@solana/web3.js'
-
-async function verifyWalletOwnership(
-  publicKey: string,
-  signature: string,
-  message: string
-) {
-  try {
-    const isValid = verify(
-      Buffer.from(message),
-      Buffer.from(signature, 'base64'),
-      Buffer.from(publicKey, 'base64')
-    )
-    return isValid
-  } catch (error) {
-    return false
-  }
-}
+// ❌ exposes internals
+return res.status(500).json({ error: err.message, stack: err.stack })
+// ✅ generic for the user, detail in server logs
+console.error("Internal", err)
+return res.status(500).json({ error: "Something went wrong" })
 ```
 
-#### Transaction Verification
-```typescript
-async function verifyTransaction(transaction: Transaction) {
-  // Verify recipient
-  if (transaction.to !== expectedRecipient) {
-    throw new Error('Invalid recipient')
-  }
+Verify:
+- [ ] No passwords, tokens, secrets, or full PII in logs
+- [ ] User-facing errors are generic
+- [ ] Stack traces only in server logs, never in API responses
+- [ ] Sensitive fields scrubbed in error reporters (Sentry, etc.)
 
-  // Verify amount
-  if (transaction.amount > maxAmount) {
-    throw new Error('Amount exceeds limit')
-  }
+### 9. Wallet / Blockchain Security (when applicable)
 
-  // Verify user has sufficient balance
-  const balance = await getBalance(transaction.from)
-  if (balance < transaction.amount) {
-    throw new Error('Insufficient balance')
-  }
+If the project uses wallet auth or on-chain operations:
 
-  return true
-}
-```
+- **Sign-In With X (Solana / Ethereum)**: verify signatures with a
+  real ed25519 / secp256k1 verifier (`tweetnacl` /
+  `@noble/curves/ed25519` for Solana; `ethers.js` / `viem` for EVM).
+  Never invent your own verify function.
+- **Server-issued single-use nonce** on every sign-in flow; store in
+  a TTL'd cache (Redis); delete on first use. Otherwise the signature
+  is replayable.
+- **Verify confirmed transactions by signature**, not signed-but-
+  unsubmitted blobs the client hands you. Decode the *specific
+  instruction* (Solana: `SystemProgram` transfer / SPL-token
+  transfer; EVM: `Transfer` event log) — top-level fields like `to`/
+  `amount` don't exist on a Solana tx.
+- **Check `tx.meta.err == null`** before treating a Solana tx as
+  successful.
+- For SPL tokens: also verify mint address and token-account ownership.
 
-#### Verification Steps
-- [ ] Wallet signatures verified
-- [ ] Transaction details validated
-- [ ] Balance checks before transactions
-- [ ] No blind transaction signing
+Beyond this checklist, escalate to a wallet-specific reviewer or
+dedicated chain-security skill — this is dense, fast-moving terrain.
 
 ### 10. Dependency Security
 
-#### Regular Updates
-```bash
-# Check for vulnerabilities
-npm audit
+**Principle**: pin lockfiles, audit on every CI run, update on a
+cadence, watch for transitive vulns.
 
-# Fix automatically fixable issues
-npm audit fix
+| Stack | Audit | Update |
+|-------|-------|--------|
+| Node | `npm audit` / `pnpm audit` | `npm update` / `pnpm update` |
+| Python | `pip-audit` / `safety check` | `pip install -U` per locked deps |
+| Go | `govulncheck ./...` | `go get -u ./...` |
+| Rust | `cargo audit` | `cargo update` |
+| Ruby | `bundler-audit` | `bundle update` |
+| Java | `mvn dependency-check:check` (OWASP plugin) | `mvn versions:use-latest-versions` |
 
-# Update dependencies
-npm update
+In CI, prefer the deterministic install (`npm ci`, `pip install
+--require-hashes`, `cargo build --locked`) over the resolver to
+guarantee the lockfile is honored.
 
-# Check for outdated packages
-npm outdated
-```
+Verify:
+- [ ] Lock file committed
+- [ ] No known critical / high vulns from the audit tool
+- [ ] Dependabot / Renovate enabled
+- [ ] CI uses the deterministic install command
 
-#### Lock Files
-```bash
-# ALWAYS commit lock files
-git add package-lock.json
+## Pre-Deployment Checklist
 
-# Use in CI/CD for reproducible builds
-npm ci  # Instead of npm install
-```
+Before any production deploy:
 
-#### Verification Steps
-- [ ] Dependencies up to date
-- [ ] No known vulnerabilities (npm audit clean)
-- [ ] Lock files committed
-- [ ] Dependabot enabled on GitHub
-- [ ] Regular security updates
+- [ ] **Secrets**: no hardcodes, all in env / vault
+- [ ] **Input validation**: schema-based at every boundary
+- [ ] **Injection**: parameterized queries; safe shell exec
+- [ ] **XSS**: HTML sanitized; CSP without blanket `'unsafe-*'`
+- [ ] **CSRF**: tokens or `SameSite=Strict` on state-changing endpoints
+- [ ] **Auth**: tokens in httpOnly cookies; authz checks server-side
+- [ ] **Rate limiting**: shared store in serverless; user-id keyed
+- [ ] **HTTPS**: enforced; HSTS configured
+- [ ] **Security headers**: CSP, X-Frame-Options, X-Content-Type-Options
+- [ ] **Errors**: generic to users; detailed in server logs
+- [ ] **Logging**: no secrets, no full PII
+- [ ] **Dependencies**: audit clean; lockfile committed
+- [ ] **CORS**: explicit allow-list; no `*` for credentialed requests
+- [ ] **File uploads**: size, type, extension validated
+- [ ] **DB-level access control**: RLS / policies enabled where the
+      data model supports it
 
-## Security Testing
+## Per-stack security skills (use these for wiring)
 
-### Automated Security Tests
-```typescript
-// Test authentication
-test('requires authentication', async () => {
-  const response = await fetch('/api/protected')
-  expect(response.status).toBe(401)
-})
+| Stack | Skill |
+|-------|-------|
+| Django | `django-security` |
+| Spring Boot | `springboot-security` |
+| Laravel | `laravel-security` |
+| Perl | `perl-security` |
 
-// Test authorization
-test('requires admin role', async () => {
-  const response = await fetch('/api/admin', {
-    headers: { Authorization: `Bearer ${userToken}` }
-  })
-  expect(response.status).toBe(403)
-})
-
-// Test input validation
-test('rejects invalid input', async () => {
-  const response = await fetch('/api/users', {
-    method: 'POST',
-    body: JSON.stringify({ email: 'not-an-email' })
-  })
-  expect(response.status).toBe(400)
-})
-
-// Test rate limiting
-test('enforces rate limits', async () => {
-  const requests = Array(101).fill(null).map(() =>
-    fetch('/api/endpoint')
-  )
-
-  const responses = await Promise.all(requests)
-  const tooManyRequests = responses.filter(r => r.status === 429)
-
-  expect(tooManyRequests.length).toBeGreaterThan(0)
-})
-```
-
-## Pre-Deployment Security Checklist
-
-Before ANY production deployment:
-
-- [ ] **Secrets**: No hardcoded secrets, all in env vars
-- [ ] **Input Validation**: All user inputs validated
-- [ ] **SQL Injection**: All queries parameterized
-- [ ] **XSS**: User content sanitized
-- [ ] **CSRF**: Protection enabled
-- [ ] **Authentication**: Proper token handling
-- [ ] **Authorization**: Role checks in place
-- [ ] **Rate Limiting**: Enabled on all endpoints
-- [ ] **HTTPS**: Enforced in production
-- [ ] **Security Headers**: CSP, X-Frame-Options configured
-- [ ] **Error Handling**: No sensitive data in errors
-- [ ] **Logging**: No sensitive data logged
-- [ ] **Dependencies**: Up to date, no vulnerabilities
-- [ ] **Row Level Security**: Enabled in Supabase
-- [ ] **CORS**: Properly configured
-- [ ] **File Uploads**: Validated (size, type)
-- [ ] **Wallet Signatures**: Verified (if blockchain)
+These cover framework middleware, ORM-specific patterns, and
+ecosystem-particular pitfalls. Use them after this checklist
+identifies the WHAT to verify HOW in your stack.
 
 ## Resources
 
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-- [Next.js Security](https://nextjs.org/docs/security)
-- [Supabase Security](https://supabase.com/docs/guides/auth)
-- [Web Security Academy](https://portswigger.net/web-security)
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)
+- [Web Security Academy (PortSwigger)](https://portswigger.net/web-security)
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 
 ---
 
-**Remember**: Security is not optional. One vulnerability can compromise the entire platform. When in doubt, err on the side of caution.
+Security is not optional. One vulnerability can compromise the
+entire system. When in doubt, err conservative — and use the
+per-stack skill for the parts this checklist abstracts away.

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -1,463 +1,174 @@
 ---
 name: tdd-workflow
-description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
+description: "Stack-agnostic TDD spine — RED / GREEN / REFACTOR discipline, git checkpoint commits, and 80%+ coverage gate. Stack-specific test syntax, mocking, fixtures, and runner commands live in dedicated per-language testing skills (python-testing, golang-testing, kotlin-testing, rust-testing, cpp-testing, perl-testing, springboot-tdd, django-tdd, laravel-tdd, e2e-testing). Use when writing new features, fixing bugs, or refactoring."
 origin: ECC
 ---
 
 # Test-Driven Development Workflow
 
-This skill ensures all code development follows TDD principles with comprehensive test coverage.
+The methodology spine. Per-language patterns (Jest, pytest, JUnit,
+GoogleTest, Pest, Playwright, etc.) live in dedicated testing skills —
+this skill defers to them for any stack-specific concern.
 
 ## When to Activate
 
-- Writing new features or functionality
-- Fixing bugs or issues
-- Refactoring existing code
-- Adding API endpoints
-- Creating new components
+- Writing new features
+- Fixing bugs (write a reproducer first)
+- Refactoring (tests as the safety net)
+- Adding API endpoints or new components
 
-## Core Principles
-
-### 1. Tests BEFORE Code
-ALWAYS write tests first, then implement code to make tests pass.
-
-### 2. Coverage Requirements
-- Minimum 80% coverage (unit + integration + E2E)
-- All edge cases covered
-- Error scenarios tested
-- Boundary conditions verified
-
-### 3. Test Types
-
-#### Unit Tests
-- Individual functions and utilities
-- Component logic
-- Pure functions
-- Helpers and utilities
-
-#### Integration Tests
-- API endpoints
-- Database operations
-- Service interactions
-- External API calls
-
-#### E2E Tests (Playwright)
-- Critical user flows
-- Complete workflows
-- Browser automation
-- UI interactions
-
-### 4. Git Checkpoints
-- If the repository is under Git, create a checkpoint commit after each TDD stage
-- Do not squash or rewrite these checkpoint commits until the workflow is complete
-- Each checkpoint commit message must describe the stage and the exact evidence captured
-- Count only commits created on the current active branch for the current task
-- Do not treat commits from other branches, earlier unrelated work, or distant branch history as valid checkpoint evidence
-- Before treating a checkpoint as satisfied, verify that the commit is reachable from the current `HEAD` on the active branch and belongs to the current task sequence
-- The preferred compact workflow is:
-  - one commit for failing test added and RED validated
-  - one commit for minimal fix applied and GREEN validated
-  - one optional commit for refactor complete
-- Separate evidence-only commits are not required if the test commit clearly corresponds to RED and the fix commit clearly corresponds to GREEN
-
-## TDD Workflow Steps
-
-### Step 1: Write User Journeys
-```
-As a [role], I want to [action], so that [benefit]
-
-Example:
-As a user, I want to search for markets semantically,
-so that I can find relevant markets even without exact keywords.
-```
-
-### Step 2: Generate Test Cases
-For each user journey, create comprehensive test cases:
-
-```typescript
-describe('Semantic Search', () => {
-  it('returns relevant markets for query', async () => {
-    // Test implementation
-  })
-
-  it('handles empty query gracefully', async () => {
-    // Test edge case
-  })
-
-  it('falls back to substring search when Redis unavailable', async () => {
-    // Test fallback behavior
-  })
-
-  it('sorts results by similarity score', async () => {
-    // Test sorting logic
-  })
-})
-```
-
-### Step 3: Run Tests (They Should Fail)
-```bash
-npm test
-# Tests should fail - we haven't implemented yet
-```
-
-This step is mandatory and is the RED gate for all production changes.
-
-Before modifying business logic or other production code, you must verify a valid RED state via one of these paths:
-- Runtime RED:
-  - The relevant test target compiles successfully
-  - The new or changed test is actually executed
-  - The result is RED
-- Compile-time RED:
-  - The new test newly instantiates, references, or exercises the buggy code path
-  - The compile failure is itself the intended RED signal
-- In either case, the failure is caused by the intended business-logic bug, undefined behavior, or missing implementation
-- The failure is not caused only by unrelated syntax errors, broken test setup, missing dependencies, or unrelated regressions
-
-A test that was only written but not compiled and executed does not count as RED.
-
-Do not edit production code until this RED state is confirmed.
-
-If the repository is under Git, create a checkpoint commit immediately after this stage is validated.
-Recommended commit message format:
-- `test: add reproducer for <feature or bug>`
-- This commit may also serve as the RED validation checkpoint if the reproducer was compiled and executed and failed for the intended reason
-- Verify that this checkpoint commit is on the current active branch before continuing
-
-### Step 4: Implement Code
-Write minimal code to make tests pass:
-
-```typescript
-// Implementation guided by tests
-export async function searchMarkets(query: string) {
-  // Implementation here
-}
-```
-
-If the repository is under Git, stage the minimal fix now but defer the checkpoint commit until GREEN is validated in Step 5.
-
-### Step 5: Run Tests Again
-```bash
-npm test
-# Tests should now pass
-```
-
-Rerun the same relevant test target after the fix and confirm the previously failing test is now GREEN.
-
-Only after a valid GREEN result may you proceed to refactor.
-
-If the repository is under Git, create a checkpoint commit immediately after GREEN is validated.
-Recommended commit message format:
-- `fix: <feature or bug>`
-- The fix commit may also serve as the GREEN validation checkpoint if the same relevant test target was rerun and passed
-- Verify that this checkpoint commit is on the current active branch before continuing
-
-### Step 6: Refactor
-Improve code quality while keeping tests green:
-- Remove duplication
-- Improve naming
-- Optimize performance
-- Enhance readability
-
-If the repository is under Git, create a checkpoint commit immediately after refactoring is complete and tests remain green.
-Recommended commit message format:
-- `refactor: clean up after <feature or bug> implementation`
-- Verify that this checkpoint commit is on the current active branch before considering the TDD cycle complete
-
-### Step 7: Verify Coverage
-```bash
-npm run test:coverage
-# Verify 80%+ coverage achieved
-```
-
-## Testing Patterns
-
-### Unit Test Pattern (Jest/Vitest)
-```typescript
-import { render, screen, fireEvent } from '@testing-library/react'
-import { Button } from './Button'
-
-describe('Button Component', () => {
-  it('renders with correct text', () => {
-    render(<Button>Click me</Button>)
-    expect(screen.getByText('Click me')).toBeInTheDocument()
-  })
-
-  it('calls onClick when clicked', () => {
-    const handleClick = jest.fn()
-    render(<Button onClick={handleClick}>Click</Button>)
-
-    fireEvent.click(screen.getByRole('button'))
-
-    expect(handleClick).toHaveBeenCalledTimes(1)
-  })
-
-  it('is disabled when disabled prop is true', () => {
-    render(<Button disabled>Click</Button>)
-    expect(screen.getByRole('button')).toBeDisabled()
-  })
-})
-```
-
-### API Integration Test Pattern
-```typescript
-import { NextRequest } from 'next/server'
-import { GET } from './route'
-
-describe('GET /api/markets', () => {
-  it('returns markets successfully', async () => {
-    const request = new NextRequest('http://localhost/api/markets')
-    const response = await GET(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(data.success).toBe(true)
-    expect(Array.isArray(data.data)).toBe(true)
-  })
-
-  it('validates query parameters', async () => {
-    const request = new NextRequest('http://localhost/api/markets?limit=invalid')
-    const response = await GET(request)
-
-    expect(response.status).toBe(400)
-  })
-
-  it('handles database errors gracefully', async () => {
-    // Mock database failure
-    const request = new NextRequest('http://localhost/api/markets')
-    // Test error handling
-  })
-})
-```
-
-### E2E Test Pattern (Playwright)
-```typescript
-import { test, expect } from '@playwright/test'
-
-test('user can search and filter markets', async ({ page }) => {
-  // Navigate to markets page
-  await page.goto('/')
-  await page.click('a[href="/markets"]')
-
-  // Verify page loaded
-  await expect(page.locator('h1')).toContainText('Markets')
-
-  // Search for markets
-  await page.fill('input[placeholder="Search markets"]', 'election')
-
-  // Wait for debounce and results
-  await page.waitForTimeout(600)
-
-  // Verify search results displayed
-  const results = page.locator('[data-testid="market-card"]')
-  await expect(results).toHaveCount(5, { timeout: 5000 })
-
-  // Verify results contain search term
-  const firstResult = results.first()
-  await expect(firstResult).toContainText('election', { ignoreCase: true })
-
-  // Filter by status
-  await page.click('button:has-text("Active")')
-
-  // Verify filtered results
-  await expect(results).toHaveCount(3)
-})
-
-test('user can create a new market', async ({ page }) => {
-  // Login first
-  await page.goto('/creator-dashboard')
-
-  // Fill market creation form
-  await page.fill('input[name="name"]', 'Test Market')
-  await page.fill('textarea[name="description"]', 'Test description')
-  await page.fill('input[name="endDate"]', '2025-12-31')
-
-  // Submit form
-  await page.click('button[type="submit"]')
-
-  // Verify success message
-  await expect(page.locator('text=Market created successfully')).toBeVisible()
-
-  // Verify redirect to market page
-  await expect(page).toHaveURL(/\/markets\/test-market/)
-})
-```
-
-## Test File Organization
+## The Discipline
 
 ```
-src/
-├── components/
-│   ├── Button/
-│   │   ├── Button.tsx
-│   │   ├── Button.test.tsx          # Unit tests
-│   │   └── Button.stories.tsx       # Storybook
-│   └── MarketCard/
-│       ├── MarketCard.tsx
-│       └── MarketCard.test.tsx
-├── app/
-│   └── api/
-│       └── markets/
-│           ├── route.ts
-│           └── route.test.ts         # Integration tests
-└── e2e/
-    ├── markets.spec.ts               # E2E tests
-    ├── trading.spec.ts
-    └── auth.spec.ts
+Write a test that fails for the right reason   → RED
+   ↓
+Write the smallest code that makes it pass     → GREEN
+   ↓
+Improve the code while keeping tests green     → REFACTOR
 ```
 
-## Mocking External Services
+Three non-negotiable rules:
 
-### Supabase Mock
-```typescript
-jest.mock('@/lib/supabase', () => ({
-  supabase: {
-    from: jest.fn(() => ({
-      select: jest.fn(() => ({
-        eq: jest.fn(() => Promise.resolve({
-          data: [{ id: 1, name: 'Test Market' }],
-          error: null
-        }))
-      }))
-    }))
-  }
-}))
+1. **Test BEFORE code.** A test written *after* the fix is regression
+   coverage, not TDD — you lose the RED signal.
+2. **RED is a gate, not a formality.** A test that compiles but was
+   never executed does not count. Confirm the test fails for the
+   *intended* reason before writing any implementation.
+3. **GREEN means the new test passes AND no other test regressed.**
+   If unrelated tests went red, fix that before refactoring.
+
+## The Cycle
+
+### Step 1 — Frame the user-visible behavior
+
+```
+As a [role], I want to [action], so that [benefit].
 ```
 
-### Redis Mock
-```typescript
-jest.mock('@/lib/redis', () => ({
-  searchMarketsByVector: jest.fn(() => Promise.resolve([
-    { slug: 'test-market', similarity_score: 0.95 }
-  ])),
-  checkRedisHealth: jest.fn(() => Promise.resolve({ connected: true }))
-}))
-```
+TDD the user-visible contract; let private helpers emerge. Don't TDD
+a private function directly.
 
-### OpenAI Mock
-```typescript
-jest.mock('@/lib/openai', () => ({
-  generateEmbedding: jest.fn(() => Promise.resolve(
-    new Array(1536).fill(0.1) // Mock 1536-dim embedding
-  ))
-}))
-```
+### Step 2 — Write the failing test
 
-## Test Coverage Verification
+Use the matching per-language testing skill for syntax / fixtures /
+mocking (table below). The test must exercise the production code
+path you're about to add or change, and have a descriptive name
+(`returns_404_when_user_missing` beats `test_get_user_2`).
 
-### Run Coverage Report
-```bash
-npm run test:coverage
-```
+### Step 3 — Confirm RED (mandatory gate)
 
-### Coverage Thresholds
-```json
-{
-  "jest": {
-    "coverageThresholds": {
-      "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
-      }
-    }
-  }
-}
-```
+Two valid RED states:
 
-## Common Testing Mistakes to Avoid
+- **Runtime RED**: test runs and fails on the assertion the missing
+  implementation produces.
+- **Compile-time RED**: the test references a function/method that
+  doesn't exist yet, and the compile error clearly points at the new
+  production code path.
 
-### FAIL: WRONG: Testing Implementation Details
-```typescript
-// Don't test internal state
+If under git, commit:
+`test: add reproducer for <bug/feature>`
+
+### Step 4 — Minimal implementation
+
+Smallest code that could make the test pass. Don't pre-implement
+features the current test doesn't cover — that's untested code with
+extra steps.
+
+### Step 5 — Confirm GREEN
+
+Rerun the same test target. Failing test now passes; no other test
+regressed. Commit:
+`fix: <bug>` or `feat: <feature>`.
+
+### Step 6 — Refactor
+
+Improve names, remove duplication, extract helpers — tests stay green
+throughout. If a refactor breaks a test, the test was probably coupled
+to implementation (see anti-patterns) or the refactor changed
+behavior.
+
+Optional commit: `refactor: clean up after <feature>`.
+
+### Step 7 — Coverage gate
+
+Defer command discovery to `verification-loop` (project entrypoint
+first) or the per-language testing skill. Threshold:
+
+- Project's own threshold if declared (`coverageThreshold` in Jest,
+  `[tool.coverage]` in pyproject, `--cov-fail-under` in pytest config).
+- Otherwise the team default of **80%** (matches `~/.claude/rules/testing.md`).
+
+If under threshold:
+
+- Add tests for uncovered branches, OR
+- Justify and exclude untestable defensive branches with the
+  language's pragma (`# pragma: no cover`, `/* istanbul ignore */`,
+  etc.).
+
+Don't silently leave the gap.
+
+## Git Checkpoint Rules
+
+The RED → GREEN → (Refactor) commit sequence is the audit trail of
+this skill. To keep it honest:
+
+- Count only commits **on the current active branch** for this task —
+  don't claim a checkpoint exists from another branch.
+- Verify each checkpoint is reachable from `HEAD`:
+  `git merge-base --is-ancestor <commit> HEAD`
+- Don't squash or rewrite checkpoint commits until the workflow
+  completes. The audit trail is the point.
+
+## Per-Language Testing Skills
+
+| Language / Framework | Skill |
+|---|---|
+| Python (pytest) | `python-testing` |
+| Go (table-driven, fuzzing) | `golang-testing` |
+| Rust (built-in, proptest) | `rust-testing` |
+| Kotlin (Kotest, MockK) | `kotlin-testing` |
+| C++ (GoogleTest, CTest) | `cpp-testing` |
+| Perl (Test2::V0) | `perl-testing` |
+| Spring Boot (JUnit 5, Mockito, Testcontainers) | `springboot-tdd` |
+| Django (pytest-django, factory_boy) | `django-tdd` |
+| Laravel (Pest, PHPUnit) | `laravel-tdd` |
+| E2E (Playwright) | `e2e-testing` |
+| TS / JS (Jest, Vitest, RTL) | per project — see `coding-standards` |
+
+These cover test syntax, fixtures, mocking, runner setup, and
+framework-specific anti-patterns. **Don't reinvent here — read there.**
+
+## Anti-Patterns
+
+### Testing implementation details
+
+```js
+// ❌ couples to internal state — breaks on refactor
 expect(component.state.count).toBe(5)
-```
-
-### PASS: CORRECT: Test User-Visible Behavior
-```typescript
-// Test what users see
+// ✅ test the user-visible result — survives refactor
 expect(screen.getByText('Count: 5')).toBeInTheDocument()
 ```
 
-### FAIL: WRONG: Brittle Selectors
-```typescript
-// Breaks easily
-await page.click('.css-class-xyz')
-```
+### Test-after-fix
 
-### PASS: CORRECT: Semantic Selectors
-```typescript
-// Resilient to changes
-await page.click('button:has-text("Submit")')
-await page.click('[data-testid="submit-button"]')
-```
+Writing the test only after the bug is fixed — RED was never observed,
+so the test no longer proves the fix works (it might pass with the
+bug still present).
 
-### FAIL: WRONG: No Test Isolation
-```typescript
-// Tests depend on each other
-test('creates user', () => { /* ... */ })
-test('updates same user', () => { /* depends on previous test */ })
-```
+### Tests that depend on each other
 
-### PASS: CORRECT: Independent Tests
-```typescript
-// Each test sets up its own data
-test('creates user', () => {
-  const user = createTestUser()
-  // Test logic
-})
+Each test sets up its own data. Shared mutable state turns one failure
+into many cascading failures and makes order-dependence a debugging
+nightmare.
 
-test('updates user', () => {
-  const user = createTestUser()
-  // Update logic
-})
-```
+### Skipped tests left on the default branch
 
-## Continuous Testing
-
-### Watch Mode During Development
-```bash
-npm test -- --watch
-# Tests run automatically on file changes
-```
-
-### Pre-Commit Hook
-```bash
-# Runs before every commit
-npm test && npm run lint
-```
-
-### CI/CD Integration
-```yaml
-# GitHub Actions
-- name: Run Tests
-  run: npm test -- --coverage
-- name: Upload Coverage
-  uses: codecov/codecov-action@v3
-```
-
-## Best Practices
-
-1. **Write Tests First** - Always TDD
-2. **One Assert Per Test** - Focus on single behavior
-3. **Descriptive Test Names** - Explain what's tested
-4. **Arrange-Act-Assert** - Clear test structure
-5. **Mock External Dependencies** - Isolate unit tests
-6. **Test Edge Cases** - Null, undefined, empty, large
-7. **Test Error Paths** - Not just happy paths
-8. **Keep Tests Fast** - Unit tests < 50ms each
-9. **Clean Up After Tests** - No side effects
-10. **Review Coverage Reports** - Identify gaps
+`test.skip(...)`, `@pytest.mark.skip`, `t.Skip()` — fix it or delete it.
+CI doesn't check what doesn't run.
 
 ## Success Metrics
 
-- 80%+ code coverage achieved
-- All tests passing (green)
-- No skipped or disabled tests
-- Fast test execution (< 30s for unit tests)
-- E2E tests cover critical user flows
-- Tests catch bugs before production
-
----
-
-**Remember**: Tests are not optional. They are the safety net that enables confident refactoring, rapid development, and production reliability.
+- ≥ 80% coverage (lines + branches), or the project's own threshold.
+- RED → GREEN → (optional) Refactor commits visible in git history.
+- No skipped tests on the default branch.
+- Unit suite < 30 s total; individual unit tests < 50 ms.

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -1,126 +1,146 @@
 ---
 name: verification-loop
-description: "A comprehensive verification system for Claude Code sessions."
+description: "Pre-PR verification orchestrator. Honors the project's declared verification entrypoint (make verify, npm run verify, justfile) when present; falls back to stack-detected commands. Defers secret scanning to /security-review and debug-statement detection to lint/hooks rather than duplicating shell pipelines inline."
 origin: ECC
 ---
 
-# Verification Loop Skill
+# Verification Loop
 
-A comprehensive verification system for Claude Code sessions.
+Walk a declarative checklist; run the project's existing verification
+tooling; report PASS / FAIL / SKIP per gate. Built around two ideas:
+
+1. **Honor the project's own verification command** when it has one.
+   `make verify` / `npm run verify` / `just verify` are authoritative —
+   don't second-guess them with a generic stack table.
+2. **Defer specialized concerns to specialized skills.** Secrets →
+   `/security-review`. Debug statements → lint config or PostToolUse
+   hook. This skill is the orchestrator, not the encyclopedia.
 
 ## When to Use
 
-Invoke this skill:
 - After completing a feature or significant code change
 - Before creating a PR
-- When you want to ensure quality gates pass
 - After refactoring
+- When the user asks for a quality gate
 
-## Verification Phases
+## Step 1 — Use the project's verification entrypoint (preferred)
 
-### Phase 1: Build Verification
+Look for a declared entrypoint, in this order:
+
+| Source | Look for |
+|--------|----------|
+| `Makefile` | targets `verify`, `ci`, `check`, `test-all` |
+| `package.json` (`scripts`) | `verify`, `ci`, `check`, `precommit` |
+| `justfile` / `Justfile` | recipes `verify` / `ci` |
+| `pyproject.toml` (`[tool.poe.tasks]` / `[tool.taskipy.tasks]`) | task `verify` / `ci` |
+| `README.md` / `CONTRIBUTING.md` | a "How to test" / "Local CI" section |
+
+If found, **run it and trust its exit code**. The project author wrote
+that command on purpose; running a different command from the table
+below contradicts their CI. Skip directly to Step 3 (the checklist) to
+review what the entrypoint actually covered and what it left for you.
+
+## Step 2 — Stack-detected fallback (only if Step 1 finds nothing)
+
+| File present | Stack | Build | Types | Lint | Test (with coverage) |
+|--------------|-------|-------|-------|------|----------------------|
+| `package.json` | Node / TS | `<pm> run build` | `npx tsc --noEmit` | `<pm> run lint` | `<pm> test -- --coverage` |
+| `pyproject.toml` / `requirements.txt` | Python | (no build) | `pyright .` or `mypy .` | `ruff check .` | `pytest --cov` |
+| `go.mod` | Go | `go build ./...` | `go vet ./...` | `golangci-lint run` | `go test -cover ./...` |
+| `Cargo.toml` | Rust | `cargo build` | `cargo check` | `cargo clippy --all-targets` | `cargo test` |
+| `pom.xml` | Java/Maven | `mvn compile` | (build covers) | `mvn checkstyle:check` | `mvn test` |
+| `build.gradle*` | Java/Kotlin/Gradle | `gradle build` | (build covers) | `gradle check` | `gradle test` |
+| `Gemfile` | Ruby | (no build) | (n/a) | `rubocop` | `bundle exec rspec` |
+
+`<pm>` = the package manager matching the lockfile (`npm` / `pnpm` /
+`yarn` / `bun`). Don't run `npm` if the project commits a `pnpm-lock.yaml`.
+
+### Skip-not-Fail rule
+
+If a phase's tool isn't configured (no `lint` script, no `pyright`
+config, no `golangci-lint.yml`), report `skipped: no <phase> tooling`
+and continue. Build and Test are exceptions — if neither is configured
+that's a real gap, not a skip.
+
+### Multi-stack repos
+
+If multiple stack files match (monorepo / polyglot), either run
+verification per surface or ask the user which surface to verify.
+Don't run all stacks blindly — slow and noisy.
+
+## Step 3 — Pre-PR checklist (declarative)
+
+Independent of which path Step 1/2 took, walk this checklist before
+flagging "ready":
+
+- [ ] **Build green** — exit 0 from build command
+- [ ] **Types clean** — 0 errors (or no type system → SKIP)
+- [ ] **Tests pass** — exit 0 from test runner
+- [ ] **Coverage meets project threshold** — read from project config
+      (`coverageThreshold` in Jest, `[tool.coverage]` in pyproject,
+      `--cov-fail-under` in pytest config). If undeclared, use the
+      team default (`~/.claude/rules/testing.md` — typically 80%).
+- [ ] **Lint clean** — 0 errors (warnings ≠ failures unless CI treats
+      them as such)
+- [ ] **Diff vs base sanity-checked** — see below
+- [ ] **No new secrets** → DEFER to `/security-review` (don't grep here)
+- [ ] **No leftover debug statements** → DEFER to lint config or
+      PostToolUse hook (don't grep here)
+
+### Diff sanity check
+
 ```bash
-# Check if project builds
-npm run build 2>&1 | tail -20
-# OR
-pnpm build 2>&1 | tail -20
+BASE="$(git merge-base HEAD origin/main 2>/dev/null \
+       || git merge-base HEAD origin/master 2>/dev/null \
+       || echo HEAD~1)"
+git diff --stat "$BASE"..HEAD
+git diff --name-only "$BASE"..HEAD
 ```
 
-If build fails, STOP and fix before continuing.
+`HEAD~1` is wrong for multi-commit branches; always merge-base against
+the default branch. Flag for each changed file:
 
-### Phase 2: Type Check
-```bash
-# TypeScript projects
-npx tsc --noEmit 2>&1 | head -30
+- Unintended changes (formatting drift, lockfile churn, accidental reverts)
+- Missing error handling at new system boundaries
+- TODOs / FIXMEs added without a follow-up issue
 
-# Python projects
-pyright . 2>&1 | head -30
-```
-
-Report all type errors. Fix critical ones before continuing.
-
-### Phase 3: Lint Check
-```bash
-# JavaScript/TypeScript
-npm run lint 2>&1 | head -30
-
-# Python
-ruff check . 2>&1 | head -30
-```
-
-### Phase 4: Test Suite
-```bash
-# Run tests with coverage
-npm run test -- --coverage 2>&1 | tail -50
-
-# Check coverage threshold
-# Target: 80% minimum
-```
-
-Report:
-- Total tests: X
-- Passed: X
-- Failed: X
-- Coverage: X%
-
-### Phase 5: Security Scan
-```bash
-# Check for secrets
-grep -rn "sk-" --include="*.ts" --include="*.js" . 2>/dev/null | head -10
-grep -rn "api_key" --include="*.ts" --include="*.js" . 2>/dev/null | head -10
-
-# Check for console.log
-grep -rn "console.log" --include="*.ts" --include="*.tsx" src/ 2>/dev/null | head -10
-```
-
-### Phase 6: Diff Review
-```bash
-# Show what changed
-git diff --stat
-git diff HEAD~1 --name-only
-```
-
-Review each changed file for:
-- Unintended changes
-- Missing error handling
-- Potential edge cases
-
-## Output Format
-
-After running all phases, produce a verification report:
+## Output format
 
 ```
 VERIFICATION REPORT
 ==================
+Entrypoint: <make verify | npm run ci | stack-fallback>
+Stack:      <detected stack>
+Base:       <merge-base SHA>
 
-Build:     [PASS/FAIL]
-Types:     [PASS/FAIL] (X errors)
-Lint:      [PASS/FAIL] (X warnings)
-Tests:     [PASS/FAIL] (X/Y passed, Z% coverage)
-Security:  [PASS/FAIL] (X issues)
-Diff:      [X files changed]
+Build:      [PASS/FAIL]
+Types:      [PASS/FAIL/SKIP] (X errors)
+Tests:      [PASS/FAIL] (X/Y passed, Z% coverage, threshold T%)
+Lint:       [PASS/FAIL/SKIP] (X warnings)
+Diff:       X files changed, Y additions, Z deletions
 
-Overall:   [READY/NOT READY] for PR
+Deferred:
+- Secrets: run /security-review
+- Debug statements: ensure lint config / hook covers your stack
 
-Issues to Fix:
+Overall:    [READY/NOT READY] for PR
+
+Skipped phases:
+- <phase>: <reason>
+
+Issues to fix:
 1. ...
-2. ...
 ```
 
-## Continuous Mode
+## Continuous mode (lightweight)
 
-For long sessions, run verification every 15 minutes or after major changes:
+For long sessions, between major changes run only the cheap gates —
+**Build + Types + Tests** — and save the full checklist (lint, diff
+review, security-review handoff) for pre-PR.
 
-```markdown
-Set a mental checkpoint:
-- After completing each function
-- After finishing a component
-- Before moving to next task
+## Integration with hooks
 
-Run: /verify
-```
-
-## Integration with Hooks
-
-This skill complements PostToolUse hooks but provides deeper verification.
-Hooks catch issues immediately; this skill provides comprehensive review.
+PostToolUse hooks (formatter, linter on save) catch issues per-edit;
+this skill provides the pre-PR sweep. They're complementary — if your
+`Edit` hook already runs `ruff` on save, Step 3's lint gate will
+likely show 0 issues, which is fine.

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -8,6 +8,16 @@ origin: ECC
 
 Programmatic interaction with X (Twitter) for posting, reading, searching, and analytics.
 
+> ⚠️ **Drift-prone skill.** The X / Twitter API has changed access
+> tier and pricing structure repeatedly since 2023; specific
+> endpoints, rate limits, and OAuth scopes cited in this skill may
+> be outdated. Before recommending an endpoint or quota, verify
+> against X's current developer docs (`developer.x.com`) and the
+> currently active access tier for the user's app. If the user
+> hasn't confirmed which tier their app is on, ask first — capacity
+> assumptions silently break paid integrations. See
+> [`~/.claude/rules/drift-proof.md`](~/.claude/rules/drift-proof.md).
+
 ## When to Activate
 
 - User wants to post tweets or threads programmatically


### PR DESCRIPTION
## Summary

Audit-driven curation pass over 11 global skills. Three concerns addressed:

1. **Lane overlap** — `coding-standards`, `backend-patterns`, and `api-design` had duplicated REST conventions, response envelope guidance, validation examples, auth, and rate-limiting. Each now has one clear lane with explicit cross-references.
2. **Embedded fragility / tool assumptions** — `verification-loop` had inline secret regex and debug-statement grep that overlapped with `/security-review` and lint hooks. `tdd-workflow` had a stack-command table that duplicated `verification-loop` and per-language testing skills. `search-first` had `Task(...)` legacy tool naming and assumed external tools were always available without checking.
3. **Drift exposure** — 4 external-tool-dependent skills (`exa-search`, `deep-research`, `fal-ai-media`, `x-api`) had no \`drift-prone\` marker. After this PR all 11 skills the audit flagged carry a verify-first banner.

The CSP guidance in \`security-review\` is also corrected: previous text included \`'unsafe-inline'\` as a defaulted fallback (with a misleading comment about \`'strict-dynamic'\` superseding it for style-src, which it doesn't). The new text explicitly forbids blanket \`'unsafe-*'\` and frames any need for them as tech debt with a removal plan.

## Stats

| Skill | Before | After | Δ | Type |
|-------|--------|-------|---|---|
| verification-loop | 174 | 146 | -16% | rewrite |
| tdd-workflow | 238 | 174 | -27% | rewrite |
| security-review | 605 | 378 | -38% | rewrite + CSP fix |
| api-design | 523 | 431 | -18% | dedup cut |
| coding-standards | 530 | 438 | -17% | dedup cut |
| backend-patterns | 598 | 475 | -21% | dedup cut + remove unsafe rate-limiter |
| **Subtotal (rewrites/cuts)** | **2668** | **2042** | **-23%** | |
| search-first | 170 | 242 | +42% | adds Step 0 preflight + tool-name fix |
| exa-search / deep-research / fal-ai-media / x-api | — | +preamble (~12 lines each) | additive | drift markers |

Total: 11 files, +758 / -1334.

## Concrete behaviour changes (not just slimming)

- **CSP default fixed** — \`security-review\` no longer documents \`'unsafe-inline'\` as a CSP fallback. New text: \`> Do NOT default to 'unsafe-inline' or 'unsafe-eval' — they neutralize CSP's main purpose.\`
- **Naïve rate-limiter removed** — \`backend-patterns\` had a 40-line in-memory \`RateLimiter\` example that silently breaks in any multi-instance / serverless deployment (each replica has its own counter). Replaced with a pointer to \`/api-design\` which has the correct shared-store guidance.
- **Project-entrypoint preferred for verification** — \`verification-loop\` now treats \`make verify\` / \`npm run verify\` / \`just verify\` / declared task-runner targets as authoritative, falling back to the stack table only when no entrypoint exists. Honours what the project author actually wrote.
- **Tool-availability preflight** — \`search-first\` adds Step 0: explicit checks for repo grep, package managers, \`gh\`, Context7 MCP, Exa MCP, skills directory. Each has a "if missing" fallback so the skill degrades gracefully rather than silently skipping search channels and reporting "found nothing".
- **Tool naming corrected** — \`search-first\` updated \`Task(...)\` → \`Agent(...)\`. The legacy \`Task\` name still appears in older Claude Code docs but is no longer the canonical tool. Inline note added so future readers don't get confused.
- **Per-stack handoffs explicit** — every cut adds a \`> see <other-skill>\` pointer at the deletion site so users land at the right doorway.

## Convergent maintainer work

The audit also flagged \`continuous-agent-loop\` as needing stronger canonical-skill marking. While I prepared this PR, the maintainer independently rewrote that skill on \`main\` to a much shorter form that already includes the canonical claim (\`"v1.8+ canonical loop skill name. It supersedes autonomous-loops"\`). My change to that file is therefore **dropped from this PR** — the maintainer's version solves the same concern more elegantly. No regression.

## Out of scope

- \`visa-doc-translate\` full rewrite. Still FROZEN per \`~/.claude/rules/skill-preferences.md\` until a visa / NAATI domain-safety review lands. Engineering-only edits would not be safe here.

## Test plan

- [ ] Skim each \`SKILL.md\` for accidental content loss vs intent
- [ ] Verify the cross-references all point at currently-existing skills (no dangling pointers)
- [ ] Confirm CSP example block has no \`'unsafe-*'\` defaults
- [ ] Verify naïve in-memory \`RateLimiter\` is gone from \`backend-patterns\`
- [ ] Verify all 11 audit-flagged skills carry a \`> ⚠️ **Drift-prone skill.**\` banner
- [ ] Verify \`search-first\` Step 0 preflight section exists and lists each search channel with a check command + missing-fallback
- [ ] If you have a \`/skill-stocktake\` or \`harness-audit\` workflow, run it against the changes

Backups of every changed file remain in the maintainer's active runtime as \`*.bak\` for quick local revert. Not committed here.

🤖 Curation done with [Claude Code](https://claude.com/claude-code).