### PR TITLE
fix: lock patched fast-uri

### DIFF
--- a/ecc2/Cargo.lock
+++ b/ecc2/Cargo.lock
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,9 +1044,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the root npm lockfile from fast-uri 3.1.0 to 3.1.2 through ajv
- update ecc2/Cargo.lock from rustls-webpki 0.103.10 to 0.103.13 through the ureq/rustls chain
- resolves high-severity fast-uri advisories and three RustSec rustls-webpki vulnerability advisories surfaced during local audit
- leaves unrelated local docs/drafts/ untracked and untouched

## Security notes

- no active manifest/lockfile references @tanstack/*, @tanstack/setup, router_init.js, or the malicious TanStack git ref
- existing ECC workflows were already full-SHA pinned
- cargo audit is vulnerability-clean after the lock bump; it still reports one allowed warning for rand 0.8.5 through the ratatui/termwiz chain

## Validation

- npm audit --json
- uv tool run pip-audit --disable-pip --no-deps --requirement <(uv export --no-hashes --no-dev)
- cargo audit
- node tests/run-all.js (2361 passed, 0 failed)
- cargo test attempted: 458 passed, 4 failed; rerun showed 3/4 failed cases pass individually, with refresh_enforces_conflicts_and_surfaces_active_incidents still failing as an existing unrelated test issue
- git diff --check