### PR TITLE
docs: record AgentShield policy pack evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -44,6 +44,11 @@ As of 2026-05-12:
   `policy` / `fail-on-policy` inputs, `policy-status` /
   `policy-violations` outputs, job-summary evidence, and policy violation
   annotations.
+- AgentShield PR #56 added SARIF/code-scanning output for organization-policy
+  violations as `agentshield-policy/*` results.
+- AgentShield PR #57 added OSS, team, enterprise, regulated,
+  high-risk-hooks/MCP, and CI-enforcement policy-pack presets plus
+  `agentshield policy init --pack`.
 - ECC PR #1778 recovered the useful stale #1413 network/homelab architect-agent
   concepts.
 - ECC-Tools PR #26 added cost/token-risk predictive follow-ups for AI routing,
@@ -207,7 +212,7 @@ Acceptance:
 
 ## Next Engineering Slices
 
-1. Start AgentShield enterprise policy schema and SARIF implementation in the
-   AgentShield repo.
+1. Continue AgentShield enterprise supply-chain intelligence and reporting in
+   the AgentShield repo.
 2. Audit ECC Tools billing and check-run surfaces before any native GitHub
    payments announcement.


### PR DESCRIPTION
## Summary

- record AgentShield PR #56 as SARIF/code-scanning evidence for organization-policy violations
- record AgentShield PR #57 as policy-pack preset evidence
- update the next engineering slice from policy/SARIF to supply-chain intelligence/reporting

## Test plan

- `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `node tests/docs/ecc2-release-surface.test.js`
- `node tests/docs/harness-adapter-compliance.test.js`
- `node tests/docs/stale-pr-salvage-ledger.test.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ECC-2.0-GA-ROADMAP to record AgentShield policy evidence and shift the next engineering slice to enterprise supply‑chain intelligence and reporting. Document PR #56 (SARIF/code-scanning for org-policy violations as `agentshield-policy/*`) and PR #57 (policy-pack presets and `agentshield policy init --pack`).

<sup>Written for commit ea96f2a8c7fc4eb7d5388e1903589a4dc667d5ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release roadmap to reflect new AgentShield capabilities for SARIF/code-scanning output related to policy violations and policy-pack preset functionality.
  * Adjusted next engineering priorities in roadmap.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1791)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->