### PR TITLE
docs: record ECC Tools skill quality evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -85,6 +85,9 @@ As of 2026-05-12:
   plugin, agent, hook, command, and harness config changes that lack harness
   audit, adapter matrix, cross-harness docs, or compatibility regression
   evidence.
+- ECC-Tools PR #34 added skill-quality predictive follow-ups and a Skill
+  Quality PR-risk bucket for skill, agent, command, and rule guidance changes
+  that lack examples, validation, eval, or reference evidence.
 - ECC PR #1803 landed the contributor Quarkus handling branch after maintainer
   cleanup, current-`main` alignment, full local validation, and preservation of
   the author's removal of incomplete ja-JP and zh-CN Quarkus translations.
@@ -120,8 +123,8 @@ is not complete unless the evidence column exists and has been freshly verified.
 | Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness gate exists | Not complete |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
 | AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports | PRs #53, #55-#60 landed with test evidence | Needs next value decision |
-| ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog | PRs #26-#33 landed with test evidence | Needs skill/RAG and Linear sync slice |
-| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy and deterministic follow-up checks | ECC-Tools risk taxonomy check plus follow-up signals landed | Partially complete |
+| ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog | PRs #26-#34 landed with test evidence | Needs RAG and Linear sync slice |
+| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy and deterministic follow-up checks | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality | Partially complete |
 | Harness-agnostic learning system | Audit, adapter matrix, observability, traces, promotion loop | Audit/adapters/observability gates exist | Needs evaluation/RAG prototype |
 | Linear roadmap is detailed | Linear project status plus repo mirror | Repo mirror exists; issue creation is blocked by workspace limit | Needs recurring status updates |
 | Flow separation and progress tracking | Flow lanes with owner artifacts and update cadence | This roadmap defines lanes below | Active |
@@ -143,7 +146,7 @@ back to the repo evidence and merge commits.
 | Harness OS core | Audit, adapter matrix, observability docs, `ecc2/` | HUD/session-control acceptance spec | Weekly until GA |
 | Evaluation and RAG | Reference-set validation, harness audit, traces | Read-only evaluator/RAG prototype design | Before deep analyzer expansion |
 | AgentShield enterprise | AgentShield PR evidence and roadmap notes | PDF-export decision or next enterprise signal | After value decision |
-| ECC Tools app | ECC-Tools PR evidence, billing audit, risk taxonomy | Skill-quality/RAG follow-up signal slice | Next implementation batch |
+| ECC Tools app | ECC-Tools PR evidence, billing audit, risk taxonomy | RAG/evaluator follow-up signal slice | Next implementation batch |
 | Linear progress | Linear project status updates and this mirror | Status update with queue/evidence/missing gates | Every significant merge batch |
 
 The project status update should always include:


### PR DESCRIPTION
## Summary

Records the merged ECC-Tools #34 skill-quality follow-up signal in the ECC 2.0 GA roadmap mirror.

## Updates

- adds #34 to current evidence
- updates the ECC Tools app checklist evidence from #26-#33 to #26-#34
- narrows the next ECC Tools slice to the remaining RAG/evaluator work

## Validation

- `npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `npm run observability:ready`
- `npm run harness:adapters -- --check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded ECC-Tools PR #34 in the ECC 2.0 GA roadmap to capture the new skill‑quality follow-up signal and Skill Quality PR‑risk bucket. Updated the evidence table to include PRs #26‑#34, noted Skill Quality in follow-up signals, and narrowed the next ECC Tools slice to RAG/evaluator work.

<sup>Written for commit ce2ae2818f0ff8d6e58f8d58e811c6aeed244e33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA Roadmap to reflect current development progress and clarify execution tracking definitions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1805)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->