### PR TITLE
fix: load saved LLM selector config

### DIFF
--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -51,8 +51,12 @@ def _resolve_provider_type(provider_type: ProviderType | str | None) -> Provider
     if provider_type is not None:
         return provider_type
 
+    env_provider = os.environ.get("LLM_PROVIDER")
+    if env_provider:
+        return env_provider.lower()
+
     saved_config = _read_saved_llm_config()
-    return os.environ.get("LLM_PROVIDER") or saved_config.get("LLM_PROVIDER", "claude").lower()
+    return saved_config.get("LLM_PROVIDER", "claude").lower()
 
 
 def get_provider(provider_type: ProviderType | str | None = None, **kwargs: str) -> LLMProvider:

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from llm.core.interface import LLMProvider
 from llm.core.types import ProviderType
 from llm.providers.claude import ClaudeProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
+
+LLM_ENV_FILE = ".llm.env"
 
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
@@ -18,9 +21,42 @@ _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
 }
 
 
+def _strip_env_value(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _read_saved_llm_config(env_path: str | Path = LLM_ENV_FILE) -> dict[str, str]:
+    path = Path(env_path)
+    if not path.is_file():
+        return {}
+
+    config: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        if key in {"LLM_PROVIDER", "LLM_MODEL"}:
+            config[key] = _strip_env_value(value)
+
+    return config
+
+
+def _resolve_provider_type(provider_type: ProviderType | str | None) -> ProviderType | str:
+    if provider_type is not None:
+        return provider_type
+
+    saved_config = _read_saved_llm_config()
+    return os.environ.get("LLM_PROVIDER") or saved_config.get("LLM_PROVIDER", "claude").lower()
+
+
 def get_provider(provider_type: ProviderType | str | None = None, **kwargs: str) -> LLMProvider:
-    if provider_type is None:
-        provider_type = os.environ.get("LLM_PROVIDER", "claude").lower()
+    provider_type = _resolve_provider_type(provider_type)
 
     if isinstance(provider_type, str):
         try:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -26,3 +26,27 @@ class TestGetProvider:
     def test_invalid_provider_raises(self):
         with pytest.raises(ValueError, match="Unknown provider type"):
             get_provider("invalid")
+
+    def test_saved_llm_env_selects_default_provider(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        tmp_path.joinpath(".llm.env").write_text(
+            "LLM_PROVIDER=ollama\nLLM_MODEL=mistral\n",
+            encoding="utf-8",
+        )
+
+        provider = get_provider()
+
+        assert isinstance(provider, OllamaProvider)
+
+    def test_environment_provider_overrides_saved_llm_env(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        tmp_path.joinpath(".llm.env").write_text(
+            "LLM_PROVIDER=openai\nLLM_MODEL=gpt-4o-mini\n",
+            encoding="utf-8",
+        )
+
+        provider = get_provider()
+
+        assert isinstance(provider, OllamaProvider)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -50,3 +50,23 @@ class TestGetProvider:
         provider = get_provider()
 
         assert isinstance(provider, OllamaProvider)
+
+    def test_uppercase_environment_provider_is_normalized(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LLM_PROVIDER", "OLLAMA")
+
+        provider = get_provider()
+
+        assert isinstance(provider, OllamaProvider)
+
+    def test_explicit_provider_type_overrides_saved_llm_env(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        tmp_path.joinpath(".llm.env").write_text(
+            "LLM_PROVIDER=openai\nLLM_MODEL=gpt-4o-mini\n",
+            encoding="utf-8",
+        )
+
+        provider = get_provider("ollama")
+
+        assert isinstance(provider, OllamaProvider)


### PR DESCRIPTION
## Summary
- load `.llm.env` saved by `llm-select` when no explicit provider or `LLM_PROVIDER` environment variable is set
- keep direct provider arguments and environment variables ahead of the saved config
- add resolver coverage for saved config loading and environment override precedence

## Testing
- `PYTHONPATH=src OPENAI_API_KEY=test ANTHROPIC_API_KEY=test pytest -q tests/test_resolver.py`
- `git diff --check origin/main...HEAD`
- `PYTHONPATH=src python3 -m compileall -q src/llm tests/test_resolver.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load provider from `.llm.env` when no provider is passed and `LLM_PROVIDER` is unset, fixing cases where `llm-select` config was ignored. Precedence is now: explicit arg > `LLM_PROVIDER` > saved `.llm.env` > `claude`.

- **Bug Fixes**
  - Parse `.llm.env` written by `llm-select`, read `LLM_PROVIDER`/`LLM_MODEL`, strip quotes and comments, and normalize values to lowercase.
  - Added tests for saved-config selection, environment override precedence, and case normalization (e.g., `LLM_PROVIDER=OLLAMA`).

<sup>Written for commit bb18e50a34e6136205e6ac85aa0ecc38dc3c183f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider configuration can be saved in a local .llm.env file
  * Provider selection priority: explicit argument → environment variable → config file → default provider
  * Configuration values with surrounding quotes are trimmed automatically
  * Environment values are normalized so different casing resolves correctly

* **Tests**
  * Added tests covering config-file selection, env var precedence, normalization, and explicit-argument override
<!-- end of auto-generated comment: release notes by coderabbit.ai -->