### PR TITLE
docs: inventory workspace legacy repos

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -31,8 +31,10 @@ As of 2026-05-12:
   npm dist-tag, Claude plugin, Codex plugin, OpenCode package, billing, and
   announcement publication on fresh evidence fields.
 - `docs/legacy-artifact-inventory.md` records that no `_legacy-documents-*`
-  directories exist in the current checkout and classifies
-  `legacy-command-shims/` as an opt-in archive/no-action surface.
+  directories exist in the current checkout, inventories the two sibling
+  workspace-level `_legacy-documents-*` repos as sanitized extraction sources,
+  and classifies `legacy-command-shims/` as an opt-in archive/no-action
+  surface.
 - `docs/stale-pr-salvage-ledger.md` records stale PR salvage outcomes,
   skipped PRs, superseded work, and the remaining #1687 translator/manual
   review tail.
@@ -183,6 +185,9 @@ Acceptance:
 - Legacy directories and orphaned handoffs are inventoried.
 - Each useful artifact is marked landed, Linear/project-tracked, salvage
   branch, or archive/no-action.
+- Workspace-level legacy repos are mined only through sanitized maintainer
+  branches; raw context, secrets, personal paths, local settings, and private
+  drafts are never imported wholesale.
 - Stale PR salvage policy stays in force: close stale/conflicted PRs first,
   record a salvage ledger item, then port useful compatible content on
   maintainer branches with attribution.

--- a/docs/legacy-artifact-inventory.md
+++ b/docs/legacy-artifact-inventory.md
@@ -29,6 +29,24 @@ Expected result: no output.
 The only tracked legacy directory currently found by filename scan is
 `legacy-command-shims/`.
 
+The umbrella ECC workspace also contains sibling legacy git repositories outside
+this tracked checkout. These are intentionally inventoried separately because
+they can contain raw operator context, local settings, private drafts, or
+untracked files that should not be copied into the public repo wholesale.
+
+Fresh workspace-level check from the ECC umbrella directory:
+
+```sh
+find .. -maxdepth 1 -type d -name '_legacy-documents-*' -print | sort
+```
+
+Expected result:
+
+```text
+../_legacy-documents-ecc-context-2026-04-30
+../_legacy-documents-ecc-everything-claude-code-2026-04-30
+```
+
 ## Inventory
 
 | Artifact | State | Evidence | Action |
@@ -37,6 +55,28 @@ The only tracked legacy directory currently found by filename scan is
 | `legacy-command-shims/` | Archive/no-action | `legacy-command-shims/README.md` states these retired short-name shims are opt-in and no longer loaded by the default plugin command surface. | Keep as an explicit compatibility archive. Do not move these back into the default plugin surface without a migration decision. |
 | Closed-stale PR salvage ledger | Landed | `docs/stale-pr-salvage-ledger.md` records useful stale work recovered through maintainer PRs. | Continue using the ledger pattern for future stale closures. |
 | #1687 zh-CN localization tail | Translator/manual review | Large safe subsets landed in #1746-#1752; remaining pieces require translator/manual review per salvage ledger. | Do not blindly cherry-pick. Split by docs, commands, agents, and skills if a translator review lane opens. |
+
+## Workspace-Level Legacy Repos
+
+These sibling repositories live outside the tracked `everything-claude-code`
+checkout. They are source material for future salvage passes, not installable
+release assets.
+
+| Artifact | State | Evidence | Action |
+| --- | --- | --- | --- |
+| `../_legacy-documents-ecc-everything-claude-code-2026-04-30` | Archive/no-action | Separate legacy checkout on `fix/configure-ecc-skill-copy-paths-1483` at `b78ddbd0`; useful configure-ecc and install-path concepts have been superseded by current install docs and tests. The checkout also has untracked localized project-guidelines examples and a Finder duplicate `skills/social-graph-ranker/SKILL 2.md`. | Do not import wholesale. If configure-ecc copy-root regressions reappear, use this branch only as source-attributed archaeology and port through a fresh maintainer branch. Leave Finder duplicates out of source control. |
+| `../_legacy-documents-ecc-context-2026-04-30` | Milestone-tracked | Archived `ECC-context` repo is four commits ahead of its origin and contains context, gameplan, knowledge, marketing, AgentShield, and ECC Tools planning material. It also contains local/private surfaces such as `.env` and local settings. | Keep as a sanitized extraction source for roadmap, launch, AgentShield, and ECC Tools work. Never copy raw context, secrets, personal paths, private settings, or unpublished drafts into this repo. Port only focused, public-safe content with attribution. |
+
+## Workspace Legacy Import Rules
+
+When mining workspace-level legacy repos:
+
+1. Do not read, print, stage, or copy `.env` files, tokens, OAuth secrets,
+   local settings, personal paths, or private operator context.
+2. Do not import raw marketing drafts, gameplans, or chat/context dumps.
+3. Extract only focused, public-safe ideas into current docs or code.
+4. Attribute the source legacy repo, branch, commit, or stale PR in the new PR.
+5. Validate the result with the same tests and release checks as native work.
 
 ## Legacy Command Shim Contents
 

