### PR TITLE
fix(hooks): close plain (...) and brace { ...; } bypass in gateguard destructive scan

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -25,6 +25,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { extractCommandSubstitutions } = require('../lib/shell-substitution');
 
 // Session state — scoped per session to avoid cross-session races.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
@@ -82,105 +83,6 @@ function explodeSubshells(input) {
     if (out === before) break;
   }
   return out;
-}
-
-/**
- * Extract executable command-substitution bodies from a shell line. Single
- * quotes are literal, so substitutions inside them are ignored; double quotes
- * still permit substitutions, so those bodies are scanned before quoted text
- * is stripped.
- *
- * @param {string} input
- * @returns {string[]}
- */
-function extractCommandSubstitutions(input) {
-  const source = String(input || '');
-  const substitutions = [];
-  let inSingle = false;
-  let inDouble = false;
-
-  for (let i = 0; i < source.length; i++) {
-    const ch = source[i];
-    const prev = source[i - 1];
-
-    if (ch === '\\' && !inSingle) {
-      i += 1;
-      continue;
-    }
-
-    if (ch === "'" && !inDouble && prev !== '\\') {
-      inSingle = !inSingle;
-      continue;
-    }
-
-    if (ch === '"' && !inSingle && prev !== '\\') {
-      inDouble = !inDouble;
-      continue;
-    }
-
-    if (inSingle) {
-      continue;
-    }
-
-    if (ch === '`') {
-      let body = '';
-      i += 1;
-      while (i < source.length) {
-        const inner = source[i];
-        if (inner === '\\') {
-          body += inner;
-          if (i + 1 < source.length) {
-            body += source[i + 1];
-            i += 2;
-            continue;
-          }
-        }
-        if (inner === '`') {
-          break;
-        }
-        body += inner;
-        i += 1;
-      }
-      if (body.trim()) {
-        substitutions.push(body);
-        substitutions.push(...extractCommandSubstitutions(body));
-      }
-      continue;
-    }
-
-    if (ch === '$' && source[i + 1] === '(') {
-      let depth = 1;
-      let body = '';
-      i += 2;
-      while (i < source.length && depth > 0) {
-        const inner = source[i];
-        if (inner === '\\') {
-          body += inner;
-          if (i + 1 < source.length) {
-            body += source[i + 1];
-            i += 2;
-            continue;
-          }
-        }
-        if (inner === '(') {
-          depth += 1;
-        } else if (inner === ')') {
-          depth -= 1;
-          if (depth === 0) {
-            break;
-          }
-        }
-        body += inner;
-        i += 1;
-      }
-      if (body.trim()) {
-        substitutions.push(body);
-        substitutions.push(...extractCommandSubstitutions(body));
-      }
-    }
-  }
-
-  return substitutions;
 }
 
 /**

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -25,7 +25,11 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const { extractCommandSubstitutions } = require('../lib/shell-substitution');
+const {
+  extractCommandSubstitutions,
+  extractSubshellGroups,
+  extractBraceGroups
+} = require('../lib/shell-substitution');
 
 // Session state — scoped per session to avoid cross-session races.
 const STATE_DIR = process.env.GATEGUARD_STATE_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.gateguard');
@@ -294,6 +298,51 @@ function isDestructiveGit(tokens) {
  * @param {string} command
  * @returns {boolean}
  */
