### PR TITLE
fix: serialize llm tools per provider

### DIFF
--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -57,6 +57,24 @@ class ToolDefinition:
             "strict": self.strict,
         }
 
+    def to_openai_tool(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+                "strict": self.strict,
+            },
+        }
+
+    def to_anthropic_tool(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.parameters,
+        }
+
 
 @dataclass(frozen=True)
 class ToolCall:

--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -60,7 +60,7 @@ class ClaudeProvider(LLMProvider):
             else:
                 params["max_tokens"] = 8192  # required by Anthropic API
             if input.tools:
-                params["tools"] = [tool.to_dict() for tool in input.tools]
+                params["tools"] = [tool.to_anthropic_tool() for tool in input.tools]
 
             response = self.client.messages.create(**params)
 

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -67,7 +67,7 @@ class OpenAIProvider(LLMProvider):
             if input.max_tokens:
                 params["max_tokens"] = input.max_tokens
             if input.tools:
-                params["tools"] = [tool.to_dict() for tool in input.tools]
+                params["tools"] = [tool.to_openai_tool() for tool in input.tools]
 
             response = self.client.chat.completions.create(**params)
             choice = response.choices[0]

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+from llm.core.types import LLMInput, Message, Role, ToolDefinition
+from llm.providers.claude import ClaudeProvider
+from llm.providers.openai import OpenAIProvider
+
+
+class _OpenAICompletions:
+    def __init__(self):
+        self.params = None
+
+    def create(self, **params):
+        self.params = params
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="done", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            model=params["model"],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+        )
+
+
+class _AnthropicMessages:
+    def __init__(self):
+        self.params = None
+
+    def create(self, **params):
+        self.params = params
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="done")],
+            model=params["model"],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=2),
+            stop_reason="end_turn",
+        )
+
+
+def _llm_input_with_tool():
+    return LLMInput(
+        messages=[Message(role=Role.USER, content="Search for docs")],
+        tools=[
+            ToolDefinition(
+                name="search",
+                description="Search docs",
+                parameters={
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            )
+        ],
+    )
+
+
+def test_openai_provider_serializes_tools_as_functions():
+    provider = OpenAIProvider(api_key="test")
+    completions = _OpenAICompletions()
+    provider.client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+    provider.generate(_llm_input_with_tool())
+
+    assert completions.params["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search docs",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "strict": True,
+            },
+        }
+    ]
+
+
+def test_claude_provider_serializes_tools_as_input_schemas():
+    provider = ClaudeProvider(api_key="test")
+    messages = _AnthropicMessages()
+    provider.client = SimpleNamespace(messages=messages)
+
+    provider.generate(_llm_input_with_tool())
+
+    assert messages.params["tools"] == [
+        {
+            "name": "search",
+            "description": "Search docs",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        }
+    ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -63,6 +63,36 @@ class TestToolDefinition:
         assert result["name"] == "search"
         assert result["strict"] is True
 
+    def test_tool_to_openai_tool(self):
+        tool = ToolDefinition(
+            name="search",
+            description="Search",
+            parameters={"type": "object"},
+        )
+
+        assert tool.to_openai_tool() == {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search",
+                "parameters": {"type": "object"},
+                "strict": True,
+            },
+        }
+
+    def test_tool_to_anthropic_tool(self):
+        tool = ToolDefinition(
+            name="search",
+            description="Search",
+            parameters={"type": "object"},
+        )
+
+        assert tool.to_anthropic_tool() == {
+            "name": "search",
+            "description": "Search",
+            "input_schema": {"type": "object"},
+        }
+
 
 class TestToolCall:
     def test_create_tool_call(self):


### PR DESCRIPTION
## Summary
- add provider-specific serializers for Python LLM tool definitions
- send OpenAI tools as `type: function` function definitions
- send Anthropic tools with `input_schema`
- cover both provider request payloads with focused regression tests

## Tests
- `PYTHONPATH=src python3 -m pytest tests/test_types.py tests/test_provider_tools.py tests/test_executor.py tests/test_resolver.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider-specific serialization of LLM tool definitions to match OpenAI and Anthropic APIs. Prevents malformed tool payloads and adds regression tests.

- **Bug Fixes**
  - OpenAI: send tools as `type: "function"` with `function` payload.
  - Anthropic: send tools with `input_schema`.
  - Added `to_openai_tool` and `to_anthropic_tool` on `ToolDefinition`, and focused tests for both providers.

<sup>Written for commit 875835a67565b4a81d8716f8e87ab84908ad91b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented provider-specific tool serialization to ensure proper formatting when using OpenAI and Anthropic AI integrations

* **Tests**
  * Added test coverage validating tool serialization formats across OpenAI and Anthropic providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->