### PR TITLE
docs: record ECC Tools reference validation evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -69,6 +69,9 @@ As of 2026-05-12:
 - ECC-Tools PR #28 added billing readiness audit checks for plan limits,
   entitlements, Marketplace plan shape, subscription source, seats, and
   overage metering.
+- ECC-Tools PR #29 added deterministic Reference Set Validation signals for
+  analyzer, skill, agent, command, and harness-guidance changes that lack eval,
+  golden trace, benchmark, or reference-set evidence.
 
 ## Operating Rules
 
@@ -206,6 +209,9 @@ Acceptance:
   Review.
 - Cost/token-risk predictive follow-ups flag AI routing, model-call, usage,
   quota, and budget changes when budget evidence is missing.
+- Reference-set validation follow-ups flag analyzer, skill, agent, command, and
+  harness-guidance changes that lack eval, golden trace, benchmark, or
+  maintained reference-set evidence.
 - Linear sync design maps findings to issues/status without flooding the
   workspace.
 


### PR DESCRIPTION
## Summary

- record ECC-Tools PR #29 in the ECC 2.0 GA roadmap
- note the new Reference Set Validation signals for analyzer, skill, agent, command, and harness-guidance changes
- update ECC Tools acceptance criteria with reference-set validation follow-ups

## Validation

- `npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `npm run harness:audit -- --format json` (70/70)
- `npm run harness:adapters -- --check` (PASS, 11 adapters)
- `npm run observability:ready` (14/14)
- `npm test` (2324 passed, 0 failed)
- `git diff --check`

## Notes

- Unrelated local `docs/drafts/` remains untracked and untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ECC 2.0 GA roadmap to record ECC-Tools PR #29. Document deterministic Reference Set Validation signals for analyzer, skill, agent, command, and harness-guidance changes, and update ECC Tools acceptance criteria with follow-ups when eval, golden trace, benchmark, or maintained reference-set evidence is missing.

<sup>Written for commit 43be8dd28d8983039730be7b06d6e6889558a4ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA Roadmap "Current Evidence" section with new ECC-Tools evidence bullets addressing cost/token-risk predictive follow-ups and deterministic Reference Set Validation signals.
  * Expanded milestone acceptance documentation to include comprehensive evaluation, golden trace, benchmark, and reference-set evidence requirements for analyzer, skill, agent, command, and harness-guidance system changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1798)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->