### PR TITLE
docs: record post-hardening rc1 release evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -39,6 +39,12 @@ As of 2026-05-13:
   `docs/security/supply-chain-incident-response.md`, plus a workflow-security
   validator rule blocking `pull_request_target` workflows from restoring or
   saving shared dependency caches.
+- PR #1850 merged as `248673271455e9dc85b8add2a6ab76107b718639` and removed
+  shell access from read-only analyzer agents and zh-CN copies, reducing
+  AgentShield high findings on that surface without changing operator agents.
+- PR #1851 merged as `209abd403b7eaa968c6d4fa67be82e04b55706d6` and made
+  `persist-credentials: false` mandatory for `actions/checkout` in workflows
+  with write permissions.
 - `docs/architecture/harness-adapter-compliance.md` maps Claude Code, Codex,
   OpenCode, Cursor, Gemini, Zed-adjacent, dmux, Orca, Superset, Ghast, and
   terminal-only support to install paths, verification commands, and risk
@@ -61,8 +67,12 @@ As of 2026-05-13:
   release-readiness evidence refresh: 70/70 harness audit, adapter compliance
   PASS, 16/16 observability readiness, 2376/2376 root Node tests, markdownlint,
   release-surface and npm publish-surface tests, and 462/462 `ecc2` Rust tests.
-- After #1848, `node tests/run-all.js` reports 2377/2377 and the current
-  observability gate reports 18/18.
+- `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-13-post-hardening.md`
+  records the post-hardening release-readiness refresh after PR #1850 and
+  PR #1851: 70/70 harness audit, adapter compliance PASS, 18/18 observability
+  readiness, 2380/2380 root Node tests, markdownlint, release-surface and
+  npm publish-surface tests, 462/462 `ecc2` Rust tests, npm audit/signature
+  checks, Rust advisory audit, and TanStack/Mini Shai-Hulud IOC checks.
 - A detached clean worktree at
   `bfacf37715b39655cbc2c48f12f2a35c67cb0253` verified Claude plugin tag
   dry-run without `--force`, local marketplace discovery, temp-home local
@@ -225,10 +235,10 @@ is not complete unless the evidence column exists and has been freshly verified.
 
 | Prompt requirement | Required artifact or gate | Current evidence | Status |
 | --- | --- | --- | --- |
-| Keep public PRs below 20 | Repo-family PR recheck | 0 open PRs across the tracked public repos on 2026-05-13 after merging #1848 | Complete for this checkpoint |
+| Keep public PRs below 20 | Repo-family PR recheck | 0 open PRs across the tracked public repos on 2026-05-13 after merging #1851 | Complete for this checkpoint |
 | Keep public issues below 20 | Repo-family issue recheck | 0 open issues across the tracked public repos on 2026-05-13 | Complete for this checkpoint |
 | Manage repository discussions | Repo-family discussion recheck | Latest trunk discussion GraphQL sweep returned closed discussions only; satellite repos remain disabled or empty | Complete for this checkpoint |
-| Manage PR discussions | PR review/comment closure plus merge/close state | #1848 merged after current-head CI; no open PRs remain | Complete for this checkpoint |
+| Manage PR discussions | PR review/comment closure plus merge/close state | #1851 merged after current-head CI; no open PRs remain | Complete for this checkpoint |
 | Salvage useful stale work | `docs/stale-pr-salvage-ledger.md` | Ledger records salvaged, superseded, skipped, and manual-review tails; #1815-#1818 added cost tracking, skill scout, frontend design guidance, code-reviewer false-positive guardrails, and the May 12 gap pass | Complete except translation/manual review tail |
 | ECC 2.0 preview pack ready | Release docs, quickstart, publication readiness, release notes | `docs/releases/2.0.0-rc.1/` and readiness docs are in-tree; May 13 evidence refresh records harness, adapter, observability, Node, lint, release-surface, npm publish-surface, and Rust checks | Needs final clean-checkout release approval |
 | Hermes specialized skills included safely | Hermes setup/import docs and sanitized skill surface | Hermes setup and import playbook are public; secrets stay local | Needs final release review |
@@ -237,7 +247,7 @@ is not complete unless the evidence column exists and has been freshly verified.
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
 | AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, enterprise research roadmap | PRs #53, #55-#64 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` selects baseline drift as the first control-plane slice | Baseline-drift Action and CLI write surfaces landed; evidence-pack routing remains |
 | ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog, evaluator/RAG corpus | PRs #26-#40 landed with test evidence | Needs capacity-backed Linear rollout |
-| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy, deterministic follow-up checks, and local supply-chain gates | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, and PR Review/Salvage Evidence; #1846 added npm registry signature gates; #1848 added the supply-chain incident-response playbook and `pull_request_target` cache-poisoning validator guard | Partially complete |
+| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy, deterministic follow-up checks, and local supply-chain gates | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, and PR Review/Salvage Evidence; #1846 added npm registry signature gates; #1848 added the supply-chain incident-response playbook and `pull_request_target` cache-poisoning validator guard; #1851 added the privileged checkout credential-persistence guard | Partially complete |
 | Harness-agnostic learning system | Audit, adapter matrix, observability, traces, promotion loop | Audit/adapters/observability gates plus `docs/architecture/evaluator-rag-prototype.md`, `examples/evaluator-rag-prototype/`, and ECC-Tools PR #40 define read-only stale-salvage, billing-readiness, CI-failure-diagnosis, harness-config-quality, AgentShield policy-exception, skill-quality evidence, deep-analyzer evidence, and RAG/evaluator comparison scenarios with trace, report, playbook, verifier, and predictive-check artifacts | Local corpus complete; hosted integration remains future |
 | Linear roadmap is detailed | Linear project status plus repo mirror | Repo mirror exists; issue creation was retried on 2026-05-12 and remains blocked by the workspace free issue limit | Needs recurring status updates after each merge batch |
 | Flow separation and progress tracking | Flow lanes with owner artifacts and update cadence | This roadmap defines lanes below and `docs/architecture/progress-sync-contract.md` makes GitHub/Linear/handoff/roadmap sync part of the readiness gate | Active |

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-13-post-hardening.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-13-post-hardening.md
@@ -1,0 +1,96 @@
+# ECC v2.0.0-rc.1 Publication Evidence - 2026-05-13 Post-Hardening
+
+This is release-readiness evidence only. It does not create a GitHub release,
+npm publication, plugin tag, marketplace submission, or announcement post.
+
+## Source Commit
+
+| Field | Evidence |
+| --- | --- |
+| Upstream main base | `209abd403b7eaa968c6d4fa67be82e04b55706d6` |
+| Evidence branch | `docs/post-hardening-release-evidence-20260513` |
+| Evidence scope | Current `main` after PR #1850 and PR #1851 |
+| Git remote | `https://github.com/affaan-m/everything-claude-code.git` |
+| Local status caveat | Working tree had the unrelated untracked `docs/drafts/` directory |
+
+The actual release operator should repeat these checks from the final release
+commit with a clean checkout before publishing.
+
+## Queue And Release State
+
+| Surface | Command | Result |
+| --- | --- | --- |
+| GitHub PRs and issues | `gh pr list` / `gh issue list` across trunk, AgentShield, and JARVIS | 0 open PRs and 0 open issues on accessible `affaan-m` repos |
+| Trunk discussions | GraphQL discussion count for `affaan-m/everything-claude-code` | 0 open discussions |
+| Dependabot alerts | Dependabot alert API for trunk, AgentShield, and JARVIS | 0 open alerts |
+| Release state | `gh release view v2.0.0-rc.1` | Still not created; release remains approval-gated |
+
+ECC-Tools organization repo counts were not rechecked through the current
+GraphQL token in this pass because the token cannot resolve those org repos.
+The prior post-#42 local checkout handoff recorded both ECC-Tools repos at
+0 open PRs and 0 open issues.
+
+## Hardening Landed Since Previous Evidence
+
+| PR | Merge commit | Evidence |
+| --- | --- | --- |
+| #1850 | `248673271455e9dc85b8add2a6ab76107b718639` | Removed `Bash` tool access from read-only analyzer agents and zh-CN copies; AgentShield high findings on that surface dropped 21 -> 18 with no new high findings |
+| #1851 | `209abd403b7eaa968c6d4fa67be82e04b55706d6` | Disabled `actions/checkout` credential persistence in write-permission workflows and added a workflow-security validator rule to keep that guard in place |
+
+## Required Command Evidence
+
+| Evidence | Command | Result |
+| --- | --- | --- |
+| Harness audit | `npm run harness:audit -- --format json` | `overall_score: 70`, `max_score: 70`, no top actions |
+| Adapter scorecard | `npm run harness:adapters -- --check` | `Harness Adapter Compliance: PASS`; 11 adapters |
+| Observability readiness | `npm run observability:ready -- --format json` | `overall_score: 18`, `max_score: 18`, `ready: true`, no top actions |
+| Workflow security validator | `node scripts/ci/validate-workflow-security.js` | Validated 7 workflow files |
+| Workflow validator tests | `node tests/ci/validate-workflow-security.test.js` | Passed 14/14 |
+| Release surface | `node tests/docs/ecc2-release-surface.test.js` | Passed 18/18 |
+| Package surface | `node tests/scripts/npm-publish-surface.test.js` | Passed 2/2 |
+| Root suite | `node tests/run-all.js` | Passed 2380/2380, 0 failed |
+| Markdown lint | `npx markdownlint-cli '**/*.md' --ignore node_modules --ignore docs/drafts` | Passed |
+| Rust surface | `cd ecc2 && cargo test` | Passed 462/462; warnings only for unused functions/fields |
+
+## Supply-Chain Evidence
+
+| Surface | Command or check | Result |
+| --- | --- | --- |
+| Local npm vulnerability audit | `npm audit --json` | 0 vulnerabilities |
+| Local npm signature audit | `npm audit signatures` | 241 verified registry signatures and 30 verified attestations |
+| Rust advisory audit | `cd ecc2 && cargo audit -q` | Passed silently |
+| TanStack / Mini Shai-Hulud IOC check | Grep for affected package namespaces, payload filenames, and known commit marker | No runtime or lockfile dependency on affected packages; no worm IOC matches |
+
+## External Advisory Mapping
+
+The May 2026 TanStack incident maps to ECC release risk through three workflow
+classes:
+
+- `pull_request_target` workflows that execute or checkout untrusted PR code;
+- shared dependency caches crossing fork, base, and release workflow trust
+  boundaries;
+- release jobs with writable tokens or OIDC tokens exposed to subsequent
+  process execution.
+
+ECC's current guardrails cover those classes through:
+
+- rejection of untrusted checkout refs in `workflow_run` and
+  `pull_request_target` workflows;
+- rejection of shared caches in `pull_request_target` and `id-token: write`
+  workflows;
+- mandatory `npm audit signatures` when workflows run `npm audit`;
+- mandatory `npm ci --ignore-scripts` in workflows with write permissions;
+- mandatory `persist-credentials: false` on `actions/checkout` in workflows
+  with write permissions.
+
+## Blockers Still Requiring Approval Or External Action
+
+- Create or verify GitHub prerelease `v2.0.0-rc.1`.
+- Publish `ecc-universal@2.0.0-rc.1` with npm dist-tag `next`.
+- Create and push the Claude plugin tag only after explicit approval.
+- Confirm the live Claude/Codex/OpenCode marketplace submission path or record
+  the manual submission owner and status.
+- Verify ECC Tools billing/App/Marketplace claims before using them in launch
+  copy.
+- Refresh announcement copy with live URLs after release and package/plugin
+  URLs exist.

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -10,6 +10,8 @@ For the May 12 dry-run evidence pass, see
 [`publication-evidence-2026-05-12.md`](publication-evidence-2026-05-12.md).
 For the May 13 release-readiness evidence refresh, see
 [`publication-evidence-2026-05-13.md`](publication-evidence-2026-05-13.md).
