### PR TITLE
docs: record rc1 publication dry-run evidence

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,17 @@ scripts/release.sh
 
 # Plugin dev notes (not needed by consumers)
 .claude-plugin/PLUGIN_SCHEMA_NOTES.md
+
+# Python/test cache artifacts are local build byproducts, not runtime surface
+__pycache__/
+**/__pycache__/
+**/__pycache__/**
+*.pyc
+*.pyo
+*.pyd
+**/*.pyc
+**/*.pyo
+**/*.pyd
+*$py.class
+.pytest_cache/
+**/.pytest_cache/**

--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -45,6 +45,12 @@ As of 2026-05-12:
   rc.1 naming decision: ship as Everything Claude Code (ECC), keep
   `ecc-universal` for npm, keep `ecc` for Claude/Codex plugin slugs, and defer
   any broader repo/package rename until after the release pipeline is proven.
+- `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md` records the
+  dry-run publication evidence pass: npm pack/publish dry-runs, temp install
+  smoke, Claude plugin validation/tag preflight, Codex marketplace CLI shape,
+  OpenCode build, and the remaining approval-gated release blockers.
+- The npm package surface now excludes Python bytecode/cache artifacts through
+  package `files` negation rules and a publish-surface regression test.
 - `docs/legacy-artifact-inventory.md` records that no `_legacy-documents-*`
   directories exist in the current checkout, inventories the two sibling
   workspace-level `_legacy-documents-*` repos as sanitized extraction sources,
@@ -178,7 +184,7 @@ is not complete unless the evidence column exists and has been freshly verified.
 | ECC 2.0 preview pack ready | Release docs, quickstart, publication readiness, release notes | `docs/releases/2.0.0-rc.1/` and readiness docs are in-tree | Needs final release evidence |
 | Hermes specialized skills included safely | Hermes setup/import docs and sanitized skill surface | Hermes setup and import playbook are public; secrets stay local | Needs final release review |
 | Naming and rename readiness | Naming matrix across package/plugin/docs/social surfaces | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` records current package, repo, Claude plugin, Codex plugin, OpenCode, and npm availability evidence | Complete for rc.1; post-rc rename remains future work |
-| Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness plus naming matrix document local validation and CLI marketplace/tag surfaces | Needs final release-commit plugin tag/install evidence |
+| Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness, naming matrix, and May 12 dry-run evidence document plugin validation, Claude tag preflight, and Codex marketplace CLI shape | Needs clean-checkout release tag/install evidence and explicit approval |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
 | AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit | PRs #53, #55-#62 landed with test evidence | Needs PDF/export decision or next enterprise signal |
 | ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog | PRs #26-#39 landed with test evidence | Needs capacity-backed Linear rollout / broader evaluator corpus |

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md
@@ -1,0 +1,82 @@
+# ECC v2.0.0-rc.1 Publication Evidence — 2026-05-12
+
+This is dry-run release evidence only. It does not create a GitHub release, npm
+publication, plugin tag, marketplace submission, or announcement post.
+
+## Source Commit
+
+| Field | Evidence |
+| --- | --- |
+| Upstream main base | `0598af70a51346bae34d987b9bed143386055967` |
+| Evidence branch | `codex/release-publication-evidence` |
+| Evidence scope | Working tree with this branch's package hygiene and release-doc updates |
+| Git remote | `https://github.com/affaan-m/everything-claude-code.git` |
+| Local status caveat | Working tree had the unrelated untracked `docs/drafts/` directory |
+
+The actual release operator should repeat these checks from the final release
+commit with a clean checkout before publishing.
+
+## Registry And Release State
+
+| Surface | Command | Result |
+| --- | --- | --- |
+| GitHub prerelease | `gh release view v2.0.0-rc.1 --repo affaan-m/everything-claude-code --json tagName,url,isPrerelease` | `release not found` |
+| npm dist-tags | `npm view ecc-universal dist-tags --json` | `{ "latest": "1.10.0" }` |
+| npm package metadata | `node -p "require('./package.json').name + '@' + require('./package.json').version"` | `ecc-universal@2.0.0-rc.1` |
+| Product identity | `rg -n "Everything Claude Code" README.md CHANGELOG.md docs/releases/2.0.0-rc.1` | Present in README and rc.1 release docs |
+
+## npm Dry Run
+
+The first pack pass exposed local Python bytecode cache files in the tarball
+because broad package `files` entries included untracked local `__pycache__`
+paths. This branch adds explicit package-file exclusions and a regression test
+so `npm pack` fails if Python bytecode appears in the package surface.
+
+| Command | Result |
+| --- | --- |
+| `node tests/scripts/npm-publish-surface.test.js` | Passed `2/2`; includes Python bytecode exclusion assertion |
+| `npm pack --dry-run --json` | `ecc-universal-2.0.0-rc.1.tgz`; `entryCount: 965`; `size: 1565968`; `unpackedSize: 4934637`; `hasBytecode: false` |
+| `npm publish --tag next --dry-run --json` | Dry-run target is npm registry with `tag next`; `entryCount: 965`; `hasBytecode: false` |
+
+Temporary install smoke:
+
+| Command | Result |
+| --- | --- |
+| `npm pack --pack-destination /tmp/ecc-publication-smoke-dd9ud5 --json` | Created `ecc-universal-2.0.0-rc.1.tgz` for local install smoke |
+| `npm install --prefix /tmp/ecc-publication-smoke-dd9ud5 /tmp/ecc-publication-smoke-dd9ud5/ecc-universal-2.0.0-rc.1.tgz` | Added 8 packages |
+| `node /tmp/ecc-publication-smoke-dd9ud5/node_modules/ecc-universal/scripts/ecc.js --help` | Printed ECC selective-install CLI help |
+| `node /tmp/ecc-publication-smoke-dd9ud5/node_modules/ecc-universal/scripts/catalog.js profiles --json` | Returned the 6 install profiles: `minimal`, `core`, `developer`, `security`, `research`, `full` |
+| `find /tmp/ecc-publication-smoke-dd9ud5/node_modules/ecc-universal -path '*__pycache__*' -o -name '*.pyc' -o -name '*.pyo' -o -name '*.pyd'` | No output |
+
+## Plugin And Harness Evidence
+
+| Surface | Command | Result |
+| --- | --- | --- |
+| Claude plugin manifest | `claude plugin validate .claude-plugin/plugin.json` | Passed |
+| Claude plugin tag preflight | `claude plugin tag .claude-plugin --dry-run` | Blocked by unrelated untracked `docs/drafts/` |
+| Claude plugin tag forced dry-run | `claude plugin tag .claude-plugin --dry-run --force` | Would create `ecc--v2.0.0-rc.1` at HEAD; do not use `--force` for real release unless maintainer decides |
+| Codex marketplace CLI | `codex plugin marketplace --help` and subcommand help | Supports `add`, `upgrade`, and `remove`; `add` supports repo and local marketplace roots |
+| OpenCode package | `npm run build:opencode` | Passed |
+| Claude hook/plugin route | `node tests/hooks/hooks.test.js` | Passed `236/236` |
+| Codex release surface | `node tests/docs/ecc2-release-surface.test.js` | Passed `18/18` |
+| Agent/catalog metadata | `node tests/scripts/catalog.test.js` | Passed `7/7` |
+| Observability gate | `npm run observability:ready` | Passed `16/16` |
+
+## Announcement Placeholder Check
+
+The forbidden-placeholder scan only returned the publication-readiness checklist
+lines that name those forbidden placeholders. No launch-pack placeholder
+instances were found.
+
+## Remaining Blockers
+
+- Create or verify GitHub prerelease `v2.0.0-rc.1`.
+- Publish `ecc-universal@2.0.0-rc.1` with npm dist-tag `next`.
+- Re-run `claude plugin tag .claude-plugin --dry-run` from a clean checkout,
+  then create and push the plugin tag only after explicit approval.
+- Confirm the live Claude/Codex/OpenCode marketplace submission path or record
+  the manual submission owner and status.
+- Verify ECC Tools billing/App/Marketplace claims before using them in launch
+  copy.
+- Refresh announcement copy with live URLs after release and package/plugin
+  URLs exist.

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -6,33 +6,35 @@ URLs from the exact commit being released.
 
 For the current rc.1 naming decision and package/plugin publication path, see
 [`naming-and-publication-matrix.md`](naming-and-publication-matrix.md).
+For the May 12 dry-run evidence pass, see
+[`publication-evidence-2026-05-12.md`](publication-evidence-2026-05-12.md).
 
 ## Release Identity Matrix
 
 | Surface | Expected value | Source of truth | Fresh check | Evidence artifact | Owner | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| Product name | Everything Claude Code / ECC | `README.md`, `CHANGELOG.md`, release notes | `rg -n "Everything Claude Code" README.md CHANGELOG.md docs/releases/2.0.0-rc.1` | Pending | Release owner | Pending |
-| GitHub repo | `affaan-m/everything-claude-code` | Git remote and release URLs | `git remote get-url origin` | Pending | Release owner | Pending |
-| Git tag | `v2.0.0-rc.1` | GitHub releases | `gh release view v2.0.0-rc.1 --repo affaan-m/everything-claude-code` | Pending | Release owner | Pending |
-| npm package | `ecc-universal` | `package.json` | `node -p "require('./package.json').name"` | Pending | Package owner | Pending |
-| npm version | `2.0.0-rc.1` | `VERSION`, `package.json`, lockfiles | `node -p "require('./package.json').version"` | Pending | Package owner | Pending |
-| npm dist-tag | `next` for rc, `latest` only for GA | npm registry | `npm view ecc-universal dist-tags --json` | Pending | Package owner | Pending |
-| Claude plugin slug | `ecc` / `ecc@ecc` install path | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` | `node tests/hooks/hooks.test.js` | Pending | Plugin owner | Pending |
-| Claude plugin manifest | `2.0.0-rc.1`, no unsupported `agents` or explicit `hooks` fields | `.claude-plugin/plugin.json`, `.claude-plugin/PLUGIN_SCHEMA_NOTES.md` | `claude plugin validate .claude-plugin/plugin.json` | Pending | Plugin owner | Pending |
-| Codex plugin manifest | `2.0.0-rc.1` with shared skill source | `.codex-plugin/plugin.json` | `node tests/docs/ecc2-release-surface.test.js` | Pending | Plugin owner | Pending |
-| OpenCode package | `ecc-universal` plugin module | `.opencode/package.json`, `.opencode/index.ts` | `npm run build:opencode` | Pending | Package owner | Pending |
-| Agent metadata | `2.0.0-rc.1` | `agent.yaml`, `.agents/plugins/marketplace.json` | `node tests/scripts/catalog.test.js` | Pending | Release owner | Pending |
-| Migration copy | rc.1 upgrade path, not GA claim | `release-notes.md`, `quickstart.md`, `HERMES-SETUP.md` | `npx markdownlint-cli docs/releases/2.0.0-rc.1/*.md` | Pending | Docs owner | Pending |
+| Product name | Everything Claude Code / ECC | `README.md`, `CHANGELOG.md`, release notes | `rg -n "Everything Claude Code" README.md CHANGELOG.md docs/releases/2.0.0-rc.1` | `publication-evidence-2026-05-12.md` | Release owner | Evidence recorded |
+| GitHub repo | `affaan-m/everything-claude-code` | Git remote and release URLs | `git remote get-url origin` | `publication-evidence-2026-05-12.md` | Release owner | Evidence recorded |
+| Git tag | `v2.0.0-rc.1` | GitHub releases | `gh release view v2.0.0-rc.1 --repo affaan-m/everything-claude-code` | `release not found` | Release owner | Blocked until release approval |
+| npm package | `ecc-universal` | `package.json` | `node -p "require('./package.json').name"` | `publication-evidence-2026-05-12.md` | Package owner | Evidence recorded |
+| npm version | `2.0.0-rc.1` | `VERSION`, `package.json`, lockfiles | `node -p "require('./package.json').version"` | `publication-evidence-2026-05-12.md` | Package owner | Evidence recorded |
+| npm dist-tag | `next` for rc, `latest` only for GA | npm registry | `npm view ecc-universal dist-tags --json` | Current registry only has `latest: 1.10.0`; `next` is pending publish | Package owner | Blocked until publish approval |
+| Claude plugin slug | `ecc` / `ecc@ecc` install path | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` | `node tests/hooks/hooks.test.js` | `publication-evidence-2026-05-12.md` | Plugin owner | Evidence recorded |
+| Claude plugin manifest | `2.0.0-rc.1`, no unsupported `agents` or explicit `hooks` fields | `.claude-plugin/plugin.json`, `.claude-plugin/PLUGIN_SCHEMA_NOTES.md` | `claude plugin validate .claude-plugin/plugin.json` | `publication-evidence-2026-05-12.md` | Plugin owner | Evidence recorded |
+| Codex plugin manifest | `2.0.0-rc.1` with shared skill source | `.codex-plugin/plugin.json` | `node tests/docs/ecc2-release-surface.test.js` | `publication-evidence-2026-05-12.md` | Plugin owner | Evidence recorded |
+| OpenCode package | `ecc-universal` plugin module | `.opencode/package.json`, `.opencode/index.ts` | `npm run build:opencode` | `publication-evidence-2026-05-12.md` | Package owner | Evidence recorded |
+| Agent metadata | `2.0.0-rc.1` | `agent.yaml`, `.agents/plugins/marketplace.json` | `node tests/scripts/catalog.test.js` | `publication-evidence-2026-05-12.md` | Release owner | Evidence recorded |
+| Migration copy | rc.1 upgrade path, not GA claim | `release-notes.md`, `quickstart.md`, `HERMES-SETUP.md` | `npx markdownlint-cli docs/releases/2.0.0-rc.1/*.md` | Pending final lint on release commit | Docs owner | Pending |
 
 ## Publication Gates
 
 | Gate | Required evidence | Fresh check | Blocker field | Owner | Status |
 | --- | --- | --- | --- | --- | --- |
-| GitHub release | Tag exists, release notes use final URLs, assets attached if needed | `gh release view v2.0.0-rc.1 --json tagName,url,isPrerelease` | `Blocker:` | Release owner | Pending |
-| npm package | `npm pack --dry-run` has expected files, version matches, rc goes to `next` | `npm pack --dry-run` and `npm publish --tag next --dry-run` where supported | `Blocker:` | Package owner | Pending |
-| Claude plugin | Manifest validates, marketplace JSON points to public repo, install docs match slug | `claude plugin validate .claude-plugin/plugin.json` | `Blocker:` | Plugin owner | Pending |
-| Codex plugin | Manifest version matches package and docs, hook limitations are explicit | `node tests/docs/ecc2-release-surface.test.js` | `Blocker:` | Plugin owner | Pending |
-| OpenCode package | Build output is regenerated from source and package metadata is current | `npm run build:opencode` | `Blocker:` | Package owner | Pending |
+| GitHub release | Tag exists, release notes use final URLs, assets attached if needed | `gh release view v2.0.0-rc.1 --json tagName,url,isPrerelease` | `Blocker: release not found on 2026-05-12` | Release owner | Pending approval |
+| npm package | `npm pack --dry-run` has expected files, version matches, rc goes to `next` | `npm pack --dry-run` and `npm publish --tag next --dry-run` where supported | `Blocker: actual publish requires approval; dry run passed with next tag` | Package owner | Dry-run passed |
+| Claude plugin | Manifest validates, marketplace JSON points to public repo, install docs match slug | `claude plugin validate .claude-plugin/plugin.json` | `Blocker: real tag must run from clean checkout and requires approval` | Plugin owner | Dry-run preflight recorded |
+| Codex plugin | Manifest version matches package and docs, hook limitations are explicit | `node tests/docs/ecc2-release-surface.test.js` | `Blocker: marketplace submission path still manual/owner-gated` | Plugin owner | Evidence recorded |
+| OpenCode package | Build output is regenerated from source and package metadata is current | `npm run build:opencode` | `Blocker: none for local build; public distribution still follows npm/plugin release` | Package owner | Evidence recorded |
 | ECC Tools billing reference | Any billing claim links to verified Marketplace/App state | `gh api repos/ECC-Tools/ECC-Tools` plus app/marketplace URL check | `Blocker:` | ECC Tools owner | Pending |
 | Announcement copy | X, LinkedIn, GitHub release, and longform copy point to live URLs | `rg -n "TODO" docs/releases/2.0.0-rc.1` and repeat for `TBD` | `Blocker:` | Release owner | Pending |
 
@@ -48,7 +50,7 @@ Record the exact commit SHA and command output before any publication action:
 | Observability readiness | `npm run observability:ready` | 16/16 passing | Pending |
 | Root suite | `node tests/run-all.js` | 0 failures | Pending |
 | Markdown lint | `npx markdownlint-cli '**/*.md' --ignore node_modules` | 0 failures | Pending |
