### PR TITLE
fix: close two block-no-verify bypass holes (core.hooksPath case, -tn)

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -35,7 +35,12 @@ const GIT_COMMANDS_WITH_NO_VERIFY = [
  */
 const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
 
-const GIT_CONFIG_KEY_PREFIX = 'core.hooksPath=';
+// Git config section and variable names are case-insensitive
+// (subsection names are case-sensitive but core.hooksPath has none),
+// so we normalize the candidate token to lowercase before matching.
+// See https://git-scm.com/docs/git-config — "The variable names are
+// case-insensitive."
+const GIT_CONFIG_KEY_PREFIX = 'core.hookspath=';
 
 const COMMIT_OPTIONS_WITH_VALUE = new Set([
   '-m',
@@ -67,7 +72,12 @@ const COMMIT_OPTIONS_WITH_INLINE_VALUE = [
   '--pathspec-from-file=',
 ];
 
-const COMMIT_SHORT_OPTIONS_WITH_VALUE = new Set(['m', 'F', 'C', 'c']);
+// Short options that take a value. When seen as part of a combined
+// short-option token (e.g. -tn), git's parser treats the rest of the
+// token as the option's value (template path 'n' here), so the scanner
+// must stop at this character — anything after it is the inline value,
+// not another flag.
+const COMMIT_SHORT_OPTIONS_WITH_VALUE = new Set(['m', 'F', 'C', 'c', 't']);
 
 function tokenizeShellWords(input, start = 0, end = input.length) {
   const tokens = [];
@@ -413,17 +423,21 @@ function hasHooksPathOverride(input, detected) {
 
   for (let i = 0; i < tokens.length; i++) {
     const value = tokens[i].value;
+    // Git config section + variable names are case-insensitive, so a
+    // bypass attempt like `core.HOOKSPATH=...` or `core.hookspath=...`
+    // must compare against the lowercased token.
+    const lowered = value.toLowerCase();
 
     if (value === '-c') {
       const next = tokens[i + 1] && tokens[i + 1].value;
-      if (typeof next === 'string' && next.startsWith(GIT_CONFIG_KEY_PREFIX)) {
+      if (typeof next === 'string' && next.toLowerCase().startsWith(GIT_CONFIG_KEY_PREFIX)) {
         return true;
       }
       i++;
       continue;
     }
 
-    if (value.startsWith(`-c${GIT_CONFIG_KEY_PREFIX}`)) {
+    if (lowered.startsWith(`-c${GIT_CONFIG_KEY_PREFIX}`)) {
       return true;
     }
   }

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -179,6 +179,24 @@ if (test('blocks plain text input with --no-verify', () => {
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
+// --- Case-insensitivity of git config keys + -t template short option ---
+
+if (test('blocks case-variant core.hooksPath (lowercase)', () => {
+  const r = runHook({ tool_input: { command: 'git -c core.hookspath=/dev/null commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(/core\.hookspath/i.test(r.stderr), `stderr should mention core.hooksPath: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks case-variant core.hooksPath (uppercase)', () => {
+  const r = runHook({ tool_input: { command: 'git -c core.HOOKSPATH=/dev/null commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still allows -tn (n is the -t template path, not a flag)', () => {
+  const r = runHook({ tool_input: { command: 'git commit -tn -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 


### PR DESCRIPTION
## Summary

Two real bypass holes in `scripts/hooks/block-no-verify.js`, surfaced during a CodeRabbit round-3 review on the downstream EGC port ([Jamkris/everything-gemini-code#68](https://github.com/Jamkris/everything-gemini-code/pull/68)). Both ship in current `main`.

## Bug 1 — `core.hooksPath` case-sensitivity bypass (critical)

`GIT_CONFIG_KEY_PREFIX` was compared case-sensitively, but Git config section and variable names are case-insensitive (https://git-scm.com/docs/git-config — *"The variable names are case-insensitive"*). The following both slipped past the guard:

```bash
git -c core.hookspath=/dev/null commit -m "msg"
git -c core.HOOKSPATH=/dev/null commit -m "msg"
```

**Fix:** lowercase the prefix constant and compare candidate tokens in lowercase form inside `hasHooksPathOverride` (both the `-c <key>` and `-c<key>` code paths).

## Bug 2 — `-tn` false positive (major)

`COMMIT_SHORT_OPTIONS_WITH_VALUE` was missing `'t'`. Git parses `git commit -tn` as `-t` with template path `'n'` (stuck-arg form per https://git-scm.com/docs/api-parse-options), **not** as `-t -n`. Without `'t'` in the set, `isCommitNoVerifyShortFlag` reached the `n` check and falsely flagged the command as a `--no-verify` bypass — breaking legitimate `-t <template>` usage when the template path starts with the letter `n` (or is just the letter `n`).

**Fix:** add `'t'` to `COMMIT_SHORT_OPTIONS_WITH_VALUE` so the scanner treats the rest of the combined-short token as the option's value and stops scanning before checking for `n`.

## Tests (+3, 25 total in `tests/hooks/block-no-verify.test.js`)

- `blocks case-variant core.hooksPath (lowercase)` — `git -c core.hookspath=/dev/null commit -m "msg"` → exit 2
- `blocks case-variant core.hooksPath (uppercase)` — `git -c core.HOOKSPATH=/dev/null commit -m "msg"` → exit 2
- `still allows -tn (n is the -t template path, not a flag)` — `git commit -tn -m "msg"` → exit 0

## Local verification

- [x] `yarn lint` clean
- [x] All CI validators pass: `validate-agents`, `validate-commands`, `validate-rules`, `validate-skills`, `validate-hooks`, `validate-install-manifests`, `validate-no-personal-paths`
- [x] `node tests/run-all.js`: **2369/2369** pass including the 3 new block-no-verify cases
- [ ] **Caveat (unrelated):** `yarn test` currently fails at `check-unicode-safety` on `skills/windows-desktop-e2e/SKILL.md` (U+2605 stars) which landed in commit 14816289. That failure exists on `main` independently of this PR and would also fail without these changes — flagging it here in case it's news.

## Provenance

Originally discovered and fixed downstream in [Jamkris/everything-gemini-code#68](https://github.com/Jamkris/everything-gemini-code/pull/68) (commit [`fbf7908`](https://github.com/Jamkris/everything-gemini-code/commit/fbf7908)). Backporting here since the same code path exists upstream. The downstream port has been running with these fixes against EGC's own pre-commit hooks for a day with no false-positive reports.

Happy to split into two PRs (one critical, one major) if that's easier to triage — the two changes are independent. Also happy to drop the new tests or rework them in any direction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two bypass holes in `scripts/hooks/block-no-verify.js` to correctly block `core.hooksPath` overrides and stop false positives for `git commit -tn`. This strengthens hook enforcement without breaking valid commits.

- **Bug Fixes**
  - Treat `core.hooksPath` as case-insensitive when parsing `-c` (supports both `-c key=...` and `-ckey=...` forms).
  - Add `-t` to short options that take a value so `-tn` is parsed as a template path, not `-n`.

<sup>Written for commit ff37e4032f389cc174ebb41ae349b324907f30a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git hook bypass protection with enhanced detection for configuration overrides and commit options.

* **Tests**
  * Added test coverage for edge cases in git hook bypass detection scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1843)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->