### PR TITLE
fix(rules/ruby): correct brakeman flag and unify bundle-audit invocation

### DIFF
--- a/rules/ruby/hooks.md
+++ b/rules/ruby/hooks.md
@@ -15,7 +15,7 @@ paths:
 Configure project-local hooks to prefer binstubs and checked-in tooling:
 
 - **RuboCop**: run `bundle exec rubocop -A <file>` or the project's safer formatter command after Ruby edits.
-- **Brakeman**: run `bundle exec brakeman --no-pager` after security-sensitive Rails changes.
+- **Brakeman**: run `bundle exec brakeman --no-progress` after security-sensitive Rails changes.
 - **Tests**: run the narrowest matching `bin/rails test ...` or `bundle exec rspec ...` command for touched files.
 - **Bundler audit**: run `bundle exec bundle-audit check --update` when `Gemfile` or `Gemfile.lock` changes and the project has bundler-audit installed.
 
@@ -29,7 +29,7 @@ Configure project-local hooks to prefer binstubs and checked-in tooling:
 
 ```bash
 bundle exec rubocop
-bundle exec brakeman --no-pager
+bundle exec brakeman --no-progress
 bin/rails test
 bundle exec rspec
 ```

--- a/rules/ruby/security.md
+++ b/rules/ruby/security.md
@@ -34,8 +34,8 @@ paths:
 - Run dependency checks when the lockfile changes:
 
 ```bash
-bundle audit check --update
-bundle exec brakeman --no-pager
+bundle exec bundle-audit check --update
+bundle exec brakeman --no-progress
 ```
 
 - Review new gems for maintainer activity, native extension risk, transitive dependencies, and whether the same behavior can be implemented with Rails core.


### PR DESCRIPTION
## What Changed

Two surgical fixes in `rules/ruby/hooks.md` and `rules/ruby/security.md`:

1. **`brakeman --no-pager` → `brakeman --no-progress`** (3 locations)
   - `rules/ruby/hooks.md` L18 (bullet recommendation)
   - `rules/ruby/hooks.md` L32 (CI gate snippet)
   - `rules/ruby/security.md` L38 (dependency check snippet)

2. **`bundle audit check --update` → `bundle exec bundle-audit check --update`** (1 location)
   - `rules/ruby/security.md` L37, unifying with the form already used in `rules/ruby/hooks.md` L20.

## Why This Change

Both issues were flagged in the PR #1860 review (post-merge) and are
still present on `main`:

### 1. `brakeman --no-pager` is not a real flag

Brakeman has no `--no-pager` option — that's `git` / `gh` syntax.
Users following the docs verbatim will hit
`error: invalid option: --no-pager`. Closest valid replacements:

- `--no-progress` — suppresses the progress bar while keeping warning output (likely intended)
- `-q` / `--quiet` — fully quiet
- `--no-color` — clean output

`--no-progress` matches what hook contexts (PostToolUse / CI) usually want.

### 2. `bundle-audit` invocation form inconsistency

`rules/ruby/security.md` L37 used the `bundle audit check --update`
Bundler-plugin subcommand form, while `rules/ruby/hooks.md` L20 used
the direct `bundle exec bundle-audit check --update` binary form.
Both invoke the same `bundler-audit` gem but look different enough to
confuse readers comparing the two files.

Standardized on `bundle exec bundle-audit` because:
- it's the portable invocation that works across bundler-audit gem versions
- doesn't depend on the gem registering a `bundle audit` Rubygems plugin (this depends on the Rubygems plugin loader state)
- matches the form already canonical in `hooks.md`

Both findings were also independently caught by `greptile-apps` and
`coderabbitai` bots on PR #1860 (see review comments on
`rules/ruby/security.md` L37-39).

## Testing Done

- [x] Manual verification:
  - `grep -rn "no-pager" rules/ruby/` → empty (clean)
  - `grep -rn -E "bundle (audit|exec bundle-audit)" rules/ruby/` → both files use the same form
- [x] Automated tests pass locally: `node tests/run-all.js` reports
      **2382 passed, 0 failed**
- [x] `markdownlint-cli` clean on both modified files

## Type of Change

- [x] `fix:` Bug fix

## Scope

Tightly scoped to the two issues above. Does not touch:
- Any other `rules/ruby/*.md` file
- The `manifests/install-components.json` security-module asymmetry
  flagged by greptile-apps P2 #2 (that's a design question, not a bug,
  and is out of scope here).

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] Follows conventional commits format (`fix:`)

## Documentation
- [x] The change itself is documentation correctness; install/hook
  instructions now use real flags and consistent invocations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ruby rules docs to use the correct `brakeman` flag and a consistent `bundle-audit` command. Replaces `--no-pager` with `--no-progress` and standardizes on `bundle exec bundle-audit check --update` to prevent errors and ensure portability.

<sup>Written for commit f3f63dee4ef9645a833ebcf22f1968e6b17bcf3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ruby/Rails security hook documentation with revised Brakeman command configurations in PostToolUse Hooks and CI Gate examples.
  * Updated Ruby security guide with streamlined bundle-audit invocation and refined Brakeman command options in dependency-checking code examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1884)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->