### PR TITLE
fix(hooks): emit suggest-compact via hookSpecificOutput stdout

### DIFF
--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -19,7 +19,8 @@ const {
   getTempDir,
   writeFile,
   readStdinJson,
-  log
+  log,
+  output
 } = require('../lib/utils');
 
 async function resolveSessionId() {
@@ -77,14 +78,25 @@ async function main() {
     writeFile(counterFile, String(count));
   }
 
-  // Suggest compact after threshold tool calls
+  // Suggest compact after threshold tool calls.
+  //
+  // log() writes to stderr (debug log). Per the Claude Code hooks guide,
+  // non-blocking PreToolUse stderr (exit 0) is only written to the debug log;
+  // it does not reach the model. To inject a user-facing suggestion without
+  // blocking the tool call, emit structured JSON to stdout with
+  // hookSpecificOutput.additionalContext — the documented mechanism for
+  // PreToolUse hooks to add context to the next model turn.
   if (count === threshold) {
-    log(`[StrategicCompact] ${threshold} tool calls reached - consider /compact if transitioning phases`);
+    const msg = `[StrategicCompact] ${threshold} tool calls reached - consider /compact if transitioning phases`;
+    log(msg);
+    output({ hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: msg } });
   }
 
   // Suggest at regular intervals after threshold (every 25 calls from threshold)
   if (count > threshold && (count - threshold) % 25 === 0) {
-    log(`[StrategicCompact] ${count} tool calls - good checkpoint for /compact if context is stale`);
+    const msg = `[StrategicCompact] ${count} tool calls - good checkpoint for /compact if context is stale`;
+    log(msg);
+    output({ hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: msg } });
   }
 
   process.exit(0);

--- a/tests/hooks/suggest-compact.test.js
+++ b/tests/hooks/suggest-compact.test.js
@@ -366,6 +366,66 @@ function runTests() {
   })) passed++;
   else failed++;
 
+  // ── hookSpecificOutput JSON on stdout ──
+  // Claude Code 2.1+ drops non-blocking PreToolUse stderr; the suggestion has
+  // to ride on stdout as { hookSpecificOutput: { additionalContext } } to reach
+  // the model. These tests pin that contract.
+  console.log('\nhookSpecificOutput stdout JSON:');
+
+  if (test('emits hookSpecificOutput.additionalContext on stdout at threshold', () => {
+    const { sessionId, counterFile, cleanup } = createCounterContext();
+    cleanup();
+    fs.writeFileSync(counterFile, '49');
+    const result = runCompact({ CLAUDE_SESSION_ID: sessionId });
+    assert.strictEqual(result.code, 0, 'Should exit 0');
+    assert.ok(result.stdout.trim().length > 0, `Expected stdout payload at threshold. Got: "${result.stdout}"`);
+    const parsed = JSON.parse(result.stdout);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PreToolUse',
+      `hookEventName should be PreToolUse. Got: ${JSON.stringify(parsed)}`);
+    assert.ok(parsed.hookSpecificOutput.additionalContext.includes('50 tool calls reached'),
+      `additionalContext should include threshold text. Got: ${parsed.hookSpecificOutput.additionalContext}`);
+    cleanup();
+  })) passed++;
+  else failed++;
+
+  if (test('emits hookSpecificOutput.additionalContext on stdout at +25 interval', () => {
+    const { sessionId, counterFile, cleanup } = createCounterContext();
+    cleanup();
+    // threshold=3, set counter to 27 → next run = 28 → 28-3=25 → interval hit
+    fs.writeFileSync(counterFile, '27');
+    const result = runCompact({ CLAUDE_SESSION_ID: sessionId, COMPACT_THRESHOLD: '3' });
+    assert.strictEqual(result.code, 0, 'Should exit 0');
+    assert.ok(result.stdout.trim().length > 0, `Expected stdout payload at interval. Got: "${result.stdout}"`);
+    const parsed = JSON.parse(result.stdout);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'PreToolUse');
+    assert.ok(parsed.hookSpecificOutput.additionalContext.includes('28 tool calls'),
+      `additionalContext should include count. Got: ${parsed.hookSpecificOutput.additionalContext}`);
+    cleanup();
+  })) passed++;
+  else failed++;
+
+  if (test('emits no stdout below threshold (silent)', () => {
+    const { sessionId, cleanup } = createCounterContext();
+    cleanup();
+    const result = runCompact({ CLAUDE_SESSION_ID: sessionId, COMPACT_THRESHOLD: '5' });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout.trim(), '',
+      `Expected empty stdout below threshold. Got: "${result.stdout}"`);
+    cleanup();
+  })) passed++;
+  else failed++;
+
+  if (test('still writes [StrategicCompact] to stderr (debug log retained)', () => {
+    const { sessionId, counterFile, cleanup } = createCounterContext();
+    cleanup();
+    fs.writeFileSync(counterFile, '49');
+    const result = runCompact({ CLAUDE_SESSION_ID: sessionId });
+    assert.ok(result.stderr.includes('[StrategicCompact]'),
+      `stderr should retain [StrategicCompact] for debug log capture. Got: "${result.stderr}"`);
+    cleanup();
+  })) passed++;
+  else failed++;
+
   // ── Round 64: default session ID fallback ──
   console.log('\nDefault session ID fallback (Round 64):');
 


