### PR TITLE
fix: fall back to ASCII instinct status bars

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -82,6 +82,27 @@ def _normalize_remote_url(remote_url: str) -> str:
     return normalized.lower() if is_network else normalized
 
 
+def _stream_can_encode(text: str, stream=None) -> bool:
+    stream = stream or sys.stdout
+    encoding = getattr(stream, "encoding", None) or sys.getdefaultencoding()
+    try:
+        text.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def _confidence_bar(confidence, stream=None) -> str:
+    try:
+        filled = int(float(confidence) * 10)
+    except (TypeError, ValueError):
+        filled = 5
+    filled = max(0, min(10, filled))
+
+    full, empty = ("\u2588", "\u2591") if _stream_can_encode("\u2588\u2591", stream) else ("#", ".")
+    return full * filled + empty * (10 - filled)
+
+
 def _project_hash(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
 
@@ -550,7 +571,7 @@ def _print_instincts_by_domain(instincts: list[dict]) -> None:
 
         for inst in sorted(domain_instincts, key=lambda x: -x.get('confidence', 0.5)):
             conf = inst.get('confidence', 0.5)
-            conf_bar = '\u2588' * int(conf * 10) + '\u2591' * (10 - int(conf * 10))
+            conf_bar = _confidence_bar(conf)
             trigger = inst.get('trigger', 'unknown trigger')
             scope_tag = f"[{inst.get('scope', '?')}]"
 

--- a/skills/continuous-learning-v2/scripts/test_parse_instinct.py
+++ b/skills/continuous-learning-v2/scripts/test_parse_instinct.py
@@ -45,6 +45,7 @@ _find_cross_project_instincts = _mod._find_cross_project_instincts
 load_registry = _mod.load_registry
 _validate_instinct_id = _mod._validate_instinct_id
 _update_registry = _mod._update_registry
+_confidence_bar = _mod._confidence_bar
 
 
 # ─────────────────────────────────────────────
@@ -640,6 +641,39 @@ def test_cmd_status_with_instincts(patch_globals, monkeypatch, capsys):
     assert "Global instincts:  1" in out
     assert "PROJECT-SCOPED" in out
     assert "GLOBAL" in out
+
+
+def test_confidence_bar_uses_unicode_when_supported():
+    """Confidence bars should retain block glyphs on UTF-8 streams."""
+    stream = SimpleNamespace(encoding="utf-8")
+    assert _confidence_bar(0.8, stream=stream) == "\u2588" * 8 + "\u2591" * 2
+
+
+def test_confidence_bar_uses_ascii_when_stream_rejects_block_glyphs():
+    """Windows cp1252 streams cannot encode block glyphs."""
+    stream = SimpleNamespace(encoding="cp1252")
+    assert _confidence_bar(0.8, stream=stream) == "########.."
+
+
+def test_print_instincts_by_domain_is_cp1252_safe(monkeypatch):
+    """Status rendering should not crash on Windows cp1252 stdout."""
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="cp1252")
+    monkeypatch.setattr(_mod.sys, "stdout", stream)
+
+    _mod._print_instincts_by_domain([{
+        "id": "windows-safe",
+        "trigger": "when stdout uses cp1252",
+        "confidence": 0.8,
+        "domain": "platform",
+        "scope": "project",
+    }])
+
+    stream.flush()
+    out = raw.getvalue().decode("cp1252")
+    assert "########.." in out
+    assert "\u2588" not in out
+    assert "\u2591" not in out
 
 
 def test_cmd_status_returns_int(patch_globals, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #1855.

- render `/instinct-status` confidence bars with Unicode only when stdout can encode the block glyphs
- fall back to ASCII bars on cp1252 streams so Windows status output does not crash
- add regression coverage for UTF-8 and cp1252 status rendering

## Validation

- `uv run --with pytest python -m pytest skills/continuous-learning-v2/scripts/test_parse_instinct.py`
- `python3 -m py_compile skills/continuous-learning-v2/scripts/instinct-cli.py skills/continuous-learning-v2/scripts/test_parse_instinct.py`
- `node tests/run-all.js`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make instinct status bars encoding-safe. Use Unicode blocks only when stdout supports them; fall back to ASCII on Windows to prevent crashes.

- **Bug Fixes**
  - Detect stream encoding and render Unicode bars only when encodable.
  - Fall back to ASCII (`#` and `.`) on `cp1252` streams to avoid Windows crashes.
  - Added regression tests for UTF-8 and `cp1252`, and verified `_print_instincts_by_domain` is safe.

<sup>Written for commit d75b7cf19d19071379cefea34362a588a34c6d69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved confidence bar rendering to work seamlessly across all terminals by automatically detecting character encoding support and gracefully falling back to ASCII characters when Unicode block characters are unavailable.

* **Tests**
  * Added comprehensive test coverage for confidence bar rendering, validating compatibility across different character encodings and terminal types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1856)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->