### PR TITLE
docs: record ECC Tools followup flood control

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -72,6 +72,9 @@ As of 2026-05-12:
 - ECC-Tools PR #29 added deterministic Reference Set Validation signals for
   analyzer, skill, agent, command, and harness-guidance changes that lack eval,
   golden trace, benchmark, or reference-set evidence.
+- ECC-Tools PR #30 capped follow-up generation to three new GitHub issues and
+  one draft PR per run, then emits the remaining deterministic findings as a
+  project sync backlog for Linear/status tracking without flooding trackers.
 
 ## Operating Rules
 
@@ -214,6 +217,8 @@ Acceptance:
   maintained reference-set evidence.
 - Linear sync design maps findings to issues/status without flooding the
   workspace.
+- Follow-up generation caps automatic GitHub object creation and keeps overflow
+  findings in a copy-ready project sync backlog.
 
 ### 7. Legacy Audit And Stale-Work Salvage Closure
 


### PR DESCRIPTION
## Summary

- record ECC-Tools PR #30 as current GA roadmap evidence
- note that follow-up generation now caps new GitHub object creation and emits overflow as a project sync backlog for Linear/status tracking

## Test plan

- [x] `npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- [x] `npm run harness:audit -- --format json` (70/70)
- [x] `npm run harness:adapters -- --check` (11 adapters)
- [x] `npm run observability:ready` (14/14)
- [x] `npm test` (2324/2324)
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the ECC 2.0 GA roadmap to document ECC-Tools PR #30, which adds follow-up flood control. It caps automatic GitHub creation to three issues and one draft PR per run, and routes overflow to a project sync backlog for Linear/status tracking to prevent flooding.

<sup>Written for commit 2b00ecf1aee725255cf4c541d373ef6609a916bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap and operating rules to clarify rate limiting for automatic GitHub object creation. Follow-up generation is now capped to three new issues and one draft PR per run, with additional findings retained in a project sync backlog.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1799)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->