### PR TITLE
docs: record ECC Tools CI failure history evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -78,6 +78,9 @@ As of 2026-05-12:
 - ECC-Tools PR #31 added review follow-up signals to analysis completion
   comments for outstanding change requests, unresolved or outdated review
   threads, and review activity without an explicit approval.
+- ECC-Tools PR #32 added CI failure-mode predictive follow-ups for workflow
+  and test-runner changes that lack failure fixtures, captured logs,
+  troubleshooting notes, dry-run evidence, or regression coverage.
 
 ## Operating Rules
 
@@ -220,6 +223,9 @@ Acceptance:
   maintained reference-set evidence.
 - PR analysis comments summarize review follow-up signals for requested
   changes, unresolved or outdated review threads, and missing approvals.
+- CI failure-mode predictive follow-ups flag workflow and test-runner changes
+  that lack failure fixtures, captured logs, troubleshooting notes, dry-run
+  evidence, or regression coverage.
 - Linear sync design maps findings to issues/status without flooding the
   workspace.
 - Follow-up generation caps automatic GitHub object creation and keeps overflow


### PR DESCRIPTION
## Summary

- record ECC-Tools PR #32 in the GA roadmap evidence log
- add CI failure-mode predictive follow-ups to the ECC Tools acceptance surface

## Test plan

- npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md
- npm run harness:audit -- --format json
- npm run harness:adapters -- --check
- npm run observability:ready
- npm test
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the ECC-2.0 GA roadmap evidence log to record ECC-Tools PR #32 and expands the acceptance criteria. Documents CI failure‑mode predictive follow-ups that flag workflow/test-runner changes missing failure fixtures, captured logs, troubleshooting notes, dry‑run evidence, or regression coverage.

<sup>Written for commit 49fd766ba95b9e08b1840b4e10986b6b5b036c73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the roadmap documentation to reflect current project planning and milestone specifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1801)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->