### PR TITLE
ci: ignore install scripts in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Verify OpenCode package payload
         run: node tests/scripts/build-opencode.test.js

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -50,7 +50,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Verify OpenCode package payload
         run: node tests/scripts/build-opencode.test.js

--- a/tests/scripts/release-publish.test.js
+++ b/tests/scripts/release-publish.test.js
@@ -41,6 +41,10 @@ for (const workflow of [
     assert.match(content, /registry-url:\s*['"]https:\/\/registry\.npmjs\.org['"]/);
   });
 
+  test(`${workflow} ignores dependency lifecycle scripts before privileged publish`, () => {
+    assert.match(content, /npm ci --ignore-scripts/);
+  });
+
   test(`${workflow} checks whether the tagged npm version already exists`, () => {
     assert.match(content, /Check npm publish state/);
     assert.match(content, /npm view "\$\{PACKAGE_NAME\}@\$\{PACKAGE_VERSION\}" version/);


### PR DESCRIPTION
## Summary

- run privileged release workflow installs with `npm ci --ignore-scripts`
- keep explicit release validation/build/publish steps intact
- add a release workflow regression assertion for the hardened install mode

## Security context

This is defense-in-depth for the current Mini Shai-Hulud/TanStack-style supply-chain pattern: release jobs have npm publish credentials/OIDC, so dependency lifecycle scripts should not execute during the install phase.

## Test plan

- `node tests/scripts/release-publish.test.js`
- `node tests/scripts/release.test.js`
- `node scripts/ci/validate-workflow-security.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the release workflows by running `npm ci --ignore-scripts`, preventing dependency lifecycle scripts from executing during privileged publish jobs. Added a regression test to enforce this in both `release.yml` and `reusable-release.yml`.

<sup>Written for commit 8c34ed48abe84667b21638539c2d61523f3c5d1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to prevent npm lifecycle scripts from executing during dependency installation, enhancing release process reliability and consistency.
  * Added validation tests to verify npm lifecycle scripts remain properly controlled in the release pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1839)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->