### PR TITLE
docs: refresh rc1 publication evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -1,36 +1,39 @@
 # ECC 2.0 GA Roadmap
 
-This roadmap is the durable repo mirror for the Linear project:
+This roadmap is the durable repo mirror for the active Linear project:
 
-<https://linear.app/ecctools/project/ecc-20-ga-harness-os-security-platform-de2a0ecace6f>
+<https://linear.app/itomarkets/project/ecc-platform-roadmap-52b328ee03e1>
 
-Linear issue creation is currently blocked by the workspace active issue limit,
-so the live execution truth is split across:
+Linear issue creation is available again in the Ito Markets workspace. The live
+execution truth is split across:
 
-- the Linear project description, status updates, and milestones;
+- the Linear project documents, issue lanes, dependencies, and milestones;
 - this repo document;
 - merged PR evidence;
 - handoffs under `~/.cluster-swarm/handoffs/`.
 
 ## Current Evidence
 
-As of 2026-05-13:
+As of 2026-05-15:
 
 - GitHub queues are clean across `affaan-m/everything-claude-code`,
   `affaan-m/agentshield`, `affaan-m/JARVIS`, `ECC-Tools/ECC-Tools`, and
-  `ECC-Tools/ECC-website`: the latest sweep found 0 open PRs and 0 open
-  issues across all five repos.
-- GitHub discussions are also clean across those tracked repos:
-  the latest GraphQL sweep found 52 total trunk discussions with 0 open,
-  and 0 total/open discussions on AgentShield, JARVIS, ECC-Tools, and the
-  ECC-Tools website.
-- The final open public GitHub issue, #1314, was closed as a non-actionable
-  external badge/listing notification with a courtesy comment.
-- Linear issue creation for this project was re-tested after GitHub cleanup and
-  is still blocked by the workspace free issue limit. Seven roadmap-lane issue
-  creation attempts all returned the same limit error, so this repo mirror and
-  Linear project status updates remain the active tracking surfaces until the
-  workspace is upgraded or issue capacity is freed.
+  `ECC-Tools/ECC-website`: the latest sweep found 0 open PRs and 0 open issues
+  across all five repos. ECC Tools org verification requires
+  `env -u GITHUB_TOKEN` in this shell so the configured GitHub host credential
+  is used instead of the incompatible environment token.
+- GitHub discussions are current across those tracked repos:
+  `affaan-m/everything-claude-code` has 57 total discussions and 0 without
+  maintainer touch after May 15 maintainer updates on #73 and #1239; AgentShield,
+  JARVIS, ECC Tools, and the ECC Tools website have discussions disabled or 0
+  total discussions.
+- The current Linear roadmap contains 16 issue lanes (`ITO-44` through
+  `ITO-59`) and five milestones: Security and Access Baseline, ECC 2.0 Preview
+  and Publication, AgentShield Enterprise Iteration, ECC Tools Next-Level
+  Platform, and Legacy Audit and Salvage.
+- `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` records the
+  queue, discussion, Linear roadmap, ECC Tools access, and PR #1921
+  Mini Shai-Hulud/TanStack follow-up evidence refresh.
 - `npm run harness:audit -- --format json` reports 70/70 on current `main`.
 - `npm run observability:ready` reports 21/21 readiness on current `main`,
   including the GitHub/Linear/handoff/roadmap progress-sync contract.

--- a/docs/releases/2.0.0-rc.1/launch-checklist.md
+++ b/docs/releases/2.0.0-rc.1/launch-checklist.md
@@ -4,6 +4,7 @@
 
 - verify local `main` is synced to `origin/main`
 - verify `docs/ECC-2.0-GA-ROADMAP.md` reflects the current Linear milestone plan
+  and the May 15 `ECC Platform Roadmap` project under the Ito Markets workspace
 - verify `docs/HERMES-SETUP.md` is present
 - verify `docs/architecture/cross-harness.md` is present
 - verify this release directory is committed
@@ -14,6 +15,8 @@
 - verify package, plugin, marketplace, OpenCode, and agent metadata stays at `2.0.0-rc.1`
 - verify `ecc2/Cargo.toml` stays at `0.1.0` for rc.1; `ecc2/` remains an alpha control-plane scaffold
 - complete `publication-readiness.md` with fresh evidence before any GitHub release, npm publish, plugin submission, or announcement post