-| Package surface | `node tests/scripts/npm-publish-surface.test.js` | 0 failures | Pending |
+| Package surface | `node tests/scripts/npm-publish-surface.test.js` | 0 failures; no Python bytecode in npm tarball | `2/2` passed in May 12 evidence pass |
 | Release surface | `node tests/docs/ecc2-release-surface.test.js` | 0 failures | Pending |
 | Optional Rust surface | `cd ecc2 && cargo test` | 0 failures or explicit deferral | Pending |
 

--- a/package.json
+++ b/package.json
@@ -270,7 +270,12 @@
     "skills/windows-desktop-e2e/",
     "skills/workspace-surface-audit/",
     "skills/x-api/",
-    "the-security-guide.md"
+    "the-security-guide.md",
+    "!**/__pycache__/**",
+    "!**/*.pyc",
+    "!**/*.pyo",
+    "!**/*.pyd",
+    "!**/.pytest_cache/**"
   ],
   "bin": {
     "ecc": "scripts/ecc.js",

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -71,9 +71,16 @@ function buildExpectedPublishPaths(repoRoot) {
     "agent.yaml",
     "VERSION",
   ]
+  const exclusionPaths = [
+    "!**/__pycache__/**",
+    "!**/*.pyc",
+    "!**/*.pyo",
+    "!**/*.pyd",
+    "!**/.pytest_cache/**",
+  ]
 
   const combined = new Set(
-    [...modules.flatMap((module) => module.paths || []), ...extraPaths].map(normalizePublishPath)
+    [...modules.flatMap((module) => module.paths || []), ...extraPaths, ...exclusionPaths].map(normalizePublishPath)
   )
 
   return [...combined]
@@ -137,6 +144,17 @@ function main() {
         assert.ok(
           !packagedPaths.has(excludedPath),
           `npm pack should not include ${excludedPath}`
+        )
+      }
+
+      for (const packagedPath of packagedPaths) {
+        assert.ok(
+          !packagedPath.includes("__pycache__/"),
+          `npm pack should not include Python bytecode cache path ${packagedPath}`
+        )
+        assert.ok(
+          !/\.py[cod]$/.test(packagedPath),
+          `npm pack should not include Python bytecode file ${packagedPath}`
         )
       }
     }],


