### PR TITLE
docs: record ECC Tools harness config evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -81,6 +81,10 @@ As of 2026-05-12:
 - ECC-Tools PR #32 added CI failure-mode predictive follow-ups for workflow
   and test-runner changes that lack failure fixtures, captured logs,
   troubleshooting notes, dry-run evidence, or regression coverage.
+- ECC-Tools PR #33 added harness-config quality predictive follow-ups for MCP,
+  plugin, agent, hook, command, and harness config changes that lack harness
+  audit, adapter matrix, cross-harness docs, or compatibility regression
+  evidence.
 
 ## Operating Rules
 
@@ -226,6 +230,9 @@ Acceptance:
 - CI failure-mode predictive follow-ups flag workflow and test-runner changes
   that lack failure fixtures, captured logs, troubleshooting notes, dry-run
   evidence, or regression coverage.
+- Harness-config quality predictive follow-ups flag MCP, plugin, agent, hook,
+  command, and harness config changes that lack audit, adapter matrix,
+  cross-harness doc, or compatibility regression evidence.
 - Linear sync design maps findings to issues/status without flooding the
   workspace.
 - Follow-up generation caps automatic GitHub object creation and keeps overflow


### PR DESCRIPTION
## Summary

Records the ECC-Tools #33 harness-config quality signal in the ECC 2.0 GA roadmap evidence ledger and acceptance checklist.

## Evidence

- ECC-Tools PR #33 added predictive follow-ups for MCP, plugin, agent, hook, command, and harness config changes that lack harness audit, adapter matrix, cross-harness docs, or compatibility regression evidence.

## Validation

- `npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `npm run harness:audit -- --format json`
- `npm run harness:adapters -- --check`
- `npm run observability:ready`
- `npm test` (2324 passed, 0 failed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs/ECC-2.0-GA-ROADMAP.md to record the ECC-Tools PR #33 harness-config quality signal in the evidence ledger and the acceptance checklist. Documents predictive follow-ups that flag MCP, plugin, agent, hook, command, and harness config changes lacking harness audit, adapter matrix, cross-harness docs, or compatibility regression evidence.

<sup>Written for commit e31de258ba0406d6fe626c692ad40260929ff647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ECC-2.0-GA-ROADMAP with expanded information about follow-up capabilities for harness configuration quality scenarios and their coverage across multiple components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1802)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->