### PR TITLE
docs: sync AgentShield evidence-pack roadmap

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -131,6 +131,14 @@ As of 2026-05-13:
   CLI command with severity filtering, JSON metadata output, README/API docs,
   rebuilt CLI bundle, local TDD coverage, and green remote action/self-scan/Node
   verification.
+- AgentShield PR #65 pinned workflow actions for release/security CI hardening.
+- AgentShield PR #66 disabled cache use in the release publish job so release
+  publication does not depend on mutable restored build state.
+- AgentShield PR #67 added the first portable enterprise evidence-pack bundle:
+  `agentshield scan --evidence-pack <dir>` writes deterministic manifest,
+  README, JSON, HTML, SARIF, policy-evaluation, baseline-comparison, and
+  supply-chain artifacts with default redaction and `not-run` markers for
+  optional policy/baseline evidence.
 - AgentShield PDF-export decision: defer a native PDF writer for now. The
   self-contained HTML executive report remains the exportable buyer artifact
   and can be printed to PDF when needed; native PDF generation should wait for
@@ -193,6 +201,14 @@ As of 2026-05-13:
   quality, AgentShield policy exceptions, skill-quality evidence,
   deep-analyzer evidence, and RAG/evaluator comparison evidence, with each
   scenario exercising missing-evidence and evidence-backed diffs.
+- ECC-Tools PR #41 hardened supply-chain dependencies.
+- ECC-Tools PR #42 added AgentShield evidence-pack gap prediction and routed
+  missing policy/baseline/allowlist/suppression/supply-chain evidence into the
+  PR-risk taxonomy, follow-up drafts, and Linear-ready backlog table.
+- ECC-Tools PR #43 recognized the concrete AgentShield #67 evidence-pack
+  artifact contract so canonical bundle files now satisfy the taxonomy and
+  generated follow-up PRs point maintainers at
+  `agentshield scan --evidence-pack <dir>`.
 - ECC PR #1803 landed the contributor Quarkus handling branch after maintainer
   cleanup, current-`main` alignment, full local validation, and preservation of
   the author's removal of incomplete ja-JP and zh-CN Quarkus translations.
@@ -245,9 +261,9 @@ is not complete unless the evidence column exists and has been freshly verified.
 | Naming and rename readiness | Naming matrix across package/plugin/docs/social surfaces | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` records current package, repo, Claude plugin, Codex plugin, OpenCode, and npm availability evidence | Complete for rc.1; post-rc rename remains future work |
 | Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness, naming matrix, and May 12 dry-run evidence document plugin validation, clean-checkout Claude tag/install smoke, and Codex marketplace CLI shape | Needs explicit approval for real tag/push and marketplace submission |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
-| AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, enterprise research roadmap | PRs #53, #55-#64 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` selects baseline drift as the first control-plane slice | Baseline-drift Action and CLI write surfaces landed; evidence-pack routing remains |
-| ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog, evaluator/RAG corpus | PRs #26-#40 landed with test evidence | Needs capacity-backed Linear rollout |
-| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy, deterministic follow-up checks, and local supply-chain gates | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, and PR Review/Salvage Evidence; #1846 added npm registry signature gates; #1848 added the supply-chain incident-response playbook and `pull_request_target` cache-poisoning validator guard; #1851 added the privileged checkout credential-persistence guard | Partially complete |
+| AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, enterprise research roadmap | PRs #53, #55-#64 and #67 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` now has baseline drift and evidence-pack bundle slices landed | Evidence-pack bundle and ECC-Tools routing landed; next adapter/corpus/remediation slice |
+| ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog, evaluator/RAG corpus | PRs #26-#43 landed with test evidence, including AgentShield evidence-pack gap routing and canonical bundle recognition | Needs capacity-backed Linear rollout |
+| GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy, deterministic follow-up checks, and local supply-chain gates | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, PR Review/Salvage Evidence, and AgentShield evidence-pack evidence; #1846 added npm registry signature gates; #1848 added the supply-chain incident-response playbook and `pull_request_target` cache-poisoning validator guard; #1851 added the privileged checkout credential-persistence guard | Partially complete |
 | Harness-agnostic learning system | Audit, adapter matrix, observability, traces, promotion loop | Audit/adapters/observability gates plus `docs/architecture/evaluator-rag-prototype.md`, `examples/evaluator-rag-prototype/`, and ECC-Tools PR #40 define read-only stale-salvage, billing-readiness, CI-failure-diagnosis, harness-config-quality, AgentShield policy-exception, skill-quality evidence, deep-analyzer evidence, and RAG/evaluator comparison scenarios with trace, report, playbook, verifier, and predictive-check artifacts | Local corpus complete; hosted integration remains future |
 | Linear roadmap is detailed | Linear project status plus repo mirror | Repo mirror exists; issue creation was retried on 2026-05-12 and remains blocked by the workspace free issue limit | Needs recurring status updates after each merge batch |
 | Flow separation and progress tracking | Flow lanes with owner artifacts and update cadence | This roadmap defines lanes below and `docs/architecture/progress-sync-contract.md` makes GitHub/Linear/handoff/roadmap sync part of the readiness gate | Active |
