### PR TITLE
docs: record ECC Tools billing audit evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -60,6 +60,9 @@ As of 2026-05-12:
 - ECC-Tools PR #27 added the non-blocking `ECC Tools / PR Risk Taxonomy`
   check-run for Security Evidence, Harness Drift, Install Manifest Integrity,
   CI/CD Recommendation, Cost/Token Risk, and Agent Config Review buckets.
+- ECC-Tools PR #28 added billing readiness audit checks for plan limits,
+  entitlements, Marketplace plan shape, subscription source, seats, and
+  overage metering.
 
 ## Operating Rules
 
@@ -185,8 +188,9 @@ Acceptance:
 
 - Native GitHub Marketplace billing announcement is backed by verified
   implementation and docs.
-- Billing audit covers plan limits, seats, org/account mapping, subscription
-  state, overage hooks, and failure modes.
+- Internal billing readiness audit covers plan limits, seats, entitlement
+  mapping, Marketplace plan shape, subscription state, overage hooks, and
+  failure modes.
 - Deep analyzer covers diff patterns, CI/CD workflows, dependency/security
   surface, PR review behavior, failure history, harness config, skill quality,
   and reference-set/RAG comparison.
@@ -220,5 +224,5 @@ Acceptance:
 
 1. Extend AgentShield enterprise reporting beyond terminal/JSON supply-chain
    evidence toward executive HTML/PDF or equivalent report output.
-2. Audit ECC Tools billing, entitlement, and marketplace surfaces before any
-   native GitHub payments announcement.
+2. Extend ECC Tools deep analysis and Linear/project sync without flooding the
+   workspace.


### PR DESCRIPTION
## Summary

Records the merged ECC-Tools #28 billing readiness audit work in the ECC 2.0 GA roadmap.

- adds #28 to current evidence
- updates the ECC Tools billing acceptance line now that the internal readiness audit covers plan limits, entitlements, Marketplace shape, subscription state, seats, and overage metering
- moves the next ECC Tools slice toward deep analysis plus Linear/project sync

## Test plan

- [x] `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- [x] `node tests/docs/ecc2-release-surface.test.js`
- [x] `node tests/docs/harness-adapter-compliance.test.js`
- [x] `node tests/docs/stale-pr-salvage-ledger.test.js`
- [x] `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the ECC 2.0 GA roadmap to record ECC‑Tools PR #28 billing readiness audit and align billing acceptance with verified coverage. The audit checks plan limits, entitlements, Marketplace plan shape, subscription source/state, seats, and overage metering, and shifts the next ECC Tools slice toward deep analysis and Linear/project sync.

<sup>Written for commit 21116ed9ae6ce12e11c5293162286ea161af8ff4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed ECC 2.0 GA roadmap with updated billing readiness audit specifications.
  * Clarified Milestone 6 criteria for billing audit validation scope.
  * Revised upcoming engineering initiatives to prioritize analysis tool enhancements and integration improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1794)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->