### PR TITLE
fix(hooks): close subshell bypass in pre-bash-dev-server-block

### DIFF
--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -127,6 +127,8 @@ function getLeadingCommandWord(segment) {
       continue;
     }
 
+    if (token === '{' || token === '}') continue;
+
     if (/^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token)) continue;
 
     const normalizedToken = normalizeCommandWord(token);
@@ -159,7 +161,7 @@ process.stdin.on('data', chunk => {
 });
 
 const TMUX_LAUNCHER = /^\s*tmux\s+(new|new-session|new-window|split-window)\b/;
-const DEV_PATTERN = /\b(npm\s+run\s+dev|pnpm(?:\s+run)?\s+dev|yarn\s+dev|bun\s+run\s+dev)\b/;
+const DEV_PATTERN = /\b(npm\s+run\s+dev|pnpm(?:\s+run)?\s+dev|yarn(?:\s+run)?\s+dev|bun(?:\s+run)?\s+dev)\b/;
 
 /**
  * Collect every command-line segment we should evaluate. Returns the top-level

--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -4,6 +4,10 @@
 const MAX_STDIN = 1024 * 1024;
 const path = require('path');
 const { splitShellSegments } = require('../lib/shell-split');
+const {
+  extractCommandSubstitutions,
+  extractSubshellGroups
+} = require('../lib/shell-substitution');
 
 const DEV_COMMAND_WORDS = new Set([
   'npm',
@@ -154,23 +158,55 @@ process.stdin.on('data', chunk => {
   }
 });
 
+const TMUX_LAUNCHER = /^\s*tmux\s+(new|new-session|new-window|split-window)\b/;
+const DEV_PATTERN = /\b(npm\s+run\s+dev|pnpm(?:\s+run)?\s+dev|yarn\s+dev|bun\s+run\s+dev)\b/;
+
+/**
+ * Collect every command-line segment we should evaluate. Returns the top-level
+ * segments first, then segments harvested from `$(...)` / backtick command
+ * substitutions and plain `(...)` subshell groups, recursively.
+ *
+ * Without this expansion the leading-command and dev-pattern check below only
+ * sees the outermost command, so wrappers like `$(npm run dev)` and
+ * `(npm run dev)` (which still spawn a dev server) sneak past.
+ */
+function collectCheckSegments(cmd) {
+  const segments = [...splitShellSegments(cmd)];
+  const queue = [cmd];
+  const seen = new Set();
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    for (const body of extractCommandSubstitutions(current)) {
+      for (const seg of splitShellSegments(body)) segments.push(seg);
+      queue.push(body);
+    }
+    for (const body of extractSubshellGroups(current)) {
+      for (const seg of splitShellSegments(body)) segments.push(seg);
+      queue.push(body);
+    }
+  }
+
+  return segments;
+}
+
+function isBlockedDevSegment(segment) {
+  const commandWord = getLeadingCommandWord(segment);
+  if (!commandWord || !DEV_COMMAND_WORDS.has(commandWord)) return false;
+  return DEV_PATTERN.test(segment) && !TMUX_LAUNCHER.test(segment);
+}
+
 process.stdin.on('end', () => {
   try {
     const input = JSON.parse(raw);
     const cmd = String(input.tool_input?.command || '');
 
     if (process.platform !== 'win32') {
-      const segments = splitShellSegments(cmd);
-      const tmuxLauncher = /^\s*tmux\s+(new|new-session|new-window|split-window)\b/;
-      const devPattern = /\b(npm\s+run\s+dev|pnpm(?:\s+run)?\s+dev|yarn\s+dev|bun\s+run\s+dev)\b/;
-
-      const hasBlockedDev = segments.some(segment => {
-        const commandWord = getLeadingCommandWord(segment);
-        if (!commandWord || !DEV_COMMAND_WORDS.has(commandWord)) {
-          return false;
-        }
-        return devPattern.test(segment) && !tmuxLauncher.test(segment);
-      });
+      const segments = collectCheckSegments(cmd);
+      const hasBlockedDev = segments.some(isBlockedDevSegment);
 
       if (hasBlockedDev) {
         console.error('[Hook] BLOCKED: Dev server must run in tmux for log access');

--- a/scripts/lib/shell-substitution.js
+++ b/scripts/lib/shell-substitution.js
@@ -106,4 +106,114 @@ function extractCommandSubstitutions(input) {
   return substitutions;
 }
 
-module.exports = { extractCommandSubstitutions };
+/**
+ * Extract bodies of plain `(...)` subshell groups.
+ *
+ * Bash treats `(npm run dev)` as a subshell that executes its contents, but
+ * the regex-light segment splitters used by our PreToolUse hooks don't peer
+ * inside those parens. This helper finds top-level `(...)` groups (skipping
+ * `$(...)` command substitutions and backticks, which `extractCommandSubstitutions`
+ * already covers) and returns each body, recursing for nested groups.
+ *
+ * Quote semantics:
+ * - Single quotes are literal: `'( ... )'` is a string, not a subshell.
+ * - Double quotes are literal *for parens*: `"( ... )"` is a string too —
+ *   bash only honors `$( )` inside double quotes, not bare `( )`.
+ *
+ * @param {string} input
+ * @returns {string[]}
+ */
+function extractSubshellGroups(input) {
+  const source = String(input || '');
+  const groups = [];
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+
+    if (ch === '\\' && !inSingle) {
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'" && !inDouble && prev !== '\\') {
+      inSingle = !inSingle;
+      continue;
+    }
+
+    if (ch === '"' && !inSingle && prev !== '\\') {
+      inDouble = !inDouble;
+      continue;
+    }
+
+    if (inSingle || inDouble) {
+      continue;
+    }
+
+    if (ch === '$' && source[i + 1] === '(') {
+      let depth = 1;
+      i += 2;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        if (inner === '\\') {
+          i += 2;
+          continue;
+        }
+        if (inner === '(') depth += 1;
+        else if (inner === ')') depth -= 1;
+        i += 1;
+      }
+      i -= 1;
+      continue;
+    }
+
+    if (ch === '`') {
+      i += 1;
+      while (i < source.length && source[i] !== '`') {
+        if (source[i] === '\\' && i + 1 < source.length) {
+          i += 2;
+          continue;
+        }
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '(') {
+      let depth = 1;
+      let body = '';
+      i += 1;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        if (inner === '\\') {
+          body += inner;
+          if (i + 1 < source.length) {
+            body += source[i + 1];
+            i += 2;
+            continue;
+          }
+        }
+        if (inner === '(') {
+          depth += 1;
+        } else if (inner === ')') {
+          depth -= 1;
+          if (depth === 0) {
+            break;
+          }
+        }
+        body += inner;
+        i += 1;
+      }
+      if (body.trim()) {
+        groups.push(body);
+        groups.push(...extractSubshellGroups(body));
+      }
+    }
+  }
+
+  return groups;
+}
+
+module.exports = { extractCommandSubstitutions, extractSubshellGroups };

--- a/scripts/lib/shell-substitution.js
+++ b/scripts/lib/shell-substitution.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * Extract executable command-substitution bodies from a shell line.
+ *
+ * Single quotes are literal, so substitutions inside them are ignored;
+ * double quotes still permit substitutions, so those bodies are scanned
+ * before quoted text is stripped. Returns each substitution body plus
+ * any nested substitutions discovered recursively.
+ *
+ * Originally introduced in scripts/hooks/gateguard-fact-force.js
+ * (PR #1853 round 2). Extracted to a shared lib so other PreToolUse
+ * hooks that need the same "scan inside `$(...)` and backticks"
+ * behavior can reuse it without duplicating the parser.
+ *
+ * @param {string} input
+ * @returns {string[]}
+ */
+function extractCommandSubstitutions(input) {
+  const source = String(input || '');
+  const substitutions = [];
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+
+    if (ch === '\\' && !inSingle) {
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'" && !inDouble && prev !== '\\') {
+      inSingle = !inSingle;
+      continue;
+    }
+
+    if (ch === '"' && !inSingle && prev !== '\\') {
+      inDouble = !inDouble;
+      continue;
+    }
+
+    if (inSingle) {
+      continue;
+    }
+
+    if (ch === '`') {
+      let body = '';
+      i += 1;
+      while (i < source.length) {
+        const inner = source[i];
+        if (inner === '\\') {
+          body += inner;
+          if (i + 1 < source.length) {
+            body += source[i + 1];
+            i += 2;
+            continue;
+          }
+        }
+        if (inner === '`') {
+          break;
+        }
+        body += inner;
+        i += 1;
+      }
+      if (body.trim()) {
+        substitutions.push(body);
+        substitutions.push(...extractCommandSubstitutions(body));
+      }
+      continue;
+    }
+
+    if (ch === '$' && source[i + 1] === '(') {
+      let depth = 1;
+      let body = '';
+      i += 2;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        if (inner === '\\') {
+          body += inner;
+          if (i + 1 < source.length) {
+            body += source[i + 1];
+            i += 2;
+            continue;
+          }
+        }
+        if (inner === '(') {
+          depth += 1;
+        } else if (inner === ')') {
+          depth -= 1;
+          if (depth === 0) {
+            break;
+          }
+        }
+        body += inner;
+        i += 1;
+      }
+      if (body.trim()) {
+        substitutions.push(body);
+        substitutions.push(...extractCommandSubstitutions(body));
+      }
+    }
+  }
+
+  return substitutions;
+}
+
+module.exports = { extractCommandSubstitutions };

--- a/scripts/lib/shell-substitution.js
+++ b/scripts/lib/shell-substitution.js
@@ -74,10 +74,13 @@ function extractCommandSubstitutions(input) {
     if (ch === '$' && source[i + 1] === '(') {
       let depth = 1;
       let body = '';
+      let bodyInSingle = false;
+      let bodyInDouble = false;
       i += 2;
       while (i < source.length && depth > 0) {
         const inner = source[i];
-        if (inner === '\\') {
+        const innerPrev = source[i - 1];
+        if (inner === '\\' && !bodyInSingle) {
           body += inner;
           if (i + 1 < source.length) {
             body += source[i + 1];
@@ -85,12 +88,18 @@ function extractCommandSubstitutions(input) {
             continue;
           }
         }
-        if (inner === '(') {
-          depth += 1;
-        } else if (inner === ')') {
-          depth -= 1;
-          if (depth === 0) {
-            break;
+        if (inner === "'" && !bodyInDouble && innerPrev !== '\\') {
+          bodyInSingle = !bodyInSingle;
+        } else if (inner === '"' && !bodyInSingle && innerPrev !== '\\') {
+          bodyInDouble = !bodyInDouble;
+        } else if (!bodyInSingle && !bodyInDouble) {
+          if (inner === '(') {
+            depth += 1;
+          } else if (inner === ')') {
+            depth -= 1;
+            if (depth === 0) {
+              break;
+            }
           }
         }
         body += inner;
@@ -154,15 +163,24 @@ function extractSubshellGroups(input) {
 
     if (ch === '$' && source[i + 1] === '(') {
       let depth = 1;
+      let skipInSingle = false;
+      let skipInDouble = false;
       i += 2;
       while (i < source.length && depth > 0) {
         const inner = source[i];
-        if (inner === '\\') {
+        const innerPrev = source[i - 1];
+        if (inner === '\\' && !skipInSingle) {
           i += 2;
           continue;
         }
-        if (inner === '(') depth += 1;
-        else if (inner === ')') depth -= 1;
+        if (inner === "'" && !skipInDouble && innerPrev !== '\\') {
+          skipInSingle = !skipInSingle;
+        } else if (inner === '"' && !skipInSingle && innerPrev !== '\\') {
+          skipInDouble = !skipInDouble;
+        } else if (!skipInSingle && !skipInDouble) {
+          if (inner === '(') depth += 1;
+          else if (inner === ')') depth -= 1;
+        }
         i += 1;
       }
       i -= 1;
@@ -184,10 +202,13 @@ function extractSubshellGroups(input) {
     if (ch === '(') {
       let depth = 1;
       let body = '';
+      let bodyInSingle = false;
+      let bodyInDouble = false;
       i += 1;
       while (i < source.length && depth > 0) {
         const inner = source[i];
-        if (inner === '\\') {
+        const innerPrev = source[i - 1];
+        if (inner === '\\' && !bodyInSingle) {
           body += inner;
           if (i + 1 < source.length) {
             body += source[i + 1];
@@ -195,12 +216,18 @@ function extractSubshellGroups(input) {
             continue;
           }
         }
-        if (inner === '(') {
-          depth += 1;
-        } else if (inner === ')') {
-          depth -= 1;
-          if (depth === 0) {
-            break;
+        if (inner === "'" && !bodyInDouble && innerPrev !== '\\') {
+          bodyInSingle = !bodyInSingle;
+        } else if (inner === '"' && !bodyInSingle && innerPrev !== '\\') {
+          bodyInDouble = !bodyInDouble;
+        } else if (!bodyInSingle && !bodyInDouble) {
+          if (inner === '(') {
+            depth += 1;
+          } else if (inner === ')') {
+            depth -= 1;
+            if (depth === 0) {
+              break;
+            }
           }
         }
         body += inner;

--- a/tests/hooks/pre-bash-dev-server-block.test.js
+++ b/tests/hooks/pre-bash-dev-server-block.test.js
@@ -144,6 +144,55 @@ function runTests() {
     }) ? passed++ : failed++);
   }
 
+  // --- Round 1 review fixes (Greptile + CodeRabbit on PR #1889) ---
+
+  if (!isWindows) {
+    (test('blocks $(echo ")"; (npm run dev)) — quoted ) does not terminate $() early', () => {
+      const result = runScript('$(echo ")"; (npm run dev))');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks (echo ")"; npm run dev) — quoted ) does not terminate (...) early', () => {
+      const result = runScript('(echo ")"; npm run dev)');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('allows $(echo "(npm run dev)") — () inside double-quoted substitution body is literal', () => {
+      const result = runScript('$(echo "(npm run dev)")');
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks { npm run dev; } — brace group runs in current shell', () => {
+      const result = runScript('{ npm run dev; }');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks echo hi && { npm run dev; } — brace group after &&', () => {
+      const result = runScript('echo hi && { npm run dev; }');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('allows {npm run dev} — bash requires space after { to form a group', () => {
+      const result = runScript('{npm run dev}');
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks yarn run dev — yarn 1.x convention', () => {
+      const result = runScript('yarn run dev');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks bun dev — bun bare form', () => {
+      const result = runScript('bun dev');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks "$(npm run dev)" — double-quoted substitution still substitutes', () => {
+      const result = runScript('echo "$(npm run dev)"');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+  }
+
   // --- Edge cases ---
 
   (test('empty/invalid input passes through (exit code 0)', () => {

--- a/tests/hooks/pre-bash-dev-server-block.test.js
+++ b/tests/hooks/pre-bash-dev-server-block.test.js
@@ -89,6 +89,61 @@ function runTests() {
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
   }) ? passed++ : failed++);
 
+  // --- Subshell bypass regression (issue: dev server slipped past via $(), ``, ()) ---
+
+  if (!isWindows) {
+    (test('blocks $(npm run dev) — command substitution', () => {
+      const result = runScript('$(npm run dev)');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+      assert.ok(result.stderr.includes('BLOCKED'), 'expected BLOCKED in stderr');
+    }) ? passed++ : failed++);
+
+    (test('blocks `npm run dev` — backtick substitution', () => {
+      const result = runScript('`npm run dev`');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks echo $(npm run dev) — substitution nested in argument', () => {
+      const result = runScript('echo $(npm run dev)');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks (npm run dev) — plain subshell group', () => {
+      const result = runScript('(npm run dev)');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks $(echo a; npm run dev) — substitution with sequenced segments', () => {
+      const result = runScript('$(echo a; npm run dev)');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('blocks (pnpm dev) — plain subshell group with pnpm', () => {
+      const result = runScript('(pnpm dev)');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('allows tmux launcher inside subshell wrapping (exit code 0)', () => {
+      const result = runScript('(tmux new-session -d -s dev "npm run dev")');
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('allows single-quoted "(npm run dev)" — literal string, not a subshell', () => {
+      const result = runScript("git commit -m '(npm run dev)'");
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test('allows double-quoted "(npm run dev)" — literal in double quotes (bash does not subshell)', () => {
+      const result = runScript('echo "(npm run dev)"');
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    }) ? passed++ : failed++);
+
+    (test("allows single-quoted '$(npm run dev)' — literal string, no substitution", () => {
+      const result = runScript("git commit -m '$(npm run dev) fix'");
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    }) ? passed++ : failed++);
+  }
+
   // --- Edge cases ---
 
   (test('empty/invalid input passes through (exit code 0)', () => {


### PR DESCRIPTION
## Summary

`scripts/hooks/pre-bash-dev-server-block.js` is bypassable today. The hook runs its leading-command and `DEV_PATTERN` check only against the top-level segments returned by `splitShellSegments`, which intentionally does not split on `$(...)`, backticks, or plain `(...)`. That leaves four documented bypass forms that all spawn a dev server while the hook returns exit `0` (allow):

| Form | Block before fix? |
| --- | --- |
| `npm run dev` | ✅ blocked |
| `$(npm run dev)` | ❌ allow |
| `` `npm run dev` `` | ❌ allow |
| `echo $(npm run dev)` | ❌ allow |
| `(npm run dev)` | ❌ allow |
| `$(echo a; npm run dev)` | ❌ allow |

Reproduced on `main` by piping a synthetic PreToolUse payload into the hook for each row.

## Fix

A small BFS walks the command and harvests bodies from `$(...)`, backticks, and plain `(...)` subshell groups, then splits each harvested body through `splitShellSegments` and feeds the result back into the existing `isBlockedDevSegment` check. The leading-command and `DEV_PATTERN` rule is **unchanged** — only the set of segments it runs against grew.

Two new exports live in `scripts/lib/shell-substitution.js`:

- `extractCommandSubstitutions(input)` — the same function originally introduced in `scripts/hooks/gateguard-fact-force.js` via PR #1853 round 2 (`25ea9a77`), extracted to a shared lib so multiple PreToolUse hooks can reuse the quote-aware parser without duplicating it. Body unchanged.
- `extractSubshellGroups(input)` — new sibling for plain `(...)` groups. Honors single-quote literal and double-quote literal-for-parens semantics (bash does not treat `(...)` inside double quotes as a subshell — only `$(...)` is honored there). Skips `$(...)` and backtick spans so we don't double-extract bodies the other helper already covers.

Both helpers are quote-aware. Single- and double-quoted forms remain untouched, so legitimate uses like `git commit -m '(npm run dev)'` or `echo "(npm run dev)"` continue to pass.

## Tests

`tests/hooks/pre-bash-dev-server-block.test.js` extended with 10 cases — 6 new bypass blocks and 4 new allow cases that explicitly prove the fix doesn't over-block:

```
✓ blocks $(npm run dev) — command substitution
✓ blocks `npm run dev` — backtick substitution
✓ blocks echo $(npm run dev) — substitution nested in argument
✓ blocks (npm run dev) — plain subshell group
✓ blocks $(echo a; npm run dev) — substitution with sequenced segments
✓ blocks (pnpm dev) — plain subshell group, alt package manager
✓ allows tmux launcher inside subshell wrapping
✓ allows single-quoted '(npm run dev)' — literal string
✓ allows double-quoted "(npm run dev)" — literal in double quotes
✓ allows single-quoted '$(npm run dev) fix' — literal in single quotes
```

`yarn lint` and `yarn test` both green locally.

## Commit layout

Split into four small commits to make review easier — each commit is independently sensible:

1. `feat(lib): extract shell command-substitution parser to shared lib` — pure extraction of `extractCommandSubstitutions` from `gateguard-fact-force.js` into `scripts/lib/shell-substitution.js`. No behavior change. `gateguard-fact-force.js` keeps its private copy for this PR; consolidating that call site onto the shared lib is a follow-up worth doing once this lands.
2. `feat(lib): add extractSubshellGroups for plain (...) subshells` — new sibling extractor. No consumer yet.
3. `fix(hooks): close subshell bypass in pre-bash-dev-server-block` — wires both helpers into the hook. This is the behavior change.
4. `test(hooks): regression coverage for dev-server-block subshell bypass` — locks in the new blocks plus the explicit allow-cases for quote literals.

## Known limitation (not fixed here)

`eval "$(echo npm run dev)"` is **not** caught by this PR. The substitution body's leading command is `echo`, and statically modeling echo's stdout to recover the executed command is out of scope. The same class affects `gateguard-fact-force.js` (e.g. `eval "$(echo rm -rf /)"`), so it's worth addressing in both hooks together as a follow-up rather than bolting an echo-special-case onto this one.

## Provenance

`extractCommandSubstitutions` originally landed via PR #1853 (`fix: harden GateGuard destructive bash tokenizer`, commit `25ea9a77`). This PR reuses that parser verbatim — extracting it to a shared lib is the only refactor — and adds a sibling for the `(...)` case that gateguard's threat model didn't need.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] `node tests/hooks/pre-bash-dev-server-block.test.js` — 20/20 green
- [ ] Manual: every row of the bypass table above now returns exit `2`
- [ ] Manual: every row of the allow-cases test now returns exit `0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks dev server invocations wrapped in substitutions, subshells, or brace groups, with quote-aware parsing that closes previously missed bypasses; also expands detection to cover `yarn run dev` and `bun dev`. Tmux launches remain allowed.

- **Bug Fixes**
  - Scan bodies of `$(...)`, backticks, and plain `(...)` recursively and run the existing leading-command + dev-pattern check on each.
  - Handle quotes inside those bodies so `)` in strings doesn’t end groups early (e.g. blocks `$(echo ")"; (npm run dev))`).
  - Detect dev commands inside brace groups by skipping `{`/`}` when finding the leading command (blocks `{ npm run dev; }` and similar).
  - Expand the dev regex to include `yarn(?: run)? dev` and `bun(?: run)? dev`.
  - Preserves allow cases: tmux launchers and quoted literals.
  - Known limitation: `eval "$(echo npm run dev)"` still allowed; follow-up planned.

- **Refactors**
  - Added `scripts/lib/shell-substitution.js` with `extractCommandSubstitutions` and `extractSubshellGroups`; hook uses these helpers to collect nested segments (tmux rule unchanged).

<sup>Written for commit 85d33748e08e5c4a0dcffd88c26e175cd674b33a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of dev-server invocations to catch attempts nested inside command substitutions, backticks, and subshell/grouping forms.

* **Refactor**
  * Enhanced command-line parsing logic to more thoroughly analyze nested shell constructs and avoid false negatives.

* **Tests**
  * Added comprehensive regression tests covering nested/substituted, quoted, and edge-case command patterns to ensure blocking remains effective.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1889)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->