### PR TITLE
chore: bump rand lockfile advisory

### DIFF
--- a/ecc2/Cargo.lock
+++ b/ecc2/Cargo.lock
@@ -1522,9 +1522,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]


### PR DESCRIPTION
## Summary

- update the stale `rand` lockfile entry from `0.8.5` to patched `0.8.6`
- addresses default-branch Dependabot alert #34 / `GHSA-cq8v-f236-94qc`
- keeps the change limited to `ecc2/Cargo.lock`

## Notes

`cargo tree --target all -i rand@0.8.5` reported no reachable dependency path before the bump, so this appears to be a stale/unreachable lockfile entry. Updating it still clears the advisory surface and avoids a lingering default-branch alert.

## Validation

- `cd ecc2 && cargo test` — 462 passed, 0 failed
- `cd ecc2 && cargo audit`
- `git diff --check`
- `cd ecc2 && cargo tree --target all -i rand@0.8.6` — no reachable dependency path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the stale `rand` entry in `ecc2/Cargo.lock` from 0.8.5 to 0.8.6 to resolve Dependabot alert GHSA-cq8v-f236-94qc. No runtime impact; `rand` isn’t reachable in the build, but this clears the advisory on the default branch.

<sup>Written for commit 1ef2d2228300d740c322e963c29acdee7e4e3135. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

