### PR TITLE
fix(ci): generalize personal-path validator and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,10 @@ jobs:
         run: node scripts/ci/check-unicode-safety.js
         continue-on-error: false
 
+      - name: Validate no personal paths
+        run: node scripts/ci/validate-no-personal-paths.js
+        continue-on-error: false
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Check unicode safety
         run: node scripts/ci/check-unicode-safety.js
+
+      - name: Validate no personal paths
+        run: node scripts/ci/validate-no-personal-paths.js

--- a/scripts/ci/validate-no-personal-paths.js
+++ b/scripts/ci/validate-no-personal-paths.js
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 /**
  * Prevent shipping user-specific absolute paths in public docs/skills/commands.
+ *
+ * Catches generic `/Users/<name>` (macOS) and `C:\Users\<name>` (Windows) paths,
+ * allowing a small set of obvious placeholder usernames that appear in templates
+ * and examples. Forensic incident reports under `docs/fixes/` are exempt since
+ * they intentionally document a specific reporter's machine state.
  */
 
 'use strict';
@@ -18,10 +23,45 @@ const TARGETS = [
   '.opencode/commands',
 ];
 
-const BLOCK_PATTERNS = [
-  /\/Users\/affoon\b/g,
-  /C:\\Users\\affoon\b/gi,
+// Repo-relative directory prefixes whose files legitimately reference specific
+// contributor machine paths (forensic fix reports, incident addenda, etc.).
+const EXEMPT_PREFIXES = [
+  'docs/fixes/',
 ];
+
+// Placeholder usernames in templates/examples. Matched case-insensitively.
+const PLACEHOLDER_USERNAMES = new Set([
+  'example',
+  'me',
+  'user',
+  'username',
+  'you',
+  'yourname',
+  'yourusername',
+  'your-username',
+]);
+
+const POSIX_USER_RE = /\/Users\/([a-zA-Z][a-zA-Z0-9._-]*)/g;
+const WIN_USER_RE = /C:\\Users\\([a-zA-Z][a-zA-Z0-9._-]*)/gi;
+
+function isExempt(absolutePath) {
+  const rel = path.relative(ROOT, absolutePath).split(path.sep).join('/');
+  return EXEMPT_PREFIXES.some((prefix) => rel.startsWith(prefix));
+}
+
+function findLeaks(content) {
+  const leaks = [];
+  for (const re of [POSIX_USER_RE, WIN_USER_RE]) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(content)) !== null) {
+      if (!PLACEHOLDER_USERNAMES.has(match[1].toLowerCase())) {
+        leaks.push(match[0]);
+      }
+    }
+  }
+  return leaks;
+}
 
 function collectFiles(targetPath, out) {
   if (!fs.existsSync(targetPath)) return;
@@ -45,14 +85,12 @@ for (const target of TARGETS) {
 let failures = 0;
 for (const file of files) {
   if (!/\.(md|json|js|ts|sh|toml|yml|yaml)$/i.test(file)) continue;
+  if (isExempt(file)) continue;
   const content = fs.readFileSync(file, 'utf8');
-  for (const pattern of BLOCK_PATTERNS) {
-    const match = content.match(pattern);
-    if (match) {
-      console.error(`ERROR: personal path detected in ${path.relative(ROOT, file)}`);
-      failures += match.length;
-      break;
-    }
+  const leaks = findLeaks(content);
+  for (const leak of leaks) {
+    console.error(`ERROR: personal path "${leak}" detected in ${path.relative(ROOT, file)}`);
+    failures += 1;
   }
 }
 

--- a/tests/ci/no-personal-paths.test.js
+++ b/tests/ci/no-personal-paths.test.js
@@ -1,0 +1,208 @@
+/**
+ * Tests for scripts/ci/validate-no-personal-paths.js
+ *
+ * Verifies the validator against the real repo (success path) and against
+ * temporary fixture directories (error and exemption paths) by rewriting
+ * the ROOT/TARGETS constants and running the modified source in a temp file.
+ *
+ * Run with: node tests/ci/no-personal-paths.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const validatorPath = path.join(repoRoot, 'scripts', 'ci', 'validate-no-personal-paths.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+function createTestDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'no-personal-paths-test-'));
+}
+
+function cleanupTestDir(testDir) {
+  fs.rmSync(testDir, { recursive: true, force: true });
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function stripShebang(source) {
+  let s = source;
+  if (s.charCodeAt(0) === 0xFEFF) s = s.slice(1);
+  if (s.startsWith('#!')) {
+    const nl = s.indexOf('\n');
+    s = nl === -1 ? '' : s.slice(nl + 1);
+  }
+  return s;
+}
+
+function runValidatorAgainst(testDir) {
+  let source = fs.readFileSync(validatorPath, 'utf8');
+  source = stripShebang(source);
+  source = source.replace(
+    /const ROOT = .*?;/,
+    `const ROOT = ${JSON.stringify(testDir)};`,
+  );
+  const tmpFile = path.join(repoRoot, `.tmp-no-personal-paths-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+  try {
+    fs.writeFileSync(tmpFile, source, 'utf8');
+    const stdout = execFileSync('node', [tmpFile], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+      cwd: repoRoot,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status || 1,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
+  }
+}
+
+function runValidatorAgainstRealRepo() {
+  try {
+    const stdout = execFileSync('node', [validatorPath], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status || 1,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  }
+}
+
+console.log('\n=== Testing validate-no-personal-paths.js ===\n');
+
+let passed = 0;
+let failed = 0;
+
+function record(ok) {
+  if (ok) passed += 1; else failed += 1;
+}
+
+record(test('passes against the real repository', () => {
+  const result = runValidatorAgainstRealRepo();
+  assert.strictEqual(result.code, 0, `expected exit 0; stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('Validated:'), 'expected success line in stdout');
+}));
+
+record(test('flags a leaked /Users/<name> path', () => {
+  const testDir = createTestDir();
+  try {
+    writeFile(path.join(testDir, 'skills', 'leaky', 'SKILL.md'), 'See /Users/sugig/.claude/settings.json\n');
+    const result = runValidatorAgainst(testDir);
+    assert.strictEqual(result.code, 1, 'expected non-zero exit on leak');
+    assert.ok(result.stderr.includes('/Users/sugig'), `expected stderr to mention leaked path; got: ${result.stderr}`);
+    assert.ok(result.stderr.includes('skills/leaky/SKILL.md'), 'expected stderr to mention offending file');
+  } finally {
+    cleanupTestDir(testDir);
+  }
+}));
+
+record(test('flags a leaked C:\\Users\\<name> path (case-insensitive)', () => {
+  const testDir = createTestDir();
+  try {
+    writeFile(path.join(testDir, 'docs', 'guide.md'), 'See C:\\Users\\Affaan\\projects\\thing\n');
+    const result = runValidatorAgainst(testDir);
+    assert.strictEqual(result.code, 1, 'expected non-zero exit on leak');
+    assert.ok(result.stderr.includes('C:\\Users\\Affaan'), `expected stderr to mention leaked path; got: ${result.stderr}`);
+  } finally {
+    cleanupTestDir(testDir);
+  }
+}));
+
+record(test('allows /Users/<placeholder> templates', () => {
+  const testDir = createTestDir();
+  try {
+    writeFile(path.join(testDir, 'commands', 'demo.md'), [
+      '/Users/you/.claude/session.json',
+      '/Users/example/.claude/rules/foo.md',
+      '/Users/yourname/projects/app',
+      '/Users/your-username/.claude/settings.json',
+      'C:\\Users\\USER\\.claude\\settings.json',
+    ].join('\n'));
+    const result = runValidatorAgainst(testDir);
+    assert.strictEqual(result.code, 0, `expected exit 0 for placeholders; stderr: ${result.stderr}`);
+  } finally {
+    cleanupTestDir(testDir);
+  }
+}));
+
+record(test('exempts docs/fixes/ forensic reports', () => {
+  const testDir = createTestDir();
+  try {
+    writeFile(
+      path.join(testDir, 'docs', 'fixes', 'HOOK-FIX-EXAMPLE.md'),
+      'Reporter ran: C:\\Users\\sugig\\.claude\\settings.local.json\n',
+    );
+    const result = runValidatorAgainst(testDir);
+    assert.strictEqual(result.code, 0, `expected exit 0 for docs/fixes/; stderr: ${result.stderr}`);
+  } finally {
+    cleanupTestDir(testDir);
+  }
+}));
+
+record(test('only scans configured file extensions', () => {
+  const testDir = createTestDir();
+  try {
+    writeFile(path.join(testDir, 'skills', 'demo', 'image.png'), 'binary /Users/sugig/secret');
+    const result = runValidatorAgainst(testDir);
+    assert.strictEqual(result.code, 0, `expected non-text extensions to be skipped; stderr: ${result.stderr}`);
+  } finally {
+    cleanupTestDir(testDir);
+  }
+}));
+
+record(test('reports every leak on a single offending file', () => {
+  const testDir = createTestDir();
+  try {
+    writeFile(path.join(testDir, 'skills', 'multi', 'SKILL.md'), [
+      '/Users/sugig/.claude/a.json',
+      '/Users/sugig/.claude/b.json',
+      'C:\\Users\\foo\\bar',
+    ].join('\n'));
+    const result = runValidatorAgainst(testDir);
+    assert.strictEqual(result.code, 1, 'expected non-zero exit on leak');
+    const sugigCount = (result.stderr.match(/\/Users\/sugig/g) || []).length;
+    const fooCount = (result.stderr.match(/C:\\Users\\foo/g) || []).length;
+    assert.strictEqual(sugigCount, 2, `expected both /Users/sugig occurrences reported; got: ${result.stderr}`);
+    assert.strictEqual(fooCount, 1, `expected C:\\Users\\foo reported once; got: ${result.stderr}`);
+  } finally {
+    cleanupTestDir(testDir);
+  }
+}));
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}\n`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

\`scripts/ci/validate-no-personal-paths.js\` was meant to block user-specific absolute paths from leaking into shipped docs/skills/commands, but its hardcoded \`/Users/affoon\` and \`C:\\Users\\affoon\` regexes only ever matched one literal name — so the real \`C:\\Users\\sugig\\.claude\\…\` paths currently published in \`docs/fixes/HOOK-FIX-20260421*.md\` slipped past. The validator was also only wired into \`npm test\`, which the CI workflow doesn't run, so it never fires in CI.

## Changes

| File | What |
|------|------|
| \`scripts/ci/validate-no-personal-paths.js\` | Generalize patterns to \`/Users/<name>\` and \`C:\\Users\\<name>\` (case-insensitive Windows); allow placeholder usernames (\`you\`, \`example\`, \`user\`, \`username\`, \`me\`, \`yourname\`, \`your-username\`, \`yourusername\`); exempt \`docs/fixes/\` forensic incident reports |
| \`.github/workflows/ci.yml\` | +4 lines — add \"Validate no personal paths\" step alongside other \`validate-*\` jobs |
| \`.github/workflows/reusable-validate.yml\` | +3 lines — same in the reusable workflow |
| \`tests/ci/no-personal-paths.test.js\` | new: 7 tests covering real-repo pass, leak detection on both platforms, placeholder allowlist, \`docs/fixes/\` exemption, extension filter, multi-leak reporting |

## Tests

7 new + 2218 existing = 2225 passed, 0 failed (\`node tests/run-all.js\`)

Other local checks all green:

- \`node scripts/ci/validate-no-personal-paths.js\` — exit 0 against current main
- \`npx eslint scripts/**/*.js tests/**/*.js\` — exit 0
- \`npx markdownlint \"agents/**/*.md\" \"skills/**/*.md\" \"commands/**/*.md\" \"rules/**/*.md\"\` — exit 0
- All other \`scripts/ci/validate-*\`, \`check-unicode-safety\`, and \`catalog\` scripts — exit 0 (the two pre-existing \`validate-skills\` warnings for \`openclaw-persona-forge\` and \`skill-stocktake\` are unrelated and are being addressed in #1714)

## Why exempt \`docs/fixes/\`

\`docs/fixes/HOOK-FIX-20260421.md\` and its addendum legitimately document a specific contributor's Windows machine state from a real hook incident. Treating those as leaks would force redacting authored historical content. The exempt prefix keeps the validator honest about its actual scope — public-facing docs/skills/commands — without rewriting incident reports.

## Out of scope

This PR does not touch the existing \`C:\\Users\\sugig\\…\` paths in \`docs/fixes/\`; those are intentional historical content. If you want a follow-up that redacts them anyway, happy to open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalized `scripts/ci/validate-no-personal-paths.js` to catch generic macOS/Windows user paths and integrated it into CI so personal absolute paths can't ship in docs, skills, or commands.

- **Bug Fixes**
  - Match `/Users/<name>` and `C:\Users\<name>` (case-insensitive); allow common placeholders (`you`, `example`, `user`, `username`, `me`, `yourname`, `your-username`, `yourusername`).
  - Exempt `docs/fixes/` forensic reports from checks.
  - Added targeted tests for leaks, placeholders, exemptions, extension filtering, and multi-leak reporting.

<sup>Written for commit 20a19da8fb3c2d7365dbd998f5555f35a1f61010. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI validation pipeline with new checks to detect and prevent personal file paths from being committed to the repository.
  * Added automated tests for the new validation checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1715)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->