### PR TITLE
ci: require npm audit signature checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,9 @@ jobs:
           node-version: '20.x'
 
       - name: Run npm audit
-        run: npm audit --audit-level=high
+        run: |
+          npm audit signatures
+          npm audit --audit-level=high
         continue-on-error: true  # Allows PR to proceed, but marks job as failed if vulnerabilities found
 
   lint:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           if [ -f package-lock.json ]; then
             npm ci --ignore-scripts
+            npm audit signatures
             npm audit --audit-level=high
           else
             echo "No package-lock.json found; skipping npm audit"

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -26,6 +26,8 @@ const RULES = [
 
 const WRITE_PERMISSION_PATTERN = /^\s*(?:contents|issues|pull-requests|actions|checks|deployments|discussions|id-token|packages|pages|repository-projects|security-events|statuses):\s*write\b/m;
 const NPM_CI_PATTERN = /\bnpm\s+ci\b(?![^\n]*--ignore-scripts)/g;
+const NPM_AUDIT_PATTERN = /\bnpm\s+audit\b(?!\s+signatures\b)/;
+const NPM_AUDIT_SIGNATURES_PATTERN = /\bnpm\s+audit\s+signatures\b/;
 const ACTIONS_CACHE_PATTERN = /uses:\s*['"]?actions\/cache@/m;
 const ID_TOKEN_WRITE_PATTERN = /^\s*id-token:\s*write\b/m;
 
@@ -124,6 +126,16 @@ function findViolations(filePath, source) {
       description: 'workflows with id-token: write must not restore or save shared dependency caches',
       expression: 'id-token: write + actions/cache',
       line: getLineNumber(source, source.search(ID_TOKEN_WRITE_PATTERN)),
+    });
+  }
+
+  if (NPM_AUDIT_PATTERN.test(source) && !NPM_AUDIT_SIGNATURES_PATTERN.test(source)) {
+    violations.push({
+      filePath,
+      event: 'npm audit signatures',
+      description: 'workflows that run npm audit must also verify registry signatures',
+      expression: 'npm audit without npm audit signatures',
+      line: getLineNumber(source, source.search(NPM_AUDIT_PATTERN)),
     });
   }
 

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -122,6 +122,21 @@ function run() {
     assert.match(result.stderr, /id-token: write must not restore or save shared dependency caches/);
   })) passed++; else failed++;
 
+  if (test('rejects npm audit without registry signature verification', () => {
+    const result = runValidator({
+      'unsafe-audit.yml': `name: Unsafe\non:\n  push:\njobs:\n  audit:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm audit --audit-level=high\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail when npm audit signatures is missing');
+    assert.match(result.stderr, /npm audit must also verify registry signatures/);
+  })) passed++; else failed++;
+
+  if (test('allows npm audit when registry signatures are verified', () => {
+    const result = runValidator({
+      'safe-audit.yml': `name: Safe\non:\n  push:\njobs:\n  audit:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          npm audit signatures\n          npm audit --audit-level=high\n`,
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
   console.log(`\nPassed: ${passed}`);
   console.log(`Failed: ${failed}`);
 

--- a/tests/docs/copilot-support.test.js
+++ b/tests/docs/copilot-support.test.js
@@ -27,7 +27,8 @@ function read(relativePath) {
 }
 
 function parseSimpleFrontmatter(source, relativePath) {
-  const match = source.match(/^---\n([\s\S]*?)\n---\n/);
+  const normalizedSource = source.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+  const match = normalizedSource.match(/^---\n([\s\S]*?)\n---\n/);
   assert.ok(match, `${relativePath} must start with YAML frontmatter`);
 
   const fields = {};

--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -64,6 +64,16 @@ function runNode(scriptPath, args = [], options = {}) {
   }
 }
 
+function normalizeComparablePath(filePath) {
+  const normalized = path.normalize(filePath);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+function pathListIncludes(paths, expectedPath) {
+  const normalizedExpected = normalizeComparablePath(expectedPath);
+  return paths.some(filePath => normalizeComparablePath(filePath) === normalizedExpected);
+}
+
 function test(name, fn) {
   try {
     fn();
@@ -117,7 +127,7 @@ function runTests() {
 
       const parsed = JSON.parse(repairResult.stdout);
       assert.strictEqual(parsed.results[0].status, 'repaired');
-      assert.ok(parsed.results[0].repairedPaths.includes(managedPath));
+      assert.ok(pathListIncludes(parsed.results[0].repairedPaths, managedPath));
       assert.strictEqual(fs.readFileSync(managedPath, 'utf8'), expectedContent);
       assert.ok(fs.existsSync(statePath));
     } finally {


### PR DESCRIPTION
## Summary

- run npm audit signatures anywhere workflows run npm audit
- add workflow-security validator coverage so future audit jobs must verify registry signatures first
- keep audit vulnerability checks unchanged

## Test plan

- node tests/ci/validate-workflow-security.test.js
- node scripts/ci/validate-workflow-security.js
- npm audit signatures
- npm audit --audit-level=high
- git diff --check
- node tests/run-all.js (2376 passed, 0 failed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require registry signature verification in CI before running vulnerability audits. Workflows run `npm audit signatures` before `npm audit --audit-level=high`, and the validator fails `npm audit` when signatures are not verified.

- **Refactors**
  - Updated `.github/workflows/ci.yml` and `.github/workflows/maintenance.yml` to run `npm audit signatures` before `npm audit --audit-level=high`.
  - `scripts/ci/validate-workflow-security.js` now blocks `npm audit` without `npm audit signatures`; tests cover missing vs. verified signatures.

- **Bug Fixes**
  - Normalize BOM and CRLF in docs frontmatter parsing to prevent false negatives in `tests/docs/copilot-support.test.js`.
  - Normalize and case-fold repaired path comparisons in `tests/scripts/repair.test.js` for Windows.

<sup>Written for commit 50eab236bbeaf5051e0edaeb3cf7719f3cb7f7d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI security: audit checks now verify registry signatures before running audits.
* **Tests**
  * Added validator tests to enforce audit-signature checks.
  * Improved tests for path comparisons to be platform-resilient.
  * Normalized test frontmatter parsing to handle BOM and CRLF variations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1846)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->