### PR TITLE
docs: record ECC Tools review followups

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -75,6 +75,9 @@ As of 2026-05-12:
 - ECC-Tools PR #30 capped follow-up generation to three new GitHub issues and
   one draft PR per run, then emits the remaining deterministic findings as a
   project sync backlog for Linear/status tracking without flooding trackers.
+- ECC-Tools PR #31 added review follow-up signals to analysis completion
+  comments for outstanding change requests, unresolved or outdated review
+  threads, and review activity without an explicit approval.
 
 ## Operating Rules
 
@@ -215,6 +218,8 @@ Acceptance:
 - Reference-set validation follow-ups flag analyzer, skill, agent, command, and
   harness-guidance changes that lack eval, golden trace, benchmark, or
   maintained reference-set evidence.
+- PR analysis comments summarize review follow-up signals for requested
+  changes, unresolved or outdated review threads, and missing approvals.
 - Linear sync design maps findings to issues/status without flooding the
   workspace.
 - Follow-up generation caps automatic GitHub object creation and keeps overflow


### PR DESCRIPTION
## Summary

- record ECC-Tools PR #31 review follow-up signal evidence in the ECC 2.0 GA roadmap
- add PR review behavior to the ECC Tools deep-analysis acceptance criteria

## Test plan

- [x] npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md
- [x] npm run harness:audit -- --format json (70/70)
- [x] npm run harness:adapters -- --check (PASS, 11 adapters)
- [x] npm run observability:ready (14/14)
- [x] npm test (2324 passed)
- [x] git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented ECC-Tools PR #31 review follow-up signals in the ECC 2.0 GA roadmap and updated deep-analysis acceptance criteria for PR review behavior. PR analysis comments must now summarize requested changes, unresolved or outdated review threads, and missing approvals.

<sup>Written for commit 5de4a1ee0cfbcf2785169870d49425c21fc4572d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ECC-2.0 GA roadmap with enhanced Milestone 6 acceptance criteria. PR analysis comments must now summarize review follow-up signals, including unresolved threads and missing approvals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1800)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->