### PR TITLE
feat(skills): enrich windows-desktop-e2e with trace/dpi/diagnostics

### DIFF
--- a/skills/windows-desktop-e2e/SKILL.md
+++ b/skills/windows-desktop-e2e/SKILL.md
@@ -422,6 +422,7 @@ class BasePage:
 - **PII / credentials**: `type_text` content is `<redacted>` by default. Never set `E2E_TRACE_INCLUDE_TEXT=1` on login or payment flows.
 - **Overhead**: ~50–200ms per action + one PNG per step on disk. Don't enable on the default CI matrix — only on a dedicated flake-repro job.
 - **Artifact bloat**: a long flow produces tens of MB; tune `retention-days` accordingly.
+- **Parallel/rerun hygiene**: this simple example appends to `trace.jsonl` and uses a class-level counter. Clear the artifact directory before reruns, and use per-worker artifact dirs for parallel tests.
 - **Coverage gap**: actions performed outside `BasePage` (raw `pywinauto` calls in test code) are not traced.
 
 ## Flaky Test Handling
@@ -799,7 +800,7 @@ def debug_match(template_path, out="artifacts/match_debug.png", confidence=0.85)
 
     NOT for production tests — use when calibrating confidence or chasing false matches.
     """
-    import cv2, pyautogui, numpy as np
+    import os, cv2, pyautogui, numpy as np
     screen = np.array(pyautogui.screenshot())[:, :, ::-1]
     tpl    = cv2.imread(template_path)
     if tpl is None:

--- a/skills/windows-desktop-e2e/SKILL.md
+++ b/skills/windows-desktop-e2e/SKILL.md
@@ -366,6 +366,64 @@ def stop_recording(proc):
     proc.stdin.write(b"q"); proc.stdin.flush(); proc.wait(timeout=10)
 ```
 
+## Per-Step Trace (opt-in)
+
+The default failure screenshot is often too thin for diagnosing flaky tests. The step-level trace below is **off by default** — enable it only when reproducing a flaky case.
+
+### Enable
+
+```bash
+E2E_TRACE=1 pytest tests/test_login.py -v
+# Include typed text in the JSONL log (DO NOT use on tests that type credentials/PII):
+E2E_TRACE=1 E2E_TRACE_INCLUDE_TEXT=1 pytest ...
+```
+
+### Patch into BasePage
+
+```python
+import os, json, time
+TRACE_ENABLED      = os.environ.get("E2E_TRACE") == "1"
+TRACE_INCLUDE_TEXT = os.environ.get("E2E_TRACE_INCLUDE_TEXT") == "1"
+
+class BasePage:
+    _step = 0
+
+    def _trace(self, action, spec=None, text=None):
+        if not TRACE_ENABLED:
+            return
+        BasePage._step += 1
+        idx = f"{BasePage._step:03d}"
+        os.makedirs(ARTIFACT_DIR, exist_ok=True)
+        try:
+            self.window.capture_as_image().save(
+                os.path.join(ARTIFACT_DIR, f"step_{idx}_{action}.png"))
+        except Exception:
+            pass  # capture failure must not break the test
+        rec = {
+            "ts": time.time(), "step": BasePage._step, "action": action,
+            "locator": getattr(spec, "criteria", None),
+            "text": text if TRACE_INCLUDE_TEXT else ("<redacted>" if text else None),
+        }
+        with open(os.path.join(ARTIFACT_DIR, "trace.jsonl"), "a") as f:
+            f.write(json.dumps(rec) + "\n")
+
+    def click(self, spec):
+        self.wait_visible(spec); self._trace("click_before", spec)
+        spec.click_input();      self._trace("click_after",  spec)
+
+    def type_text(self, spec, text):
+        self.wait_visible(spec); self._trace("type_before", spec, text)
+        # ... existing set_edit_text / keyboard fallback ...
+        self._trace("type_after", spec)
+```
+
+### Caveats
+
+- **PII / credentials**: `type_text` content is `<redacted>` by default. Never set `E2E_TRACE_INCLUDE_TEXT=1` on login or payment flows.
+- **Overhead**: ~50–200ms per action + one PNG per step on disk. Don't enable on the default CI matrix — only on a dedicated flake-repro job.
+- **Artifact bloat**: a long flow produces tens of MB; tune `retention-days` accordingly.
+- **Coverage gap**: actions performed outside `BasePage` (raw `pywinauto` calls in test code) are not traced.
+
 ## Flaky Test Handling
 
 ```python
@@ -387,6 +445,8 @@ Common causes and fixes:
 | Animation in progress | `wait_until(lambda: not loading_indicator.exists())` |
 | Dialog timing | `wait_window(title, timeout=15)` |
 | CI display not ready | Set `DISPLAY` or use virtual desktop in CI |
+| `set_edit_text` raises NotImplementedError | UIA ValuePattern missing (common on Qt 5.x) — `BasePage.type_text` already falls back to `keyboard.send_keys` |
+| Control exists but `wait_visible` times out | Window minimised or off-screen — call `win.restore()` + `win.set_focus()` before waiting |
 
 ## Test Isolation & Sandbox
 
@@ -717,6 +777,44 @@ def click_image(template_path, confidence=0.85):
     if pos is None:
         raise RuntimeError(f"Image not found on screen: {template_path}")
     pyautogui.click(*pos)
+```
+
+### DPI / Scaling Rules (screenshot mode only)
+
+Screenshot matching is brutally sensitive to Windows display scaling (100% / 125% / 150%). Three hard rules:
+
+1. **Capture templates at the same scale as the target machine.** Don't try to rescue a mismatch with `PIL.Image.resize` — `cv2.matchTemplate` is very fragile against resampling artefacts.
+2. **Pin the CI display scaling.** On `windows-latest` add a step like `Set-DisplayResolution 1920 1080 -Force` and disable per-monitor DPI scaling, so screenshot dimensions are reproducible.
+3. **Record the scale alongside each artefact.** On capture, write `GetDpiForWindow(hwnd) / 96` to `artifacts/<test>/metadata.json` — postmortems become obvious instead of guess-work.
+
+> Process-level DPI awareness (`SetProcessDpiAwarenessContext`) **can conflict with Qt's own DPI handling** when the app under test is Qt-based. Prefer "same-scale templates + CI pin" over flipping process-wide DPI mode in fixtures.
+
+### Debugging Match Confidence
+
+When tuning the `confidence` threshold, the only sane workflow is to **see** where the match landed. The helper below is diagnosis-only — do not call it from test code.
+
+```python
+def debug_match(template_path, out="artifacts/match_debug.png", confidence=0.85):
+    """Diagnosis-only. Draw the best-match rectangle + score back on the current screen.
+
+    NOT for production tests — use when calibrating confidence or chasing false matches.
+    """
+    import cv2, pyautogui, numpy as np
+    screen = np.array(pyautogui.screenshot())[:, :, ::-1]
+    tpl    = cv2.imread(template_path)
+    if tpl is None:
+        raise RuntimeError(f"Template unreadable: {template_path}")
+    res    = cv2.matchTemplate(screen, tpl, cv2.TM_CCOEFF_NORMED)
+    _, mv, _, ml = cv2.minMaxLoc(res)
+    h, w   = tpl.shape[:2]
+    colour = (0, 255, 0) if mv >= confidence else (0, 0, 255)  # green pass / red fail
+    cv2.rectangle(screen, ml, (ml[0]+w, ml[1]+h), colour, 2)
+    cv2.putText(screen, f"score={mv:.3f} thr={confidence}",
+                (ml[0], max(20, ml[1]-6)),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.7, colour, 2)
+    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+    cv2.imwrite(out, screen)
+    return mv
 ```
 
 **Use sparingly** — image matching breaks on DPI changes, theme switches, and partial occlusion.


### PR DESCRIPTION
## Summary

  Enrich the `windows-desktop-e2e` skill with three opt-in improvements, derived from a dual-model adversarial review (Claude Opus +
  Codex GPT-5) against Anthropic's *Best Practices for Computer and Browser Use with Claude* blog post.

  - **Per-Step Trace (opt-in)** — `E2E_TRACE=1` enables before/after screenshots + a JSONL action log per `BasePage` action. Text
  content is `<redacted>` by default; `E2E_TRACE_INCLUDE_TEXT=1` is required to log typed input. Off by default — no impact on existing
  tests.
  - **DPI / Scaling Rules** in the screenshot fallback — three hard rules (same-scale templates, CI pinning, scale-in-metadata), with a
  deliberate caveat against process-wide `SetProcessDpiAwarenessContext` when the app under test is Qt-based.
  - **`debug_match()` helper** — diagnosis-only utility that draws the best-match rectangle + score back on the screen, for tuning the
  `cv2.matchTemplate` confidence threshold.
  - **Flaky table** gains two rows covering Qt 5.x `set_edit_text` UIA-Pattern fallback and off-screen / minimised windows.

  ## Explicitly rejected (and why)

  - **Teach-Mode / POM scaffolding from recordings** — would invert the skill's AutomationId-first teaching order; recorder-first
  workflows fossilise brittle locators before testability exists.
  - **Process-wide DPI awareness code** — conflicts with Qt's own DPI handling; "same-scale templates + CI pin" is the more reliable
  rule.
  - **New "click-failure" diagnostic table** — 60–70% overlap with the existing Flaky table; folded into existing rows instead.

  ## Test plan

  - [x] `npx markdownlint-cli skills/windows-desktop-e2e/SKILL.md` — clean (exit 0)
  - [x] `node tests/run-all.js` — 32 failed / 2380; baseline on `origin/main` already shows 33 failed; **0 new failures attributable to
  this PR** (per-file comparison confirms no regression)

  ## Notes for reviewers

  - The trace mechanism is documentation-only — patching it into `BasePage` is at the user's discretion, not enforced by the skill.
  - Pre-existing 33 failures on `origin/main` (`hooks.test.js` 25 / Windows symlink permission / etc.) are out of scope here.
  - Net diff: 1 file changed, +98 lines, no deletions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in step tracing, DPI/scaling guidance, and a debugging helper update to the `windows-desktop-e2e` skill docs to speed up flaky test diagnosis. No default behavior changes; all additions are opt-in and documented in `SKILL.md`.

- **New Features**
  - Per-step trace via `E2E_TRACE=1`: before/after screenshots and a JSONL action log per `BasePage` action; text is redacted by default, enable with `E2E_TRACE_INCLUDE_TEXT=1`.
  - DPI/scaling rules for screenshot fallback: same-scale templates, pin CI scaling, record scale in metadata; avoid process-wide DPI awareness with Qt apps.
  - `debug_match()` helper to draw the best-match rectangle and score for tuning `cv2.matchTemplate` (diagnosis-only); docs example corrected to save output reliably.
  - Flaky table: adds guidance for Qt 5.x `set_edit_text` fallback and for off-screen/minimized windows (restore + focus).

<sup>Written for commit 03ab47748cdc9858994baf640eb03da817041180. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-step tracing for Windows desktop E2E automation: captures screenshots and structured action logs (configurable via environment flags); typed input is redacted by default.
  * Added a template-matching debug helper with DPI/scaling considerations.

* **Documentation**
  * Expanded troubleshooting with guidance for Qt 5.x input quirks and UI wait failures when windows/controls are minimized or off-screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1925)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->