### PR TITLE
fix(hooks): allow first-time creation of protected config files

### DIFF
--- a/scripts/hooks/config-protection.js
+++ b/scripts/hooks/config-protection.js
@@ -7,12 +7,13 @@
  * the actual code. This hook steers the agent back to fixing the source.
  *
  * Exit codes:
- *   0 = allow (not a config file)
- *   2 = block (config file modification attempted)
+ *   0 = allow (not a config file, or first-time creation of one)
+ *   2 = block (existing config file modification attempted)
  */
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 
 const MAX_STDIN = 1024 * 1024;
@@ -94,6 +95,23 @@ function run(inputOrRaw, options = {}) {
 
   const basename = path.basename(filePath);
   if (PROTECTED_FILES.has(basename)) {
+    // Allow first-time creation — there's no existing config to weaken.
+    // The hook's purpose is blocking modifications; writing a brand-new
+    // config file in a project that has none is a legitimate bootstrap
+    // path (e.g. scaffolding ESLint into a fresh repo).
+    let exists = false;
+    try {
+      exists = fs.existsSync(filePath);
+    } catch {
+      // Be conservative: on stat errors (EACCES, etc.) treat as existing
+      // so we never silently weaken the guard.
+      exists = true;
+    }
+
+    if (!exists) {
+      return { exitCode: 0 };
+    }
+
     return {
       exitCode: 2,
       stderr:

--- a/scripts/hooks/config-protection.js
+++ b/scripts/hooks/config-protection.js
@@ -59,7 +59,7 @@ const PROTECTED_FILES = new Set([
   '.stylelintrc.yml',
   '.markdownlint.json',
   '.markdownlint.yaml',
-  '.markdownlintrc',
+  '.markdownlintrc'
 ]);
 
 function parseInput(inputOrRaw) {
@@ -99,13 +99,22 @@ function run(inputOrRaw, options = {}) {
     // The hook's purpose is blocking modifications; writing a brand-new
     // config file in a project that has none is a legitimate bootstrap
     // path (e.g. scaffolding ESLint into a fresh repo).
-    let exists = false;
+    //
+    // Fail closed on any stat error other than ENOENT. fs.existsSync would
+    // swallow EACCES/EPERM and return false, which would let an agent
+    // overwrite a file whose parent directory we cannot traverse. statSync
+    // exposes the error code explicitly so we can treat only genuine
+    // "file not found" as absent.
+    let exists = true;
     try {
-      exists = fs.existsSync(filePath);
-    } catch {
-      // Be conservative: on stat errors (EACCES, etc.) treat as existing
-      // so we never silently weaken the guard.
-      exists = true;
+      fs.statSync(filePath);
+      // stat succeeded — file exists.
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        exists = false;
+      }
+      // Any other error (EACCES, EPERM, ELOOP, etc.) leaves exists=true
+      // so the guard is never silently weakened.
     }
 
     if (!exists) {
@@ -118,7 +127,7 @@ function run(inputOrRaw, options = {}) {
         `BLOCKED: Modifying ${basename} is not allowed. ` +
         'Fix the source code to satisfy linter/formatter rules instead of ' +
         'weakening the config. If this is a legitimate config change, ' +
-        'disable the config-protection hook temporarily.',
+        'disable the config-protection hook temporarily.'
     };
   }
 
@@ -143,7 +152,7 @@ process.stdin.on('data', chunk => {
 process.stdin.on('end', () => {
   const result = run(raw, {
     truncated,
-    maxStdin: Number(process.env.ECC_HOOK_INPUT_MAX_BYTES) || MAX_STDIN,
+    maxStdin: Number(process.env.ECC_HOOK_INPUT_MAX_BYTES) || MAX_STDIN
   });
 
   if (result.stderr) {

--- a/scripts/hooks/config-protection.js
+++ b/scripts/hooks/config-protection.js
@@ -100,15 +100,17 @@ function run(inputOrRaw, options = {}) {
     // config file in a project that has none is a legitimate bootstrap
     // path (e.g. scaffolding ESLint into a fresh repo).
     //
-    // Fail closed on any stat error other than ENOENT. fs.existsSync would
-    // swallow EACCES/EPERM and return false, which would let an agent
-    // overwrite a file whose parent directory we cannot traverse. statSync
-    // exposes the error code explicitly so we can treat only genuine
-    // "file not found" as absent.
+    // Fail closed on any stat error other than ENOENT. Use lstatSync so a
+    // symlink at the protected path is treated as present even if its target
+    // is missing — a dangling symlink at e.g. .eslintrc.js still represents
+    // an existing config entry that an agent should not silently replace.
+    // fs.existsSync would swallow EACCES/EPERM as false; lstatSync exposes
+    // the error code so we can treat only genuine "path not found" (ENOENT)
+    // as absent.
     let exists = true;
     try {
-      fs.statSync(filePath);
-      // stat succeeded — file exists.
+      fs.lstatSync(filePath);
+      // lstat succeeded — something (file, dir, or symlink) exists here.
     } catch (err) {
       if (err && err.code === 'ENOENT') {
         exists = false;

--- a/tests/hooks/config-protection.test.js
+++ b/tests/hooks/config-protection.test.js
@@ -4,6 +4,7 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -71,18 +72,30 @@ function runTests() {
   let failed = 0;
 
   if (test('blocks protected config file edits through run-with-flags', () => {
-    const input = {
-      tool_name: 'Write',
-      tool_input: {
-        file_path: '.eslintrc.js',
-        content: 'module.exports = {};'
-      }
-    };
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+    try {
+      const absPath = path.join(tmpDir, '.eslintrc.js');
+      fs.writeFileSync(absPath, 'module.exports = {};');
 
-    const result = runHook(input);
-    assert.strictEqual(result.code, 2, 'Expected protected config edit to be blocked');
-    assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
-    assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
+      const input = {
+        tool_name: 'Write',
+        tool_input: {
+          file_path: absPath,
+          content: 'module.exports = {};'
+        }
+      };
+
+      const result = runHook(input);
+      assert.strictEqual(result.code, 2, 'Expected protected config edit to be blocked');
+      assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
+      assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
+    } finally {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
   })) passed++; else failed++;
 
   if (test('passes through safe file edits unchanged', () => {
@@ -115,6 +128,59 @@ function runTests() {
     assert.strictEqual(result.stdout, '', 'Blocked truncated payload should not echo raw input');
     assert.ok(result.stderr.includes('Hook input exceeded 1048576 bytes'), `Expected size warning, got: ${result.stderr}`);
     assert.ok(result.stderr.includes('truncated payload'), `Expected truncated payload warning, got: ${result.stderr}`);
+  })) passed++; else failed++;
+
+  if (test('allows first-time creation of a protected config file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+    try {
+      const absPath = path.join(tmpDir, 'eslint.config.mjs');
+      const input = {
+        tool_name: 'Write',
+        tool_input: {
+          file_path: absPath,
+          content: 'export default [];'
+        }
+      };
+
+      const rawInput = JSON.stringify(input);
+      const result = runHook(input);
+      assert.strictEqual(result.code, 0, `Expected exit 0 for first-time creation, got ${result.code}; stderr: ${result.stderr}`);
+      assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough when creation is allowed');
+      assert.strictEqual(result.stderr, '', `Expected no stderr for first-time creation, got: ${result.stderr}`);
+    } finally {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  })) passed++; else failed++;
+
+  if (test('still blocks writes to an existing protected config file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+    try {
+      const absPath = path.join(tmpDir, '.eslintrc.js');
+      fs.writeFileSync(absPath, 'module.exports = { rules: {} };');
+
+      const input = {
+        tool_name: 'Edit',
+        tool_input: {
+          file_path: absPath,
+          content: 'module.exports = { rules: { "no-console": "off" } };'
+        }
+      };
+
+      const result = runHook(input);
+      assert.strictEqual(result.code, 2, 'Expected exit 2 when modifying an existing protected config');
+      assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
+      assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
+    } finally {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
   })) passed++; else failed++;
 
   if (test('legacy hooks do not echo raw input when they fail without stdout', () => {

--- a/tests/hooks/config-protection.test.js
+++ b/tests/hooks/config-protection.test.js
@@ -206,6 +206,51 @@ function runTests() {
   else failed++;
 
   if (
+    test('blocks protected paths that exist as a dangling symlink', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+      try {
+        const missingTarget = path.join(tmpDir, 'nowhere.js');
+        const linkPath = path.join(tmpDir, '.eslintrc.js');
+        try {
+          fs.symlinkSync(missingTarget, linkPath);
+        } catch (err) {
+          // Windows without Developer Mode or certain sandboxes disallow
+          // symlinks. Skip cleanly rather than fail the suite.
+          if (err.code === 'EPERM' || err.code === 'EACCES') {
+            console.log('    (skipped: symlink creation not permitted here)');
+            return;
+          }
+          throw err;
+        }
+
+        const input = {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: linkPath,
+            content: 'module.exports = {};'
+          }
+        };
+
+        const result = runHook(input);
+        assert.strictEqual(result.code, 2, `Expected exit 2 for dangling symlink, got ${result.code}; stderr: ${result.stderr}`);
+        assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
+        assert.ok(
+          result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'),
+          `Expected block message, got: ${result.stderr}`
+        );
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('still blocks writes to an existing protected config file', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
       try {

--- a/tests/hooks/config-protection.test.js
+++ b/tests/hooks/config-protection.test.js
@@ -71,150 +71,204 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
-  if (test('blocks protected config file edits through run-with-flags', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
-    try {
-      const absPath = path.join(tmpDir, '.eslintrc.js');
-      fs.writeFileSync(absPath, 'module.exports = {};');
-
-      const input = {
-        tool_name: 'Write',
-        tool_input: {
-          file_path: absPath,
-          content: 'module.exports = {};'
-        }
-      };
-
-      const result = runHook(input);
-      assert.strictEqual(result.code, 2, 'Expected protected config edit to be blocked');
-      assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
-      assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
-    } finally {
+  if (
+    test('blocks protected config file edits through run-with-flags', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
       try {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-      } catch {
-        // best-effort cleanup
+        const absPath = path.join(tmpDir, '.eslintrc.js');
+        fs.writeFileSync(absPath, 'module.exports = {};');
+
+        const input = {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: absPath,
+            content: 'module.exports = {};'
+          }
+        };
+
+        const result = runHook(input);
+        assert.strictEqual(result.code, 2, 'Expected protected config edit to be blocked');
+        assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
+        assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
       }
-    }
-  })) passed++; else failed++;
+    })
+  )
+    passed++;
+  else failed++;
 
-  if (test('passes through safe file edits unchanged', () => {
-    const input = {
-      tool_name: 'Write',
-      tool_input: {
-        file_path: 'src/index.js',
-        content: 'console.log("ok");'
-      }
-    };
-
-    const rawInput = JSON.stringify(input);
-    const result = runHook(input);
-    assert.strictEqual(result.code, 0, 'Expected safe file edit to pass');
-    assert.strictEqual(result.stdout, rawInput, 'Expected exact raw JSON passthrough');
-    assert.strictEqual(result.stderr, '', 'Expected no stderr for safe edits');
-  })) passed++; else failed++;
-
-  if (test('blocks truncated protected config payloads instead of failing open', () => {
-    const rawInput = JSON.stringify({
-      tool_name: 'Write',
-      tool_input: {
-        file_path: '.eslintrc.js',
-        content: 'x'.repeat(1024 * 1024 + 2048)
-      }
-    });
-
-    const result = runHook(rawInput);
-    assert.strictEqual(result.code, 2, 'Expected truncated protected payload to be blocked');
-    assert.strictEqual(result.stdout, '', 'Blocked truncated payload should not echo raw input');
-    assert.ok(result.stderr.includes('Hook input exceeded 1048576 bytes'), `Expected size warning, got: ${result.stderr}`);
-    assert.ok(result.stderr.includes('truncated payload'), `Expected truncated payload warning, got: ${result.stderr}`);
-  })) passed++; else failed++;
-
-  if (test('allows first-time creation of a protected config file', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
-    try {
-      const absPath = path.join(tmpDir, 'eslint.config.mjs');
+  if (
+    test('passes through safe file edits unchanged', () => {
       const input = {
         tool_name: 'Write',
         tool_input: {
-          file_path: absPath,
-          content: 'export default [];'
+          file_path: 'src/index.js',
+          content: 'console.log("ok");'
         }
       };
 
       const rawInput = JSON.stringify(input);
       const result = runHook(input);
-      assert.strictEqual(result.code, 0, `Expected exit 0 for first-time creation, got ${result.code}; stderr: ${result.stderr}`);
-      assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough when creation is allowed');
-      assert.strictEqual(result.stderr, '', `Expected no stderr for first-time creation, got: ${result.stderr}`);
-    } finally {
-      try {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-      } catch {
-        // best-effort cleanup
-      }
-    }
-  })) passed++; else failed++;
+      assert.strictEqual(result.code, 0, 'Expected safe file edit to pass');
+      assert.strictEqual(result.stdout, rawInput, 'Expected exact raw JSON passthrough');
+      assert.strictEqual(result.stderr, '', 'Expected no stderr for safe edits');
+    })
+  )
+    passed++;
+  else failed++;
 
-  if (test('still blocks writes to an existing protected config file', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
-    try {
-      const absPath = path.join(tmpDir, '.eslintrc.js');
-      fs.writeFileSync(absPath, 'module.exports = { rules: {} };');
-
-      const input = {
-        tool_name: 'Edit',
-        tool_input: {
-          file_path: absPath,
-          content: 'module.exports = { rules: { "no-console": "off" } };'
-        }
-      };
-
-      const result = runHook(input);
-      assert.strictEqual(result.code, 2, 'Expected exit 2 when modifying an existing protected config');
-      assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
-      assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
-    } finally {
-      try {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-      } catch {
-        // best-effort cleanup
-      }
-    }
-  })) passed++; else failed++;
-
-  if (test('legacy hooks do not echo raw input when they fail without stdout', () => {
-    const pluginRoot = path.join(__dirname, '..', `tmp-runner-plugin-${Date.now()}`);
-    const scriptDir = path.join(pluginRoot, 'scripts', 'hooks');
-    const scriptPath = path.join(scriptDir, 'legacy-block.js');
-
-    try {
-      fs.mkdirSync(scriptDir, { recursive: true });
-      fs.writeFileSync(
-        scriptPath,
-        '#!/usr/bin/env node\nprocess.stderr.write("blocked by legacy hook\\n");\nprocess.exit(2);\n'
-      );
-
+  if (
+    test('blocks truncated protected config payloads instead of failing open', () => {
       const rawInput = JSON.stringify({
         tool_name: 'Write',
         tool_input: {
           file_path: '.eslintrc.js',
-          content: 'module.exports = {};'
+          content: 'x'.repeat(1024 * 1024 + 2048)
         }
       });
 
-      const result = runCustomHook(pluginRoot, 'pre:legacy-block', 'scripts/hooks/legacy-block.js', rawInput);
-      assert.strictEqual(result.code, 2, 'Expected failing legacy hook exit code to propagate');
-      assert.strictEqual(result.stdout, '', 'Expected failing legacy hook to avoid raw passthrough');
-      assert.ok(result.stderr.includes('blocked by legacy hook'), `Expected legacy hook stderr, got: ${result.stderr}`);
-    } finally {
+      const result = runHook(rawInput);
+      assert.strictEqual(result.code, 2, 'Expected truncated protected payload to be blocked');
+      assert.strictEqual(result.stdout, '', 'Blocked truncated payload should not echo raw input');
+      assert.ok(result.stderr.includes('Hook input exceeded 1048576 bytes'), `Expected size warning, got: ${result.stderr}`);
+      assert.ok(result.stderr.includes('truncated payload'), `Expected truncated payload warning, got: ${result.stderr}`);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('allows first-time creation of a protected config file', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
       try {
-        fs.rmSync(pluginRoot, { recursive: true, force: true });
-      } catch {
-        // best-effort cleanup
+        const absPath = path.join(tmpDir, 'eslint.config.mjs');
+        const input = {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: absPath,
+            content: 'export default [];'
+          }
+        };
+
+        const rawInput = JSON.stringify(input);
+        const result = runHook(input);
+        assert.strictEqual(result.code, 0, `Expected exit 0 for first-time creation, got ${result.code}; stderr: ${result.stderr}`);
+        assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough when creation is allowed');
+        assert.strictEqual(result.stderr, '', `Expected no stderr for first-time creation, got: ${result.stderr}`);
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
       }
-    }
-  })) passed++; else failed++;
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('allows first-time creation when the parent directory does not exist yet', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+      try {
+        // Path under a non-existent subdirectory — statSync returns ENOENT
+        // on the final segment, which should be treated as "does not exist"
+        // and allow the write. (Agent or CLI is expected to create parents
+        // during the Write itself; this hook does not need to.)
+        const absPath = path.join(tmpDir, 'no-such-parent', '.prettierrc');
+        const input = {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: absPath,
+            content: '{}'
+          }
+        };
+
+        const rawInput = JSON.stringify(input);
+        const result = runHook(input);
+        assert.strictEqual(result.code, 0, `Expected exit 0 for ENOENT path, got ${result.code}; stderr: ${result.stderr}`);
+        assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough when path does not exist');
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('still blocks writes to an existing protected config file', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+      try {
+        const absPath = path.join(tmpDir, '.eslintrc.js');
+        fs.writeFileSync(absPath, 'module.exports = { rules: {} };');
+
+        const input = {
+          tool_name: 'Edit',
+          tool_input: {
+            file_path: absPath,
+            content: 'module.exports = { rules: { "no-console": "off" } };'
+          }
+        };
+
+        const result = runHook(input);
+        assert.strictEqual(result.code, 2, 'Expected exit 2 when modifying an existing protected config');
+        assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
+        assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('legacy hooks do not echo raw input when they fail without stdout', () => {
+      const pluginRoot = path.join(__dirname, '..', `tmp-runner-plugin-${Date.now()}`);
+      const scriptDir = path.join(pluginRoot, 'scripts', 'hooks');
+      const scriptPath = path.join(scriptDir, 'legacy-block.js');
+
+      try {
+        fs.mkdirSync(scriptDir, { recursive: true });
+        fs.writeFileSync(scriptPath, '#!/usr/bin/env node\nprocess.stderr.write("blocked by legacy hook\\n");\nprocess.exit(2);\n');
+
+        const rawInput = JSON.stringify({
+          tool_name: 'Write',
+          tool_input: {
+            file_path: '.eslintrc.js',
+            content: 'module.exports = {};'
+          }
+        });
+
+        const result = runCustomHook(pluginRoot, 'pre:legacy-block', 'scripts/hooks/legacy-block.js', rawInput);
+        assert.strictEqual(result.code, 2, 'Expected failing legacy hook exit code to propagate');
+        assert.strictEqual(result.stdout, '', 'Expected failing legacy hook to avoid raw passthrough');
+        assert.ok(result.stderr.includes('blocked by legacy hook'), `Expected legacy hook stderr, got: ${result.stderr}`);
+      } finally {
+        try {
+          fs.rmSync(pluginRoot, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    })
+  )
+    passed++;
+  else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Closes #1873.

`scripts/hooks/config-protection.js` blocks `Write`/`Edit` on any basename in the `PROTECTED_FILES` set regardless of whether the file already exists. The hook's stated purpose is to prevent agents from softening rules in an *existing* config, but the same code path also blocks the legitimate bootstrap case of scaffolding a linter config into a project that has none.

## Change

- Add `fs.existsSync(filePath)` inside `run()` after the basename match. When the file does not yet exist, return `{ exitCode: 0 }` and let the `Write` proceed. Keep the `exit 2` block for all modifications to existing files.
- Stat errors (`EACCES`, etc.) fail closed: the path is treated as existing so the guard is never silently weakened.
- Update the existing "blocks protected config file edits" test to stage a real temp file so the BLOCK path is still exercised against an existing file.
- Add two new tests:
  - first-time creation of `eslint.config.mjs` is allowed (exit 0, raw passthrough, no stderr)
  - `Edit` against an existing `.eslintrc.js` is still blocked (exit 2, no stdout, BLOCKED message in stderr)

## Testing

- `node tests/hooks/config-protection.test.js` — 6/6 pass (4 pre-existing + 2 new)
- `node tests/run-all.js` — 2384/2384 pass
- `npx eslint scripts/hooks/config-protection.js tests/hooks/config-protection.test.js` — clean
- `node scripts/ci/validate-hooks.js` — 28 matchers validated
- `node scripts/ci/check-unicode-safety.js` — clean
- `node scripts/ci/validate-no-personal-paths.js` — clean

## Risk & rollback

- Scope: one hook file plus its dedicated test; no impact on other hooks or the `run-with-flags.js` dispatcher path.
- Fail-closed on stat errors preserves the original guard semantics under permission-denied / ENOENT-on-parent conditions.
- Rollback is a single-commit revert of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow first-time creation of protected config files while still blocking edits to existing ones. Addresses #1873 by unblocking scaffolding of linter configs in repos without one.

- **Bug Fixes**
  - Use `fs.lstatSync` with explicit `ENOENT` detection; only true “not found” allows creation. Symlinks (including dangling) are treated as existing. Other errors (`EACCES`, `EPERM`, etc.) fail closed.
  - Keep blocking modifications to existing files (exit 2); allow first-time creation (exit 0).
  - Tests: stage a real temp file for the block path; add cases for first-time creation, non-existent parent directories, and blocking a dangling symlink.

<sup>Written for commit 7145ca9dfe25bf2d9700990a5b2c2117dbce865a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook now permits first-time creation of protected configuration files while continuing to block modifications.

* **Bug Fixes**
  * Clarified exit-code semantics for allowed vs blocked operations and tightened filesystem existence checks; dangling symlinks are treated as blocked.

* **Tests**
  * Expanded tests to cover creation-allowed scenarios, blocking edits to existing or symlinked protected files, and isolated per-test temporary directory setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1898)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->