### PR TITLE
docs: sync roadmap after AgentShield corpus expansion

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -65,6 +65,10 @@ As of 2026-05-13:
   and added ordered remediation workflow phases to remediation plans, routing
   safe auto-fixes, manual review, and verification through stable finding
   fingerprints without copying raw evidence.
+- AgentShield PR #82 merged as `51336ba074ad5e9fed2c0aa3237422be22147e76`
+  and expanded the built-in attack corpus with an env proxy hijack scenario
+  covering proxy/runtime mutation, env-token exfiltration, DNS exfiltration,
+  credential-store access, and clipboard access.
 - JARVIS PR #13 merged as `127efabbfb5033ae53d7a53e1546aa3c33d6f962`
   and hardened CI/deploy workflows with npm registry signature verification,
   disabled persisted checkout credentials in write-permission jobs, and pinned
@@ -311,7 +315,7 @@ is not complete unless the evidence column exists and has been freshly verified.
 | Naming and rename readiness | Naming matrix across package/plugin/docs/social surfaces | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` records current package, repo, Claude plugin, Codex plugin, OpenCode, and npm availability evidence | Complete for rc.1; post-rc rename remains future work |
 | Claude and Codex plugin publication | Contact/submission path with required artifacts and status | Publication readiness, naming matrix, and May 12 dry-run evidence document plugin validation, clean-checkout Claude tag/install smoke, and Codex marketplace CLI shape | Needs explicit approval for real tag/push and marketplace submission |
 | Articles, tweets, and announcements | X thread, LinkedIn copy, GitHub release copy, push checklist | Draft launch collateral exists under rc.1 release docs | Needs URL-backed refresh |
-| AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, evidence-pack redaction, harness adapter registry, enterprise research roadmap, supply-chain hardened release path, CI-safe baseline fingerprints, corpus accuracy recommendations, remediation workflow phases | PRs #53, #55-#64, #67-#69, and #78-#81 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` now has baseline drift, evidence-pack bundle, redaction, adapter-registry, supply-chain hardening, hashed baseline fingerprints, corpus accuracy recommendation, and remediation workflow slices landed | Next corpus expansion or hosted evidence-pack workflow |
+| AgentShield enterprise iteration | Policy gates, SARIF, packs, provenance, corpus, HTML reports, exception lifecycle audit, baseline drift Action/CLI surfaces, evidence-pack redaction, harness adapter registry, enterprise research roadmap, supply-chain hardened release path, CI-safe baseline fingerprints, corpus accuracy recommendations, remediation workflow phases, env proxy hijack corpus coverage | PRs #53, #55-#64, #67-#69, and #78-#82 landed with test evidence; native PDF export deferred in favor of self-contained HTML plus print-to-PDF until explicit enterprise demand appears; `docs/architecture/agentshield-enterprise-research-roadmap.md` now has baseline drift, evidence-pack bundle, redaction, adapter-registry, supply-chain hardening, hashed baseline fingerprints, corpus accuracy recommendation, remediation workflow, and env proxy hijack corpus slices landed | Next hosted evidence-pack workflow depth |
 | ECC Tools next-level app | Billing audit, PR checks, deep analyzer, sync backlog, evaluator/RAG corpus | PRs #26-#43 plus #53/#54 landed with test evidence, including AgentShield evidence-pack gap routing, canonical bundle recognition, supply-chain signature gates, and PR draft follow-up Linear tracking | Needs hosted/deeper analysis follow-up |
 | GitGuardian/Dependabot/CodeRabbit-style checks | Non-blocking taxonomy, deterministic follow-up checks, and local supply-chain gates | ECC-Tools risk taxonomy check plus follow-up signals landed, including Skill Quality, Deep Analyzer Evidence, Analyzer Corpus Evidence, RAG/Evaluator Evidence, PR Review/Salvage Evidence, and AgentShield evidence-pack evidence; #1846 added npm registry signature gates; #1848 added the supply-chain incident-response playbook and `pull_request_target` cache-poisoning validator guard; #1851 added the privileged checkout credential-persistence guard; AgentShield #78, JARVIS #13, and ECC-Tools #53 applied the same hardening outside trunk | Current supply-chain gate complete; deeper hosted review features remain future |
 | Harness-agnostic learning system | Audit, adapter matrix, observability, traces, promotion loop | Audit/adapters/observability gates plus `docs/architecture/evaluator-rag-prototype.md`, `examples/evaluator-rag-prototype/`, and ECC-Tools PR #40 define read-only stale-salvage, billing-readiness, CI-failure-diagnosis, harness-config-quality, AgentShield policy-exception, skill-quality evidence, deep-analyzer evidence, and RAG/evaluator comparison scenarios with trace, report, playbook, verifier, and predictive-check artifacts | Local corpus complete; hosted integration remains future |
@@ -550,8 +554,9 @@ Acceptance:
    fingerprints to hashed evidence and stopped writing raw evidence into new
    baselines; PR #80 added prioritized corpus accuracy recommendations for
    failed regression gates; PR #81 added ordered remediation workflow phases;
-   and ECC-Tools PRs #42/#43 now route and recognize evidence packs. The next
-   slice is corpus expansion or hosted evidence-pack workflow depth.
+   PR #82 expanded corpus coverage for env proxy hijacks and out-of-band
+   exfiltration; and ECC-Tools PRs #42/#43 now route and recognize evidence
+   packs. The next slice is hosted evidence-pack workflow depth.
 2. Keep ECC-Tools #53's supply-chain workflow gate and #54's PR-draft backlog
    tracking in the recurring queue evidence, and use the org-scoped GitHub auth
    path for future ECC-Tools maintenance while the narrow environment token


### PR DESCRIPTION
## Summary

- record AgentShield PR #82 and merge commit in the ECC 2.0 GA roadmap
- update the AgentShield enterprise row through PRs #78-#82
- move the next AgentShield slice to hosted evidence-pack workflow depth after corpus expansion landed

## Test plan

- [x] `npx markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md`
- [x] `node scripts/ci/validate-no-personal-paths.js docs/ECC-2.0-GA-ROADMAP.md`
- [x] `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced the ECC 2.0 GA roadmap to reflect `AgentShield` PR #82 corpus expansion. Recorded env proxy hijack coverage, updated the enterprise row to PRs #78–#82, and set the next step to hosted evidence-pack workflow depth.

<sup>Written for commit 76f4331ca68a623734090dc3f5d9b5747a9c4bb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the product roadmap with the latest AgentShield progress updates and expanded evidence scenario documentation from recent engineering work.
  * Refreshed engineering priorities, upcoming development phases, and implementation timeline to align with current project status and completed milestones.
  * Refined future development targets based on latest progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1869)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->