+- include `publication-evidence-2026-05-15.md` in the final evidence review,
+  then rerun publish-facing checks from the exact release commit
 - update release metadata in one dedicated release-version PR
 - run the root test suite
 - run `cd ecc2 && cargo test`

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
@@ -1,0 +1,97 @@
+# ECC v2.0.0-rc.1 Publication Evidence - 2026-05-15
+
+This is release-readiness evidence only. It does not create a GitHub release,
+npm publication, plugin tag, marketplace submission, or announcement post.
+
+## Source Commit
+
+| Field | Evidence |
+| --- | --- |
+| Upstream main base | `f04702bdac132662c8496e817bcd850c86e2b854` |
+| Evidence branch | `docs/ecc2-rc1-may15-readiness` |
+| Evidence scope | Current `main` after PR #1921 supply-chain IOC expansion |
+| Git remote | `https://github.com/affaan-m/everything-claude-code.git` |
+| Local status caveat | Working tree had the unrelated untracked `docs/drafts/` directory before this docs refresh |
+
+The actual release operator should repeat all publish-facing checks from the
+final release commit with a clean checkout before publishing.
+
+## Queue And Discussion State
+
+| Surface | Command | Result |
+| --- | --- | --- |
+| Trunk PRs/issues | `gh pr list` and `gh issue list` for `affaan-m/everything-claude-code` | 0 open PRs, 0 open issues |
+| AgentShield PRs/issues | `gh pr list` and `gh issue list` for `affaan-m/agentshield` | 0 open PRs, 0 open issues |
+| JARVIS PRs/issues | `gh pr list` and `gh issue list` for `affaan-m/JARVIS` | 0 open PRs, 0 open issues |
+| ECC Tools PRs/issues | `env -u GITHUB_TOKEN gh pr list` and `env -u GITHUB_TOKEN gh issue list` for `ECC-Tools/ECC-Tools` | 0 open PRs, 0 open issues |
+| ECC website PRs/issues | `env -u GITHUB_TOKEN gh pr list` and `env -u GITHUB_TOKEN gh issue list` for `ECC-Tools/ECC-website` | 0 open PRs, 0 open issues |
+| Trunk discussions | GraphQL discussion count for `affaan-m/everything-claude-code` | 57 total discussions; 0 without maintainer touch after May 15 maintainer comments |
+| Other repo discussions | GraphQL discussion count for AgentShield, JARVIS, ECC Tools, and ECC website | Discussions disabled or 0 total |
+
+The ECC Tools organization is reachable with the configured GitHub host
+credential. In this shell, the exported `GITHUB_TOKEN` overrides that credential
+and causes false 404/403 failures for `ECC-Tools/*`. Use `env -u GITHUB_TOKEN`
+for ECC Tools verification commands until that environment override is cleaned
+up.
+
+## Linear Roadmap State
+
+The detailed execution roadmap now lives in Linear project:
+
+<https://linear.app/itomarkets/project/ecc-platform-roadmap-52b328ee03e1>
+
+The project contains 16 issue-level lanes and 5 milestones:
+
+| Milestone | Issues |
+| --- | --- |
+| Security and Access Baseline | `ITO-44`, `ITO-57`, `ITO-58` |
+| ECC 2.0 Preview and Publication | `ITO-45`, `ITO-46`, `ITO-47`, `ITO-56` |
+| AgentShield Enterprise Iteration | `ITO-48`, `ITO-49` |
+| ECC Tools Next-Level Platform | `ITO-50`, `ITO-51`, `ITO-52`, `ITO-53`, `ITO-54`, `ITO-59` |
+| Legacy Audit and Salvage | `ITO-55` |
+
+Project documents added in Linear:
+
+- Roadmap Index and Current Execution Baseline
+- Status Update 2026-05-15
+- GitHub Queue Snapshot 2026-05-15
+- Completion Audit Snapshot 2026-05-15
+- Discussion Queue Evidence 2026-05-15
+- ECC-Tools Access Evidence 2026-05-15
+
+## Supply-Chain Evidence
+
+| Surface | Evidence |
+| --- | --- |
+| PR #1921 | Merged supply-chain IOC expansion for Mini Shai-Hulud/TanStack follow-up |
+| Merge commit | `f04702bdac132662c8496e817bcd850c86e2b854` |
+| Local IOC tests | `node tests/ci/scan-supply-chain-iocs.test.js` passed 11/11 |
+| Unicode safety | `node scripts/ci/check-unicode-safety.js` passed |
+| IOC scan | `npm run security:ioc-scan` passed |
+| Root suite | `npm test` passed 2426/2426, 0 failed |
+| Repo sweeps | IOC scanner sweep passed for trunk, AgentShield, ECC Tools, ECC website, JARVIS, and the ECC document mirror |
+
+The May 15 IOC expansion added coverage for OpenSearch/Mistral/Guardrails/
+UiPath/Squawk-style campaign variants, `opensearch_init.js`, `vite_setup.mjs`,
+dead-drop/session protocol strings, and AI-tooling persistence surfaces without
+committing full high-entropy indicators that trip secret scanners.
+
+## Current Publication Blockers
+
+- GitHub prerelease `v2.0.0-rc.1` is still not created in this pass.
+- npm `ecc-universal@2.0.0-rc.1` is still not published to the `next` dist-tag.
+- Claude plugin tag and marketplace propagation remain approval-gated.
+- Codex plugin public marketplace/manual submission path still needs final
+  owner verification.
+- ECC Tools billing claims are now GitHub-access-verifiable, but the billing
+  product surface still needs a dedicated payment-readiness audit before any
+  public payment announcement.
+- Release notes, X, LinkedIn, and longform copy still need final live URLs after
+  release/package/plugin URLs exist.
+
+## Result
+
+The queue, discussion, Linear roadmap, and supply-chain evidence are fresher
+than the May 13 publication evidence. They improve readiness, but they do not
+replace the final clean-checkout publish pass required by
+`publication-readiness.md`.

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -12,6 +12,9 @@ For the May 13 release-readiness evidence refresh, see
 [`publication-evidence-2026-05-13.md`](publication-evidence-2026-05-13.md).
 For the May 13 post-hardening evidence refresh after PR #1850 and PR #1851, see
 [`publication-evidence-2026-05-13-post-hardening.md`](publication-evidence-2026-05-13-post-hardening.md).
