### PR TITLE
docs: restore zh-CN autonomous-loops install warning

### DIFF
--- a/docs/zh-CN/skills/autonomous-loops/SKILL.md
+++ b/docs/zh-CN/skills/autonomous-loops/SKILL.md
@@ -237,9 +237,7 @@ PROMPT 1（协调器）              PROMPT 2（子代理）
 
 ### 安装
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/AnandChowdhary/continuous-claude/HEAD/install.sh | bash
-```
+> **警告：** 请在审阅代码后，从 continuous-claude 的仓库安装。不要将外部脚本直接管道传入 bash。
 
 ### 用法
 


### PR DESCRIPTION
## Summary
- Fixes #1902 by replacing the stale `curl | bash` install block in the zh-CN autonomous-loops skill with the translated canonical warning.
- Confirms the English and zh-CN skill now both warn users not to pipe external scripts directly to bash.

## Validation
- `node scripts/ci/check-unicode-safety.js`
- `node scripts/ci/validate-no-personal-paths.js`
- `git diff --check`

Fixes #1902


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the install warning in the zh-CN autonomous-loops skill by replacing the stale `curl | bash` block with the translated canonical warning. Aligns with the English doc and tells users not to pipe external scripts to bash (Fixes #1902).

<sup>Written for commit 0d8f4c64b807248091c207167b3ab375b9e3ea54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Continuous Claude PR Loop installation instructions to recommend code review before installation and advise against direct script execution methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1907)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->