@@ -269,8 +285,8 @@ repo evidence and merge commits.
 | Release and publication | rc.1 release docs, publication readiness doc | Naming matrix and plugin submission/contact checklist | Before any tag |
 | Harness OS core | Audit, adapter matrix, observability docs, `ecc2/` | HUD/session-control acceptance spec | Weekly until GA |
 | Evaluation and RAG | Reference-set validation, harness audit, traces, ECC-Tools corpus | Read-only evaluator/RAG prototype plus stale-salvage, billing-readiness, CI-failure-diagnosis, harness-config-quality, AgentShield policy-exception, skill-quality evidence, deep-analyzer evidence, and RAG/evaluator comparison fixtures | Hosted retrieval/check-run automation plan |
-| AgentShield enterprise | AgentShield PR evidence and roadmap notes | Baseline-drift evidence-pack and backlog sync follow-up | Next implementation batch |
-| ECC Tools app | ECC-Tools PR evidence, billing audit, risk taxonomy, evaluator/RAG corpus | Capacity-backed Linear rollout | Next implementation batch |
+| AgentShield enterprise | AgentShield PR evidence and roadmap notes | Adapter registry or corpus accuracy gate follow-up | Next implementation batch |
+| ECC Tools app | ECC-Tools PR evidence, billing audit, risk taxonomy, evaluator/RAG corpus | Capacity-backed Linear rollout plus hosted/deeper analysis follow-up | Next implementation batch |
 | Linear progress | Linear project status updates, `docs/architecture/progress-sync-contract.md`, and this mirror | Status update with queue/evidence/missing gates | Every significant merge batch |
 
 The project status update should always include:
@@ -470,12 +486,14 @@ Acceptance:
 
 ## Next Engineering Slices
 
-1. Finish the AgentShield baseline-drift control-plane slice from
+1. Continue the AgentShield enterprise control-plane sequence from
    `docs/architecture/agentshield-enterprise-research-roadmap.md`: PR #63
-   shipped the GitHub Action baseline outputs and job-summary evidence; PR #64
+   shipped GitHub Action baseline outputs and job-summary evidence; PR #64
    shipped first-class baseline snapshot creation through
-   `agentshield baseline write`; the remaining work is evidence-pack routing
-   and ECC-Tools backlog sync integration.
+   `agentshield baseline write`; PR #67 shipped the evidence-pack bundle; and
+   ECC-Tools PRs #42/#43 now route and recognize that bundle. The next slice is
+   either the multi-harness adapter registry, corpus accuracy gate, or
+   remediation/fingerprint workflow.
 2. Enable/configure the merged Linear backlog sync path after workspace issue
    capacity clears or the Linear workspace is upgraded.
 3. Use the ECC-Tools evaluator/RAG corpus as the promotion gate before adding


### PR DESCRIPTION
## Summary

Syncs the ECC 2.0 GA roadmap with the AgentShield and ECC-Tools evidence-pack work that landed after the post-hardening publication evidence PR.

## What changed

- records AgentShield #67 and its `agentshield scan --evidence-pack <dir>` bundle contract
- records ECC-Tools #42/#43 evidence-pack gap routing and canonical artifact recognition
- updates AgentShield/ECC-Tools roadmap rows now that evidence-pack bundle + routing have landed
- updates the next engineering slice toward adapter registry, corpus accuracy, or remediation/fingerprint workflow

## Validation

- `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- `node tests/docs/ecc2-release-surface.test.js` -> 18 passed
- `git diff --check`

## Notes

No release, tag, publish, marketplace submission, deployment, or announcement in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the ECC 2.0 GA roadmap to reflect the shipped `AgentShield` evidence-pack bundle and `ECC-Tools` routing/recognition, plus CI/security hardening. Records `AgentShield` #65/#66/#67 and `ECC-Tools` #41/#42/#43, documents `agentshield scan --evidence-pack <dir>` contract, updates roadmap rows, and sets the next slice (adapter registry, corpus accuracy, or remediation/fingerprint).

<sup>Written for commit 60c32cb210de000222e12c75246e0354dd23e6b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA roadmap to reflect AgentShield enterprise evidence-pack bundle delivery and canonical artifact contract.
  * Documented evidence-pack routing/recognition and PR-risk taxonomy integration for ECC Tools.
  * Noted release hardening steps for enterprise CI/release jobs and revised execution lanes, milestone tracking, and next engineering slices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1854)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->