### PR TITLE
docs: refresh rc1 preview pack manifest

### DIFF
--- a/docs/releases/2.0.0-rc.1/launch-checklist.md
+++ b/docs/releases/2.0.0-rc.1/launch-checklist.md
@@ -8,6 +8,9 @@
 - verify `docs/HERMES-SETUP.md` is present
 - verify `docs/architecture/cross-harness.md` is present
 - verify this release directory is committed
+- verify `preview-pack-manifest.md` lists the public release, Hermes, adapter,
+  observability, publication, and announcement artifacts before running final
+  publish checks
 - keep private tokens, personal docs, and raw workspace exports out of the repo
 
 ## Release Surface

--- a/docs/releases/2.0.0-rc.1/preview-pack-manifest.md
+++ b/docs/releases/2.0.0-rc.1/preview-pack-manifest.md
@@ -1,0 +1,97 @@
+# ECC v2.0.0-rc.1 Preview Pack Manifest
+
+This manifest defines the reviewed preview pack for `2.0.0-rc.1`. It is not a
+release action by itself. Use it to verify that the public launch surface is
+assembled before creating the GitHub prerelease, publishing npm, tagging plugin
+surfaces, or posting announcements.
+
+## Pack Contents
+
+| Artifact | Role | Gate |
+| --- | --- | --- |
+| `README.md` | Public onramp and install surface | Links Hermes setup, rc.1 notes, plugin install, manual install, reset, and uninstall guidance |
+| `docs/HERMES-SETUP.md` | Public Hermes operator topology | No raw workspace export, credentials, private account names, or local-only operator state |
+| `skills/hermes-imports/SKILL.md` | Sanitized Hermes-to-ECC import workflow | Includes import rules, sanitization checklist, conversion pattern, and output contract |
+| `docs/architecture/cross-harness.md` | Shared substrate model for Claude Code, Codex, OpenCode, Cursor, Gemini, Hermes, and terminal-only use | Names portability boundaries and does not claim unsupported native parity |
+| `docs/architecture/harness-adapter-compliance.md` | Adapter matrix and scorecard | Verified by `npm run harness:adapters -- --check` |
+| `docs/architecture/observability-readiness.md` | Local operator-readiness gate | Verified by `npm run observability:ready` |
+| `docs/architecture/progress-sync-contract.md` | GitHub, Linear, handoff, roadmap, and work-item sync boundary | Checked by `node scripts/platform-audit.js --format json --allow-untracked docs/drafts/` |
+| `docs/releases/2.0.0-rc.1/release-notes.md` | GitHub release copy source | Must be refreshed with final live release/package/plugin URLs before publication |
+| `docs/releases/2.0.0-rc.1/quickstart.md` | Clone-to-first-workflow path | Covers clone, install, verify, first skill, and harness switch |
+| `docs/releases/2.0.0-rc.1/launch-checklist.md` | Operator launch checklist | Must remain approval-gated for release, package, plugin, and announcement actions |
+| `docs/releases/2.0.0-rc.1/publication-readiness.md` | Release gate | Requires fresh evidence from the exact release commit |
+| `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` | Current May 15 queue, roadmap, security, and AgentShield evidence | Must be superseded by a final clean-checkout evidence file before real publication |
+| `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` | Naming, slug, and publication-path decision record | Keeps `Everything Claude Code / ECC`, npm `ecc-universal`, and plugin slug `ecc` for rc.1 |
+| `docs/releases/2.0.0-rc.1/x-thread.md` | X launch draft | Must replace placeholders with live URLs after release/package/plugin publication |
+| `docs/releases/2.0.0-rc.1/linkedin-post.md` | LinkedIn launch draft | Must replace placeholders with live URLs after release/package/plugin publication |
+| `docs/releases/2.0.0-rc.1/article-outline.md` | Longform launch outline | Must stay release-candidate framed until GA evidence exists |
+| `docs/releases/2.0.0-rc.1/telegram-handoff.md` | Internal/shareable handoff copy | Must not include private workspace or credential details |
+| `docs/releases/2.0.0-rc.1/demo-prompts.md` | Demo prompts and proof-of-work prompts | Must keep private Hermes workflows abstracted into public examples |
+
+## Hermes Skill Boundary
+
+The preview pack includes one public Hermes-specialized skill:
+
+- `skills/hermes-imports/SKILL.md`
+
+That is intentional for rc.1. The skill is a sanitization and conversion
+workflow, not a dump of private Hermes automations. Additional Hermes-generated
+skills should enter ECC only after they pass the same rules:
+
+- no raw workspace exports;
+- no live account names, client data, finance data, CRM data, health data, or
+  private contact graph;
+- provider requirements described by capability, not by secret value;
+- repo-relative examples instead of local absolute paths;
+- tests or docs proving the workflow is useful without private state.
+
+## Reference-Inspired Adapter Direction
+
+The preview pack uses outside systems as design pressure, not as copy targets:
+
+| Reference pressure | ECC preview-pack interpretation |
+| --- | --- |
+| Claude Code | Native plugin, skills, commands, hooks, MCP conventions, and statusline-oriented workflows |
+| Codex | Instruction-backed plugin metadata, shared skills, MCP reference config, and explicit hook-parity caveats |
+| OpenCode | Adapter-backed package/plugin surface with shared hook logic at the edge |
+| Zed-adjacent tools | Instruction-backed portability until a verified native adapter exists |
+| dmux | Session/runtime orchestration signals and handoff exports, not a replacement for repo validation |
+| Orca, Superset, Ghast | Reference-only pressure for worktree lifecycle, session grouping, notifications, and workspace presets |
+| Hermes Agent, meta-harness, autocontext-style systems | Evaluation, memory, and context-routing pressure routed through public artifacts, verifier outputs, and the evaluator/RAG prototype |
+
+## Final Verification Commands
+
+Run these from the exact release commit before publication:
+
+```bash
+git status --short --branch
+node scripts/platform-audit.js --format json --allow-untracked docs/drafts/
+npm run harness:adapters -- --check
+npm run harness:audit -- --format json
+npm run observability:ready
+npm run security:ioc-scan
+npm audit --audit-level=high
+npm audit signatures
+node tests/docs/ecc2-release-surface.test.js
+node tests/run-all.js
+cd ecc2 && cargo test
+```
+
+## Publication Blockers
+
+The preview pack is assembled, but publication is still blocked until these live
+surfaces exist and are recorded in a final evidence file:
+
+- GitHub prerelease `v2.0.0-rc.1`;
+- npm `ecc-universal@2.0.0-rc.1` on the `next` dist-tag;
+- Claude plugin tag / marketplace propagation for `ecc@ecc`;
+- Codex plugin publication or owner-approved manual submission path;
+- final announcement URLs in X, LinkedIn, GitHub release, and longform copy;
+- ECC Tools billing/product readiness evidence before any native-payments
+  announcement copy is published.
+
+## Result
+
+The rc.1 preview pack is ready for a final clean-checkout release gate, but not
+for public publication without the approval-gated release, package, plugin, and
+announcement steps above.

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
@@ -7,9 +7,9 @@ npm publication, plugin tag, marketplace submission, or announcement post.
 
 | Field | Evidence |
 | --- | --- |
