### PR TITLE
docs: sync rc1 catalog counts

### DIFF
--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -12,7 +12,7 @@ This directory contains the **Codex plugin manifest** for Everything Claude Code
 
 ## What This Provides
 
-- **185 skills** from `./skills/` — reusable Codex workflows for TDD, security,
+- **200 skills** from `./skills/` — reusable Codex workflows for TDD, security,
   code review, architecture, and more
 - **6 MCP servers** — GitHub, Context7, Exa, Memory, Playwright, Sequential Thinking
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ecc",
   "version": "2.0.0-rc.1",
-  "description": "Battle-tested Codex workflows — 185 shared ECC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
+  "description": "Battle-tested Codex workflows — 200 shared ECC skills, production-ready MCP configs, and selective-install-aligned conventions for TDD, security scanning, code review, and autonomous development.",
   "author": {
     "name": "Affaan Mustafa",
     "email": "me@affaanmustafa.com",
@@ -15,7 +15,7 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Everything Claude Code",
-    "shortDescription": "185 battle-tested ECC skills plus MCP configs for TDD, security, code review, and autonomous development.",
+    "shortDescription": "200 battle-tested ECC skills plus MCP configs for TDD, security, code review, and autonomous development.",
     "longDescription": "Everything Claude Code (ECC) is a community-maintained collection of Codex-ready skills and MCP configs evolved over 10+ months of intensive daily use. It covers TDD workflows, security scanning, code review, architecture decisions, operator workflows, and more — all in one installable plugin.",
     "developerName": "Affaan Mustafa",
     "category": "Productivity",

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This repo is the raw code only. The guides explain everything.
 ### v2.0.0-rc.1 — Surface Refresh, Operator Workflows, and ECC 2.0 Alpha (Apr 2026)
 
 - **Dashboard GUI** — New Tkinter-based desktop application (`ecc_dashboard.py` or `npm run dashboard`) with dark/light theme toggle, font customization, and project logo in header and taskbar.
-- **Public surface synced to the live repo** — metadata, catalog counts, plugin manifests, and install-facing docs now match the actual OSS surface: 48 agents, 185 skills, and 68 legacy command shims.
+- **Public surface synced to the live repo** — metadata, catalog counts, plugin manifests, and install-facing docs now match the actual OSS surface: 53 agents, 200 skills, and 69 legacy command shims.
 - **Operator and outbound workflow expansion** — `brand-voice`, `social-graph-ranker`, `connections-optimizer`, `customer-billing-ops`, `ecc-tools-cost-audit`, `google-workspace-ops`, `project-flow-ops`, and `workspace-surface-audit` round out the operator lane.
 - **Media and launch tooling** — `manim-video`, `remotion-video-creation`, and upgraded social publishing surfaces make technical explainers and launch content part of the same system.
 - **Framework and product surface growth** — `nestjs-patterns`, richer Codex/OpenCode install surfaces, and expanded cross-harness packaging keep the repo usable beyond Claude Code alone.


### PR DESCRIPTION
## Summary

- sync README rc.1 catalog counts to the current validated surface: 53 agents, 200 skills, 69 command shims
- sync Codex plugin README and manifest copy from 185 skills to 200 skills

## Validation

- `node scripts/ci/catalog.js --text`
- `node tests/plugin-manifest.test.js`
- `node tests/docs/ecc2-release-surface.test.js`
- `npx markdownlint-cli README.md .codex-plugin/README.md`
- `npm pack --dry-run --json`
- `npm run lint`
- `node tests/run-all.js` (2240 passed before this metadata-only count sync)
- `cd ecc2 && cargo test` (462 passed)
- `git diff --check`

## Notes

`npm view ecc-universal@2.0.0-rc.1` returns 404, so the rc.1 package version is not published yet. No tag or publish action was taken.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync rc.1 catalog counts across README and Codex plugin to match the validated surface: 53 agents, 200 skills, and 69 command shims. Updated `.codex-plugin/README.md` and `.codex-plugin/plugin.json` copy from 185 to 200 skills; no functional changes.

<sup>Written for commit 1182d889c3f477245d6591c59c7f4e3b2133c28b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated component counts in release notes and plugin descriptions: skills increased to 200, agents to 53, and legacy command shims to 69
  * Refreshed plugin metadata to reflect current component inventory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->