### PR TITLE
docs: add release publication readiness gate

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -27,6 +27,9 @@ As of 2026-05-12:
 - `npm run harness:adapters -- --check` validates that the public adapter
   matrix still matches the source data in
   `scripts/lib/harness-adapter-compliance.js`.
+- `docs/releases/2.0.0-rc.1/publication-readiness.md` gates GitHub release,
+  npm dist-tag, Claude plugin, Codex plugin, OpenCode package, billing, and
+  announcement publication on fresh evidence fields.
 - AgentShield PR #53 reduced two context-rule false positives and closed the
   remaining AgentShield issues.
 - ECC PR #1778 recovered the useful stale #1413 network/homelab architect-agent
@@ -182,12 +185,11 @@ Acceptance:
 
 ## Next Engineering Slices
 
-1. Add the release/name/plugin publication checklist with evidence fields.
-2. Start AgentShield enterprise policy schema and SARIF implementation in the
+1. Start AgentShield enterprise policy schema and SARIF implementation in the
    AgentShield repo.
-3. Audit ECC Tools billing and check-run surfaces before any native GitHub
+2. Audit ECC Tools billing and check-run surfaces before any native GitHub
    payments announcement.
-4. Inventory `_legacy-documents-*` and map useful artifacts to landed,
+3. Inventory `_legacy-documents-*` and map useful artifacts to landed,
    milestone-tracked, salvage, or archive states.
-5. Build the stale-PR salvage ledger from closed cleanup batches, then port
+4. Build the stale-PR salvage ledger from closed cleanup batches, then port
    useful pieces in small attributed maintainer PRs.

--- a/docs/releases/2.0.0-rc.1/launch-checklist.md
+++ b/docs/releases/2.0.0-rc.1/launch-checklist.md
@@ -13,6 +13,7 @@
 
 - verify package, plugin, marketplace, OpenCode, and agent metadata stays at `2.0.0-rc.1`
 - verify `ecc2/Cargo.toml` stays at `0.1.0` for rc.1; `ecc2/` remains an alpha control-plane scaffold