-| Upstream main base | `f04702bdac132662c8496e817bcd850c86e2b854` |
-| Evidence branch | `docs/ecc2-rc1-may15-readiness` |
-| Evidence scope | Current `main` after PR #1921 supply-chain IOC expansion |
+| Upstream main base | `acbc152375c215b4fe2a20abb29dfb733727c4cb` |
+| Evidence branch | `docs/ecc2-rc1-preview-pack-refresh` |
+| Evidence scope | Current `main` after PR #1921, #1924, #1925, #1926, and AgentShield #83 follow-up |
 | Git remote | `https://github.com/affaan-m/everything-claude-code.git` |
 | Local status caveat | Working tree had the unrelated untracked `docs/drafts/` directory before this docs refresh |
 
@@ -25,7 +25,7 @@ final release commit with a clean checkout before publishing.
 | JARVIS PRs/issues | `gh pr list` and `gh issue list` for `affaan-m/JARVIS` | 0 open PRs, 0 open issues |
 | ECC Tools PRs/issues | `env -u GITHUB_TOKEN gh pr list` and `env -u GITHUB_TOKEN gh issue list` for `ECC-Tools/ECC-Tools` | 0 open PRs, 0 open issues |
 | ECC website PRs/issues | `env -u GITHUB_TOKEN gh pr list` and `env -u GITHUB_TOKEN gh issue list` for `ECC-Tools/ECC-website` | 0 open PRs, 0 open issues |
