### PR TITLE
[codex] add operator readiness dashboard gate

### DIFF
--- a/docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md
+++ b/docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md
@@ -1,0 +1,112 @@
+# ECC Operator Readiness Dashboard - 2026-05-15
+
+This dashboard is an operator snapshot, not a release approval. Use it to decide
+the next ECC 2.0 work batch and to keep Linear, GitHub, and repo evidence in
+sync. Before publishing, repeat the checks from the final release commit in a
+clean checkout.
+
+## Current Status
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| PR queue | Current | 0 open PRs across checked repos |
+| Issue queue | Current | 0 open issues across checked repos |
+| Discussions | Current | 58 main-repo discussions; 0 need maintainer touch |
+| Local worktree | Current with caveat | `main...origin/main`; unrelated `?? docs/drafts/` ignored |
+| Security sweep | Current with follow-up | IOC scan, audits, and package-manager hardening completed |
+| Linear roadmap | Current with follow-up | `ECC Platform Roadmap`, ITO-44 through ITO-59 |
+| ECC 2.0 publication | Not complete | Release, npm, plugin, and announcement gates pending |
+| AgentShield enterprise depth | In progress | AgentShield #86 merged; live IOC loop still pending |
+| ECC Tools next-level app | In progress | Billing announcement gate merged; live readback pending |
+| Legacy audit and salvage | Not complete | ITO-55 remains open |
+
+## Live Command Evidence
+
+Run these from `everything-claude-code` unless a row says otherwise.
+
+| Evidence | Command | 2026-05-15 result |
+| --- | --- | --- |
+| Platform audit | `node scripts/platform-audit.js --json --allow-untracked docs/drafts/` | `ready: true`; open PRs 0/20; open issues 0/20; discussions needing maintainer touch 0; blocking dirty files 0 |
+| Main repo status | `git status --short --branch` | `## main...origin/main`; `?? docs/drafts/` remains unrelated |
+| Main commit | `git rev-parse HEAD` | `c0f8c3bc813360f29e9f2b66bcae7e977cd03327` |
+| Main repo PRs/issues | GitHub connector and `gh` readback | 0 open PRs; 0 open issues |
+| AgentShield PRs/issues | GitHub connector and `gh` readback | 0 open PRs; 0 open issues |
+| ECC Tools PRs/issues | Local `gh pr list` and `gh issue list` | 0 open PRs; 0 open issues |
+| Discussion baseline | GraphQL discussion sweep | Main repo #1923 marked answered; no answerable Q&A missing an answer |
+| Supply-chain IOC scan | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` | Passed; 1241 files inspected |
+| IOC unit tests | `node tests/ci/scan-supply-chain-iocs.test.js` | 15/15 passed |
+| Dead-man switch persistence sweep | Process, LaunchAgent, and known payload filename sweep for Mini Shai-Hulud markers | No matches |
+| Workflow security gate | `node scripts/ci/validate-workflow-security.js` | Passed; 7 workflow files inspected |
+| npm signatures and audit | `npm audit signatures && npm audit --audit-level=moderate` in main, AgentShield, ECC Tools | 0 vulnerabilities in each checked package |
+
+## Prompt-To-Artifact Checklist
+
+| Objective requirement | Artifact or evidence | Status | Gap |
+| --- | --- | --- | --- |
+| Keep PRs under 20 | `scripts/platform-audit.js`; live GitHub readback | Current | Repeat before release |
+| Keep issues under 20 | `scripts/platform-audit.js`; live GitHub readback | Current | Repeat before release |
+| Respond and manage discussions | Discussion GraphQL sweep; #1923 answer marked | Current | Automate repeatable queue scanner |
+| ECC 2.0 preview pack ready | `preview-pack-manifest.md`; `publication-readiness.md` | In progress | Final publish evidence still pending |
+| Include Hermes specialized skills | `docs/HERMES-SETUP.md`; `skills/hermes-imports/SKILL.md` | In progress | Final preview-pack smoke still pending |
+| Name-change and availability path | `naming-and-publication-matrix.md`; ITO-46 | In progress | Final name/package/channel choice not approved |
+| Claude plugin publication path | `.claude-plugin/`; `publication-readiness.md`; ITO-46 | In progress | Actual publication still pending |
+| Codex plugin publication path | `.codex-plugin/`; repo marketplace evidence; ITO-46 | In progress | Official directory path still pending |
+| Release notes and push notifications | `release-notes.md`; `x-thread.md`; `linkedin-post.md`; ITO-47/56 | In progress | Live URLs and publish approval missing |
+| AgentShield enterprise iteration | AgentShield PRs #83-#86; ITO-48/49 | In progress | Live IOC update loop and cross-harness depth pending |
+| ECC Tools native payments announcement | ECC-Tools #75; ITO-50 | In progress | Live Marketplace test-account readback pending |
+| ECC Tools AI-native harness-agnostic roadmap | ITO-51/52/53/54 | In progress | Implementation and hosted deep-analysis proof pending |
+| Linear roadmap extremely detailed | Linear `ECC Platform Roadmap`; ITO-44 through ITO-59 | Current | Keep status comments synchronized |
+| Legacy work audited, pruned, or attached | `docs/legacy-artifact-inventory.md`; ITO-55 | In progress | Final salvage/prune pass pending |
+| Realtime progress tracking with Linear | ITO-54; Linear progress comments | In progress | Productized sync/observability plane pending |
+| ECC 2.0 observability | `docs/architecture/observability-readiness.md`; ITO-54 | In progress | Runtime/dashboard implementation pending |
+
+## Linear Operating State
+
+Project:
+<https://linear.app/itomarkets/project/ecc-platform-roadmap-52b328ee03e1>
+
+Active issue state after this pass:
+
+| Issue | Lane | State |
+| --- | --- | --- |
+| ITO-44 | Completion audit and readiness dashboard | In Progress |
+| ITO-57 | Supply-chain intelligence and local protection loop | In Progress |
+| ITO-59 | Discussions and public response queue | In Progress |
+
+Still-open lanes:
+
+- ITO-45: ECC 2.0 preview pack, Hermes skills, packaging, and cross-harness
+  readiness.
+- ITO-46: name availability, Claude plugin, Codex plugin, and package channels.
+- ITO-47: release notes, articles, and social copy since last release.
+- ITO-48 and ITO-49: AgentShield enterprise iteration and live supply-chain
+  intelligence.
+- ITO-50 through ITO-54: ECC Tools payments, deep analysis, setup
+  recommendations, queue automation, Linear sync, and observability.
+- ITO-55: legacy audit, prune, attach, or salvage.
+- ITO-56: final publication gate, release notes, and push notifications.
+- ITO-58: ECC Tools GitHub access blocker.
+
+## Decisions From This Pass
+
+- The checked GitHub queues are below the explicit target, so the next work
+  should not spend more time closing nonexistent PRs/issues.
+- The discussion queue is current, but repeatability is weak. ITO-59 remains
+  open until the sweep is scripted or documented as an operator command.
+- The Mini Shai-Hulud/TanStack protection pass is strong enough for current
+  local protection, but ITO-57 remains open until incident response and IOC
+  updates become a durable workflow.
+- The release is still blocked by publication, package, plugin, billing, and
+  announcement gates. Passing `platform:audit` alone is not proof that ECC 2.0
+  is publishable.
+
+## Next Work Order
+
+1. Build the ITO-44 completion dashboard into a repeatable command or generated
+   markdown artifact.
+2. Productize the ITO-59 discussion queue sweep so the maintainer-touch and
+   accepted-answer checks do not depend on manual GraphQL.
+3. Continue ITO-57 by turning emergency hardening into documented incident
+   response and scanner update workflow.
+4. Resume release/publication lanes ITO-45, ITO-46, and ITO-56 only after the
+   readiness dashboard can be refreshed from commands.

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -19,6 +19,9 @@ follow-up, restore-only cache, AgentShield release-verification, billing-gate,
 AgentShield #86 evidence-pack provenance, and `ecc2` current-dir guard evidence
 refresh through PR #1936, see
 [`publication-evidence-2026-05-15.md`](publication-evidence-2026-05-15.md).
+For the operator-facing prompt-to-artifact readiness dashboard from the same
+May 15 pass, see
+[`operator-readiness-dashboard-2026-05-15.md`](operator-readiness-dashboard-2026-05-15.md).
 
 ## Release Identity Matrix
 
@@ -71,6 +74,7 @@ Record the exact commit SHA and command output before any publication action:
 | Queue baseline | `gh pr list` / `gh issue list` across trunk, AgentShield, JARVIS, ECC Tools, and ECC website | Under 20 open PRs and under 20 open issues | `publication-evidence-2026-05-15.md`: platform audit ready, 0 open PRs and 0 open issues across checked repos |
 | Discussion baseline | GraphQL discussion count and maintainer-touch sweep | No unmanaged active discussion queue | `publication-evidence-2026-05-15.md`: 58 trunk discussions, 0 without maintainer touch; other tracked repos disabled or 0 |
 | Linear roadmap | Linear project and issue readback | Detailed roadmap exists with release, security, AgentShield, ECC Tools, legacy, and observability lanes | `publication-evidence-2026-05-15.md`: project and 16 issue lanes recorded |
+| Operator readiness dashboard | `node scripts/platform-audit.js --json --allow-untracked docs/drafts/` plus prompt-to-artifact audit | Current queue state mapped to macro-goal deliverables and incomplete gaps | `operator-readiness-dashboard-2026-05-15.md`: live status, command evidence, Linear state, and next work order |
 
 ## Do Not Publish If
 

--- a/scripts/platform-audit.js
+++ b/scripts/platform-audit.js
@@ -477,6 +477,7 @@ function buildLocalEvidenceChecks(rootDir) {
   const progressSync = readText(rootDir, 'docs/architecture/progress-sync-contract.md');
   const supplyChain = readText(rootDir, 'docs/security/supply-chain-incident-response.md');
   const evidence = readText(rootDir, 'docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md');
+  const operatorDashboard = readText(rootDir, 'docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md');
 
   return [
     buildCheck(
@@ -508,6 +509,12 @@ function buildLocalEvidenceChecks(rootDir) {
       includesAll(evidence, ['TanStack', 'Mini Shai-Hulud', 'Node IPC follow-up', 'node-ipc', 'IOC scan']) ? 'pass' : 'fail',
       'rc.1 evidence includes current supply-chain verification artifacts',
       { path: 'docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md' }
+    ),
+    buildCheck(
+      'operator-readiness-dashboard',
+      includesAll(operatorDashboard, ['Prompt-To-Artifact Checklist', 'ITO-44', 'ITO-59', 'PR queue', 'Not complete']) ? 'pass' : 'fail',
+      'operator dashboard maps macro-goal requirements to current evidence and open gaps',
+      { path: 'docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md' }
     ),
   ];
 }

--- a/tests/scripts/platform-audit.test.js
+++ b/tests/scripts/platform-audit.test.js
@@ -60,6 +60,13 @@ function seedRepo(rootDir, overrides = {}) {
       'Node IPC follow-up',
       'node-ipc',
       'IOC scan'
+    ].join('\n'),
+    'docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md': [
+      'Prompt-To-Artifact Checklist',
+      'ITO-44',
+      'ITO-59',
+      'PR queue',
+      'Not complete'
     ].join('\n')
   };
 
@@ -188,6 +195,7 @@ function runTests() {
       assert.strictEqual(parsed.github.skipped, true);
       assert.ok(parsed.checks.some(check => check.id === 'roadmap-linear-mirror' && check.status === 'pass'));
       assert.ok(parsed.checks.some(check => check.id === 'supply-chain-runbook' && check.status === 'pass'));
+      assert.ok(parsed.checks.some(check => check.id === 'operator-readiness-dashboard' && check.status === 'pass'));
       assert.deepStrictEqual(parsed.top_actions, []);
     } finally {
       cleanup(projectRoot);


### PR DESCRIPTION
## Summary
- add an rc.1 operator readiness dashboard mapping the macro-goal to live evidence and open gaps
- wire the platform audit local-evidence gate to require the dashboard
- link the dashboard from publication readiness

## Validation
- node tests/scripts/platform-audit.test.js
- node scripts/platform-audit.js --json --allow-untracked docs/drafts/
- npx --no-install markdownlint-cli docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md docs/releases/2.0.0-rc.1/publication-readiness.md
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator readiness dashboard for rc.1 and makes `platform:audit` require it, so release work maps to live evidence and open gaps. Links the dashboard from publication readiness and covers it with tests. Supports Linear ITO-44, with signals tied to ITO-59.

- **New Features**
  - Added `docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md` with status, live command evidence, Linear state, and next steps.
  - Added an `operator-readiness-dashboard` local-evidence check in `scripts/platform-audit.js` that validates key content (`Prompt-To-Artifact Checklist`, `ITO-44`, `ITO-59`, `PR queue`, “Not complete”).
  - Updated `publication-readiness.md` to link the dashboard and include a matrix row.
  - Expanded `tests/scripts/platform-audit.test.js` to seed and assert the new gate.

<sup>Written for commit 77d63fe98f4a829a0c1c6bf05a1134bbfa278d23. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1938?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an operator readiness dashboard detailing queue/status summaries, evidence outputs, checklist mapping to release objectives, Linear operating state, and next work priorities for the 2.0.0-rc.1 pass.
  * Updated publication-readiness guidance to reference the new dashboard as required evidence.

* **Chores**
  * Extended platform audit verification and test fixtures to validate presence and pass status of the operator readiness dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1938)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->