### PR TITLE
fix: harden Windows post-edit-format path guard against cmd.exe metacharacters

### DIFF
--- a/scripts/hooks/post-edit-format.js
+++ b/scripts/hooks/post-edit-format.js
@@ -21,7 +21,7 @@ const { execFileSync, spawnSync } = require('child_process');
 const path = require('path');
 
 // Shell metacharacters that cmd.exe interprets as command separators/operators
-const UNSAFE_PATH_CHARS = /[&|<>^%!]/;
+const UNSAFE_PATH_CHARS = /[&|<>^%!;`()$]/;
 
 const { findProjectRoot, detectFormatter, resolveFormatterBin } = require('../lib/resolve-formatter');
 

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2548,6 +2548,68 @@ async function runTests() {
   else failed++;
 
   if (
+    await asyncTest('blocks Windows shell metacharacters before shell:true formatter execution', async () => {
+      const hookPath = path.join(scriptsDir, 'post-edit-format.js');
+      const resolverPath = path.join(scriptsDir, '..', 'lib', 'resolve-formatter.js');
+      const childProcess = require('child_process');
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      const originalSpawnSync = childProcess.spawnSync;
+      const originalExecFileSync = childProcess.execFileSync;
+      const resolvedResolverPath = require.resolve(resolverPath);
+      const resolvedHookPath = require.resolve(hookPath);
+      const originalResolverCache = require.cache[resolvedResolverPath];
+      const originalHookCache = require.cache[resolvedHookPath];
+      const blockedPaths = ['semicolon;test.js', 'backtick`test.js', 'subshell$(test).js', 'group(test).js'];
+
+      try {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+        let spawnCalls = [];
+        childProcess.spawnSync = (...args) => {
+          spawnCalls.push(args);
+          return { status: 0, stderr: Buffer.from('') };
+        };
+        childProcess.execFileSync = () => {
+          throw new Error('execFileSync should not run for Windows .cmd formatter shims');
+        };
+
+        require.cache[resolvedResolverPath] = {
+          id: resolvedResolverPath,
+          filename: resolvedResolverPath,
+          loaded: true,
+          exports: {
+            findProjectRoot: () => process.cwd(),
+            detectFormatter: () => 'prettier',
+            resolveFormatterBin: () => ({ bin: 'formatter.cmd', prefix: [] })
+          }
+        };
+        delete require.cache[resolvedHookPath];
+
+        const { run } = require(hookPath);
+
+        for (const filePath of blockedPaths) {
+          spawnCalls = [];
+          const stdinJson = JSON.stringify({ tool_input: { file_path: filePath } });
+          assert.strictEqual(run(stdinJson), stdinJson, 'Should pass through original stdin JSON');
+          assert.strictEqual(spawnCalls.length, 0, `Should reject ${filePath} before spawnSync`);
+        }
+      } finally {
+        if (originalPlatform) {
+          Object.defineProperty(process, 'platform', originalPlatform);
+        }
+        childProcess.spawnSync = originalSpawnSync;
+        childProcess.execFileSync = originalExecFileSync;
+        if (originalResolverCache) require.cache[resolvedResolverPath] = originalResolverCache;
+        else delete require.cache[resolvedResolverPath];
+        if (originalHookCache) require.cache[resolvedHookPath] = originalHookCache;
+        else delete require.cache[resolvedHookPath];
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     await asyncTest('matches .tsx extension for formatting', async () => {
       const stdinJson = JSON.stringify({ tool_input: { file_path: '/nonexistent/component.tsx' } });
       const result = await runScript(path.join(scriptsDir, 'post-edit-format.js'), stdinJson);


### PR DESCRIPTION
## Summary

Hardens the Windows code path in `scripts/hooks/post-edit-format.js` against shell metacharacter injection via attacker-influenced file paths. The hook is invoked as a Claude Code `PostToolUse` hook and reads `tool_input.file_path` from stdin. On Windows, when the resolved formatter binary is a `.cmd` shim (the default for Biome/Prettier installs), Node's `spawnSync` runs it through `cmd.exe` with `shell: true`, which interprets shell metacharacters in arguments.

- **Class:** OS Command Injection (CWE-78)
- **File:** `scripts/hooks/post-edit-format.js`
- **Trigger:** A file path containing cmd.exe metacharacters reaches the `shell: true` branch

## Vulnerability detail

The pre-existing guard `UNSAFE_PATH_CHARS = /[&|<>^%!]/` blocked the most obvious cmd.exe operators but did not include `(` or `)`. Parentheses are command-grouping operators in cmd.exe and can, under realistic quoting conditions, terminate a quoted argument and start a new command group. A path like `C:\proj\foo(bar).js` reaching `spawnSync('formatter.cmd', [filePath], { shell: true })` is sufficient to start exploring grouping behavior; constructing a malicious filename that escapes quoting on cmd.exe is well-documented (see e.g. CVE-2024-27980 for the broader class on Node + Windows).

Data flow: stdin JSON → `JSON.parse(stdinJson).tool_input.file_path` → passed as argv to `spawnSync` with `shell: true` on Windows when `bin` ends in `.cmd`.

Preconditions:
- Windows host running the hook
- Formatter resolves to a `.cmd` shim (default for npm-installed Prettier/Biome on Windows)
- Attacker controls or influences the edited file path (e.g. a checked-in file, a generated path, or any flow where a tool-driven edit produces a crafted filename)
- File extension matches `/\.(ts|tsx|js|jsx)$/`

## Fix

Expand `UNSAFE_PATH_CHARS` to include `;`, backtick, `(`, `)`, and `$`:

```js
const UNSAFE_PATH_CHARS = /[&|<>^%!;`()$]/;
```

`(` and `)` are the meaningful additions for cmd.exe hardening. The other three (`;`, backtick, `$`) are not cmd.exe metacharacters but are POSIX/PowerShell operators; they're included defensively at zero cost since legitimate JS/TS source filenames never contain them. Paths matching the regex are skipped (the hook returns the original stdin unchanged), preserving the existing fail-open-but-safe behavior.

The change is one character class. No behavior change for any legitimate filename.

## Tests

Added a unit test in `tests/hooks/hooks.test.js` that:
- Stubs `process.platform = 'win32'` and the formatter resolver to return a `.cmd` shim
- Stubs `spawnSync` to record calls
- Feeds in file paths containing each newly blocked character: `semicolon;test.js`, `` backtick`test.js ``, `subshell$(test).js`, `group(test).js`
- Asserts `spawnSync` is never called and the hook returns the stdin unchanged

The existing test suite continues to pass.

## Adversarial review

Before submitting we tried to disprove this. The candidates for "already mitigated":

- **Could Node's argv quoting save us?** No — `child_process` on Windows with `shell: true` concatenates argv into a cmd.exe string with minimal escaping; this is exactly the surface the existing regex was already trying to guard.
- **Could the file extension filter prevent it?** No — `foo(bar).js` is a valid `.js` filename.
- **Is the path truly attacker-influenced?** Yes in realistic flows: Claude Code hooks are invoked on tool-driven edits, and `file_path` originates from `tool_input` JSON on stdin. An attacker who can cause an Edit/Write of a crafted filename (e.g. via an MCP tool, a malicious repo, or a prompt-injected agent step) reaches this sink.
- **Is this redundant with the existing guard?** No — `(` and `)` were not in the previous character class, so this closes a real gap rather than restating an existing block.

## Scope

Minimal: one regex character class extended, one focused test added. No refactor, no API change.

cc @lewiswigmore


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Windows path guard in `post-edit-format` to block cmd.exe metacharacters and prevent command injection when `.cmd` formatter shims run. This adds a stricter regex and keeps behavior unchanged for valid file names.

- **Bug Fixes**
  - Expanded `UNSAFE_PATH_CHARS` to `/[&|<>^%!;`()$]/`, including `(` and `)`.
  - Skip formatter execution and return stdin unchanged when a path matches.
  - Added a unit test that simulates win32 with a `.cmd` shim and verifies `spawnSync` is not called for `;`, backtick, `$`, `(`, `)`.

<sup>Written for commit e1cb4b9619c5e239b8048009f5a9dcc664b66629. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows shell injection protection by treating additional metacharacters as unsafe, preventing potential vulnerabilities when processing files with special characters in their names.

* **Tests**
  * Added security validation tests to verify unsafe file paths are properly blocked from execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->