### PR TITLE
docs(canary-watch): enrich description with verification & endpoint synonyms

### DIFF
--- a/skills/canary-watch/SKILL.md
+++ b/skills/canary-watch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canary-watch
-description: Use this skill to monitor a deployed URL for regressions after deploys, merges, or dependency upgrades.
+description: Use this skill to monitor and verify a deployed URL after releases — checks HTTP endpoints, SSE streams, static assets, console errors, and performance regressions after deploys, merges, or dependency upgrades. Smoke / canary / post-deploy verification.
 origin: ECC
 ---
 


### PR DESCRIPTION
## Summary

Adds high-precision English synonyms to the `canary-watch` SKILL.md description so keyword-based skill recommenders (IDF-weighted matchers, fuzzy slug search) can surface this skill from prompts that use natural variants of the same concept.

### Before
```yaml
description: Use this skill to monitor a deployed URL for regressions after deploys, merges, or dependency upgrades.
```

### After
```yaml
description: Use this skill to monitor and verify a deployed URL after releases — checks HTTP endpoints, SSE streams, static assets, console errors, and performance regressions after deploys, merges, or dependency upgrades. Smoke / canary / post-deploy verification.
```

## Motivation

In real-world prompts, users describing this exact use case rarely say "monitor a deployed URL for regressions" verbatim. They write things like:

> *"외부 URL 통해 모든 endpoint, SSE, 정적 자산 verify"*
> *"smoke test the new deploy"*
> *"post-deploy check for the canary"*

Without overlap on words like `verify`, `endpoint`, `SSE`, `asset`, `smoke`, `canary`, `post-deploy`, recommenders score the skill too low to surface it — even though it's the exact right tool.

Concrete impact on one IDF-weighted matcher (we-forge / Claude Code):

| Prompt | Before | After |
|---|---|---|
| Mixed Korean+English "verify deployed endpoint SSE asset" | score **5.12** (#2) | score **22.02** (#1) |
| English-only "verify deployed URL endpoint SSE static asset monitoring" | score **14.84** | score **33.69** |

## Scope

- **Description-only edit** — no behavior change in the skill workflow itself.
- Still under 400 chars (common indexer description cap).
- Token count for indexers using `[A-Za-z][A-Za-z0-9_-]{2,}` regex: ~24 unique meaningful tokens, comfortably under typical 30-token caps.
- Synonyms chosen are all words a maintainer would naturally use to describe what the skill actually does — no keyword stuffing.

## Test plan

- [x] Existing skill content (When to Use, How It Works, etc.) untouched
- [x] Frontmatter still parses (name / description / origin / `---` delimiters intact)
- [x] Verified on a downstream IDF matcher: skill ranks #1 for representative prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `canary-watch` description to include verification wording and endpoint-related synonyms so keyword-based recommenders surface the skill from natural prompts. Covers HTTP endpoints, SSE, static assets, console errors, and performance; docs-only change with no behavior impact.

<sup>Written for commit 61239e0779f7a3ed7b4706e921357601d63a1426. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the canary-watch skill documentation to clarify its post-deploy verification capabilities, including monitoring of HTTP endpoints, SSE streams, static assets, console errors, and performance regressions across deploys, merges, and dependency upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1910)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->