### PR TITLE
[codex] refresh rc1 publication evidence

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -23,7 +23,7 @@ As of 2026-05-15:
   `env -u GITHUB_TOKEN` in this shell so the configured GitHub host credential
   is used instead of the incompatible environment token.
 - GitHub discussions are current across those tracked repos:
-  `affaan-m/everything-claude-code` has 57 total discussions and 0 without
+  `affaan-m/everything-claude-code` has 58 total discussions and 0 without
   maintainer touch after May 15 maintainer updates on #73 and #1239; AgentShield,
   JARVIS, ECC Tools, and the ECC Tools website have discussions disabled or 0
   total discussions.
@@ -32,8 +32,10 @@ As of 2026-05-15:
   and Publication, AgentShield Enterprise Iteration, ECC Tools Next-Level
   Platform, and Legacy Audit and Salvage.
 - `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` records the
-  queue, discussion, Linear roadmap, ECC Tools access, and PR #1921
-  Mini Shai-Hulud/TanStack follow-up evidence refresh.
+  queue, discussion, Linear roadmap, ECC Tools access, Mini Shai-Hulud/TanStack
+  full-campaign follow-up, restore-only CI cache hardening, AgentShield #85
+  registry-signature verification, ECC-Tools #75 billing-gate tightening, and
+  PR #1935 `ecc2` current-dir test stabilization evidence refresh.
 - `npm run harness:audit -- --format json` reports 70/70 on current `main`.
 - `npm run observability:ready` reports 21/21 readiness on current `main`,
   including the GitHub/Linear/handoff/roadmap progress-sync contract.

--- a/docs/releases/2.0.0-rc.1/preview-pack-manifest.md
+++ b/docs/releases/2.0.0-rc.1/preview-pack-manifest.md
@@ -20,7 +20,7 @@ surfaces, or posting announcements.
 | `docs/releases/2.0.0-rc.1/quickstart.md` | Clone-to-first-workflow path | Covers clone, install, verify, first skill, and harness switch |
 | `docs/releases/2.0.0-rc.1/launch-checklist.md` | Operator launch checklist | Must remain approval-gated for release, package, plugin, and announcement actions |
 | `docs/releases/2.0.0-rc.1/publication-readiness.md` | Release gate | Requires fresh evidence from the exact release commit |
-| `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` | Current May 15 queue, roadmap, security, and AgentShield evidence | Must be superseded by a final clean-checkout evidence file before real publication |
+| `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` | Current May 15 queue, roadmap, security, AgentShield, ECC Tools billing-gate, CI cache, and `ecc2` test evidence through PR #1935 | Must be superseded by a final clean-checkout evidence file before real publication |
 | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` | Naming, slug, and publication-path decision record | Keeps `Everything Claude Code / ECC`, npm `ecc-universal`, and plugin slug `ecc` for rc.1 |
 | `docs/releases/2.0.0-rc.1/x-thread.md` | X launch draft | Must replace placeholders with live URLs after release/package/plugin publication |
 | `docs/releases/2.0.0-rc.1/linkedin-post.md` | LinkedIn launch draft | Must replace placeholders with live URLs after release/package/plugin publication |
@@ -70,7 +70,7 @@ npm run harness:adapters -- --check
 npm run harness:audit -- --format json
 npm run observability:ready
 npm run security:ioc-scan
-npm audit --audit-level=high
+npm audit --audit-level=moderate
 npm audit signatures
 node tests/docs/ecc2-release-surface.test.js
 node tests/run-all.js

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
@@ -7,9 +7,9 @@ npm publication, plugin tag, marketplace submission, or announcement post.
 
 | Field | Evidence |
 | --- | --- |
-| Upstream main base | `acbc152375c215b4fe2a20abb29dfb733727c4cb` |
-| Evidence branch | `docs/ecc2-rc1-preview-pack-refresh` |
-| Evidence scope | Current `main` after PR #1921, #1924, #1925, #1926, AgentShield #83/#84 follow-ups, and ECC-Tools #74 billing verifier follow-up |
+| Upstream main base | `6b8a49a6eed11cc7df19d8b1f2add085b37cf466` |
+| Evidence branch | `codex/rc1-current-publication-evidence` |
+| Evidence scope | Current `main` after PR #1932, #1933, #1934, and #1935; AgentShield #85; and ECC-Tools #75 |
 | Git remote | `https://github.com/affaan-m/everything-claude-code.git` |
 | Local status caveat | Working tree had the unrelated untracked `docs/drafts/` directory before this docs refresh |
 
