### PR TITLE
fix: harden opencode project file probes

### DIFF
--- a/.opencode/plugins/ecc-hooks.ts
+++ b/.opencode/plugins/ecc-hooks.ts
@@ -45,7 +45,7 @@ export const ECCHooksPlugin: ECCHooksPluginFn = async ({
 
   function hasProjectFile(relativePath: string): boolean {
     try {
-      return fs.existsSync(resolvePath(relativePath))
+      return fs.statSync(resolvePath(relativePath)).isFile()
     } catch {
       return false
     }

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -128,7 +128,10 @@ function waitForFile(filePath, timeoutMs = 5000) {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
     if (fs.existsSync(filePath)) {
-      return fs.readFileSync(filePath, 'utf8');
+      const content = fs.readFileSync(filePath, 'utf8');
+      if (content.trim()) {
+        return content;
+      }
     }
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
   }

--- a/tests/opencode-plugin-hooks.test.js
+++ b/tests/opencode-plugin-hooks.test.js
@@ -119,6 +119,52 @@ async function main() {
         )
       }),
     ],
+    [
+      "session.created ignores directories named CLAUDE.md",
+      async () => {
+        const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "ecc-opencode-plugin-"))
+        try {
+          fs.mkdirSync(path.join(projectDir, "CLAUDE.md"))
+
+          const client = createClient()
+          const $ = createFailingShell()
+          const hooks = await ECCHooksPlugin({ client, $, directory: projectDir })
+
+          await hooks["session.created"]()
+
+          assert.deepStrictEqual($.calls, [], `Unexpected shell probes: ${$.calls.join(", ")}`)
+          assert.ok(
+            !client.logs.some((entry) => entry.message === "[ECC] Found CLAUDE.md - loading project context"),
+            "Directory named CLAUDE.md should not be treated as project context"
+          )
+        } finally {
+          fs.rmSync(projectDir, { recursive: true, force: true })
+        }
+      },
+    ],
+    [
+      "shell.env ignores directories named like lockfiles and language markers",
+      async () => {
+        const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "ecc-opencode-plugin-"))
+        try {
+          fs.mkdirSync(path.join(projectDir, "pnpm-lock.yaml"))
+          fs.mkdirSync(path.join(projectDir, "tsconfig.json"))
+
+          const client = createClient()
+          const $ = createFailingShell()
+          const hooks = await ECCHooksPlugin({ client, $, directory: projectDir })
+
+          const env = await hooks["shell.env"]()
+
+          assert.deepStrictEqual($.calls, [], `Unexpected shell probes: ${$.calls.join(", ")}`)
+          assert.ok(!("PACKAGE_MANAGER" in env), "Lockfile directory should not set PACKAGE_MANAGER")
+          assert.ok(!("DETECTED_LANGUAGES" in env), "Marker directory should not set DETECTED_LANGUAGES")
+          assert.ok(!("PRIMARY_LANGUAGE" in env), "Marker directory should not set PRIMARY_LANGUAGE")
+        } finally {
+          fs.rmSync(projectDir, { recursive: true, force: true })
+        }
+      },
+    ],
   ]
 
   let passed = 0


### PR DESCRIPTION
## Summary

Salvages the useful remaining piece of closed stale PR #1578 into current `main`.

- OpenCode project probes now require regular files instead of accepting any path that exists.
- Directories named `CLAUDE.md`, `pnpm-lock.yaml`, or `tsconfig.json` no longer trigger project context, package-manager, or language detection.
- Kept the current local test layout instead of adding a second OpenCode test file.

## Why

The shell-probe removal from #1578 is already mostly present on `main`, but the current helper still used existence checks. That leaves a small false-positive edge case where directories masquerading as files are treated as valid project markers.

## Test plan

- [x] `node tests/opencode-plugin-hooks.test.js`
- [x] `node tests/scripts/build-opencode.test.js`
- [x] `node scripts/ci/check-unicode-safety.js`
- [x] `git diff --check`
- [x] `npm test` (2290 passed, 0 failed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require regular files for OpenCode project markers to prevent false positives. Also harden the MCP health-check test to wait for real readiness.

- **Bug Fixes**
  - Use `fs.statSync(...).isFile()` in `.opencode/plugins/ecc-hooks.ts` to only accept regular files.
  - Ignore directories named `CLAUDE.md`, `pnpm-lock.yaml`, and `tsconfig.json` for project/env detection.
  - Strengthen tests: cover directory false positives and make `mcp-health-check` wait for non-empty file contents.

<sup>Written for commit d393d72d6125e83f94054efef60c4b4442a23e25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project file detection to ensure only regular files (not directories) are recognized as project markers.

* **Tests**
  * Added tests covering cases where project-marker paths exist as directories so they’re ignored.
  * Enhanced test helper to wait for target files to exist and contain non-whitespace content before proceeding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1773)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->