+For the May 13 post-hardening evidence refresh after PR #1850 and PR #1851, see
+[`publication-evidence-2026-05-13-post-hardening.md`](publication-evidence-2026-05-13-post-hardening.md).
 
 ## Release Identity Matrix
 
@@ -39,6 +41,7 @@ For the May 13 release-readiness evidence refresh, see
 | OpenCode package | Build output is regenerated from source and package metadata is current | `npm run build:opencode` | `Blocker: none for local build; public distribution still follows npm/plugin release` | Package owner | Evidence recorded |
 | ECC Tools billing reference | Any billing claim links to verified Marketplace/App state | `gh api repos/ECC-Tools/ECC-Tools` plus app/marketplace URL check | `Blocker:` | ECC Tools owner | Pending |
 | Announcement copy | X, LinkedIn, GitHub release, and longform copy point to live URLs | `rg -n "TODO" docs/releases/2.0.0-rc.1` and repeat for `TBD` | `Blocker:` | Release owner | Pending |
+| Privileged workflow hardening | Release and maintenance workflows avoid persisted checkout tokens | `node scripts/ci/validate-workflow-security.js` | `Blocker:` | Release owner | Evidence recorded in post-hardening refresh |
 
 ## Required Command Evidence
 
@@ -49,8 +52,8 @@ Record the exact commit SHA and command output before any publication action:
 | Clean release branch | `git status --short --branch` | On intended release commit; no unrelated files | Pending final clean-checkout release pass; May 13 evidence branch still had unrelated untracked `docs/drafts/` |
 | Harness audit | `npm run harness:audit -- --format json` | 70/70 passing | `publication-evidence-2026-05-13.md`: 70/70 |
 | Adapter scorecard | `npm run harness:adapters -- --check` | PASS | `publication-evidence-2026-05-13.md`: PASS, 11 adapters |