@@ -27,6 +27,7 @@ final release commit with a clean checkout before publishing.
 | ECC website PRs/issues | `env -u GITHUB_TOKEN gh pr list` and `env -u GITHUB_TOKEN gh issue list` for `ECC-Tools/ECC-website` | 0 open PRs, 0 open issues |
 | Trunk discussions | GraphQL discussion count and maintainer-touch sweep | 58 total discussions; 0 without maintainer touch after May 15 maintainer comments |
 | Other repo discussions | GraphQL discussion count for AgentShield, JARVIS, ECC Tools, and ECC website | Discussions disabled or 0 total |
+| Platform audit | `node scripts/platform-audit.js --json --allow-untracked docs/drafts/` | Ready; open PRs 0/20, open issues 0/20, discussions needing maintainer touch 0, conflicting open PRs 0, blocking dirty files 0 |
 
 The ECC Tools organization is reachable with the configured GitHub host
 credential. In this shell, the exported `GITHUB_TOKEN` overrides that credential
@@ -66,15 +67,24 @@ Project documents added in Linear:
 | PR #1921 | Merged supply-chain IOC expansion for Mini Shai-Hulud/TanStack follow-up |
 | Node IPC follow-up / PR #1924 | Added May 14 `node-ipc` malicious-version, hash, DNS, and runtime IOC coverage |
 | PR #1926 | Added `platform:audit` and `security-ioc-scan` command surfaces plus release workflow IOC gates |
+| PR #1932 | Added `scripts/platform-audit.js` JSON/Markdown/file-output modes so queue, discussion, roadmap, and release evidence can be captured as a durable artifact instead of terminal-only output |
+| PR #1933 | Expanded home-scan IOC coverage to Claude `settings.local.json`, `.claude/hooks/hooks.json`, and user-level VS Code / Code Insiders `tasks.json` across macOS, Linux, and Windows |
+| PR #1934 | Switched ordinary CI dependency caches to restore-only `actions/cache/restore` usage so test jobs do not save mutable dependency state back into shared caches |
+| PR #1935 | Stabilized `ecc2` current-directory-mutating tests with a test-only serialized current-dir guard, preserving the Rust release-surface gate under parallel test execution |
 | AgentShield PR #83 | Merged Mini Shai-Hulud IOC coverage for TanStack, Mistral, OpenSearch, Guardrails, UiPath, Squawk, Claude Code / VS Code persistence, and dead-man switch artifacts |
 | AgentShield PR #84 | Merged the broader Mini Shai-Hulud full-campaign affected-package table, including additional `@cap-js`, `@draftlab`, `@tallyui`, `intercom-client`, `lightning`, and related package/version IOCs |
-| Trunk merge commits | `f04702bdac132662c8496e817bcd850c86e2b854`, `ee85e1482e3d6322ddb2706392ea0fc97469bd26`, `13585f1092c92fa3f20ffe0d756e40c5720b0de5` |
-| AgentShield merge commits | `f899b27ba3fa60ec7e0dca41cc2dadcb1a1fb75d`, `d1aa5313afd915d0b7296e57aabaeb979b1ea93b` |
-| Local IOC tests | `node tests/ci/scan-supply-chain-iocs.test.js` passed 12/12 |
+| AgentShield PR #85 | Added GitHub Action supply-chain verification, gating, and evidence packs so AgentShield's enterprise scanner release path has a verified registry-signature surface |
+| ECC-Tools PR #75 | Tightened the native GitHub payments announcement gate so public billing claims remain blocked until live Marketplace-managed test-account readback is ready |
+| Trunk merge commits | `f04702bdac132662c8496e817bcd850c86e2b854`, `ee85e1482e3d6322ddb2706392ea0fc97469bd26`, `13585f1092c92fa3f20ffe0d756e40c5720b0de5`, `553d507ea63bc252e815a924c0d2baea961351a1`, `c0bac4d6ced7f78a5464c6e3fd8cfbb43515a9d5`, `c2c54e7c0b84a213848b9ab3dfeb3ae16fb9844d`, `6b8a49a6eed11cc7df19d8b1f2add085b37cf466` |
+| AgentShield merge commits | `f899b27ba3fa60ec7e0dca41cc2dadcb1a1fb75d`, `d1aa5313afd915d0b7296e57aabaeb979b1ea93b`, `908d8f3a52a6a65b21e737339b56906603eb1345` |
+| ECC-Tools merge commits | `6d00d67043e92cadc80f160bfe947115bfef33b1` |
+| Local IOC tests | `node tests/ci/scan-supply-chain-iocs.test.js` passed 15/15 |
 | Unicode safety | `node scripts/ci/check-unicode-safety.js` passed |