+For the May 15 queue, discussion, Linear roadmap, and Mini Shai-Hulud/TanStack
+follow-up evidence refresh after PR #1921, see
+[`publication-evidence-2026-05-15.md`](publication-evidence-2026-05-15.md).
 
 ## Release Identity Matrix
 
@@ -39,8 +42,8 @@ For the May 13 post-hardening evidence refresh after PR #1850 and PR #1851, see
 | Claude plugin | Manifest validates, marketplace JSON points to public repo, install docs match slug | `claude plugin validate .claude-plugin/plugin.json`; `claude plugin tag .claude-plugin --dry-run`; isolated temp-home install smoke | `Blocker: real tag creation/push requires approval` | Plugin owner | Clean-checkout dry-run and install smoke recorded |
 | Codex plugin | Manifest version matches package and docs, hook limitations are explicit | `node tests/docs/ecc2-release-surface.test.js` | `Blocker: marketplace submission path still manual/owner-gated` | Plugin owner | Evidence recorded |
 | OpenCode package | Build output is regenerated from source and package metadata is current | `npm run build:opencode` | `Blocker: none for local build; public distribution still follows npm/plugin release` | Package owner | Evidence recorded |
-| ECC Tools billing reference | Any billing claim links to verified Marketplace/App state | `gh api repos/ECC-Tools/ECC-Tools` plus app/marketplace URL check | `Blocker:` | ECC Tools owner | Pending |
-| Announcement copy | X, LinkedIn, GitHub release, and longform copy point to live URLs | `rg -n "TODO" docs/releases/2.0.0-rc.1` and repeat for `TBD` | `Blocker:` | Release owner | Pending |
+| ECC Tools billing reference | Any billing claim links to verified Marketplace/App state | `env -u GITHUB_TOKEN gh repo view ECC-Tools/ECC-Tools --json nameWithOwner,isPrivate,viewerPermission` plus app/marketplace URL check | `Blocker: repo access verified on 2026-05-15; billing/product readiness still requires dedicated ECC Tools audit` | ECC Tools owner | Access verified; billing audit pending |
+| Announcement copy | X, LinkedIn, GitHub release, and longform copy point to live URLs | `rg -n "TODO" docs/releases/2.0.0-rc.1` and repeat for `TBD` | `Blocker: final live release/npm/plugin URLs do not exist yet` | Release owner | Pending |
 | Privileged workflow hardening | Release and maintenance workflows avoid persisted checkout tokens | `node scripts/ci/validate-workflow-security.js` | `Blocker:` | Release owner | Evidence recorded in post-hardening refresh |
 
 ## Required Command Evidence
@@ -60,6 +63,9 @@ Record the exact commit SHA and command output before any publication action:
 | Package surface | `node tests/scripts/npm-publish-surface.test.js` | 0 failures; no Python bytecode in npm tarball | `2/2` passed in May 12 evidence pass |
 | Release surface | `node tests/docs/ecc2-release-surface.test.js` | 0 failures | `publication-evidence-2026-05-13.md`: 18/18 passed |
 | Optional Rust surface | `cd ecc2 && cargo test` | 0 failures or explicit deferral | `publication-evidence-2026-05-13.md`: 462/462 passed, warnings only |
