### PR TITLE
docs: align rc1 operating system copy

### DIFF
--- a/docs/releases/2.0.0-rc.1/article-outline.md
+++ b/docs/releases/2.0.0-rc.1/article-outline.md
@@ -2,7 +2,7 @@
 
 ## Working Title
 
-Turning ECC Into a Cross-Harness Operator System
+Turning ECC Into a Cross-Harness Operating System
 
 ## Core Argument
 
@@ -58,4 +58,4 @@ The leverage comes from treating the harness, reusable workflow layer, and opera
 
 The goal is not to copy one exact stack.
 
-The goal is to build an operator system that turns repeated work into reusable, measurable surfaces.
+The goal is to build an operating system around the agent that turns repeated work into reusable, measurable surfaces.


### PR DESCRIPTION
## Summary

- standardize the rc.1 article outline on “operating system” language
- align the article working title and closing point with release notes, checklist, X draft, and LinkedIn draft

## Validation

- `rg -n "operator system|operating system" docs/releases/2.0.0-rc.1/article-outline.md docs/releases/2.0.0-rc.1/linkedin-post.md docs/releases/2.0.0-rc.1/release-notes.md docs/releases/2.0.0-rc.1/x-thread.md docs/releases/2.0.0-rc.1/launch-checklist.md`
- `npx markdownlint-cli docs/releases/2.0.0-rc.1/article-outline.md`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized “operating system” wording in the 2.0.0-rc.1 article outline and aligned the working title and final sentence with the release notes, launch checklist, X thread, and LinkedIn draft. Clarifies the focus with “operating system around the agent” and fixes the “operator system” typo.

<sup>Written for commit 8c3faeb2a9077cd771bf79d636a94650a8449200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected terminology in release documentation for improved clarity and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1756)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->