### PR TITLE
docs: align rules README install namespace

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -55,23 +55,38 @@ rules/
 > Flattening them into one directory causes language-specific files to overwrite
 > common rules, and breaks the relative `../common/` references used by
 > language-specific files.
+>
+> Use the ECC-owned namespace below for user-level Claude installs. Flat
+> package-level destinations can collide with non-ECC rule packs and do not
+> match the main README guidance.
 
 ```bash
+# Create the ECC rule namespace once.
+mkdir -p ~/.claude/rules/ecc
+
 # Install common rules (required for all projects)
-cp -r rules/common ~/.claude/rules/common
+cp -r rules/common ~/.claude/rules/ecc/
 
 # Install language-specific rules based on your project's tech stack
-cp -r rules/typescript ~/.claude/rules/typescript
-cp -r rules/angular ~/.claude/rules/angular
-cp -r rules/python ~/.claude/rules/python
-cp -r rules/golang ~/.claude/rules/golang
-cp -r rules/web ~/.claude/rules/web
-cp -r rules/swift ~/.claude/rules/swift
-cp -r rules/php ~/.claude/rules/php
-cp -r rules/ruby ~/.claude/rules/ruby
-cp -r rules/arkts ~/.claude/rules/arkts
+cp -r rules/typescript ~/.claude/rules/ecc/
+cp -r rules/angular ~/.claude/rules/ecc/
+cp -r rules/python ~/.claude/rules/ecc/
+cp -r rules/golang ~/.claude/rules/ecc/
+cp -r rules/web ~/.claude/rules/ecc/
+cp -r rules/swift ~/.claude/rules/ecc/
+cp -r rules/php ~/.claude/rules/ecc/
+cp -r rules/ruby ~/.claude/rules/ecc/
+cp -r rules/arkts ~/.claude/rules/ecc/
 
 # Attention ! ! ! Configure according to your actual project requirements; the configuration here is for reference only.
+```
+
+For project-local rules, use the same namespace under the project root:
+
+```bash
+mkdir -p .claude/rules/ecc
+cp -r rules/common .claude/rules/ecc/
+cp -r rules/typescript .claude/rules/ecc/
 ```
 
 ## Rules vs Skills

--- a/tests/scripts/install-readme-clarity.test.js
+++ b/tests/scripts/install-readme-clarity.test.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const path = require('path');
 
 const README = path.join(__dirname, '..', '..', 'README.md');
+const RULES_README = path.join(__dirname, '..', '..', 'rules', 'README.md');
 
 function test(name, fn) {
   try {
@@ -27,6 +28,7 @@ function runTests() {
   let failed = 0;
 
   const readme = fs.readFileSync(README, 'utf8');
+  const rulesReadme = fs.readFileSync(RULES_README, 'utf8');
 
   if (test('README marks one default path and warns against stacked installs', () => {
     assert.ok(
@@ -135,6 +137,29 @@ function runTests() {
     assert.ok(
       readme.includes('~/.claude/rules/ecc/'),
       'README should steer plugin-path rules into an ECC-owned namespace'
+    );
+  })) passed++; else failed++;
+
+  if (test('rules README mirrors ECC namespaced install path', () => {
+    assert.ok(
+      rulesReadme.includes('mkdir -p ~/.claude/rules/ecc'),
+      'rules README should create the ECC-owned user-level rules namespace'
+    );
+    assert.ok(
+      rulesReadme.includes('cp -r rules/common ~/.claude/rules/ecc/'),
+      'rules README should copy common rules under ~/.claude/rules/ecc/'
+    );
+    assert.ok(
+      rulesReadme.includes('cp -r rules/typescript ~/.claude/rules/ecc/'),
+      'rules README should copy language rules under ~/.claude/rules/ecc/'
+    );
+    assert.ok(
+      rulesReadme.includes('mkdir -p .claude/rules/ecc'),
+      'rules README should document the project-local ECC namespace'
+    );
+    assert.ok(
+      !rulesReadme.includes('~/.claude/rules/typescript'),
+      'rules README should not recommend flat user-level rule destinations'
     );
   })) passed++; else failed++;
 


### PR DESCRIPTION
## Summary

Fixes #1913 by aligning `rules/README.md` with the main README rule-copy guidance:

- use `~/.claude/rules/ecc/` for user-level manual rule copies
- document `.claude/rules/ecc/` for project-local copies
- add regression coverage so the rules README does not drift back to flat destinations

## Validation

- `node tests/scripts/install-readme-clarity.test.js`
- `node scripts/ci/check-unicode-safety.js`
- `node scripts/ci/validate-no-personal-paths.js`
- `npm run lint`
- `npm test` (2421/2421)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `rules/README.md` with the main README by using the ECC namespace for installs: user-level `~/.claude/rules/ecc/` and project-local `.claude/rules/ecc/`. Adds tests to enforce this (requires ECC mkdir/copy commands and rejects flat paths), fixing #1913.

<sup>Written for commit 8af4b5dafb43a364a1c91ed0f1e81e3e9fc73667. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated manual installation instructions to recommend an ECC-owned namespace for user-level and project-local Claude rule installs, with commands to create and populate that namespace and a warning against using flat per-language destinations.

* **Tests**
  * Added a regression test to validate the README documents the namespaced install layout and discourages flat per-language installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1916)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->