### PR DESCRIPTION
## What Changed

`scripts/hooks/suggest-compact.js` now emits the threshold and interval suggestions as structured JSON on stdout (via `output()` from `lib/utils.js`) in addition to the existing `log()` call to stderr:

```js
const msg = `[StrategicCompact] ${threshold} tool calls reached - consider /compact if transitioning phases`;
log(msg);
output({ hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: msg } });
```

Six-line change at lines 80–88, plus `output` added to the destructured import from `../lib/utils`.

## Why This Change

The hook is currently silent on Claude Code 2.1.x. Per the [hooks guide](https://code.claude.com/docs/en/hooks-guide.md), non-blocking PreToolUse stderr (exit code 0) is written **only to the debug log** — it does not reach the model. So `log()` calls in suggest-compact.js never produce a user-facing nudge, defeating the script's design intent.

The documented mechanism for a non-blocking PreToolUse hook to inject context into the next model turn is structured JSON on stdout under `hookSpecificOutput.additionalContext`. That path is correctly surfaced by the harness as a `<system-reminder>` block (verified live on Claude Code 2.1.142, VSCode native extension, Windows 11).

`log()` is retained so the debug log still captures the event when the user explicitly looks for it.

## Testing Done

- [x] Manual testing completed — verified end-to-end on Claude Code 2.1.142. Bumped counter to 49, fired a Write tool call. The `[StrategicCompact] 50 tool calls reached - consider /compact if transitioning phases` message surfaced in the next model turn as a `<system-reminder>` block, exactly as documented.
- [x] Automated tests pass locally (`node tests/run-all.js`) — see test notes below.
- [x] Edge cases considered and tested — added 4 new cases:
  - `emits hookSpecificOutput.additionalContext on stdout at threshold` — parses stdout as JSON, asserts shape and content.
  - `emits hookSpecificOutput.additionalContext on stdout at +25 interval` — same, for the interval suggestion at threshold+25.
  - `emits no stdout below threshold (silent)` — asserts stdout is empty when the suggestion shouldn't fire (prevents future regressions that spam the model).
  - `still writes [StrategicCompact] to stderr (debug log retained)` — pins the debug-log behavior so a future "drop log()" refactor can't silently remove it.

`tests/hooks/suggest-compact.test.js`: **19 → 23 tests, all passing**.

Full `tests/run-all.js`: **2355/2359 pass**. The 4 failures pre-existed on this branch and are Windows-specific broken-symlink tests in `ci/validators.test.js`, `lib/session-manager.test.js`, and `lib/utils.test.js` — unrelated to this change.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (no JSON files changed)
- [x] Shell scripts pass shellcheck (n/a — JS only)
- [x] Pre-commit hooks pass locally
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation — comment added inline at the threshold branches explaining the stdout-JSON requirement and linking the design rationale (stderr → debug-log-only on Claude Code 2.1+).
- [x] Added comments for complex logic — the new comment block explains the dual-channel emit (stderr for debug log, stdout JSON for model context) so the next maintainer doesn't strip what looks like a duplicate log call.
- [ ] README updated — n/a, no user-facing surface change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the suggest-compact hook so its nudges reach the model by emitting structured JSON on stdout, while keeping stderr logs for debugging. Adds targeted tests to pin this behavior.

- **Bug Fixes**
  - In `scripts/hooks/suggest-compact.js`, import `output` from `../lib/utils` and emit `{ hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: msg } }` on the threshold and every +25 calls.
  - Retain `log()` to stderr for the debug log.
  - Add tests for stdout JSON at threshold and interval, silence below threshold, and stderr retention.

<sup>Written for commit c802c33abcda3e9b44a08614a127241283be2c07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Suggestions now emit as structured output when tool-call thresholds are reached, enabling user-facing suggestion delivery at specified intervals.

* **Tests**
  * Added comprehensive tests validating suggestion emission behavior, threshold detection, and debug output preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1903)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->