### PR TITLE
docs: sync AgentShield adapter roadmap

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -139,6 +139,14 @@ As of 2026-05-13:
   README, JSON, HTML, SARIF, policy-evaluation, baseline-comparison, and
   supply-chain artifacts with default redaction and `not-run` markers for
   optional policy/baseline evidence.
+- AgentShield PR #68 hardened evidence-pack redaction for enterprise credential
+  families including GitHub fine-grained PATs, GitLab PATs, npm tokens, Linear
+  API keys, Stripe keys, Google API keys, Hugging Face tokens, Vercel tokens,
+  AWS access key IDs, and JWT-shaped credentials.
+- AgentShield PR #69 added the deterministic harness adapter registry. Scan
+  reports now surface local marker evidence for Claude Code, OpenCode, Codex,
+  Gemini, dmux, generic terminal agents, and project-local templates in JSON,
+  markdown, terminal, and HTML outputs.
 - AgentShield PDF-export decision: defer a native PDF writer for now. The
   self-contained HTML executive report remains the exportable buyer artifact
   and can be printed to PDF when needed; native PDF generation should wait for
@@ -261,7 +269,7 @@ is not complete unless the evidence column exists and has been freshly verified.
 | Naming and rename readiness | Naming matrix across package/plugin/docs/social surfaces | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` records current package, repo, Claude plugin, Codex plugin, OpenCode, and npm availability evidence | Complete for rc.1; post-rc rename remains future work |
 | Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness, naming matrix, and May 12 dry-run evidence document plugin validation, clean-checkout Claude tag/install smoke, and Codex marketplace CLI shape | Needs explicit approval for real tag/push and marketplace submission |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
-| AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, enterprise research roadmap | PRs #53, #55-#64 and #67 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` now has baseline drift and evidence-pack bundle slices landed | Evidence-pack bundle and ECC-Tools routing landed; next adapter/corpus/remediation slice |
+| AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, evidence-pack redaction, harness adapter registry, enterprise research roadmap | PRs #53, #55-#64 and #67-#69 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` now has baseline drift, evidence-pack bundle, redaction, and adapter-registry slices landed | Next corpus accuracy gate or remediation/fingerprint workflow |
 | ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog, evaluator/RAG corpus | PRs #26-#43 landed with test evidence, including AgentShield evidence-pack gap routing and canonical bundle recognition | Needs capacity-backed Linear rollout |
 | GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy, deterministic follow-up checks, and local supply-chain gates | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, PR Review/Salvage Evidence, and AgentShield evidence-pack evidence; #1846 added npm registry signature gates; #1848 added the supply-chain incident-response playbook and `pull_request_target` cache-poisoning validator guard; #1851 added the privileged checkout credential-persistence guard | Partially complete |
 | Harness-agnostic learning system | Audit, adapter matrix, observability, traces, promotion loop | Audit/adapters/observability gates plus `docs/architecture/evaluator-rag-prototype.md`, `examples/evaluator-rag-prototype/`, and ECC-Tools PR #40 define read-only stale-salvage, billing-readiness, CI-failure-diagnosis, harness-config-quality, AgentShield policy-exception, skill-quality evidence, deep-analyzer evidence, and RAG/evaluator comparison scenarios with trace, report, playbook, verifier, and predictive-check artifacts | Local corpus complete; hosted integration remains future |
@@ -490,9 +498,10 @@ Acceptance:
    `docs/architecture/agentshield-enterprise-research-roadmap.md`: PR #63
    shipped GitHub Action baseline outputs and job-summary evidence; PR #64
    shipped first-class baseline snapshot creation through
-   `agentshield baseline write`; PR #67 shipped the evidence-pack bundle; and
-   ECC-Tools PRs #42/#43 now route and recognize that bundle. The next slice is
-   either the multi-harness adapter registry, corpus accuracy gate, or
+   `agentshield baseline write`; PR #67 shipped the evidence-pack bundle; PR
+   #68 hardened evidence-pack redaction; PR #69 shipped the multi-harness
+   adapter registry; and ECC-Tools PRs #42/#43 now route and recognize evidence
+   packs. The next slice is either the corpus accuracy gate or
    remediation/fingerprint workflow.
 2. Enable/configure the merged Linear backlog sync path after workspace issue
    capacity clears or the Linear workspace is upgraded.


### PR DESCRIPTION
## Summary

Updates the ECC 2.0 GA roadmap after the AgentShield enterprise-control-plane batch.

## Changes

- records AgentShield #68 evidence-pack credential redaction hardening
- records AgentShield #69 harness adapter registry across report formats
- moves the next AgentShield enterprise slice from adapter registry to corpus accuracy gate or remediation/fingerprint workflow

## Validation

- `npm run observability:ready -- --format json` — 21/21, ready true
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the ECC 2.0 GA roadmap to reflect the latest AgentShield enterprise updates. Documents evidence-pack credential redaction hardening (PR #68) and the deterministic harness adapter registry (PR #69) across JSON/Markdown/terminal/HTML reports, and shifts the next slice to the corpus accuracy gate or remediation/fingerprint workflow.

<sup>Written for commit ed604ab9e8d9d203244528df8e3e9c6193745f12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the product roadmap with AgentShield feature progress and implementation status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1858)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->