-| Observability readiness | `npm run observability:ready` | 16/16 passing | `publication-evidence-2026-05-13.md`: 16/16, ready true |
-| Root suite | `node tests/run-all.js` | 0 failures | `publication-evidence-2026-05-13.md`: 2376 passed, 0 failed |
+| Observability readiness | `npm run observability:ready` | 18/18 passing | `publication-evidence-2026-05-13-post-hardening.md`: 18/18, ready true |
+| Root suite | `node tests/run-all.js` | 0 failures | `publication-evidence-2026-05-13-post-hardening.md`: 2380 passed, 0 failed |
 | Markdown lint | `npx markdownlint-cli '**/*.md' --ignore node_modules` | 0 failures | `publication-evidence-2026-05-13.md`: passed after zh-CN CLAUDE list-marker normalization |
 | Package surface | `node tests/scripts/npm-publish-surface.test.js` | 0 failures; no Python bytecode in npm tarball | `2/2` passed in May 12 evidence pass |
 | Release surface | `node tests/docs/ecc2-release-surface.test.js` | 0 failures | `publication-evidence-2026-05-13.md`: 18/18 passed |


### PR DESCRIPTION
## Summary

Records a fresh rc.1 release-readiness evidence pass from current `main` after the #1850 and #1851 hardening merges.

- add `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-13-post-hardening.md`
- link the post-hardening evidence from `publication-readiness.md`
- refresh `docs/ECC-2.0-GA-ROADMAP.md` with #1850/#1851 evidence and current gate counts

## Evidence recorded

- source commit: `209abd403b7eaa968c6d4fa67be82e04b55706d6`
- queues: 0 open PRs, 0 open issues, 0 open discussions on accessible affaan-m repos
- Dependabot alerts: 0 open on trunk, AgentShield, and JARVIS
- harness audit: 70/70
- adapter scorecard: PASS, 11 adapters
- observability readiness: 18/18, ready true
- workflow validator: 7 workflow files validated
- workflow validator tests: 14/14
- release surface: 18/18
- npm publish surface: 2/2
- root suite: 2380/2380
- markdownlint: passed
- `ecc2` Rust tests: 462/462, warnings only
- npm audit: 0 vulnerabilities
- npm audit signatures: 241 signatures and 30 attestations verified
- cargo audit: passed silently
- TanStack / Mini Shai-Hulud IOC pass: no runtime or lockfile dependency on affected packages; no worm IOC matches

## Validation for this docs PR

- `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md docs/releases/2.0.0-rc.1/publication-readiness.md docs/releases/2.0.0-rc.1/publication-evidence-2026-05-13-post-hardening.md`
- `node tests/docs/ecc2-release-surface.test.js`
- `git diff --check`

## Release note

No release, tag, publish, marketplace submission, or announcement action is performed here. This is evidence only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add post-hardening release evidence for v2.0.0-rc.1 and update readiness docs and the GA roadmap to reflect #1850 and #1851. Adds the new evidence file, links it from `publication-readiness.md`, and refreshes gate counts; no publish or release action.

<sup>Written for commit 57cb0989cc1ab527ad52b5761c1029b00e38ad9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated 2.0 release roadmap with recent security hardening measures and validation requirements
  * Added post-hardening release evidence documentation including supply-chain validation, security audits, and comprehensive test results
  * Refreshed publication readiness checklist with updated validation metrics and hardening verification status across all required checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1852)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->