### PR TITLE
docs: record clean plugin publication smoke

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -49,6 +49,11 @@ As of 2026-05-12:
   dry-run publication evidence pass: npm pack/publish dry-runs, temp install
   smoke, Claude plugin validation/tag preflight, Codex marketplace CLI shape,
   OpenCode build, and the remaining approval-gated release blockers.
+- A detached clean worktree at
+  `bfacf37715b39655cbc2c48f12f2a35c67cb0253` verified Claude plugin tag
+  dry-run without `--force`, local marketplace discovery, temp-home local
+  install, enabled plugin listing, and clean uninstall for `ecc@ecc`
+  `2.0.0-rc.1`.
 - The npm package surface now excludes Python bytecode/cache artifacts through
   package `files` negation rules and a publish-surface regression test.
 - `docs/legacy-artifact-inventory.md` records that no `_legacy-documents-*`
@@ -184,7 +189,7 @@ is not complete unless the evidence column exists and has been freshly verified.
 | ECC 2.0 preview pack ready | Release docs, quickstart, publication readiness, release notes | `docs/releases/2.0.0-rc.1/` and readiness docs are in-tree | Needs final release evidence |
 | Hermes specialized skills included safely | Hermes setup/import docs and sanitized skill surface | Hermes setup and import playbook are public; secrets stay local | Needs final release review |
 | Naming and rename readiness | Naming matrix across package/plugin/docs/social surfaces | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` records current package, repo, Claude plugin, Codex plugin, OpenCode, and npm availability evidence | Complete for rc.1; post-rc rename remains future work |
-| Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness, naming matrix, and May 12 dry-run evidence document plugin validation, Claude tag preflight, and Codex marketplace CLI shape | Needs clean-checkout release tag/install evidence and explicit approval |
+| Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness, naming matrix, and May 12 dry-run evidence document plugin validation, clean-checkout Claude tag/install smoke, and Codex marketplace CLI shape | Needs explicit approval for real tag/push and marketplace submission |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
 | AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit | PRs #53, #55-#62 landed with test evidence | Needs PDF/export decision or next enterprise signal |
 | ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog | PRs #26-#39 landed with test evidence | Needs capacity-backed Linear rollout / broader evaluator corpus |

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md
@@ -62,6 +62,27 @@ Temporary install smoke:
 | Agent/catalog metadata | `node tests/scripts/catalog.test.js` | Passed `7/7` |
 | Observability gate | `npm run observability:ready` | Passed `16/16` |
 
+## Clean-Checkout Claude Plugin Smoke
+
+This follow-up pass used a detached clean worktree at
+`/tmp/ecc-clean-plugin-evidence` from commit
+`bfacf37715b39655cbc2c48f12f2a35c67cb0253`. It used an isolated temp home
+(`HOME=/tmp/ecc-clean-plugin-home`) and a temp local project
+(`/tmp/ecc-plugin-install-smoke`), so it did not write to the user's real Claude
+plugin config.
+
+| Command | Result |
+| --- | --- |
+| `git -C /tmp/ecc-clean-plugin-evidence status --short --branch` | `## HEAD (no branch)` with no dirty or untracked files |
+| `claude plugin validate .claude-plugin/plugin.json` | Passed |
+| `claude plugin validate .claude-plugin/marketplace.json` | Passed |
+| `claude plugin tag .claude-plugin --dry-run` | Passed without `--force`; would create `ecc--v2.0.0-rc.1` at HEAD and push `refs/tags/ecc--v2.0.0-rc.1` |
+| `claude plugin marketplace add /tmp/ecc-clean-plugin-evidence --scope local` with temp `HOME` | Added marketplace `ecc` in local settings |
+| `claude plugin list --available --json` with temp `HOME` | Listed `ecc@ecc`, version `2.0.0-rc.1`, source `./` |
+| `claude plugin install ecc@ecc --scope local` with temp `HOME` | Installed `ecc@ecc` in local scope |
+| `claude plugin list --json` with temp `HOME` | Listed `ecc@ecc`, version `2.0.0-rc.1`, enabled, local scope, install path under `/tmp/ecc-clean-plugin-home/.claude/plugins/cache/ecc/ecc/2.0.0-rc.1` |
+| `claude plugin uninstall ecc@ecc --scope local` with temp `HOME` | Uninstalled successfully; final plugin list was `[]` |
+
 ## Announcement Placeholder Check
 
 The forbidden-placeholder scan only returned the publication-readiness checklist
@@ -72,8 +93,8 @@ instances were found.
 
 - Create or verify GitHub prerelease `v2.0.0-rc.1`.
 - Publish `ecc-universal@2.0.0-rc.1` with npm dist-tag `next`.
