### PR TITLE
fix: route backlog work from lead working dirs

### DIFF
--- a/ecc2/src/session/manager.rs
+++ b/ecc2/src/session/manager.rs
@@ -908,11 +908,10 @@ pub async fn drain_inbox(
     use_worktree: bool,
     limit: usize,
 ) -> Result<Vec<InboxDrainOutcome>> {
-    let repo_root =
-        std::env::current_dir().context("Failed to resolve current working directory")?;
     let runner_program =
         std::env::current_exe().context("Failed to resolve ECC executable path")?;
     let lead = resolve_session(db, lead_id)?;
+    let repo_root = lead.working_dir.clone();
     let messages = db.unread_task_handoffs_for_session(&lead.id, limit)?;
     let mut outcomes = Vec::new();
 
@@ -1057,11 +1056,10 @@ pub async fn rebalance_team_backlog(
     use_worktree: bool,
     limit: usize,
 ) -> Result<Vec<RebalanceOutcome>> {
-    let repo_root =
-        std::env::current_dir().context("Failed to resolve current working directory")?;
     let runner_program =
         std::env::current_exe().context("Failed to resolve ECC executable path")?;
     let lead = resolve_session(db, lead_id)?;
+    let repo_root = lead.working_dir.clone();
     let mut outcomes = Vec::new();
 
     if limit == 0 {


### PR DESCRIPTION
## Summary

- route ECC2 inbox drain and backlog rebalance work from the lead session working directory
- remove the process-current-directory dependency from backlog task dispatch
- prevent cwd-sensitive runtime/test failures when other flows mutate the process cwd

## Validation

- `cargo test auto_dispatch_backlog_routes_multiple_lead_inboxes -- --nocapture`
- `cargo test -- --test-threads=1`
- `git diff --check`

Note: a default parallel `cargo test` still exposes unrelated pre-existing global-cwd-sensitive tests. This patch removes that pattern from backlog dispatch/rebalance without broadening the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route ECC2 backlog work (inbox drain and team rebalance) from the lead session working directory instead of the process cwd. This removes cwd coupling and prevents flaky tests or runtime failures when other flows change the cwd.

- **Bug Fixes**
  - Use `lead.working_dir` in `drain_inbox` and `rebalance_team_backlog` (replaces `std::env::current_dir()`).
  - Keeps resolving the runner via `std::env::current_exe()`; removes cwd dependency from backlog dispatch.

<sup>Written for commit c8998b494952e94e831f3b232a7e9118a4d11b1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management reliability by fixing how the repository location is determined during session coordination operations. The system now correctly derives the repository path from the active session's working directory rather than the process's current directory, ensuring consistent behavior across session management and team backlog operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1755)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->