### PR TITLE
docs: record ECC Tools PR review salvage evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -98,6 +98,9 @@ As of 2026-05-12:
 - ECC-Tools PR #37 added a maintained analyzer corpus fixture, corpus validation
   tests, and co-located analyzer reference-set evidence recognition for future
   predictive follow-ups and PR-risk taxonomy checks.
+- ECC-Tools PR #38 added PR review/stale-salvage predictive follow-ups, a
+  PR Review/Salvage Evidence taxonomy bucket, and maintained corpus fixtures
+  for stale-closure salvage, reviewer-thread, and reopen-flow evidence.
 - ECC PR #1803 landed the contributor Quarkus handling branch after maintainer
   cleanup, current-`main` alignment, full local validation, and preservation of
   the author's removal of incomplete ja-JP and zh-CN Quarkus translations.
@@ -133,8 +136,8 @@ is not complete unless the evidence column exists and has been freshly verified.
 | Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness gate exists | Not complete |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
 | AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports | PRs #53, #55-#60 landed with test evidence | Needs next value decision |
-| ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog | PRs #26-#37 landed with test evidence | Needs native Linear API sync / broader evaluator corpus |
-| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy and deterministic follow-up checks | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, and RAG/Evaluator Evidence | Partially complete |
+| ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog | PRs #26-#38 landed with test evidence | Needs native Linear API sync / broader evaluator corpus |
+| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy and deterministic follow-up checks | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, and PR Review/Salvage Evidence | Partially complete |
 | Harness-agnostic learning system | Audit, adapter matrix, observability, traces, promotion loop | Audit/adapters/observability gates exist | Needs evaluation/RAG prototype |
 | Linear roadmap is detailed | Linear project status plus repo mirror | Repo mirror exists; issue creation is blocked by workspace limit | Needs recurring status updates |
 | Flow separation and progress tracking | Flow lanes with owner artifacts and update cadence | This roadmap defines lanes below | Active |
@@ -156,7 +159,7 @@ back to the repo evidence and merge commits.
 | Harness OS core | Audit, adapter matrix, observability docs, `ecc2/` | HUD/session-control acceptance spec | Weekly until GA |
 | Evaluation and RAG | Reference-set validation, harness audit, traces | Read-only evaluator/RAG prototype design | Before deep analyzer expansion |
 | AgentShield enterprise | AgentShield PR evidence and roadmap notes | PDF-export decision or next enterprise signal | After value decision |
-| ECC Tools app | ECC-Tools PR evidence, billing audit, risk taxonomy | Native Linear sync or broader evaluator corpus slice | Next implementation batch |
+| ECC Tools app | ECC-Tools PR evidence, billing audit, risk taxonomy | Native Linear sync or broader evaluator/RAG corpus slice | Next implementation batch |
 | Linear progress | Linear project status updates and this mirror | Status update with queue/evidence/missing gates | Every significant merge batch |
 
 The project status update should always include:
@@ -284,11 +287,12 @@ Acceptance:
 - Deep analyzer covers diff patterns, CI/CD workflows, dependency/security
   surface, PR review behavior, failure history, harness config, skill quality,
   dedicated analyzer corpus evidence, co-located analyzer reference sets,
-  RAG/evaluator comparison, and reference-set validation.
+  PR review/stale-salvage evidence, RAG/evaluator comparison, and reference-set
+  validation.
 - PR check suite taxonomy includes Security Evidence, Harness Drift, Install
   Manifest Integrity, CI/CD Recommendation, Cost/Token Risk, Reference Set
-  Validation, Deep Analyzer Evidence, RAG/Evaluator Evidence, Skill Quality,
-  and Agent Config Review.
+  Validation, Deep Analyzer Evidence, RAG/Evaluator Evidence,
+  PR Review/Salvage Evidence, Skill Quality, and Agent Config Review.
 - Cost/token-risk predictive follow-ups flag AI routing, model-call, usage,
   quota, and budget changes when budget evidence is missing.
 - Reference-set validation follow-ups flag analyzer, skill, agent, command, and
@@ -304,6 +308,9 @@ Acceptance:
 - RAG/evaluator follow-ups flag retrieval, embedding, ranking, and evaluator
   changes that lack reference-set comparison, golden trace, benchmark, fixture,
   or eval-run evidence.
+- PR review/stale-salvage follow-ups flag review, triage, stale-closure, and
+  pull-request automation changes that lack stale-salvage fixtures,
+  reviewer-thread cases, or reopen-flow reference evidence.
 - PR analysis comments summarize review follow-up signals for requested
   changes, unresolved or outdated review threads, and missing approvals.
 - CI failure-mode predictive follow-ups flag workflow and test-runner changes
@@ -341,5 +348,5 @@ Acceptance:
    executive report and corpus benchmark output.
 2. Add native Linear API sync for ECC Tools backlog items after workspace issue
    capacity clears.
-3. Expand the analyzer/evaluator corpus with real stale-salvage and PR-review
-   cases as future cleanup batches produce safe maintainer-owned examples.
+3. Expand the evaluator/RAG corpus with real cleanup-batch cases as future
+   maintainer-owned examples land.


### PR DESCRIPTION
## Summary

- record ECC-Tools PR #38 in the GA roadmap evidence list
- update ECC Tools evidence count to #26-#38
- add PR Review/Salvage Evidence to the risk-taxonomy and deep-analyzer acceptance text
- adjust the next-slice wording now that the stale-salvage/PR-review corpus seed has landed

## Test plan

- [x] npx --yes markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md
- [x] npm run observability:ready
- [x] npm run harness:adapters -- --check
- [x] npm run harness:audit -- --format json
- [x] git diff --check

## Notes

- Leaves pre-existing untracked docs/drafts/ untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `docs/ECC-2.0-GA-ROADMAP.md` to record ECC-Tools PR #38 and add a PR Review/Salvage evidence bucket to the risk taxonomy and deep analyzer acceptance. Also update the ECC Tools evidence range to #26–#38 and tighten next-slice wording.

- **Docs**
  - Add PR review/stale-salvage follow-ups and acceptance checks to the taxonomy.
  - Record PR #38 with notes on reviewer-thread, stale-closure, and reopen-flow fixtures.
  - Update roadmap table and next-slice phrasing to emphasize evaluator/RAG corpus expansion.

<sup>Written for commit 7d48edcf9dc2d2e8f9798ee1cd9118df4751d0c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC-Tools roadmap with extended progress evidence and enhanced milestone criteria including PR review tracking and corpus expansion targets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1809)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->