--- a/tests/docs/legacy-artifact-inventory.test.js
+++ b/tests/docs/legacy-artifact-inventory.test.js
@@ -75,6 +75,36 @@ test('any _legacy-documents directories are explicitly inventoried', () => {
   }
 });
 
+test('workspace-level legacy repos are inventoried without personal paths', () => {
+  const source = read('docs/legacy-artifact-inventory.md');
+
+  for (const dir of [
+    '../_legacy-documents-ecc-context-2026-04-30',
+    '../_legacy-documents-ecc-everything-claude-code-2026-04-30',
+  ]) {
+    assert.ok(source.includes(dir), `Missing workspace legacy repo ${dir}`);
+  }
+
+  assert.ok(source.includes('Workspace-Level Legacy Repos'));
+  assert.ok(!source.includes('/Users/'), 'Inventory should avoid machine-local absolute paths');
+});
+
+test('workspace legacy import rules block raw private context', () => {
+  const source = read('docs/legacy-artifact-inventory.md');
+
+  for (const required of [
+    'Do not read, print, stage, or copy `.env` files',
+    'tokens',
+    'OAuth secrets',
+    'personal paths',
+    'private operator context',
+    'Do not import raw marketing drafts',
+    'public-safe ideas',
+  ]) {
+    assert.ok(source.includes(required), `Missing import guardrail: ${required}`);
+  }
+});
+
 test('legacy command shims remain classified as an opt-in archive', () => {
   const source = read('docs/legacy-artifact-inventory.md');
   const readme = read('legacy-command-shims/README.md');


### PR DESCRIPTION
## Summary

- inventory the two sibling workspace-level `_legacy-documents-*` repos outside the tracked checkout
- add explicit guardrails against importing raw context, `.env`, local settings, personal paths, or private drafts
- update the GA roadmap evidence and acceptance criteria so legacy salvage includes sanitized workspace extraction
- extend the legacy artifact inventory test to lock the new workspace-level coverage

## Test plan

- `node tests/docs/legacy-artifact-inventory.test.js`
- `node tests/ci/no-personal-paths.test.js`
- `npx markdownlint-cli docs/legacy-artifact-inventory.md docs/ECC-2.0-GA-ROADMAP.md`
- `npm run lint`
- `node tests/run-all.js` (2324/2324)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inventories two workspace-level `_legacy-documents-*` repos and adds strict import guardrails to prevent secrets and private drafts from entering the public repo. Updates docs, tests, and the GA roadmap to require sanitized, maintainer-branch extraction only.

- **New Features**
  - Documented both sibling repos and “Workspace Legacy Import Rules” in `docs/legacy-artifact-inventory.md`; `legacy-command-shims/` stays opt-in archive/no-action.
  - Updated `docs/ECC-2.0-GA-ROADMAP.md` with evidence and acceptance criteria for sanitized workspace extraction (no raw context, `.env`, personal paths, or private drafts).
  - Extended `tests/docs/legacy-artifact-inventory.test.js` to assert the repo inventory and enforce guardrails (no personal paths, no raw private context).

<sup>Written for commit 870b95c2450817a60bdb2e013a94838828c45181. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded legacy artifact inventory documentation with explicit workspace-level repository handling rules and import restrictions (excluding secrets, personal paths, and private context).

* **Tests**
  * Added test cases to verify legacy artifact inventory documentation accuracy and enforce import guardrails against sensitive content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1789)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->