### PR TITLE
fix(hooks): cost-tracker reads usage from transcript instead of stdin

### DIFF
--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -1,63 +1,157 @@
 #!/usr/bin/env node
 /**
- * Cost Tracker Hook
+ * Cost Tracker Hook (v2)
  *
- * Appends lightweight session usage metrics to ~/.claude/metrics/costs.jsonl.
+ * Reads transcript_path from Stop hook stdin, sums usage across all
+ * assistant turns in the session JSONL, and appends one row to
+ * ~/.claude/metrics/costs.jsonl.
+ *
+ * Stop hook stdin payload: { session_id, transcript_path, cwd, hook_event_name, ... }
+ * The Stop payload does NOT include `usage` or `model` directly. The previous
+ * version of this hook expected those fields and silently produced zero-filled
+ * rows (verified: 2,340 rows captured with 0.0% non-zero token rate over 52
+ * days). The fix is to read the transcript file Claude Code already passes us.
+ *
+ * JSONL assistant entry shape (per Claude Code):
+ *   { type: "assistant", message: { model, usage: { input_tokens, output_tokens,
+ *     cache_creation_input_tokens, cache_read_input_tokens } } }
+ *
+ * Cumulative behavior: Stop fires per assistant response, not per session.
+ * Each row therefore represents the cumulative session total up to that point.
+ * To get per-session cost, take the last row per session_id. To get per-day
+ * spend, aggregate.
  */
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { ensureDir, appendFile, getClaudeDir } = require('../lib/utils');
-const { estimateCost } = require('../lib/cost-estimate');
 const { sanitizeSessionId } = require('../lib/session-bridge');
 
-const MAX_STDIN = 1024 * 1024;
-let raw = '';
+// Approximate per-1M-token billing rates (USD).
+// Cache creation: 1.25x input rate. Cache read: 0.1x input rate.
+const RATE_TABLE = {
+  haiku:  { in: 0.80,  out: 4.0,  cacheWrite: 1.00,  cacheRead: 0.08 },
+  sonnet: { in: 3.00,  out: 15.0, cacheWrite: 3.75,  cacheRead: 0.30 },
+  opus:   { in: 15.00, out: 75.0, cacheWrite: 18.75, cacheRead: 1.50 }
+};
 
-function toNumber(value) {
-  const n = Number(value);
+function getRates(model) {
+  const m = String(model || '').toLowerCase();
+  if (m.includes('haiku')) return RATE_TABLE.haiku;
+  if (m.includes('opus'))  return RATE_TABLE.opus;
+  return RATE_TABLE.sonnet;
+}
+
+function toNumber(v) {
+  const n = Number(v);
   return Number.isFinite(n) ? n : 0;
 }
 
+/**
+ * Scan the session JSONL and sum token usage across all assistant turns.
+ * Returns { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model }
+ * or null on read failure.
+ */
+function sumUsageFromTranscript(transcriptPath) {
+  let content;
+  try {
+    content = fs.readFileSync(transcriptPath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheWriteTokens = 0;
+  let cacheReadTokens = 0;
+  let model = 'unknown';
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+
+    if (entry.type !== 'assistant') continue;
+    const msg = entry.message;
+    if (!msg || !msg.usage) continue;
+
+    const u = msg.usage;
+    inputTokens      += toNumber(u.input_tokens);
+    outputTokens     += toNumber(u.output_tokens);
+    cacheWriteTokens += toNumber(u.cache_creation_input_tokens);
+    cacheReadTokens  += toNumber(u.cache_read_input_tokens);
+
+    if (msg.model && msg.model !== 'unknown') model = msg.model;
+  }
+
+  return { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model };
+}
+
+const MAX_STDIN = 64 * 1024;
+let raw = '';
+
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', chunk => {
-  if (raw.length < MAX_STDIN) {
-    const remaining = MAX_STDIN - raw.length;
-    raw += chunk.substring(0, remaining);
-  }
+  if (raw.length < MAX_STDIN) raw += chunk.substring(0, MAX_STDIN - raw.length);
 });
 
 process.stdin.on('end', () => {
   try {
     const input = raw.trim() ? JSON.parse(raw) : {};
-    const usage = input.usage || input.token_usage || {};
-    const inputTokens = toNumber(usage.input_tokens || usage.prompt_tokens || 0);
-    const outputTokens = toNumber(usage.output_tokens || usage.completion_tokens || 0);
 
-    const model = String(input.model || input._cursor?.model || process.env.CLAUDE_MODEL || 'unknown');
+    const transcriptPath = (typeof input.transcript_path === 'string' && input.transcript_path)
+      ? input.transcript_path
+      : process.env.CLAUDE_TRANSCRIPT_PATH || null;
+
     const sessionId =
       sanitizeSessionId(input.session_id) ||
       sanitizeSessionId(process.env.ECC_SESSION_ID) ||
       sanitizeSessionId(process.env.CLAUDE_SESSION_ID) ||
       'default';
 
+    let usageTotals = null;
+    if (transcriptPath && fs.existsSync(transcriptPath)) {
+      usageTotals = sumUsageFromTranscript(transcriptPath);
+    }
+
+    const {
+      inputTokens = 0,
+      outputTokens = 0,
+      cacheWriteTokens = 0,
+      cacheReadTokens = 0,
+      model = 'unknown'
+    } = usageTotals || {};
+
+    const rates = getRates(model);
+    const estimatedCostUsd = Math.round((
+      (inputTokens      / 1e6) * rates.in +
+      (outputTokens     / 1e6) * rates.out +
+      (cacheWriteTokens / 1e6) * rates.cacheWrite +
+      (cacheReadTokens  / 1e6) * rates.cacheRead
+    ) * 1e6) / 1e6;
+
     const metricsDir = path.join(getClaudeDir(), 'metrics');
     ensureDir(metricsDir);
 
     const row = {
-      timestamp: new Date().toISOString(),
-      session_id: sessionId,
+      timestamp:          new Date().toISOString(),
+      session_id:         sessionId,
+      transcript_path:    transcriptPath || '',
       model,
-      input_tokens: inputTokens,
-      output_tokens: outputTokens,
-      estimated_cost_usd: estimateCost(model, inputTokens, outputTokens)
+      input_tokens:       inputTokens,
+      output_tokens:      outputTokens,
+      cache_write_tokens: cacheWriteTokens,
+      cache_read_tokens:  cacheReadTokens,
+      estimated_cost_usd: estimatedCostUsd
     };
 
     appendFile(path.join(metricsDir, 'costs.jsonl'), `${JSON.stringify(row)}\n`);
   } catch {
-    // Keep hook non-blocking.
+    // Non-blocking — never fail the Stop hook.
   }
 
+  // Pass stdin through (required by ECC hook convention).
   process.stdout.write(raw);
 });


