### PR TITLE
ci: restore dependency caches without saving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,10 @@ jobs:
         shell: bash
         run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
-      - name: Cache npm
+      - name: Restore npm cache
         if: matrix.pm == 'npm'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.node }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -93,10 +93,10 @@ jobs:
           COREPACK_ENABLE_STRICT: '0'
         run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Cache pnpm
+      - name: Restore pnpm cache
         if: matrix.pm == 'pnpm'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.node }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -115,20 +115,20 @@ jobs:
             echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
           fi
 
-      - name: Cache yarn
+      - name: Restore yarn cache
         if: matrix.pm == 'yarn'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node }}-yarn-
 
-      - name: Cache bun
+      - name: Restore bun cache
         if: matrix.pm == 'bun'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -65,10 +65,10 @@ jobs:
         shell: bash
         run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
-      - name: Cache npm
+      - name: Restore npm cache
         if: inputs.package-manager == 'npm'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ inputs.node-version }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -83,10 +83,10 @@ jobs:
           COREPACK_ENABLE_STRICT: '0'
         run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Cache pnpm
+      - name: Restore pnpm cache
         if: inputs.package-manager == 'pnpm'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -105,20 +105,20 @@ jobs:
             echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
           fi
 
-      - name: Cache yarn
+      - name: Restore yarn cache
         if: inputs.package-manager == 'yarn'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ inputs.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ inputs.node-version }}-yarn-
 
-      - name: Cache bun
+      - name: Restore bun cache
         if: inputs.package-manager == 'bun'
         continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}


### PR DESCRIPTION
## Summary
- Switch CI and reusable test workflow dependency cache steps from restore+save to restore-only actions/cache/restore.
- Keep release workflows cache-free while preserving pinned actions and existing supply-chain gates.

## Validation
- node tests/ci/validate-workflow-security.test.js
- node scripts/ci/validate-workflow-security.js
- npm run security:ioc-scan
- node tests/scripts/release-publish.test.js
- node tests/ci/scan-supply-chain-iocs.test.js
- npm audit signatures
- npm audit --audit-level=high
- node tests/run-all.js
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI dependency caching to restore-only using `actions/cache/restore` for npm/pnpm/yarn/bun to prevent cache writes from PR runs and reduce supply-chain risk. Release workflows remain cache-free with pinned actions.

- **Refactors**
  - Replaced `actions/cache` with `actions/cache/restore` in `.github/workflows/ci.yml` and `.github/workflows/reusable-test.yml`.
  - Kept cache keys/paths the same; only restore is performed.
  - Preserved pinned action SHAs and existing supply-chain gates.

<sup>Written for commit 976e4e9e59e8612fee4d549993b9d82970190919. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1934?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow caching strategy to use restore-only phase for npm, pnpm, yarn, and bun, improving build pipeline efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1934)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->