### PR TITLE
harden: remove shell access from read-only analyzers

### DIFF
--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -2,7 +2,7 @@
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, and documenting dependencies to inform new development.
 model: sonnet
-tools: [Read, Grep, Glob, Bash]
+tools: [Read, Grep, Glob]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -2,7 +2,7 @@
 name: comment-analyzer
 description: Analyze code comments for accuracy, completeness, maintainability, and comment rot risk.
 model: sonnet
-tools: [Read, Grep, Glob, Bash]
+tools: [Read, Grep, Glob]
 ---
 
 ## Prompt Defense Baseline

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -2,7 +2,7 @@
 name: type-design-analyzer
 description: Analyze type design for encapsulation, invariant expression, usefulness, and enforcement.
 model: sonnet
-tools: [Read, Grep, Glob, Bash]
+tools: [Read, Grep, Glob]
 ---
 
 ## Prompt Defense Baseline

--- a/docs/zh-CN/agents/code-explorer.md
+++ b/docs/zh-CN/agents/code-explorer.md
@@ -2,7 +2,7 @@
 name: code-explorer
 description: 通过追踪执行路径、映射架构层和记录依赖关系，深入分析现有代码库功能，为新的开发提供信息。
 model: sonnet
-tools: [Read, Grep, Glob, Bash]
+tools: [Read, Grep, Glob]
 ---
 
 # 代码探索代理

--- a/docs/zh-CN/agents/comment-analyzer.md
+++ b/docs/zh-CN/agents/comment-analyzer.md
@@ -2,7 +2,7 @@
 name: comment-analyzer
 description: 分析代码注释的准确性、完整性、可维护性和注释腐烂风险。
 model: sonnet
-tools: [Read, Grep, Glob, Bash]
+tools: [Read, Grep, Glob]
 ---
 
 # 注释分析代理

--- a/docs/zh-CN/agents/type-design-analyzer.md
+++ b/docs/zh-CN/agents/type-design-analyzer.md
@@ -2,7 +2,7 @@
 name: type-design-analyzer
 description: 分析封装、不变式表达、实用性和强制性的类型设计。
 model: sonnet
-tools: [Read, Grep, Glob, Bash]
+tools: [Read, Grep, Glob]
 ---
 
 # 类型设计分析代理


### PR DESCRIPTION
## Summary

- Remove `Bash` from three read-only analysis agents: `code-explorer`, `comment-analyzer`, and `type-design-analyzer`.
- Keep the zh-CN agent copies in sync.
- Leave operator/build/network/sanitizer agents unchanged because their workflows genuinely require shell execution and/or file mutation.

## Security impact

AgentShield high findings on current ECC trunk drop from 21 to 18 with no new high findings.

Removed high paths:
- `agents/code-explorer.md`
- `agents/comment-analyzer.md`
- `agents/type-design-analyzer.md`

The three changed agents now only carry low read-only model-cost notes in the refreshed scan.

## Validation

- `node tests/ci/validators.test.js`
- `node tests/lib/agent-compress.test.js`
- `npx markdownlint-cli 'agents/code-explorer.md' 'agents/comment-analyzer.md' 'agents/type-design-analyzer.md' 'docs/zh-CN/agents/code-explorer.md' 'docs/zh-CN/agents/comment-analyzer.md' 'docs/zh-CN/agents/type-design-analyzer.md'`
- `npm run scan -- --path /Users/affoon/GitHub/ECC/everything-claude-code --format json` from local AgentShield checkout, parsed from `/tmp/agentshield-ecc-trunk-readonly-agent-tools.clean.json`
- `node tests/run-all.js` -> 2378 passed, 0 failed
- `npm run harness:audit -- --format json` -> 70/70
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Bash tool from the read-only analyzers (code-explorer, comment-analyzer, type-design-analyzer) and synced the zh-CN copies; agents that require shell/file mutation are unchanged. This hardening reduces AgentShield high findings from 21 to 18 with no new high issues.

<sup>Written for commit 4f98f86775cba45735377b1efc2b4e1ab4dd3426. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted agent tool access across multiple AI agents by removing Bash execution capability. Code-explorer, comment-analyzer, and type-design-analyzer agents now have access to Read, Grep, and Glob tools only. Updated corresponding documentation files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1850)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->