+/**
+ * Walk every executable body reachable from a raw command line and
+ * return them as a flat list. Bodies that bash will execute live in
+ * three different syntactic constructs, each handled by a sibling
+ * extractor in `scripts/lib/shell-substitution.js`:
+ *   - `$(...)` and backticks via `extractCommandSubstitutions`
+ *   - plain `(...)` subshells   via `extractSubshellGroups`
+ *   - `{ ...; }` brace groups   via `extractBraceGroups`
+ *
+ * Each extractor recurses into its own syntax. The BFS here adds
+ * cross-syntax discovery — e.g. a `(...)` inside a `$(...)` body, or
+ * a `{ ...; }` inside a `(...)` body — by feeding every harvested
+ * body back through all three extractors. A `seen` set bounds the
+ * cost to O(unique bodies).
+ *
+ * @param {string} raw
+ * @returns {string[]}
+ */
+function collectExecutableBodies(raw) {
+  const bodies = [raw];
+  const queue = [raw];
+  const seen = new Set();
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    for (const body of extractCommandSubstitutions(current)) {
+      bodies.push(body);
+      queue.push(body);
+    }
+    for (const body of extractSubshellGroups(current)) {
+      bodies.push(body);
+      queue.push(body);
+    }
+    for (const body of extractBraceGroups(current)) {
+      bodies.push(body);
+      queue.push(body);
+    }
+  }
+
+  return bodies;
+}
+
 function isDestructiveBash(command) {
   // The SQL/dd phrases live in command bodies, not as flag-bearing
   // arguments, so we still match them by regex — but on the input
@@ -303,7 +352,7 @@ function isDestructiveBash(command) {
   const flattened = explodeSubshells(stripQuotedStrings(raw));
   if (DESTRUCTIVE_SQL_DD.test(flattened)) return true;
 
-  const segments = [raw, ...extractCommandSubstitutions(raw)].flatMap(splitCommandSegments);
+  const segments = collectExecutableBodies(raw).flatMap(splitCommandSegments);
   for (const segment of segments) {
     if (DESTRUCTIVE_SQL_DD.test(stripQuotedStrings(segment))) return true;
     const tokens = tokenize(segment);

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -327,14 +327,17 @@ function collectExecutableBodies(raw) {
     seen.add(current);
 
     for (const body of extractCommandSubstitutions(current)) {
+      if (seen.has(body)) continue;
       bodies.push(body);
       queue.push(body);
     }
     for (const body of extractSubshellGroups(current)) {
+      if (seen.has(body)) continue;
       bodies.push(body);
       queue.push(body);
     }
     for (const body of extractBraceGroups(current)) {
+      if (seen.has(body)) continue;
       bodies.push(body);
       queue.push(body);
     }

--- a/scripts/lib/shell-substitution.js
+++ b/scripts/lib/shell-substitution.js
@@ -243,4 +243,165 @@ function extractSubshellGroups(input) {
   return groups;
 }
 
-module.exports = { extractCommandSubstitutions, extractSubshellGroups };
+/**
+ * Extract bodies of `{ ...; }` brace groups.
+ *
+ * Bash brace groups run their body in the *current* shell (unlike `(...)`,
+ * which forks a subshell). Both forms group multiple commands, so for the
+ * purposes of destructive-bash and dev-server detection they are equivalent:
+ * a `rm -rf` or `npm run dev` inside `{ ...; }` still executes.
+ *
+ * Recognition rules match bash's own reserved-word semantics:
+ * - `{` is a reserved word only when followed by whitespace and preceded by
+ *   the line start, whitespace, or a shell operator (`;`, `|`, `&`, `(`).
+ *   So `{npm run dev}` is NOT a brace group (single token starting with `{`).
+ * - `}` closes the group only when preceded by `;` or whitespace.
+ *   So `foo}` inside the body is not a closing brace.
+ * - Single quotes are literal; double quotes are also literal for `{`/`}`.
+ * - `$(...)`, backticks, and plain `(...)` spans are skipped so we don't
+ *   double-extract bodies the sibling extractors already cover.
+ *
+ * @param {string} input
+ * @returns {string[]}
+ */
+function extractBraceGroups(input) {
+  const source = String(input || '');
+  const groups = [];
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+
+    if (ch === '\\' && !inSingle) {
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'" && !inDouble && prev !== '\\') {
+      inSingle = !inSingle;
+      continue;
+    }
+
+    if (ch === '"' && !inSingle && prev !== '\\') {
+      inDouble = !inDouble;
+      continue;
+    }
+
+    if (inSingle || inDouble) {
+      continue;
+    }
+
+    if (ch === '$' && source[i + 1] === '(') {
+      let depth = 1;
+      let skipInSingle = false;
+      let skipInDouble = false;
+      i += 2;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        const innerPrev = source[i - 1];
+        if (inner === '\\' && !skipInSingle) {
+          i += 2;
+          continue;
+        }
+        if (inner === "'" && !skipInDouble && innerPrev !== '\\') {
+          skipInSingle = !skipInSingle;
+        } else if (inner === '"' && !skipInSingle && innerPrev !== '\\') {
+          skipInDouble = !skipInDouble;
+        } else if (!skipInSingle && !skipInDouble) {
+          if (inner === '(') depth += 1;
+          else if (inner === ')') depth -= 1;
+        }
+        i += 1;
+      }
+      i -= 1;
+      continue;
+    }
+
+    if (ch === '`') {
+      i += 1;
+      while (i < source.length && source[i] !== '`') {
+        if (source[i] === '\\' && i + 1 < source.length) {
+          i += 2;
+          continue;
+        }
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '(') {
+      let depth = 1;
+      let skipInSingle = false;
+      let skipInDouble = false;
+      i += 1;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        const innerPrev = source[i - 1];
+        if (inner === '\\' && !skipInSingle) {
+          i += 2;
+          continue;
+        }
+        if (inner === "'" && !skipInDouble && innerPrev !== '\\') {
+          skipInSingle = !skipInSingle;
+        } else if (inner === '"' && !skipInSingle && innerPrev !== '\\') {
+          skipInDouble = !skipInDouble;
+        } else if (!skipInSingle && !skipInDouble) {
+          if (inner === '(') depth += 1;
+          else if (inner === ')') depth -= 1;
+        }
+        i += 1;
+      }
+      i -= 1;
+      continue;
+    }
+
+    if (ch === '{' && /\s/.test(source[i + 1] || '')) {
+      const prevIsBoundary = i === 0 || /[\s;|&(]/.test(prev);
+      if (!prevIsBoundary) continue;
+
+      let depth = 1;
+      let body = '';
+      let bodyInSingle = false;
+      let bodyInDouble = false;
+      i += 1;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        const innerPrev = source[i - 1];
+        if (inner === '\\' && !bodyInSingle) {
+          body += inner;
+          if (i + 1 < source.length) {
+            body += source[i + 1];
+            i += 2;
+            continue;
+          }
+        }
+        if (inner === "'" && !bodyInDouble && innerPrev !== '\\') {
+          bodyInSingle = !bodyInSingle;
+        } else if (inner === '"' && !bodyInSingle && innerPrev !== '\\') {
+          bodyInDouble = !bodyInDouble;
+        } else if (!bodyInSingle && !bodyInDouble) {
+          if (inner === '{' && /\s/.test(source[i + 1] || '')) {
+            depth += 1;
+          } else if (inner === '}' && (innerPrev === ';' || /\s/.test(innerPrev))) {
+            depth -= 1;
+            if (depth === 0) {
+              break;
+            }
+          }
+        }
+        body += inner;
+        i += 1;
+      }
+      if (body.trim()) {
+        groups.push(body);
+        groups.push(...extractBraceGroups(body));
+      }
+    }
+  }
+
+  return groups;
+}
+
+module.exports = { extractCommandSubstitutions, extractSubshellGroups, extractBraceGroups };

--- a/scripts/lib/shell-substitution.js
+++ b/scripts/lib/shell-substitution.js
@@ -379,16 +379,103 @@ function extractBraceGroups(input) {
         }
         if (inner === "'" && !bodyInDouble && innerPrev !== '\\') {
           bodyInSingle = !bodyInSingle;
-        } else if (inner === '"' && !bodyInSingle && innerPrev !== '\\') {
+          body += inner;
+          i += 1;
+          continue;
+        }
+        if (inner === '"' && !bodyInSingle && innerPrev !== '\\') {
           bodyInDouble = !bodyInDouble;
-        } else if (!bodyInSingle && !bodyInDouble) {
-          if (inner === '{' && /\s/.test(source[i + 1] || '')) {
-            depth += 1;
-          } else if (inner === '}' && (innerPrev === ';' || /\s/.test(innerPrev))) {
-            depth -= 1;
-            if (depth === 0) {
-              break;
+          body += inner;
+          i += 1;
+          continue;
+        }
+        if (bodyInSingle || bodyInDouble) {
+          body += inner;
+          i += 1;
+          continue;
+        }
+        // Skip $(...) spans — a quoted `}` or `}`-as-text inside a
+        // substitution body must not close the enclosing brace group.
+        if (inner === '$' && source[i + 1] === '(') {
+          body += inner + source[i + 1];
+          let subDepth = 1;
+          let subInSingle = false;
+          let subInDouble = false;
+          i += 2;
+          while (i < source.length && subDepth > 0) {
+            const c = source[i];
+            const p = source[i - 1];
+            body += c;
+            if (c === '\\' && !subInSingle && i + 1 < source.length) {
+              body += source[i + 1];
+              i += 2;
+              continue;
             }
+            if (c === "'" && !subInDouble && p !== '\\') subInSingle = !subInSingle;
+            else if (c === '"' && !subInSingle && p !== '\\') subInDouble = !subInDouble;
+            else if (!subInSingle && !subInDouble) {
+              if (c === '(') subDepth += 1;
+              else if (c === ')') subDepth -= 1;
+            }
+            i += 1;
+          }
+          continue;
+        }
+        // Skip backtick spans for the same reason.
+        if (inner === '`') {
+          body += inner;
+          i += 1;
+          while (i < source.length && source[i] !== '`') {
+            if (source[i] === '\\' && i + 1 < source.length) {
+              body += source[i] + source[i + 1];
+              i += 2;
+              continue;
+            }
+            body += source[i];
+            i += 1;
+          }
+          if (i < source.length) {
+            body += source[i];
+            i += 1;
+          }
+          continue;
+        }
+        // Skip plain (...) subshell spans for the same reason.
+        if (inner === '(') {
+          body += inner;
+          let subDepth = 1;
+          let subInSingle = false;
+          let subInDouble = false;
+          i += 1;
+          while (i < source.length && subDepth > 0) {
+            const c = source[i];
+            const p = source[i - 1];
+            body += c;
+            if (c === '\\' && !subInSingle && i + 1 < source.length) {
+              body += source[i + 1];
+              i += 2;
+              continue;
+            }
+            if (c === "'" && !subInDouble && p !== '\\') subInSingle = !subInSingle;
+            else if (c === '"' && !subInSingle && p !== '\\') subInDouble = !subInDouble;
+            else if (!subInSingle && !subInDouble) {
+              if (c === '(') subDepth += 1;
+              else if (c === ')') subDepth -= 1;
+            }
+            i += 1;
+          }
+          continue;
+        }
+        if (inner === '{' && /\s/.test(source[i + 1] || '')) {
+          // Match the outer-scan boundary rule for nested `{` so
+          // tokens like `foo{` (no boundary, but followed by space
+          // via `foo{ bar`) cannot bump nested depth.
+          const nestedPrevIsBoundary = /[\s;|&(]/.test(innerPrev);
+          if (nestedPrevIsBoundary) depth += 1;
+        } else if (inner === '}' && (innerPrev === ';' || /\s/.test(innerPrev))) {
+          depth -= 1;
+          if (depth === 0) {
+            break;
           }
         }
         body += inner;

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1283,16 +1283,20 @@ function runTests() {
   })) passed++; else failed++;
 
   // --- Subshell + brace-group bypass coverage ---
-  // Destructive commands inside `(...)`, `((...))`, and `{ ...; }`
-  // execute the same way they do at the top level, so the destructive
-  // classifier must see inside those bodies too.
+  // Destructive commands inside `(...)` and `{ ...; }` execute the
+  // same way they do at the top level, so the destructive classifier
+  // must see inside those bodies too. Nested parens `((...))` are
+  // arithmetic-evaluation syntax in bash (not a nested subshell), but
+  // our parser depth-tracks them conservatively — i.e. the inner
+  // tokens are still scanned for destructive intent. That's safety
+  // over precision and the right default for this gate.
 
   if (test('denies rm -rf inside plain (...) subshell group', () => {
     expectDestructiveDeny('(rm -rf /tmp/junk)', 'plain subshell group');
   })) passed++; else failed++;
 
-  if (test('denies rm -rf inside nested ((...)) subshell', () => {
-    expectDestructiveDeny('((rm -rf /tmp/junk))', 'nested subshell');
+  if (test('denies rm -rf inside ((...)) — arithmetic eval, treated conservatively', () => {
+    expectDestructiveDeny('((rm -rf /tmp/junk))', 'arithmetic-eval parens');
   })) passed++; else failed++;
 
   if (test('denies rm -rf inside { ...; } brace group', () => {
@@ -1351,6 +1355,40 @@ function runTests() {
     // would not actually run rm at runtime either.
     expectAllow('echo {rm -rf /tmp/junk}',
       'no-space brace literal');
+  })) passed++; else failed++;
+
+  // --- Round 1 review fixes: brace-group span-skip + boundary ---
+  // Verifies the body-accumulation loop in `extractBraceGroups`
+  // correctly walks past `$(...)`, `(...)`, and backtick spans so
+  // a `}` inside one of those does not terminate the brace group
+  // early, plus the nested `{` boundary rule.
+
+  if (test('denies rm -rf in brace group with backtick containing }', () => {
+    expectDestructiveDeny('{ echo `echo }`; rm -rf /tmp/junk; }',
+      'brace + backtick containing }');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf in brace group with $() containing }', () => {
+    expectDestructiveDeny('{ echo $(echo "}"); rm -rf /tmp/junk; }',
+      'brace + $() containing }');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf in brace group with nested () containing }', () => {
+    expectDestructiveDeny('{ (echo "}"); rm -rf /tmp/junk; }',
+      'brace + () containing }');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf in brace group with $() body containing }', () => {
+    expectDestructiveDeny('{ x=$(echo a}b); rm -rf /tmp/junk; }',
+      'brace + $() body with }');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf when token like foo{ appears before brace group close', () => {
+    // tokens like `foo{` are not reserved-word `{` (no boundary,
+    // no whitespace after) — must not bump nested-depth and so
+    // must not delay brace-group close
+    expectDestructiveDeny('{ echo foo{bar; rm -rf /tmp/junk; }',
+      'foo{ token inside brace body');
   })) passed++; else failed++;
 
   // Cleanup only the temp directory created by this test file.

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1282,6 +1282,77 @@ function runTests() {
       'double-quoted dollar-paren subshell');
   })) passed++; else failed++;
 
+  // --- Subshell + brace-group bypass coverage ---
+  // Destructive commands inside `(...)`, `((...))`, and `{ ...; }`
+  // execute the same way they do at the top level, so the destructive
+  // classifier must see inside those bodies too.
+
+  if (test('denies rm -rf inside plain (...) subshell group', () => {
+    expectDestructiveDeny('(rm -rf /tmp/junk)', 'plain subshell group');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf inside nested ((...)) subshell', () => {
+    expectDestructiveDeny('((rm -rf /tmp/junk))', 'nested subshell');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf inside { ...; } brace group', () => {
+    expectDestructiveDeny('{ rm -rf /tmp/junk; }', 'brace group');
+  })) passed++; else failed++;
+
+  if (test('denies git push --force inside plain (...) subshell group', () => {
+    expectDestructiveDeny('(git push --force origin main)',
+      'git-force in subshell');
+  })) passed++; else failed++;
+
+  if (test('denies git push --force inside { ...; } brace group', () => {
+    expectDestructiveDeny('{ git push --force origin main; }',
+      'git-force in brace group');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf nested across () and {} (cross-syntax)', () => {
+    expectDestructiveDeny('(echo y; { rm -rf /tmp/junk; })',
+      '() containing {} cross-syntax');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf nested across $() and () (cross-syntax)', () => {
+    expectDestructiveDeny('$(echo y; (rm -rf /tmp/junk))',
+      '$() containing () cross-syntax');
+  })) passed++; else failed++;
+
+  // Negative cases — literals and non-destructive commands must NOT
+  // be promoted to destructive by the new grouping-body walker.
+
+  if (test('allows literal (rm -rf ...) inside single quotes', () => {
+    expectAllow("git commit -m '(rm -rf /tmp/junk)'",
+      'single-quoted subshell literal');
+  })) passed++; else failed++;
+
+  if (test('allows literal (rm -rf ...) inside double quotes', () => {
+    expectAllow('echo "(rm -rf /tmp/junk)"',
+      'double-quoted subshell literal');
+  })) passed++; else failed++;
+
+  if (test('allows literal { rm -rf ...; } inside double quotes', () => {
+    expectAllow('echo "{ rm -rf /tmp/junk; }"',
+      'double-quoted brace-group literal');
+  })) passed++; else failed++;
+
+  if (test('allows non-destructive (echo hello)', () => {
+    expectAllow('(echo hello)', 'non-destructive subshell');
+  })) passed++; else failed++;
+
+  if (test('allows non-destructive { echo hello; }', () => {
+    expectAllow('{ echo hello; }', 'non-destructive brace group');
+  })) passed++; else failed++;
+
+  if (test('allows {rm -rf} — no space after { is not a brace group', () => {
+    // bash treats `{rm` as a single token; no destructive intent
+    // can be statically derived from this form, and the command
+    // would not actually run rm at runtime either.
+    expectAllow('echo {rm -rf /tmp/junk}',
+      'no-space brace literal');
+  })) passed++; else failed++;
+
   // Cleanup only the temp directory created by this test file.
   try {
     if (fs.existsSync(stateDir)) {


### PR DESCRIPTION
## Summary

`scripts/hooks/gateguard-fact-force.js` opens up `$(...)` and backtick command substitutions before running its destructive classifiers, but two other shell grouping constructs that execute their bodies are not opened up: plain `(...)` subshells and `{ ...; }` brace groups. This PR closes both.

## Bypass surface (reproduced on `main` at 375d750)

| Form | Before | After |
| --- | --- | --- |
| `rm -rf /tmp/x` | DESTRUCTIVE | DESTRUCTIVE |
| `(rm -rf /tmp/x)` | **allowed** | DESTRUCTIVE |
| `((rm -rf /tmp/x))` | **allowed** | DESTRUCTIVE |
| `{ rm -rf /tmp/x; }` | **allowed** | DESTRUCTIVE |
| `(git push --force origin main)` | **allowed** | DESTRUCTIVE |
| `{ git push --force origin main; }` | **allowed** | DESTRUCTIVE |
| `(echo y; { rm -rf /tmp/x; })` | **allowed** | DESTRUCTIVE |
| `$(echo y; (rm -rf /tmp/x))` | **allowed** | DESTRUCTIVE |

Affects every destructive classifier — `isDestructiveRm`, `isDestructiveGit`, the `DESTRUCTIVE_SQL_DD` regex — because they all run downstream of the same `splitCommandSegments` pass and that pass was never given the inner segments.

## Fix

A small BFS (`collectExecutableBodies`) walks the raw command and harvests every body returned by the three sibling extractors in `scripts/lib/shell-substitution.js`:
- `extractCommandSubstitutions` (`$(...)`, backticks) — existing
- `extractSubshellGroups` (plain `(...)`) — added in PR #1889 / #1905
- `extractBraceGroups` (`{ ...; }`) — new in this PR

The harvested bodies are fed into the existing `splitCommandSegments` flatMap; the per-segment classifiers themselves require no edits.

`extractBraceGroups` recognises bash's actual reserved-word semantics (`{` must be followed by whitespace and preceded by line start / whitespace / `;` / `|` / `&` / `(`; `}` must be preceded by `;` or whitespace) so `{npm run dev}` does **not** trigger (single token, no executable body at runtime), and `echo "{ rm -rf; }"` stays allowed (bash does not honour brace groups inside double quotes).

## Commit layout

Split into four reviewable commits:

1. `refactor(hooks): import extractCommandSubstitutions from shared lib`
   Drops gateguard's private 99-line duplicate of the function now that PR #1905 landed `scripts/lib/shell-substitution.js` on `main`. The 72 existing gateguard tests pass unchanged.
2. `feat(lib): add extractBraceGroups for { ...; } shell groups`
   Sibling to `extractSubshellGroups`. No consumer yet.
3. `fix(hooks): cover plain (...) and brace { ...; } bodies in destructive scan`
   Wires both new extractors plus `extractCommandSubstitutions` through a BFS walker. This is the behaviour change.
4. `test(hooks): regression coverage for subshell + brace destructive bypass`
   13 new cases — 7 newly-blocked, 6 explicitly-allowed (literals in quotes, non-destructive groups, the no-space brace edge case).

## Tests

- `node tests/hooks/gateguard-fact-force.test.js` — 85/85 (was 72/72)
- `yarn lint` clean
- `yarn test` green locally

## Provenance

Direct follow-up to PR #1889 (closed; integrated via #1905). In that PR I noted: "consolidating both call sites onto this shared lib is a follow-up worth doing once this PR lands". This is that follow-up. The `extractCommandSubstitutions` duplication is gone; gateguard now benefits from the same quote-state tracking the PR #1889 round-1 review added to the lib.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] Manual: every row of the bypass table now returns DESTRUCTIVE
- [ ] Manual: every row of the explicit-allow tests stays allowed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes a bypass in the gateguard destructive scan by inspecting bodies inside plain subshells `( ... )` and brace groups `{ ...; }`, and fixes brace-group parsing so nested spans can’t hide destructive commands. This blocks hidden `rm -rf`, `git push --force`, and similar commands nested in these groups.

- **Bug Fixes**
  - Walk all executable bodies via a BFS (`collectExecutableBodies`) and feed them into `splitCommandSegments`, covering `(...)`, `((...))`, and `{ ...; }` across nesting.
  - Fix `extractBraceGroups` to skip `$(...)`, backticks, and `(...)` spans and to enforce the nested-`{` boundary rule, preventing early-close cases like `{ echo \`echo }\`; ... }`.
  - Add 18 regression tests for subshell/brace cases, quotes, and span-skip edge cases; suite count: 72→90.

- **Refactors**
  - Replace the local duplicate with the shared `extractCommandSubstitutions`; add `extractBraceGroups` and wire it with `extractSubshellGroups`.
  - Deduplicate bodies during BFS to avoid re-scanning identical segments.

<sup>Written for commit 873fbadc3319ad163a46b3227bc118535ec85ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broader detection of potentially destructive shell commands across additional grouping syntaxes and nested command structures, improving safety checks for more reachable command forms.
* **Tests**
  * Added tests validating destructive detection and allow-cases across various nested groupings, quoting, and boundary scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1912)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->