### PR TITLE
ci: disable checkout credential persistence in privileged workflows

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20.x'
@@ -27,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -108,6 +108,18 @@ function findViolations(filePath, source) {
   }
 
   if (WRITE_PERMISSION_PATTERN.test(source)) {
+    for (const step of checkoutSteps) {
+      if (!/persist-credentials:\s*['"]?false['"]?\b/m.test(step.text)) {
+        violations.push({
+          filePath,
+          event: 'write-permission checkout',
+          description: 'workflows with write permissions must disable checkout credential persistence',
+          expression: 'actions/checkout without persist-credentials: false',
+          line: step.startLine,
+        });
+      }
+    }
+
     for (const match of source.matchAll(NPM_CI_PATTERN)) {
       violations.push({
         filePath,

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -122,6 +122,21 @@ function run() {
     assert.strictEqual(result.status, 0, result.stderr || result.stdout);
   })) passed++; else failed++;
 
+  if (test('rejects checkout credential persistence in workflows with write permissions', () => {
+    const result = runValidator({
+      'unsafe-write-checkout.yml': `name: Unsafe\non:\n  workflow_dispatch:\npermissions:\n  contents: write\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm ci --ignore-scripts\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on credential-persisting checkout');
+    assert.match(result.stderr, /write permissions must disable checkout credential persistence/);
+  })) passed++; else failed++;
+
+  if (test('allows checkout with disabled credential persistence in workflows with write permissions', () => {
+    const result = runValidator({
+      'safe-write-checkout.yml': `name: Safe\non:\n  workflow_dispatch:\npermissions:\n  contents: write\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          persist-credentials: false\n      - run: npm ci --ignore-scripts\n`,
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
   if (test('rejects actions/cache in workflows with id-token write', () => {
     const result = runValidator({
       'unsafe-oidc-cache.yml': `name: Unsafe\non:\n  push:\npermissions:\n  contents: read\n  id-token: write\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/cache@v5\n        with:\n          path: ~/.npm\n          key: cache\n`,


### PR DESCRIPTION
## Summary

Hardens privileged GitHub Actions jobs against the TanStack-style supply-chain path where attacker-controlled code tries to recover repository tokens from the runner environment.

- set `persist-credentials: false` on checkout steps in workflows that grant write permissions (`release.yml`, `reusable-release.yml`, `maintenance.yml`)
- extend `scripts/ci/validate-workflow-security.js` so future write-permission workflows fail if `actions/checkout` persists credentials
- add regression coverage for unsafe and safe checkout credential persistence cases

## Security context

The May 2026 TanStack incident combined `pull_request_target`, dependency-cache poisoning, and release-job token/OIDC exposure. ECC already blocks the `pull_request_target` cache class and `id-token: write` cache class; this patch tightens the remaining privileged-checkout surface by ensuring checkout does not store the GitHub token in `.git/config` for later process access.

Local IOC check found no ECC lockfile dependency on compromised `@tanstack/*` packages and no worm markers (`@tanstack/setup`, `router_init.js`, `router_runtime.js`, `tanstack_runner.js`, known commit marker, or adjacent package namespaces). TanStack appears only in frontend-pattern example prose.

## Validation

- `node tests/ci/validate-workflow-security.test.js` -> 14 passed
- `node scripts/ci/validate-workflow-security.js` -> validated 7 workflow files
- `node tests/scripts/release.test.js` -> 7 passed
- `node tests/scripts/release-publish.test.js` -> 12 passed
- `node tests/ci/validators.test.js` -> 165 passed
- `node tests/run-all.js` -> 2380 passed, 0 failed
- `git diff --check` -> clean
- `npm audit --json` -> 0 vulnerabilities
- `npm audit signatures` -> 241 package signatures and 30 attestations verified
- `cargo audit -q` in `ecc2/` -> passed
- Dependabot alert API: 0 open alerts for `affaan-m/everything-claude-code`, `affaan-m/agentshield`, and `affaan-m/JARVIS`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable checkout credential persistence in privileged GitHub Actions workflows and add CI validation to prevent regressions. This reduces the risk of token leakage from runners in release and maintenance jobs (post TanStack-style supply-chain path).

- **New Features**
  - Set `persist-credentials: false` on `actions/checkout` in `release.yml`, `reusable-release.yml`, and `maintenance.yml`.
  - Update `scripts/ci/validate-workflow-security.js` to fail write-permission workflows that allow credential persistence; add tests for safe/unsafe cases.

<sup>Written for commit 59f3e8e8ba5fc36d787cbb0cac9097aae541d9f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline security by disabling credential persistence in GitHub Actions workflows and enforcing this practice through automated validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1851)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->