-| Trunk discussions | GraphQL discussion count for `affaan-m/everything-claude-code` | 57 total discussions; 0 without maintainer touch after May 15 maintainer comments |
+| Trunk discussions | GraphQL discussion count and maintainer-touch sweep | 58 total discussions; 0 without maintainer touch after May 15 maintainer comments |
 | Other repo discussions | GraphQL discussion count for AgentShield, JARVIS, ECC Tools, and ECC website | Discussions disabled or 0 total |
 
 The ECC Tools organization is reachable with the configured GitHub host
@@ -64,13 +64,16 @@ Project documents added in Linear:
 | Surface | Evidence |
 | --- | --- |
 | PR #1921 | Merged supply-chain IOC expansion for Mini Shai-Hulud/TanStack follow-up |
-| Node IPC follow-up | Added May 14 `node-ipc` malicious-version, hash, DNS, and runtime IOC coverage |
-| Merge commit | `f04702bdac132662c8496e817bcd850c86e2b854` |
+| Node IPC follow-up / PR #1924 | Added May 14 `node-ipc` malicious-version, hash, DNS, and runtime IOC coverage |
+| PR #1926 | Added `platform:audit` and `security-ioc-scan` command surfaces plus release workflow IOC gates |
+| AgentShield PR #83 | Merged Mini Shai-Hulud IOC coverage for TanStack, Mistral, OpenSearch, Guardrails, UiPath, Squawk, Claude Code / VS Code persistence, and dead-man switch artifacts |
+| Trunk merge commits | `f04702bdac132662c8496e817bcd850c86e2b854`, `ee85e1482e3d6322ddb2706392ea0fc97469bd26`, `13585f1092c92fa3f20ffe0d756e40c5720b0de5` |
+| AgentShield merge commit | `f899b27ba3fa60ec7e0dca41cc2dadcb1a1fb75d` |
 | Local IOC tests | `node tests/ci/scan-supply-chain-iocs.test.js` passed 12/12 |
 | Unicode safety | `node scripts/ci/check-unicode-safety.js` passed |
 | IOC scan | `npm run security:ioc-scan` passed |
 | Root suite | `npm test` passed 2427/2427, 0 failed |