-| IOC scan | `npm run security:ioc-scan` passed |
-| Root suite | `npm test` passed 2427/2427, 0 failed |
-| Repo sweeps | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` passed with 1238 files inspected; targeted persistence path checks found no active `gh-token-monitor`, `pgsql-monitor`, `transformers.pyz`, or `pgmonitor.py` artifacts |
+| IOC scan | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` passed with 1241 files inspected |
+| npm registry verification | `npm audit signatures` verified 241 registry signatures and 30 attestations; `npm audit --audit-level=moderate` found 0 vulnerabilities |
+| Rust release-surface gate | `cd ecc2 && cargo test` passed 462/462 with the existing 14 dead-code/unused warnings |
+| Root suite | `node tests/run-all.js` passed 2442/2442, 0 failed |
+| Repo sweeps | Targeted persistence path checks found no active `gh-token-monitor`, `pgsql-monitor`, `transformers.pyz`, or `pgmonitor.py` artifacts |
 
 The May 15 IOC expansion added coverage for OpenSearch/Mistral/Guardrails/
 UiPath/Squawk-style campaign variants, `opensearch_init.js`, `vite_setup.mjs`,
@@ -94,6 +104,13 @@ the extra affected npm package scopes and unscoped packages reported in the
 current Wiz table, rebuilding `dist/action.js` and `dist/index.js`, and passing
 1758/1758 local tests plus the full AgentShield GitHub Actions matrix before
 merge.
+AgentShield PR #85 and trunk PR #1934 extend the response from IOC detection
+into release-path hardening: AgentShield now records registry-signature evidence
+for its action surface, while trunk CI restore-only dependency caches avoid
+writing ordinary test dependency state back into shared caches.
+PR #1933 closes the practical workstation persistence gap for the documented
+Claude Code and VS Code automation paths, including user-level config files that
+survive package uninstall.
 
 ## Preview Pack State
 

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -14,8 +14,9 @@ For the May 13 release-readiness evidence refresh, see
 [`publication-evidence-2026-05-13.md`](publication-evidence-2026-05-13.md).
 For the May 13 post-hardening evidence refresh after PR #1850 and PR #1851, see
 [`publication-evidence-2026-05-13-post-hardening.md`](publication-evidence-2026-05-13-post-hardening.md).
-For the May 15 queue, discussion, Linear roadmap, and Mini Shai-Hulud/TanStack
-follow-up evidence refresh after PR #1921, see
+For the May 15 queue, discussion, Linear roadmap, Mini Shai-Hulud/TanStack
+follow-up, restore-only cache, AgentShield release-verification, billing-gate,
+and `ecc2` current-dir guard evidence refresh through PR #1935, see
 [`publication-evidence-2026-05-15.md`](publication-evidence-2026-05-15.md).
 
 ## Release Identity Matrix
@@ -60,13 +61,13 @@ Record the exact commit SHA and command output before any publication action:
 | Adapter scorecard | `npm run harness:adapters -- --check` | PASS | `publication-evidence-2026-05-13.md`: PASS, 11 adapters |
 | Observability readiness | `npm run observability:ready` | 21/21 passing | `publication-evidence-2026-05-13-post-hardening.md`: 21/21, ready true after release-safety gate refresh |
 | Release safety gate | `npm run observability:ready -- --format json` | Release Safety category passing with publication readiness, supply-chain, workflow security, package surface, and release-surface evidence | `publication-evidence-2026-05-13-post-hardening.md`: Release Safety 3/3 |
-| Supply-chain verification | `npm audit --json`; `npm audit signatures`; `cd ecc2 && cargo audit -q`; Dependabot alerts; GitGuardian Security Checks | 0 vulnerabilities/alerts, registry signatures verified, GitGuardian clean | `publication-evidence-2026-05-13-post-hardening.md`: npm, cargo, Dependabot, TanStack/Mini Shai-Hulud, and GitGuardian evidence |
-| Root suite | `node tests/run-all.js` | 0 failures | `publication-evidence-2026-05-13-post-hardening.md`: 2381 passed, 0 failed |
+| Supply-chain verification | `npm audit --json`; `npm audit signatures`; `cd ecc2 && cargo audit -q`; Dependabot alerts; GitGuardian Security Checks | 0 vulnerabilities/alerts, registry signatures verified, GitGuardian clean | `publication-evidence-2026-05-15.md`: npm registry signatures and attestations verified, 0 moderate-or-higher npm vulnerabilities, Mini Shai-Hulud/TanStack IOC scan clean |
+| Root suite | `node tests/run-all.js` | 0 failures | `publication-evidence-2026-05-15.md`: 2442 passed, 0 failed |
 | Markdown lint | `npx markdownlint-cli '**/*.md' --ignore node_modules` | 0 failures | `publication-evidence-2026-05-13.md`: passed after zh-CN CLAUDE list-marker normalization |
 | Package surface | `node tests/scripts/npm-publish-surface.test.js` | 0 failures; no Python bytecode in npm tarball | `2/2` passed in May 12 evidence pass |
 | Release surface | `node tests/docs/ecc2-release-surface.test.js` | 0 failures | `publication-evidence-2026-05-13.md`: 18/18 passed |
