### PR TITLE
[codex] stabilize ecc2 cwd-mutating tests

### DIFF
--- a/ecc2/src/main.rs
+++ b/ecc2/src/main.rs
@@ -6,6 +6,45 @@ mod session;
 mod tui;
 mod worktree;
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    use anyhow::{Context, Result};
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    static CURRENT_DIR_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    pub(crate) struct CurrentDirGuard {
+        _lock: MutexGuard<'static, ()>,
+        original_dir: PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        pub(crate) fn enter(target_dir: &Path) -> Result<Self> {
+            let lock = CURRENT_DIR_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .expect("current-dir test lock poisoned");
+            let original_dir =
+                std::env::current_dir().context("Failed to capture current test directory")?;
+            std::env::set_current_dir(target_dir).with_context(|| {
+                format!("Failed to enter test directory {}", target_dir.display())
+            })?;
+
+            Ok(Self {
+                _lock: lock,
+                original_dir,
+            })
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original_dir);
+        }
+    }
+}
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
@@ -10828,14 +10867,7 @@ mod tests {
 
         let tempdb = TestDir::new("legacy-schedule-import-live-db")?;
         let db = StateStore::open(&tempdb.path().join("state.db"))?;
-        struct CurrentDirGuard(PathBuf);
-        impl Drop for CurrentDirGuard {
-            fn drop(&mut self) {
-                let _ = std::env::set_current_dir(&self.0);
-            }
-        }
-        let _cwd_guard = CurrentDirGuard(std::env::current_dir()?);
-        std::env::set_current_dir(&target_repo)?;
+        let _cwd_guard = crate::test_support::CurrentDirGuard::enter(&target_repo)?;
         let report = import_legacy_schedules(&db, &config::Config::default(), root, false)?;
 
         assert!(!report.dry_run);
@@ -11038,14 +11070,7 @@ Route existing installs to portal first before checkout.
 
         let tempdb = TestDir::new("legacy-remote-import-live-db")?;
         let db = StateStore::open(&tempdb.path().join("state.db"))?;
-        struct CurrentDirGuard(PathBuf);
-        impl Drop for CurrentDirGuard {
-            fn drop(&mut self) {
-                let _ = std::env::set_current_dir(&self.0);
-            }
-        }
-        let _cwd_guard = CurrentDirGuard(std::env::current_dir()?);
-        std::env::set_current_dir(&target_repo)?;
+        let _cwd_guard = crate::test_support::CurrentDirGuard::enter(&target_repo)?;
 
         let report = import_legacy_remote_dispatch(&db, &Config::default(), root, false)?;
 

--- a/ecc2/src/tui/dashboard.rs
+++ b/ecc2/src/tui/dashboard.rs
@@ -12923,8 +12923,7 @@ diff --git a/src/lib.rs b/src/lib.rs
         let repo_root = tempdir.join("repo");
         init_git_repo(&repo_root)?;
 
-        let original_dir = std::env::current_dir()?;
-        std::env::set_current_dir(&repo_root)?;
+        let cwd_guard = crate::test_support::CurrentDirGuard::enter(&repo_root)?;
 
         let mut cfg = build_config(&tempdir);
         cfg.orchestration_templates = BTreeMap::from([(
@@ -13000,7 +12999,7 @@ diff --git a/src/lib.rs b/src/lib.rs
             ])
         );
 
-        std::env::set_current_dir(original_dir)?;
+        drop(cwd_guard);
         let _ = std::fs::remove_dir_all(&tempdir);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add a test-only `CurrentDirGuard` that serializes process-wide current-directory changes
- reuse the guard in legacy import tests and the TUI orchestration-template spawn test
- preserve unrelated `docs/drafts/` worktree state outside the PR

## Why
Several Rust tests mutate the process current directory while the test harness runs tests concurrently. That can make cwd-sensitive tests interfere with one another. The guard keeps those mutations serialized and restores the original cwd on drop.

## Validation
- `cargo test` in `ecc2` (462 passed, 0 failed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky tests that change the working directory by adding a test-only `CurrentDirGuard` that serializes cwd changes and restores the original dir on drop. Replaced ad‑hoc cwd handling in legacy import and TUI orchestration-template tests to prevent cross-test interference.

- **Bug Fixes**
  - Add `#[cfg(test)]` `CurrentDirGuard` with a global mutex to serialize cwd mutations.
  - Use the guard in legacy schedule/remote import tests and the TUI orchestration-template spawn test.

<sup>Written for commit 79bb6119ee99a9ca597b0c2d0d7ad2efc25e4298. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1935?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for directory management, enhancing test reliability and isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1935)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->