### PR TITLE
docs: record ECC Tools taxonomy evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -54,6 +54,9 @@ As of 2026-05-12:
 - ECC-Tools PR #26 added cost/token-risk predictive follow-ups for AI routing,
   Claude/model calls, usage limits, quota, and analysis-budget changes that lack
   budget, quota, rate-limit, or cost validation evidence.
+- ECC-Tools PR #27 added the non-blocking `ECC Tools / PR Risk Taxonomy`
+  check-run for Security Evidence, Harness Drift, Install Manifest Integrity,
+  CI/CD Recommendation, Cost/Token Risk, and Agent Config Review buckets.
 
 ## Operating Rules
 
@@ -214,5 +217,5 @@ Acceptance:
 
 1. Continue AgentShield enterprise supply-chain intelligence and reporting in
    the AgentShield repo.
-2. Audit ECC Tools billing and check-run surfaces before any native GitHub
-   payments announcement.
+2. Audit ECC Tools billing, entitlement, and marketplace surfaces before any
+   native GitHub payments announcement.


### PR DESCRIPTION
## Summary

- record ECC-Tools PR #27 as current GA-roadmap evidence
- move the next ECC Tools slice from check-run taxonomy into billing/entitlement/marketplace audit surfaces

## Test plan

- `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `node tests/docs/ecc2-release-surface.test.js`
- `node tests/docs/harness-adapter-compliance.test.js`
- `node tests/docs/stale-pr-salvage-ledger.test.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the ECC 2.0 GA roadmap to record ECC-Tools PR #27 as evidence, documenting the non-blocking "ECC Tools / PR Risk Taxonomy" check-run for Security Evidence, Harness Drift, Install Manifest Integrity, CI/CD Recommendation, Cost/Token Risk, and Agent Config Review. Revise acceptance criteria to audit billing, entitlement, and marketplace surfaces ahead of any native GitHub payments announcement.

<sup>Written for commit 00ce5b1aee2d2d7a6eb05c37a06b8a743860a0a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated ECC 2.0 GA roadmap with current evidence of new PR Risk Taxonomy check-run capabilities covering Security, Harness, Install, CI/CD, Cost, and Agent Config reviews.
  * Expanded upcoming audit scope to include entitlement and marketplace surfaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1792)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->