-| Optional Rust surface | `cd ecc2 && cargo test` | 0 failures or explicit deferral | `publication-evidence-2026-05-13.md`: 462/462 passed, warnings only |
-| Queue baseline | `gh pr list` / `gh issue list` across trunk, AgentShield, JARVIS, ECC Tools, and ECC website | Under 20 open PRs and under 20 open issues | `publication-evidence-2026-05-15.md`: 0 open PRs and 0 open issues across checked repos |
+| Optional Rust surface | `cd ecc2 && cargo test` | 0 failures or explicit deferral | `publication-evidence-2026-05-15.md`: 462/462 passed, existing warnings only after PR #1935 current-dir guard |
+| Queue baseline | `gh pr list` / `gh issue list` across trunk, AgentShield, JARVIS, ECC Tools, and ECC website | Under 20 open PRs and under 20 open issues | `publication-evidence-2026-05-15.md`: platform audit ready, 0 open PRs and 0 open issues across checked repos |
 | Discussion baseline | GraphQL discussion count and maintainer-touch sweep | No unmanaged active discussion queue | `publication-evidence-2026-05-15.md`: 58 trunk discussions, 0 without maintainer touch; other tracked repos disabled or 0 |
 | Linear roadmap | Linear project and issue readback | Detailed roadmap exists with release, security, AgentShield, ECC Tools, legacy, and observability lanes | `publication-evidence-2026-05-15.md`: project and 16 issue lanes recorded |
 

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -264,8 +264,18 @@ test('publication readiness checklist gates public release actions on evidence',
 
   assert.ok(source.includes('publication-evidence-2026-05-15.md'));
   assert.ok(may15Evidence.includes('PR #1921'));
+  assert.ok(may15Evidence.includes('PR #1933'));
+  assert.ok(may15Evidence.includes('PR #1934'));
+  assert.ok(may15Evidence.includes('PR #1935'));
   assert.ok(may15Evidence.includes('AgentShield PR #83'));
+  assert.ok(may15Evidence.includes('AgentShield PR #85'));
   assert.ok(may15Evidence.includes('ECC Tools PR #73'));
+  assert.ok(may15Evidence.includes('ECC-Tools PR #75'));
+  assert.ok(may15Evidence.includes('| Platform audit |'));
+  assert.ok(may15Evidence.includes('Ready; open PRs 0/20'));
+  assert.ok(may15Evidence.includes('passed 15/15'));
+  assert.ok(may15Evidence.includes('restore-only'));
+  assert.ok(may15Evidence.includes('462/462'));
   assert.ok(may15Evidence.includes('## Codex Marketplace Evidence'));
   assert.ok(may15Evidence.includes('codex plugin marketplace add <local-checkout>'));
   assert.ok(may15Evidence.includes('Plugin Directory publishing is still blocked'));


### PR DESCRIPTION
## Summary
- refresh the May 15 rc.1 publication evidence against current main through PR #1935
- record platform audit, IOC scan, npm signature/audit, and ecc2 cargo evidence
- update release readiness, preview-pack manifest, roadmap mirror, and release-surface test coverage

## Validation
- node tests/ci/scan-supply-chain-iocs.test.js
- node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home
- npm audit signatures && npm audit --audit-level=moderate
- cd ecc2 && cargo test
- node tests/run-all.js
- node tests/docs/ecc2-release-surface.test.js
- npx --no-install markdownlint-cli docs/ECC-2.0-GA-ROADMAP.md docs/releases/2.0.0-rc.1/*.md
- git diff --check HEAD~1..HEAD
- node scripts/platform-audit.js --json --allow-untracked docs/drafts/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes 2.0.0-rc.1 May 15 publication evidence to match current main. Adds platform audit, expanded IOC scan results, `npm` signature/audit verification, and `ecc2` cargo test evidence; updates readiness docs, preview-pack manifest, roadmap mirror, and extends the release-surface test to gate the new evidence.

- **Release Evidence**
  - Updates evidence with platform audit readiness, IOC scan results, `npm audit signatures` and clean `npm audit --audit-level=moderate`, plus `ecc2` cargo and root suite results.
  - Aligns docs: preview-pack manifest (moderate audit level), roadmap discussion count, and release-readiness matrix.
  - Notes CI hardening (restore-only `actions/cache/restore` for dependency caches) and adds test assertions for platform audit, cache policy, and `ecc2` results.

<sup>Written for commit 215de14f5818283826feb8757f7f577c864e4af3. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1936?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v2.0.0-RC1 release readiness and publication evidence documentation with refreshed test outcomes and supply-chain verification details
  * Adjusted npm audit verification configuration for release validation commands

* **Tests**
  * Updated release readiness test assertions to reflect current evidence and verification status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1936)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->