-| Repo sweeps | IOC scanner sweep passed for trunk, AgentShield, ECC Tools, ECC website, JARVIS, and the ECC document mirror |
+| Repo sweeps | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` passed with 1238 files inspected; targeted persistence path checks found no active `gh-token-monitor`, `pgsql-monitor`, `transformers.pyz`, or `pgmonitor.py` artifacts |
 
 The May 15 IOC expansion added coverage for OpenSearch/Mistral/Guardrails/
 UiPath/Squawk-style campaign variants, `opensearch_init.js`, `vite_setup.mjs`,
@@ -80,6 +83,28 @@ The May 15 node-ipc follow-up blocks `node-ipc@9.1.6`, `9.2.3`, `10.1.1`,
 `10.1.2`, `11.0.0`, `11.1.0`, and `12.0.1`, plus the `node-ipc.cjs` payload
 hash, malicious tarball hashes, DNS exfil domains, and runtime markers reported
 by Socket.
+AgentShield PR #83 adds the matching scanner-side enterprise coverage:
+version-pinned package detections, `.claude` / `.vscode` automation-surface
+discovery, `gh-token-monitor` LaunchAgent/systemd/local-bin artifact detection,
+network/payload IOCs, built action/CLI bundles, 1758/1758 local tests, and
+green GitHub Actions verification before merge.
+
+## Preview Pack State
+
+`preview-pack-manifest.md` now assembles the rc.1 preview-pack boundary:
+
+- release notes, quickstart, launch checklist, publication readiness, naming
+  matrix, and May 15 evidence;
+- `docs/HERMES-SETUP.md` and `skills/hermes-imports/SKILL.md` as the public
+  Hermes-specialized surface;
+- cross-harness, harness-adapter, observability, and progress-sync docs;
+- X, LinkedIn, article, Telegram, and demo collateral that must receive final
+  live URLs after release/package/plugin publication;
+- explicit blockers for GitHub release, npm `next` publish, Claude plugin,
+  Codex plugin, ECC Tools billing/product-readiness, and announcements.
+
+The preview pack is assembled for final clean-checkout gating, but it is still
+not a publication action.
 
 ## Current Publication Blockers
 

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -6,6 +6,8 @@ URLs from the exact commit being released.
 
 For the current rc.1 naming decision and package/plugin publication path, see
 [`naming-and-publication-matrix.md`](naming-and-publication-matrix.md).
+For the assembled rc.1 preview pack boundary, see
+[`preview-pack-manifest.md`](preview-pack-manifest.md).
 For the May 12 dry-run evidence pass, see
 [`publication-evidence-2026-05-12.md`](publication-evidence-2026-05-12.md).
 For the May 13 release-readiness evidence refresh, see
@@ -64,7 +66,7 @@ Record the exact commit SHA and command output before any publication action:
 | Release surface | `node tests/docs/ecc2-release-surface.test.js` | 0 failures | `publication-evidence-2026-05-13.md`: 18/18 passed |
 | Optional Rust surface | `cd ecc2 && cargo test` | 0 failures or explicit deferral | `publication-evidence-2026-05-13.md`: 462/462 passed, warnings only |
 | Queue baseline | `gh pr list` / `gh issue list` across trunk, AgentShield, JARVIS, ECC Tools, and ECC website | Under 20 open PRs and under 20 open issues | `publication-evidence-2026-05-15.md`: 0 open PRs and 0 open issues across checked repos |
-| Discussion baseline | GraphQL discussion count and maintainer-touch sweep | No unmanaged active discussion queue | `publication-evidence-2026-05-15.md`: 57 trunk discussions, 0 without maintainer touch; other tracked repos disabled or 0 |
+| Discussion baseline | GraphQL discussion count and maintainer-touch sweep | No unmanaged active discussion queue | `publication-evidence-2026-05-15.md`: 58 trunk discussions, 0 without maintainer touch; other tracked repos disabled or 0 |
 | Linear roadmap | Linear project and issue readback | Detailed roadmap exists with release, security, AgentShield, ECC Tools, legacy, and observability lanes | `publication-evidence-2026-05-15.md`: project and 16 issue lanes recorded |
 
 ## Do Not Publish If

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -50,6 +50,7 @@ const expectedReleaseFiles = [
   'telegram-handoff.md',
   'demo-prompts.md',
   'quickstart.md',
+  'preview-pack-manifest.md',
   'publication-readiness.md',
 ];
 
@@ -144,6 +145,34 @@ test('release notes route new contributors through the rc.1 quickstart', () => {
   assert.ok(releaseNotes.includes('[rc.1 quickstart](quickstart.md)'));
 });
 
+test('preview pack manifest assembles release, Hermes, and publication gates', () => {
+  const manifest = read('docs/releases/2.0.0-rc.1/preview-pack-manifest.md');
+
+  for (const artifact of [
+    'docs/HERMES-SETUP.md',
+    'skills/hermes-imports/SKILL.md',
+    'docs/architecture/harness-adapter-compliance.md',
+    'docs/releases/2.0.0-rc.1/publication-readiness.md',
+    'docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md',
+  ]) {
+    assert.ok(manifest.includes(artifact), `preview pack manifest missing ${artifact}`);
+  }
+
+  for (const blocker of [
+    'GitHub prerelease `v2.0.0-rc.1`',
+    'npm `ecc-universal@2.0.0-rc.1`',
+    'Claude plugin tag',
+    'Codex plugin publication',
+    'ECC Tools billing/product readiness',
+  ]) {
+    assert.ok(manifest.includes(blocker), `preview pack manifest missing blocker ${blocker}`);
+  }
+
+  assert.ok(manifest.includes('no raw workspace exports'));
+  assert.ok(manifest.includes('Final Verification Commands'));
+  assert.ok(manifest.includes('Reference-Inspired Adapter Direction'));
+});
+
 test('rc.1 quickstart gives a clone-to-cross-harness path', () => {
   const quickstart = read('docs/releases/2.0.0-rc.1/quickstart.md');
   for (const heading of ['Clone', 'Install', 'Verify', 'First Skill', 'Switch Harness']) {
@@ -215,6 +244,9 @@ test('publication readiness checklist gates public release actions on evidence',
 
   assert.ok(source.includes('publication-evidence-2026-05-15.md'));
   assert.ok(may15Evidence.includes('PR #1921'));
+  assert.ok(may15Evidence.includes('AgentShield PR #83'));
+  assert.ok(may15Evidence.includes('| Trunk discussions | GraphQL discussion count and maintainer-touch sweep | 58 total discussions;'));
+  assert.ok(source.includes('58 trunk discussions, 0 without maintainer touch'));
   assert.ok(may15Evidence.includes('env -u GITHUB_TOKEN'));
   assert.ok(may15Evidence.includes('ITO-44'));
   assert.ok(may15Evidence.includes('0 open PRs, 0 open issues'));


### PR DESCRIPTION
## Summary
- add a concrete `2.0.0-rc.1` preview-pack manifest that maps the release, Hermes, adapter, observability, publication, and announcement artifacts into one gate
- refresh the May 15 publication evidence after #1924, #1925, #1926, and AgentShield #83
- link the manifest from publication readiness and launch checklist
- extend the release-surface regression test so the preview-pack manifest stays present and approval-gated

## Validation
- node tests/docs/ecc2-release-surface.test.js
- npx --no-install markdownlint-cli docs/releases/2.0.0-rc.1/preview-pack-manifest.md docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md docs/releases/2.0.0-rc.1/publication-readiness.md docs/releases/2.0.0-rc.1/launch-checklist.md
- npm run observability:ready
- npm run harness:adapters -- --check
- node scripts/platform-audit.js --format json --allow-untracked docs/drafts/
- git diff --check

## Notes
- This is not a release/tag/npm/plugin/announcement action. It only assembles and refreshes the rc.1 preview-pack evidence gate.
- Existing untracked `docs/drafts/` remains unrelated and is intentionally ignored by the platform audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a concrete `2.0.0-rc.1` preview-pack manifest to gate release, adapters, observability, and announcements. Refreshes the May 15 publication evidence and tightens tests to enforce the pack boundary and updated blockers.

- **New Features**
  - Added `docs/releases/2.0.0-rc.1/preview-pack-manifest.md` with pack contents, final verification commands, Hermes boundary, reference-inspired adapter direction, and publication blockers.
  - Refreshed `publication-evidence-2026-05-15.md` to include PRs #1921, #1924, #1925, #1926 and AgentShield #83; recorded the 58-discussion baseline, repo sweep results, and a new “Preview Pack State” section.
  - Linked the manifest from `publication-readiness.md`; added a launch checklist step to verify the manifest before final publish checks.
  - Extended `tests/docs/ecc2-release-surface.test.js` to require the manifest, assert key artifacts and blockers, and verify evidence includes AgentShield #83 and the 58-discussion baseline.

<sup>Written for commit d236d1ae53fed4338c9a743f2da1ee5c6f70ae50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a preview pack manifest and updated release checklist and publication-readiness docs for 2.0.0-rc.1, detailing required artifacts, observability/compliance checks, and publication blockers.
  * Refreshed publication evidence to reflect current source baseline, supply-chain checks, and AgentShield findings.

* **Tests**
  * Expanded release-surface tests to require the preview pack manifest and validate documentation, evidence rows, and publication-gate criteria for rc.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1927)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->