### PR TITLE
docs: record AgentShield corpus benchmark evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -55,6 +55,9 @@ As of 2026-05-12:
 - AgentShield PR #59 added self-contained HTML executive summaries with risk
   posture, critical/high priority findings, category exposure, README/API
   docs, built-CLI smoke validation, and 1,704-test coverage.
+- AgentShield PR #60 added category-level built-in corpus benchmark output,
+  a `readyForRegressionGate` signal, terminal `--corpus` category coverage,
+  README/API docs, built-CLI smoke validation, and 1,705-test coverage.
 - ECC PR #1778 recovered the useful stale #1413 network/homelab architect-agent
   concepts.
 - ECC-Tools PR #26 added cost/token-risk predictive follow-ups for AI routing,
@@ -180,7 +183,7 @@ Acceptance:
 - Supply-chain intelligence covers MCP package provenance and has an extension
   path for npm/pip reputation, CVEs, typosquats, and dependency risk.
 - Prompt-injection corpus and regression benchmark are ready for continuous
-  rule hardening.
+  rule hardening with category-level coverage and regression-gate output.
 - Enterprise reports include JSON plus self-contained HTML executive output
   with risk posture, priority findings, and category exposure.
 
@@ -226,7 +229,7 @@ Acceptance:
 
 ## Next Engineering Slices
 
-1. Finish AgentShield prompt-injection corpus/regression benchmark work and
-   decide whether PDF export adds value beyond the merged HTML executive report.
+1. Decide whether AgentShield PDF export adds value beyond the merged HTML
+   executive report and corpus benchmark output.
 2. Extend ECC Tools deep analysis and Linear/project sync without flooding the
    workspace.


### PR DESCRIPTION
## Summary

- record AgentShield PR #60 built-in corpus benchmark evidence in the ECC 2.0 GA roadmap
- update AgentShield acceptance criteria to reflect category-level coverage and regression-gate output
- narrow the next AgentShield slice to the PDF-export value decision

## Validation

- `npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `npm run harness:audit -- --format json` (70/70)
- `npm run harness:adapters -- --check` (PASS, 11 adapters)
- `npm run observability:ready` (14/14)
- `npm test` (2324 passed, 0 failed)
- `git diff --check`

## Notes

- Unrelated local `docs/drafts/` remains untracked and untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the ECC 2.0 GA roadmap to record AgentShield PR #60 corpus benchmark evidence: category-level coverage, `readyForRegressionGate`, and terminal `--corpus` output. Align acceptance criteria with this coverage and focus the next slice on the PDF export value decision.

<sup>Written for commit c6b91add26749f567795e97d6eda12bc594ad6db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA roadmap with AgentShield progress and validation capabilities.
  * Enhanced Milestone 5 acceptance criteria with specific coverage and regression gate requirements.
  * Clarified next engineering priorities regarding feature value assessment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1797)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->