### PR DESCRIPTION
## Summary

- add the May 12 dry-run publication evidence record for rc.1
- update publication readiness and the GA roadmap with exact evidence-backed blockers
- prevent npm package tarballs from including Python bytecode/cache artifacts via package `files` exclusions and a publish-surface regression test

## Evidence recorded

- GitHub release `v2.0.0-rc.1` is not created yet
- npm registry currently has `ecc-universal` `latest: 1.10.0`; rc.1 `next` publish remains approval-gated
- `npm pack --dry-run --json`: `entryCount: 965`, `hasBytecode: false`
- `npm publish --tag next --dry-run --json`: dry-run only, `hasBytecode: false`
- temp install smoke from packed tarball: ECC CLI help and catalog profile JSON work, no `__pycache__`/`.pyc` files installed
- Claude plugin manifest validates; real plugin tag must be run from a clean checkout with explicit approval

## Validation

- [x] `node tests/run-all.js` — 2348/2348 passing
- [x] `npm run harness:audit -- --format json` — 70/70
- [x] `npm run harness:adapters -- --check` — PASS, 11 adapters
- [x] `npm run observability:ready` — 16/16
- [x] `node tests/scripts/npm-publish-surface.test.js` — 2/2
- [x] `node tests/docs/ecc2-release-surface.test.js` — 18/18
- [x] `npx --yes markdownlint-cli docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md docs/releases/2.0.0-rc.1/publication-readiness.md docs/ECC-2.0-GA-ROADMAP.md`
- [x] `git diff --check`
- [x] `claude plugin validate .claude-plugin/plugin.json`

## Not performed

No GitHub release, npm publish, plugin tag creation/push, marketplace submission, or announcement posting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded the May 12 dry‑run publication evidence for `v2.0.0-rc.1` and updated publication readiness and the GA roadmap with explicit, evidence-backed blockers. Hardened the npm publish surface by excluding Python bytecode/cache files and adding a regression test to enforce it.

- **Bug Fixes**
  - Exclude `__pycache__`, `.pyc/.pyo/.pyd`, and `.pytest_cache` via `.npmignore` and package `files`.
  - Extend `tests/scripts/npm-publish-surface.test.js` to fail if Python bytecode appears in `npm pack`.
  - Dry-run `npm pack`/`npm publish --tag next` show no bytecode; temp install smoke passes.

<sup>Written for commit 1ee42ec33fcd864343d20544062fdbac000ac05d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