-- Re-run `claude plugin tag .claude-plugin --dry-run` from a clean checkout,
-  then create and push the plugin tag only after explicit approval.
+- Create and push the Claude plugin tag only after explicit approval. The clean
+  checkout dry run and temp install smoke now pass.
 - Confirm the live Claude/Codex/OpenCode marketplace submission path or record
   the manual submission owner and status.
 - Verify ECC Tools billing/App/Marketplace claims before using them in launch

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -32,7 +32,7 @@ For the May 12 dry-run evidence pass, see
 | --- | --- | --- | --- | --- | --- |
 | GitHub release | Tag exists, release notes use final URLs, assets attached if needed | `gh release view v2.0.0-rc.1 --json tagName,url,isPrerelease` | `Blocker: release not found on 2026-05-12` | Release owner | Pending approval |
 | npm package | `npm pack --dry-run` has expected files, version matches, rc goes to `next` | `npm pack --dry-run` and `npm publish --tag next --dry-run` where supported | `Blocker: actual publish requires approval; dry run passed with next tag` | Package owner | Dry-run passed |
-| Claude plugin | Manifest validates, marketplace JSON points to public repo, install docs match slug | `claude plugin validate .claude-plugin/plugin.json` | `Blocker: real tag must run from clean checkout and requires approval` | Plugin owner | Dry-run preflight recorded |
+| Claude plugin | Manifest validates, marketplace JSON points to public repo, install docs match slug | `claude plugin validate .claude-plugin/plugin.json`; `claude plugin tag .claude-plugin --dry-run`; isolated temp-home install smoke | `Blocker: real tag creation/push requires approval` | Plugin owner | Clean-checkout dry-run and install smoke recorded |
 | Codex plugin | Manifest version matches package and docs, hook limitations are explicit | `node tests/docs/ecc2-release-surface.test.js` | `Blocker: marketplace submission path still manual/owner-gated` | Plugin owner | Evidence recorded |
 | OpenCode package | Build output is regenerated from source and package metadata is current | `npm run build:opencode` | `Blocker: none for local build; public distribution still follows npm/plugin release` | Package owner | Evidence recorded |
 | ECC Tools billing reference | Any billing claim links to verified Marketplace/App state | `gh api repos/ECC-Tools/ECC-Tools` plus app/marketplace URL check | `Blocker:` | ECC Tools owner | Pending |
@@ -58,8 +58,8 @@ Record the exact commit SHA and command output before any publication action:
 
 - `main` has unreviewed release-surface changes after the evidence was recorded.
 - `npm view ecc-universal dist-tags --json` contradicts the intended rc/GA tag.
-- Claude plugin validation is unavailable and no manual install smoke test is
-  recorded.
+- Claude plugin validation is unavailable or no clean-checkout install smoke
+  test is recorded for the intended release commit.
 - Release notes or announcement drafts still contain placeholder URLs,
   `TODO`, `TBD`, private workspace paths, or personal operator references.
 - Billing, Marketplace, or plugin-submission copy claims a live surface before


### PR DESCRIPTION
## Summary

Records the clean-checkout Claude plugin publication smoke that was still pending after the rc.1 publication dry-run evidence pass.

## Details

- adds clean detached-worktree evidence for `claude plugin tag .claude-plugin --dry-run` without `--force`
- records temp-home/local-project marketplace discovery, local install, enabled plugin listing, and uninstall smoke for `ecc@ecc` `2.0.0-rc.1`
- updates publication readiness and the GA roadmap so the remaining Claude plugin blocker is only approval for the real tag/push and marketplace submission

## Validation

- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .claude-plugin/marketplace.json`
- `claude plugin tag .claude-plugin --dry-run` from `/tmp/ecc-clean-plugin-evidence`
- temp-home `claude plugin marketplace add /tmp/ecc-clean-plugin-evidence --scope local`
- temp-home `claude plugin install ecc@ecc --scope local`
- temp-home `claude plugin uninstall ecc@ecc --scope local`
- `npx --yes markdownlint-cli docs/releases/2.0.0-rc.1/publication-evidence-2026-05-12.md docs/releases/2.0.0-rc.1/publication-readiness.md docs/ECC-2.0-GA-ROADMAP.md`
- `git diff --check`

## Notes

No release tag was created and no package/plugin was published.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clean-checkout smoke evidence for the Claude plugin and updates rc.1 publication readiness and the ECC 2.0 GA roadmap. Verifies `claude plugin tag .claude-plugin --dry-run` without `--force` and temp-home local marketplace discovery, install/list, and uninstall for `ecc@ecc` `2.0.0-rc.1`, leaving only approval to create/push the real tag and submit to the marketplace.

<sup>Written for commit 48d534e486da7da96b4c520e80ca6d7958213d5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release roadmap and publication readiness documentation for version 2.0.0-rc.1.
  * Enhanced validation and dry-run requirements documentation.
  * Revised approval gates and blocking conditions for release publication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1823)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->