### PR TITLE
docs: record AgentShield HTML report evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -52,6 +52,9 @@ As of 2026-05-12:
 - AgentShield PR #58 added MCP package provenance fields and report-level
   counts for npm vs git, pinned vs unpinned, known-good, and registry-backed
   supply-chain evidence.
+- AgentShield PR #59 added self-contained HTML executive summaries with risk
+  posture, critical/high priority findings, category exposure, README/API
+  docs, built-CLI smoke validation, and 1,704-test coverage.
 - ECC PR #1778 recovered the useful stale #1413 network/homelab architect-agent
   concepts.
 - ECC-Tools PR #26 added cost/token-risk predictive follow-ups for AI routing,
@@ -178,7 +181,8 @@ Acceptance:
   path for npm/pip reputation, CVEs, typosquats, and dependency risk.
 - Prompt-injection corpus and regression benchmark are ready for continuous
   rule hardening.
-- Enterprise reports include JSON plus HTML/PDF or equivalent executive output.
+- Enterprise reports include JSON plus self-contained HTML executive output
+  with risk posture, priority findings, and category exposure.
 
 ### 6. ECC Tools Billing, Deep Analysis, PR Checks, And Linear Sync
 
@@ -222,7 +226,7 @@ Acceptance:
 
 ## Next Engineering Slices
 
-1. Extend AgentShield enterprise reporting beyond terminal/JSON supply-chain
-   evidence toward executive HTML/PDF or equivalent report output.
+1. Finish AgentShield prompt-injection corpus/regression benchmark work and
+   decide whether PDF export adds value beyond the merged HTML executive report.
 2. Extend ECC Tools deep analysis and Linear/project sync without flooding the
    workspace.


### PR DESCRIPTION
## Summary

Records the merged AgentShield executive HTML report work in the ECC 2.0 GA roadmap.

## Details

- Adds AgentShield PR #59 to current evidence
- Marks self-contained HTML executive reporting as the enterprise report output evidence
- Moves the next AgentShield slice to prompt-injection benchmark work and the optional PDF decision

## Test plan

- [x] `npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- [x] `npm test` (2324 tests)
- [x] `npm run harness:audit -- --format json` (70/70)
- [x] `npm run harness:adapters -- --check` (PASS, 11 adapters)
- [x] `npm run observability:ready` (14/14)
- [x] `git diff --check`

## Notes

Unrelated local `docs/drafts/` remains untracked and was not touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the ECC 2.0 GA roadmap to record the merged AgentShield self-contained HTML executive report and reflect it in acceptance criteria. Adds evidence for AgentShield PR #59, clarifies enterprise output as JSON + HTML, and shifts next work to the prompt-injection benchmark with a follow-up decision on PDF export.

<sup>Written for commit eab2f8a42c5e64db81720d8501cd5e1c816f1fed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap with current milestone progress and clarified enterprise report specifications for JSON plus self-contained HTML executive output format.
  * Documented test coverage achievements and defined future engineering priorities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1796)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->