### PR TITLE
docs: salvage focused skill curation updates

### DIFF
--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -430,51 +430,14 @@ export const DELETE = requirePermission('delete')(
 
 ## Rate Limiting
 
-### Simple In-Memory Rate Limiter
+Rate limiting must use a shared store such as Redis, a gateway, or the
+platform's native limiter. Do not use per-process in-memory counters for
+production APIs: they reset on deploy, split across replicas, and fail open in
+serverless or multi-instance environments.
 
-```typescript
-class RateLimiter {
-  private requests = new Map<string, number[]>()
-
-  async checkLimit(
-    identifier: string,
-    maxRequests: number,
-    windowMs: number
-  ): Promise<boolean> {
-    const now = Date.now()
-    const requests = this.requests.get(identifier) || []
-
-    // Remove old requests outside window
-    const recentRequests = requests.filter(time => now - time < windowMs)
-
-    if (recentRequests.length >= maxRequests) {
-      return false  // Rate limit exceeded
-    }
-
-    // Add current request
-    recentRequests.push(now)
-    this.requests.set(identifier, recentRequests)
-
-    return true
-  }
-}
-
-const limiter = new RateLimiter()
-
-export async function GET(request: Request) {
-  const ip = request.headers.get('x-forwarded-for') || 'unknown'
-
-  const allowed = await limiter.checkLimit(ip, 100, 60000)  // 100 req/min
-
-  if (!allowed) {
-    return NextResponse.json({
-      error: 'Rate limit exceeded'
-    }, { status: 429 })
-  }
-
-  // Continue with request
-}
-```
+Keep the backend layer responsible for choosing the integration point and error
+shape; use `api-design` for the HTTP contract and `security-review` for abuse
+case review.
 
 ## Background Jobs & Queues
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # Deep Research
 
+> **Drift-prone skill.** Firecrawl/Exa MCP tool names, quotas, and result
+> shapes change. Verify the configured MCP tools and current API docs before
+> promising coverage or quoting live source counts.
+
 Produce thorough, cited research reports from multiple web sources using firecrawl and exa MCP tools.
 
 ## When to Activate

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # Exa Search
 
+> **Drift-prone skill.** Exa MCP tool names, parameters, and account limits can
+> change. Confirm the exposed tool surface and current Exa docs before relying
+> on a specific search mode, category, or livecrawl behavior.
+
 Neural search for web content, code, companies, and people via the Exa MCP server.
 
 ## When to Activate

--- a/skills/fal-ai-media/SKILL.md
+++ b/skills/fal-ai-media/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # fal.ai Media Generation
 
+> **Drift-prone skill.** fal.ai model IDs, pricing, inputs, and MCP tool names
+> change quickly. Search or fetch the current model metadata before promising a
+> specific model, parameter, output format, or cost.
+
 Generate images, videos, and audio using fal.ai models via MCP.
 
 ## When to Activate

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -20,6 +20,10 @@ Use this skill when:
 
 ```
 ┌─────────────────────────────────────────────┐
+│  0. TOOL AVAILABILITY PREFLIGHT             │
+│     Check search channels before relying on │
+│     them; report skipped channels honestly   │
+├─────────────────────────────────────────────┤
 │  1. NEED ANALYSIS                           │
 │     Define what functionality is needed      │
 │     Identify language/framework constraints  │
@@ -57,6 +61,19 @@ Use this skill when:
 
 ## How to Use
 
+### Step 0: Tool Availability Preflight
+
+This is agent guidance, not an executable setup script. Check only the channels
+that are relevant to the task and project in front of you.
+
+| Channel | Check | If missing |
+|---------|-------|------------|
+| Repository search | `rg --files` and targeted `rg` queries | State that only visible files were inspected |
+| Package registry | `npm --version`, `python -m pip --version`, or project package manager | Use web/docs search and avoid claiming registry coverage |
+| GitHub CLI | `gh auth status` | Use public web or local git history only |
+| MCP/docs tools | Available tool list or local MCP config | Fall back to official docs/web search |
+| Skills directory | `ls ~/.claude/skills ~/.codex/skills` where applicable | Say no local skill catalog was available |
+
 ### Quick Mode (inline)
 
 Before writing a utility or adding functionality, mentally run through:
@@ -72,7 +89,7 @@ Before writing a utility or adding functionality, mentally run through:
 For non-trivial functionality, launch the researcher agent:
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Agent(subagent_type="general-purpose", prompt="
   Research existing tools for: [DESCRIPTION]
   Language/framework: [LANG]
   Constraints: [ANY]
@@ -81,6 +98,9 @@ Task(subagent_type="general-purpose", prompt="
   Return: Structured comparison with recommendation
 ")
 ```
+
+Older Claude Code docs may call this `Task(...)`; use the current agent/subagent
+tool name exposed by the active harness.
 
 ## Search Shortcuts by Category
 
@@ -96,7 +116,7 @@ Task(subagent_type="general-purpose", prompt="
 - Document processing → `unstructured`, `pdfplumber`, `mammoth`
 
 ### Data & APIs
-- HTTP clients → `httpx` (Python), `ky`/`got` (Node)
+- HTTP clients → `httpx` (Python), `ky`/`undici` (Node)
 - Validation → `zod` (TS), `pydantic` (Python)
 - Database → Check for MCP servers first
 
@@ -157,5 +177,6 @@ Result: 1 package + 1 schema file, no custom validation logic
 
 - **Jumping to code**: Writing a utility without checking if one exists
 - **Ignoring MCP**: Not checking if an MCP server already provides the capability
+- **Silent skipping**: Reporting "nothing found" when a search channel was unavailable
 - **Over-customizing**: Wrapping a library so heavily it loses its benefits
 - **Dependency bloat**: Installing a massive package for one small feature

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -208,6 +208,11 @@ function renderUserContent(html: string) {
 ```
 
 #### Content Security Policy
+
+Start strict and loosen only with a documented removal plan. Do not default to
+`'unsafe-inline'` or `'unsafe-eval'`; they neutralize much of CSP's protection
+and should be treated as temporary compatibility debt.
+
 ```typescript
 // next.config.js
 const securityHeaders = [
@@ -215,8 +220,11 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: `
       default-src 'self';
-      script-src 'self' 'unsafe-eval' 'unsafe-inline';
-      style-src 'self' 'unsafe-inline';
+      base-uri 'self';
+      object-src 'none';
+      frame-ancestors 'none';
+      script-src 'self';
+      style-src 'self';
       img-src 'self' data: https:;
       font-src 'self';
       connect-src 'self' https://api.example.com;

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # X API
 
+> **Drift-prone skill.** X API endpoints, access tiers, quotas, and write
+> permissions change frequently. Verify current developer docs and account
+> access before quoting rate limits or implementing a posting/search flow.
+
 Programmatic interaction with X (Twitter) for posting, reading, searching, and analytics.
 
 ## When to Activate


### PR DESCRIPTION
## Summary

Maintainer-port of the safe, focused pieces from contributor PR #1694 without taking the broad 11-skill rewrite.

## What changed

- Add drift-prone warnings to `deep-research`, `exa-search`, `fal-ai-media`, and `x-api`
- Add a Step 0 tool availability preflight to `search-first`
- Update `search-first` from the legacy `Task(...)` example to current agent/subagent naming, with a compatibility note
- Replace the production-unsafe in-memory rate limiter example in `backend-patterns` with shared-store guidance
- Tighten the `security-review` CSP example: no default `unsafe-inline`/`unsafe-eval`, plus `base-uri`, `object-src`, and `frame-ancestors`

## Why this shape

PR #1694 contains useful audit work, but the full diff rewrites 11 core skills and Greptile flagged unresolved cross-reference issues. This PR extracts the low-risk, high-confidence improvements and leaves the broad skill-lane rewrite for a dedicated review.

Supersedes the useful focused portions of #1694.

## Validation

- `node scripts/ci/validate-skills.js --strict`
- `npx markdownlint skills/search-first/SKILL.md skills/deep-research/SKILL.md skills/exa-search/SKILL.md skills/fal-ai-media/SKILL.md skills/x-api/SKILL.md skills/security-review/SKILL.md skills/backend-patterns/SKILL.md`
- `node tests/ci/validators.test.js && node tests/ci/catalog.test.js`
- `npm run lint`
- `node tests/run-all.js` -> 2237 passed, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the safe, focused parts of #1694 to improve skill docs: adds tool-availability checks, flags external API drift, and tightens security guidance. Keeps scope small with no broad skill rewrites.

- **Refactors**
  - Add drift-prone warnings to `deep-research`, `exa-search`, `fal-ai-media`, and `x-api`.
  - Add Step 0 tool-availability preflight and update to current agent/subagent naming in `search-first` (with a compatibility note).
  - Replace production-unsafe in-memory rate limiter example in `backend-patterns` with shared-store guidance.
  - Tighten CSP in `security-review`: drop default 'unsafe-inline'/'unsafe-eval'; add `base-uri`, `object-src`, and `frame-ancestors`.

<sup>Written for commit 97b5d12ac4e6836308dc35c5c3125a8ac19219d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added drift-prone warnings to multiple skills, alerting users to verify API tool compatibility and parameters before reliance
  * Updated backend rate limiting guidance to recommend shared stores over in-memory solutions for production
  * Strengthened Content Security Policy recommendations by removing unsafe defaults
  * Enhanced search workflow documentation with tool availability verification step

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1723)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->