+| Queue baseline | `gh pr list` / `gh issue list` across trunk, AgentShield, JARVIS, ECC Tools, and ECC website | Under 20 open PRs and under 20 open issues | `publication-evidence-2026-05-15.md`: 0 open PRs and 0 open issues across checked repos |
+| Discussion baseline | GraphQL discussion count and maintainer-touch sweep | No unmanaged active discussion queue | `publication-evidence-2026-05-15.md`: 57 trunk discussions, 0 without maintainer touch; other tracked repos disabled or 0 |
+| Linear roadmap | Linear project and issue readback | Detailed roadmap exists with release, security, AgentShield, ECC Tools, legacy, and observability lanes | `publication-evidence-2026-05-15.md`: project and 16 issue lanes recorded |
 
 ## Do Not Publish If
 

--- a/docs/releases/2.0.0-rc.1/release-notes.md
+++ b/docs/releases/2.0.0-rc.1/release-notes.md
@@ -14,6 +14,7 @@ Claude Code remains a core target. Codex, OpenCode, Cursor, Gemini, and other ha
 - Documented the cross-harness portability model for skills, hooks, MCPs, rules, and instructions.
 - Added a Hermes import playbook for turning local operator patterns into publishable ECC skills.
 - Added a local [observability readiness gate](../../architecture/observability-readiness.md) for loop status, session traces, harness audit, and ECC2 tool-risk logs.
+- Refreshed the release-readiness evidence after the May 2026 Mini Shai-Hulud/TanStack campaign follow-up, including expanded IOC coverage, clean queue/discussion checks, and a detailed Linear roadmap gate.
 
 ## Why This Matters
 
@@ -37,6 +38,7 @@ What ships in this surface:
 - release notes and launch collateral
 - cross-harness architecture documentation
 - Hermes import guidance for sanitized operator workflows
+- publication-readiness evidence for queue state, discussion state, Linear roadmap coverage, and supply-chain follow-up
 
 What stays local:
 

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -178,6 +178,7 @@ test('launch checklist records the ecc2 alpha version policy', () => {
 
 test('publication readiness checklist gates public release actions on evidence', () => {
   const source = read('docs/releases/2.0.0-rc.1/publication-readiness.md');
+  const may15Evidence = read('docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md');
 
   for (const section of [
     '## Release Identity Matrix',
@@ -211,6 +212,12 @@ test('publication readiness checklist gates public release actions on evidence',
   ]) {
     assert.ok(source.includes(surface), `publication readiness missing ${surface}`);
   }
+
+  assert.ok(source.includes('publication-evidence-2026-05-15.md'));
+  assert.ok(may15Evidence.includes('PR #1921'));
+  assert.ok(may15Evidence.includes('env -u GITHUB_TOKEN'));
+  assert.ok(may15Evidence.includes('ITO-44'));
+  assert.ok(may15Evidence.includes('0 open PRs, 0 open issues'));
 });
 
 test('release checklist and roadmap link to publication readiness evidence gate', () => {


### PR DESCRIPTION
## Summary
- add May 15 rc.1 publication evidence for queue/discussion state, Linear roadmap coverage, ECC-Tools access, and PR #1921 supply-chain follow-up
- update publication readiness, launch checklist, release notes, and GA roadmap to point at the current Linear project/evidence
- extend the release-surface regression test to require the May 15 evidence markers

## Validation
- node tests/docs/ecc2-release-surface.test.js
- git diff --check
- npx markdownlint-cli docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md docs/releases/2.0.0-rc.1/publication-readiness.md docs/releases/2.0.0-rc.1/launch-checklist.md docs/releases/2.0.0-rc.1/release-notes.md docs/ECC-2.0-GA-ROADMAP.md
- npm test (2426/2426 passed)

No release, tag, npm publish, plugin tag, marketplace submission, or announcement action is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes ECC v2.0.0-rc.1 publication evidence with May 15 updates and points docs to the active Ito Markets Linear roadmap for clearer release readiness. Extends release-surface tests to require the new evidence markers.

- **Docs and Tests**
  - Added `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` with clean queue/discussion checks, ECC-Tools access note (`env -u GITHUB_TOKEN`), Linear lanes (`ITO-44`–`ITO-59`), and PR #1921 supply-chain follow-up.
  - Updated `ECC-2.0-GA-ROADMAP.md` to new Linear project URL and current evidence; refreshed `publication-readiness.md`, `launch-checklist.md`, and `release-notes.md` to reference the May 15 evidence and clarify blockers.
  - Strengthened `tests/docs/ecc2-release-surface.test.js` to assert presence of the May 15 evidence, Linear lane IDs, the env-var caveat, and zero open PR/issue checks.

<sup>Written for commit 5b563bd018c4a6824e15b0a46cccb3fe5475a641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release readiness documentation and roadmap evidence for v2.0.0-rc.1
  * Added publication evidence tracking and verification checkpoints

* **Tests**
  * Enhanced release verification tests with additional evidence validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1922)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->