### PR TITLE
docs: gate rc1 announcement live claims

### DIFF
--- a/docs/business/social-launch-copy.md
+++ b/docs/business/social-launch-copy.md
@@ -5,7 +5,7 @@ Use these templates as launch-ready starting points. Review channel tone before 
 ## X Post: Release Announcement
 
 ```text
-ECC v2.0.0-rc.1 is live.
+ECC v2.0.0-rc.1 preview pack is ready for final release review.
 
 The repo is moving from a Claude Code config pack into a cross-harness operating system for agentic work.
 
@@ -55,7 +55,7 @@ ECC v2.0.0-rc.1 pushes that further: reusable skills, thin harness adapters, and
 ## LinkedIn Post: Partner-Friendly Summary
 
 ```text
-ECC v2.0.0-rc.1 is live.
+ECC v2.0.0-rc.1 preview pack is ready for final release review.
 
 The practical shift: ECC is no longer just a Claude Code config pack. It is becoming a cross-harness operating system for agentic work.
 

--- a/docs/releases/2.0.0-rc.1/linkedin-post.md
+++ b/docs/releases/2.0.0-rc.1/linkedin-post.md
@@ -1,6 +1,6 @@
 # LinkedIn Draft - ECC v2.0.0-rc.1
 
-ECC v2.0.0-rc.1 is live as the first release-candidate pass at the 2.0 direction.
+ECC v2.0.0-rc.1 is ready for final release review as the first release-candidate pass at the 2.0 direction.
 
 The practical shift is simple: ECC is no longer framed as only a Claude Code plugin or config bundle.
 

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -106,6 +106,10 @@ test('business launch copy stays aligned with the rc.1 public surface', () => {
   const source = read('docs/business/social-launch-copy.md');
   assert.ok(source.includes('ECC v2.0.0-rc.1'), 'business launch copy should use the rc.1 release');
   assert.ok(
+    source.includes('preview pack is ready for final release review'),
+    'business launch copy should stay pre-publication until release URLs exist'
+  );
+  assert.ok(
     source.includes('https://github.com/affaan-m/everything-claude-code'),
     'business launch copy should include the public repo URL'
   );
@@ -117,6 +121,21 @@ test('business launch copy stays aligned with the rc.1 public surface', () => {
   );
   assert.ok(!source.includes('<repo-link>'), 'business launch copy should not contain repo placeholders');
   assert.ok(!source.includes('v1.8.0'), 'business launch copy should not stay pinned to v1.8.0');
+});
+
+test('announcement drafts avoid live-release claims before publication', () => {
+  const announcementFiles = [
+    'docs/releases/2.0.0-rc.1/linkedin-post.md',
+    'docs/business/social-launch-copy.md',
+  ];
+
+  for (const relativePath of announcementFiles) {
+    const source = read(relativePath);
+    assert.ok(
+      !/ECC v2\.0\.0-rc\.1 is live\./.test(source),
+      `${relativePath} must not claim rc.1 is live before the release gate completes`
+    );
+  }
 });
 
 test('Hermes setup uses release-candidate wording for the rc.1 surface', () => {


### PR DESCRIPTION
## Summary
- replace pre-publication “rc.1 is live” phrasing in LinkedIn and business launch copy
- keep launch drafts framed as ready for final release review until live release/package/plugin URLs exist
- add a release-surface regression test to block premature live-release claims

## Validation
- node tests/docs/ecc2-release-surface.test.js
- npx --no-install markdownlint-cli docs/releases/2.0.0-rc.1/linkedin-post.md docs/business/social-launch-copy.md
- rg -n "ECC v2\.0\.0-rc\.1 is live\.|TODO|TBD|<repo-link>|/Users/|/\.hermes/" docs/releases/2.0.0-rc.1/linkedin-post.md docs/business/social-launch-copy.md tests/docs/ecc2-release-surface.test.js || true
- git diff --check

No release, tag, npm publish, plugin submission, or announcement action is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates rc.1 announcement wording to avoid premature “is live” claims and keeps posts in pre-publication state until release URLs exist. Adds a regression test to enforce this; no release or publish actions are included.

- **Bug Fixes**
  - Updated docs in LinkedIn and business copy to say “preview pack is ready for final release review.”
  - Extended tests/docs/ecc2-release-surface.test.js to fail on “ECC v2.0.0-rc.1 is live.” and to verify rc.1 wording and public repo URL.

<sup>Written for commit 2f1e77a688fb446d7299e0280f3da6341030559f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release announcement messaging to reflect ECC v2.0.0-rc.1 as a preview release candidate ready for final review.

* **Tests**
  * Added validation to ensure pre-publication messaging is correct and live-release claims are not present before publication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1928)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->