### PR TITLE
docs: mark JARVIS backend audit clean

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -61,7 +61,8 @@ As of 2026-05-13:
   records the May 13 supply-chain sweep: no active lockfile/manifest hit for
   TanStack/Mini Shai-Hulud indicators; npm audit/signature checks clean across
   active npm lockfiles; `cargo audit` clean for `ecc2`; trunk `pip-audit`
-  clean; JARVIS backend Python audit blocked by unresolved `mediapipe==0.10.32`.
+  clean; JARVIS backend pinned-graph Python audit clean under the supported
+  Python 3.12 target.
 - Local PR #1861 validation refreshed `node scripts/harness-audit.js --format json`
   at 70/70 and `npm run observability:ready` at 21/21.
 - `ECC-Tools` has a local-only hardening branch


### PR DESCRIPTION
## Summary

- update the ECC 2.0 GA roadmap after rerunning the JARVIS backend Python audit in the backend's supported Python range
- replace the stale mediapipe blocker note with the successful Python 3.12 pinned-graph audit result

## Validation

- npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md
- node scripts/ci/validate-no-personal-paths.js
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ECC 2.0 GA roadmap to mark the JARVIS backend pinned-graph Python audit as clean under Python 3.12. Replaces the prior `mediapipe==0.10.32` blocker note.

<sup>Written for commit 84aeb4a014ddda5a6e3361a0664254095f00313c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the supply-chain audit status in the roadmap documentation, reflecting that the JARVIS backend Python audit is now clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1862)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->