### PR TITLE
docs: record cross repo roadmap evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -40,8 +40,15 @@ As of 2026-05-12:
   review tail.
 - AgentShield PR #53 reduced two context-rule false positives and closed the
   remaining AgentShield issues.
+- AgentShield PR #55 added GitHub Action organization-policy enforcement with
+  `policy` / `fail-on-policy` inputs, `policy-status` /
+  `policy-violations` outputs, job-summary evidence, and policy violation
+  annotations.
 - ECC PR #1778 recovered the useful stale #1413 network/homelab architect-agent
   concepts.
+- ECC-Tools PR #26 added cost/token-risk predictive follow-ups for AI routing,
+  Claude/model calls, usage limits, quota, and analysis-budget changes that lack
+  budget, quota, rate-limit, or cost validation evidence.
 
 ## Operating Rules
 
@@ -149,6 +156,8 @@ Acceptance:
 - Formal policy schema exists for org baselines, exceptions, owners,
   expiration, severity, and audit trails.
 - SARIF/code-scanning output is implemented and tested.
+- GitHub Action policy gates expose organization policy status and violation
+  counts for branch-protection and CI evidence.
 - Policy packs are defined for OSS, team, enterprise, regulated, high-risk
   hooks/MCP, and CI enforcement.
 - Supply-chain intelligence plan covers MCP package provenance, npm/pip
@@ -173,6 +182,8 @@ Acceptance:
 - PR check suite taxonomy includes Security Evidence, Harness Drift, Install
   Manifest Integrity, CI/CD Recommendation, Cost/Token Risk, and Agent Config
   Review.
+- Cost/token-risk predictive follow-ups flag AI routing, model-call, usage,
+  quota, and budget changes when budget evidence is missing.
 - Linear sync design maps findings to issues/status without flooding the
   workspace.
 


### PR DESCRIPTION
## Summary

- record AgentShield #55 as current enterprise policy-gate evidence
- record ECC-Tools #26 as current cost/token-risk follow-up evidence
- update roadmap acceptance bullets for action policy-gate CI evidence and cost/token-risk predictive follow-ups

## Test plan

- `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `node tests/docs/ecc2-release-surface.test.js`
- `node tests/docs/harness-adapter-compliance.test.js`
- `node tests/docs/stale-pr-salvage-ledger.test.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `docs/ECC-2.0-GA-ROADMAP.md` to record cross-repo evidence from AgentShield #55 (GitHub Action org-policy gate with inputs/outputs, job summary, and annotations) and ECC-Tools #26 (cost/token-risk predictive follow-ups).
Also tighten acceptance criteria to require CI evidence for policy gates and predictive follow-ups when budget evidence is missing.

<sup>Written for commit f98cca77a998eb6c2620c59cd195b5a3ea4bac3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA roadmap with GitHub Action organization-policy enforcement details
  * Extended milestone acceptance criteria for policy gates and predictive cost/token-risk features

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1790)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->