### PR DESCRIPTION
## Summary

The Stop hook's stdin payload does not include `usage` or `model` — those fields exist only in the session transcript JSONL (per-assistant-turn `message.usage` blocks). The previous `cost-tracker.js` implementation read `input.usage.input_tokens` from stdin and silently produced zero-filled rows.

**Observed impact on my install:** 2,340 rows captured with **0.0% non-zero token rate over 52 days** (since ECC install on 2026-03-23). Every row of `~/.claude/metrics/costs.jsonl` was `{"input_tokens":0,"output_tokens":0,"model":"unknown","estimated_cost_usd":0}`. Cost tracking has been silently broken for any user on this hook.

## What the fix does

- Reads `transcript_path` from Stop hook stdin (the field Claude Code DOES provide)
- Scans the JSONL for `type:"assistant"` entries, sums `message.usage.{input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}`
- Uses `message.model` to select a rate tier (haiku/sonnet/opus) from a rate table
- Tracks cache tokens separately — cache write is ~1.25x input rate, cache read is ~0.1x input rate
- Writes a richer row: `{timestamp, session_id, transcript_path, model, input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, estimated_cost_usd}`

## Behavior note for users

Stop fires per assistant response, not per session. Each row in `costs.jsonl` therefore represents the **cumulative session total at that point**, not a per-turn delta. To get per-session cost: take the last row per `session_id`. To get per-day spend: aggregate across rows.

This is consistent with how `session-end.js` and `evaluate-session.js` already read transcripts.

## Verification

I verified the Stop hook payload by reading a real `async_hook_response` entry from `~/.claude/projects/-Users-levishantz/<uuid>.jsonl`. The Stop payload contains exactly:
```json
{
  "session_id": "...",
  "transcript_path": "...",
  "cwd": "...",
  "permission_mode": "...",
  "hook_event_name": "Stop",
  "stop_hook_active": false,
  "last_assistant_message": "..."
}
```
No `usage`, no `model`, no token counts. This matches the published [Claude Code hooks docs](https://docs.anthropic.com/en/docs/claude-code/hooks).

## Test plan

- [x] `node -c scripts/hooks/cost-tracker.js` passes (syntax check)
- [x] Non-blocking on errors (always exits 0 — preserves "never fail the Stop hook" convention)
- [x] Stdin pass-through preserved (writes raw input back to stdout, required by ECC hook chain)
- [x] CommonJS, plain JS, under 200 lines per repo conventions
- [ ] (For maintainer) Run on a real Stop event and confirm non-zero rows appear in `~/.claude/metrics/costs.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost tracking by reading usage from the session transcript JSONL instead of stdin. Previously all rows were zero because Stop hook stdin has no `usage` or `model`.

- **Bug Fixes**
  - Read `transcript_path` from Stop stdin and sum `message.usage` across assistant turns in the transcript.
  - Pick rate tier from `message.model` (haiku/sonnet/opus) and include cache write/read tokens with distinct rates to compute `estimated_cost_usd`.
  - Append richer metrics rows: timestamp, session_id, transcript_path, model, input/output/cache tokens, estimated_cost_usd.
  - Keep the hook non-blocking and preserve stdin pass-through.

<sup>Written for commit 2707ef2eb20ddf492fa04cacd727e6d8a1ab9b2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cost tracking to derive usage data from transcript files for improved accuracy.

* **Improvements**
  * Cost metrics now include cache token usage (creation and read operations).
  * Expanded cost logs now contain transcript path and detailed token breakdowns for better monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1899)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->