+- complete `publication-readiness.md` with fresh evidence before any GitHub release, npm publish, plugin submission, or announcement post
 - update release metadata in one dedicated release-version PR
 - run the root test suite
 - run `cd ecc2 && cargo test`

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -1,0 +1,73 @@
+# ECC v2.0.0-rc.1 Publication Readiness
+
+This checklist is the release gate for public publication surfaces. Do not use
+it as evidence by itself. Fill the evidence fields with fresh command output or
+URLs from the exact commit being released.
+
+## Release Identity Matrix
+
+| Surface | Expected value | Source of truth | Fresh check | Evidence artifact | Owner | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Product name | Everything Claude Code / ECC | `README.md`, `CHANGELOG.md`, release notes | `rg -n "Everything Claude Code" README.md CHANGELOG.md docs/releases/2.0.0-rc.1` | Pending | Release owner | Pending |
+| GitHub repo | `affaan-m/everything-claude-code` | Git remote and release URLs | `git remote get-url origin` | Pending | Release owner | Pending |
+| Git tag | `v2.0.0-rc.1` | GitHub releases | `gh release view v2.0.0-rc.1 --repo affaan-m/everything-claude-code` | Pending | Release owner | Pending |
+| npm package | `ecc-universal` | `package.json` | `node -p "require('./package.json').name"` | Pending | Package owner | Pending |
+| npm version | `2.0.0-rc.1` | `VERSION`, `package.json`, lockfiles | `node -p "require('./package.json').version"` | Pending | Package owner | Pending |
+| npm dist-tag | `next` for rc, `latest` only for GA | npm registry | `npm view ecc-universal dist-tags --json` | Pending | Package owner | Pending |
+| Claude plugin slug | `ecc` / `ecc@ecc` install path | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` | `node tests/hooks/hooks.test.js` | Pending | Plugin owner | Pending |
+| Claude plugin manifest | `2.0.0-rc.1`, no unsupported `agents` or explicit `hooks` fields | `.claude-plugin/plugin.json`, `.claude-plugin/PLUGIN_SCHEMA_NOTES.md` | `claude plugin validate .claude-plugin/plugin.json` | Pending | Plugin owner | Pending |
+| Codex plugin manifest | `2.0.0-rc.1` with shared skill source | `.codex-plugin/plugin.json` | `node tests/docs/ecc2-release-surface.test.js` | Pending | Plugin owner | Pending |
+| OpenCode package | `ecc-universal` plugin module | `.opencode/package.json`, `.opencode/index.ts` | `npm run build:opencode` | Pending | Package owner | Pending |
+| Agent metadata | `2.0.0-rc.1` | `agent.yaml`, `.agents/plugins/marketplace.json` | `node tests/scripts/catalog.test.js` | Pending | Release owner | Pending |
+| Migration copy | rc.1 upgrade path, not GA claim | `release-notes.md`, `quickstart.md`, `HERMES-SETUP.md` | `npx markdownlint-cli docs/releases/2.0.0-rc.1/*.md` | Pending | Docs owner | Pending |
+
+## Publication Gates
+
+| Gate | Required evidence | Fresh check | Blocker field | Owner | Status |
+| --- | --- | --- | --- | --- | --- |
+| GitHub release | Tag exists, release notes use final URLs, assets attached if needed | `gh release view v2.0.0-rc.1 --json tagName,url,isPrerelease` | `Blocker:` | Release owner | Pending |
+| npm package | `npm pack --dry-run` has expected files, version matches, rc goes to `next` | `npm pack --dry-run` and `npm publish --tag next --dry-run` where supported | `Blocker:` | Package owner | Pending |
+| Claude plugin | Manifest validates, marketplace JSON points to public repo, install docs match slug | `claude plugin validate .claude-plugin/plugin.json` | `Blocker:` | Plugin owner | Pending |
+| Codex plugin | Manifest version matches package and docs, hook limitations are explicit | `node tests/docs/ecc2-release-surface.test.js` | `Blocker:` | Plugin owner | Pending |
+| OpenCode package | Build output is regenerated from source and package metadata is current | `npm run build:opencode` | `Blocker:` | Package owner | Pending |
+| ECC Tools billing reference | Any billing claim links to verified Marketplace/App state | `gh api repos/ECC-Tools/ECC-Tools` plus app/marketplace URL check | `Blocker:` | ECC Tools owner | Pending |
+| Announcement copy | X, LinkedIn, GitHub release, and longform copy point to live URLs | `rg -n "TODO" docs/releases/2.0.0-rc.1` and repeat for `TBD` | `Blocker:` | Release owner | Pending |
+
+## Required Command Evidence
+
+Record the exact commit SHA and command output before any publication action:
+
+| Evidence | Command | Required result | Recorded output |
+| --- | --- | --- | --- |
+| Clean release branch | `git status --short --branch` | On intended release commit; no unrelated files | Pending |
+| Harness audit | `npm run harness:audit -- --format json` | 70/70 passing | Pending |
+| Adapter scorecard | `npm run harness:adapters -- --check` | PASS | Pending |
+| Observability readiness | `npm run observability:ready` | 14/14 passing | Pending |
+| Root suite | `node tests/run-all.js` | 0 failures | Pending |
+| Markdown lint | `npx markdownlint-cli '**/*.md' --ignore node_modules` | 0 failures | Pending |
+| Package surface | `node tests/scripts/npm-publish-surface.test.js` | 0 failures | Pending |
+| Release surface | `node tests/docs/ecc2-release-surface.test.js` | 0 failures | Pending |
+| Optional Rust surface | `cd ecc2 && cargo test` | 0 failures or explicit deferral | Pending |
+
+## Do Not Publish If
+
+- `main` has unreviewed release-surface changes after the evidence was recorded.
+- `npm view ecc-universal dist-tags --json` contradicts the intended rc/GA tag.
+- Claude plugin validation is unavailable and no manual install smoke test is
+  recorded.
+- Release notes or announcement drafts still contain placeholder URLs,
+  `TODO`, `TBD`, private workspace paths, or personal operator references.
+- Billing, Marketplace, or plugin-submission copy claims a live surface before
+  the live URL exists.
+- Stale PR salvage work is mid-flight on the same branch.
+
+## Announcement Order
+
+1. Merge the release-version PR.
+2. Record the required command evidence from the release commit.
+3. Create or verify the GitHub prerelease.
+4. Publish npm with the rc dist-tag.
+5. Submit or update plugin marketplace surfaces.
+6. Update release notes with final live URLs.
+7. Publish GitHub release copy.
+8. Publish X, LinkedIn, and longform copy only after the public URLs work.

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -50,6 +50,7 @@ const expectedReleaseFiles = [
   'telegram-handoff.md',
   'demo-prompts.md',
   'quickstart.md',
+  'publication-readiness.md',
 ];
 
 test('release candidate directory includes the public launch pack', () => {
@@ -173,6 +174,53 @@ test('launch checklist records the ecc2 alpha version policy', () => {
   assert.ok(cargoToml.includes('version = "0.1.0"'));
   assert.ok(launchChecklist.includes('`ecc2/Cargo.toml` stays at `0.1.0`'));
   assert.ok(!launchChecklist.includes('confirm whether `ecc2/Cargo.toml` moves'));
+});
+
+test('publication readiness checklist gates public release actions on evidence', () => {
+  const source = read('docs/releases/2.0.0-rc.1/publication-readiness.md');
+
+  for (const section of [
+    '## Release Identity Matrix',
+    '## Publication Gates',
+    '## Required Command Evidence',
+    '## Do Not Publish If',
+    '## Announcement Order',
+  ]) {
+    assert.ok(source.includes(section), `publication readiness missing ${section}`);
+  }
+
+  for (const field of [
+    'Fresh check',
+    'Evidence artifact',
+    'Owner',
+    'Status',
+    'Blocker field',
+    'Recorded output',
+  ]) {
+    assert.ok(source.includes(field), `publication readiness missing ${field}`);
+  }
+
+  for (const surface of [
+    'GitHub release',
+    'npm package',
+    'Claude plugin',
+    'Codex plugin',
+    'OpenCode package',
+    'ECC Tools billing reference',
+    'Announcement copy',
+  ]) {
+    assert.ok(source.includes(surface), `publication readiness missing ${surface}`);
+  }
+});
+
+test('release checklist and roadmap link to publication readiness evidence gate', () => {
+  const launchChecklist = read('docs/releases/2.0.0-rc.1/launch-checklist.md');
+  const roadmap = read('docs/ECC-2.0-GA-ROADMAP.md');
+
+  assert.ok(launchChecklist.includes('publication-readiness.md'));
+  assert.ok(launchChecklist.includes('fresh evidence'));
+  assert.ok(roadmap.includes('docs/releases/2.0.0-rc.1/publication-readiness.md'));
+  assert.ok(roadmap.includes('npm dist-tag'));
 });
 
 test('localized changelogs include rc.1 and 1.10.0 release entries', () => {


### PR DESCRIPTION
## Summary

Adds a release publication readiness gate for the rc.1 launch pack:

- new `docs/releases/2.0.0-rc.1/publication-readiness.md` covering release identity, publication gates, command evidence, do-not-publish conditions, and announcement order
- launch checklist now points to the publication gate before GitHub release, npm publish, plugin submission, or announcements
- GA roadmap marks this slice as current evidence and removes it from next engineering work
- release-surface tests now require the checklist and evidence fields

## Test plan

- `node tests/docs/ecc2-release-surface.test.js` passed, 18/18
- `npx markdownlint-cli docs/releases/2.0.0-rc.1/publication-readiness.md docs/releases/2.0.0-rc.1/launch-checklist.md docs/ECC-2.0-GA-ROADMAP.md` passed
- `npm run lint` passed
- `node tests/scripts/npm-publish-surface.test.js` passed, 2/2
- `node tests/run-all.js > /tmp/ecc-run-all-20260512-0325.log 2>&1` passed, 2312/2312
- `git diff --check` passed

## Notes

The existing untracked local `docs/drafts/` path was not staged or touched.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a publication readiness gate for v2.0.0-rc.1 to block public release actions until fresh evidence is recorded. Integrates the gate into the launch checklist and roadmap, with tests to enforce it.

- **New Features**
  - Added `docs/releases/2.0.0-rc.1/publication-readiness.md` with identity matrix, publication gates, required command evidence, do-not-publish conditions, and announcement order; covers GitHub release, `ecc-universal` `npm` dist-tag, Claude/Codex plugins, OpenCode, billing, and announcements.
  - Updated `launch-checklist.md` to require completing the publication readiness evidence before any GitHub release, `npm publish`, plugin submission, or announcements; linked from the GA roadmap and clarified rc vs GA dist-tag policy.
  - Extended `tests/docs/ecc2-release-surface.test.js` to assert the new checklist exists, includes required sections/fields, and that the launch checklist and roadmap link to it.

<sup>Written for commit eb4467fd567c7f309d4d81a556c47d099a04e9c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GA release roadmap with refined release gate requirements covering GitHub releases, npm distribution, plugin publications, billing, and announcements
  * Added publication-readiness checklist with validation steps, release identity matrix, and step-by-step announcement sequence

* **Tests**
  * Expanded test coverage for release documentation to verify required sections and checklist fields

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1786)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->