### PR TITLE
docs: record AgentShield provenance evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -49,6 +49,9 @@ As of 2026-05-12:
 - AgentShield PR #57 added OSS, team, enterprise, regulated,
   high-risk-hooks/MCP, and CI-enforcement policy-pack presets plus
   `agentshield policy init --pack`.
+- AgentShield PR #58 added MCP package provenance fields and report-level
+  counts for npm vs git, pinned vs unpinned, known-good, and registry-backed
+  supply-chain evidence.
 - ECC PR #1778 recovered the useful stale #1413 network/homelab architect-agent
   concepts.
 - ECC-Tools PR #26 added cost/token-risk predictive follow-ups for AI routing,
@@ -168,8 +171,8 @@ Acceptance:
   counts for branch-protection and CI evidence.
 - Policy packs are defined for OSS, team, enterprise, regulated, high-risk
   hooks/MCP, and CI enforcement.
-- Supply-chain intelligence plan covers MCP package provenance, npm/pip
-  reputation, CVEs, typosquats, and dependency risk.
+- Supply-chain intelligence covers MCP package provenance and has an extension
+  path for npm/pip reputation, CVEs, typosquats, and dependency risk.
 - Prompt-injection corpus and regression benchmark are ready for continuous
   rule hardening.
 - Enterprise reports include JSON plus HTML/PDF or equivalent executive output.
@@ -215,7 +218,7 @@ Acceptance:
 
 ## Next Engineering Slices
 
-1. Continue AgentShield enterprise supply-chain intelligence and reporting in
-   the AgentShield repo.
+1. Extend AgentShield enterprise reporting beyond terminal/JSON supply-chain
+   evidence toward executive HTML/PDF or equivalent report output.
 2. Audit ECC Tools billing, entitlement, and marketplace surfaces before any
    native GitHub payments announcement.


### PR DESCRIPTION
## Summary

Records the AgentShield #58 supply-chain provenance reporting work in the ECC 2.0 GA roadmap.

- adds #58 to current evidence
- updates AgentShield enterprise acceptance language now that MCP package provenance/counts exist
- moves the next AgentShield slice toward executive report output beyond terminal/JSON

## Test plan

- [x] `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- [x] `node tests/docs/ecc2-release-surface.test.js`
- [x] `node tests/docs/harness-adapter-compliance.test.js`
- [x] `node tests/docs/stale-pr-salvage-ledger.test.js`
- [x] `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the ECC 2.0 GA roadmap to record AgentShield PR #58 supply-chain provenance evidence and reflect it in enterprise acceptance and next steps. Adds MCP package provenance and report-level counts (npm vs git, pinned vs unpinned, known-good, registry-backed), updates acceptance wording, and sets the next slice to deliver executive HTML/PDF reports beyond terminal/JSON.

<sup>Written for commit 7fc330c5a673639d0b3c96ab3e97d556560cb4fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA roadmap with refined supply-chain intelligence milestones, including enhanced provenance tracking capabilities and improved reporting outputs transitioning to executive-ready HTML and PDF formats for upcoming releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1793)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->