### PR TITLE
[codex] Refresh release evidence after CI hardening

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -33,9 +33,10 @@ As of 2026-05-15:
   Platform, and Legacy Audit and Salvage.
 - `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` records the
   queue, discussion, Linear roadmap, ECC Tools access, Mini Shai-Hulud/TanStack
-  full-campaign follow-up, restore-only CI cache hardening, AgentShield #85
+  full-campaign follow-up, scheduled supply-chain watch coverage, no-lifecycle
+  CI install hardening, GitHub Actions cache purge, AgentShield #85
   registry-signature verification, AgentShield #86 evidence-pack CI provenance,
-  ECC-Tools #75 billing-gate tightening, and PR #1936 release-evidence refresh.
+  ECC-Tools #75 billing-gate tightening, and PR #1941 release-evidence refresh.
 - `npm run harness:audit -- --format json` reports 70/70 on current `main`.
 - `npm run observability:ready` reports 21/21 readiness on current `main`,
   including the GitHub/Linear/handoff/roadmap progress-sync contract.
@@ -46,6 +47,12 @@ As of 2026-05-15:
   `docs/security/supply-chain-incident-response.md`, plus a workflow-security
   validator rule blocking `pull_request_target` workflows from restoring or
   saving shared dependency caches.
+- PR #1940 merged as `6951b8d5d29d13cac6b89b461104ad03838553de` and added a
+  scheduled supply-chain watch workflow that emits a durable IOC report.
+- PR #1941 merged as `f7035b5644ffc857879b71c39353b2141f17c3f0` and hardened
+  CI dependency installs against lifecycle-hook compromise by disabling package
+  manager lifecycle scripts, removing Actions dependency cache use, and adding
+  validator coverage so those patterns cannot be reintroduced silently.
 - PR #1850 merged as `248673271455e9dc85b8add2a6ab76107b718639` and removed
   shell access from read-only analyzer agents and zh-CN copies, reducing
   AgentShield high findings on that surface without changing operator agents.

--- a/docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md
+++ b/docs/releases/2.0.0-rc.1/operator-readiness-dashboard-2026-05-15.md
@@ -29,17 +29,17 @@ Run these from `everything-claude-code` unless a row says otherwise.
 | Platform audit | `node scripts/platform-audit.js --json --allow-untracked docs/drafts/` | `ready: true`; open PRs 0/20; open issues 0/20; discussions needing maintainer touch 0; answerable discussions missing accepted answers 0; blocking dirty files 0 |
 | Discussion audit | `node scripts/discussion-audit.js --json --repo affaan-m/everything-claude-code` | `ready: true`; 58 discussions sampled; 0 need maintainer touch; 0 answerable discussions missing accepted answers |
 | Main repo status | `git status --short --branch` | `## main...origin/main`; `?? docs/drafts/` remains unrelated |
-| Main commit | `git rev-parse HEAD` | `6887f2952d193cff10b3eb79af7765555d8ca9f5` |
+| Main commit | `git rev-parse HEAD` | `f7035b5644ffc857879b71c39353b2141f17c3f0` |
 | Main repo PRs/issues | GitHub connector and `gh` readback | 0 open PRs; 0 open issues |
 | AgentShield PRs/issues | GitHub connector and `gh` readback | 0 open PRs; 0 open issues |
 | ECC Tools PRs/issues | Local `gh pr list` and `gh issue list` | 0 open PRs; 0 open issues |
 | Discussion baseline | GraphQL discussion sweep | Main repo #1923 marked answered; no answerable Q&A missing an answer |
-| Supply-chain IOC scan | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` | Passed; repo/home targeted scan inspected 200 files after clean no-script reinstall |
+| Supply-chain IOC scan | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` | Passed; repo/home targeted scan inspected 229 files after clean no-script reinstall |
 | IOC unit tests | `node tests/ci/scan-supply-chain-iocs.test.js` | 15/15 passed |
 | Dead-man switch persistence sweep | Process, LaunchAgent, and known payload filename sweep for Mini Shai-Hulud markers | No matches |
 | Workflow security gate | `node scripts/ci/validate-workflow-security.js` | Passed; 8 workflow files inspected; package-manager test installs disable lifecycle scripts and no Actions cache use remains |
 | Supply-chain watch workflow | `.github/workflows/supply-chain-watch.yml` | Scheduled every 6 hours; emits `supply-chain-ioc-report.json` |
-| npm signatures and audit | `npm audit signatures && npm audit --audit-level=high` in main | 213 verified signatures, 17 verified attestations, 0 high vulnerabilities |
+| npm signatures and audit | `npm audit signatures && npm audit --audit-level=high` in main | 241 verified signatures, 30 verified attestations, 0 high vulnerabilities |
 
 ## Prompt-To-Artifact Checklist
 

--- a/docs/releases/2.0.0-rc.1/preview-pack-manifest.md
+++ b/docs/releases/2.0.0-rc.1/preview-pack-manifest.md
@@ -20,7 +20,7 @@ surfaces, or posting announcements.
 | `docs/releases/2.0.0-rc.1/quickstart.md` | Clone-to-first-workflow path | Covers clone, install, verify, first skill, and harness switch |
 | `docs/releases/2.0.0-rc.1/launch-checklist.md` | Operator launch checklist | Must remain approval-gated for release, package, plugin, and announcement actions |
 | `docs/releases/2.0.0-rc.1/publication-readiness.md` | Release gate | Requires fresh evidence from the exact release commit |
-| `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` | Current May 15 queue, roadmap, security, AgentShield #86 evidence-pack provenance, ECC Tools billing-gate, CI cache, and `ecc2` test evidence through PR #1936 | Must be superseded by a final clean-checkout evidence file before real publication |
+| `docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md` | Current May 15 queue, roadmap, security, supply-chain watch, no-lifecycle CI install hardening, AgentShield #86 evidence-pack provenance, ECC Tools billing-gate, Actions cache purge, and `ecc2` test evidence through PR #1941 | Must be superseded by a final clean-checkout evidence file before real publication |
 | `docs/releases/2.0.0-rc.1/naming-and-publication-matrix.md` | Naming, slug, and publication-path decision record | Keeps `Everything Claude Code / ECC`, npm `ecc-universal`, and plugin slug `ecc` for rc.1 |
 | `docs/releases/2.0.0-rc.1/x-thread.md` | X launch draft | Must replace placeholders with live URLs after release/package/plugin publication |
 | `docs/releases/2.0.0-rc.1/linkedin-post.md` | LinkedIn launch draft | Must replace placeholders with live URLs after release/package/plugin publication |

--- a/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
+++ b/docs/releases/2.0.0-rc.1/publication-evidence-2026-05-15.md
@@ -71,18 +71,21 @@ Project documents added in Linear:
 | PR #1933 | Expanded home-scan IOC coverage to Claude `settings.local.json`, `.claude/hooks/hooks.json`, and user-level VS Code / Code Insiders `tasks.json` across macOS, Linux, and Windows |
 | PR #1934 | Switched ordinary CI dependency caches to restore-only `actions/cache/restore` usage so test jobs do not save mutable dependency state back into shared caches |
 | PR #1935 | Stabilized `ecc2` current-directory-mutating tests with a test-only serialized current-dir guard, preserving the Rust release-surface gate under parallel test execution |
+| PR #1940 | Added `.github/workflows/supply-chain-watch.yml`, scheduled every 6 hours, so the TanStack/Mini Shai-Hulud/node-ipc IOC scan and npm signature/audit checks produce a durable `supply-chain-ioc-report.json` artifact |
+| PR #1941 | Removed GitHub Actions dependency cache use from CI test workflows, disabled package-manager lifecycle scripts for npm/pnpm/Yarn/Bun installs, purged existing Actions caches, and added validator tests that reject unsafe install/cache patterns |
 | AgentShield PR #83 | Merged Mini Shai-Hulud IOC coverage for TanStack, Mistral, OpenSearch, Guardrails, UiPath, Squawk, Claude Code / VS Code persistence, and dead-man switch artifacts |
 | AgentShield PR #84 | Merged the broader Mini Shai-Hulud full-campaign affected-package table, including additional `@cap-js`, `@draftlab`, `@tallyui`, `intercom-client`, `lightning`, and related package/version IOCs |
 | AgentShield PR #85 | Added GitHub Action supply-chain verification, gating, and evidence packs so AgentShield's enterprise scanner release path has a verified registry-signature surface |
 | AgentShield PR #86 | Added `ci-context.json` to AgentShield evidence packs with whitelisted GitHub Actions workflow, commit, run, and runtime provenance while keeping arbitrary environment variables and tokens out of the bundle |
 | ECC-Tools PR #75 | Tightened the native GitHub payments announcement gate so public billing claims remain blocked until live Marketplace-managed test-account readback is ready |
-| Trunk merge commits | `f04702bdac132662c8496e817bcd850c86e2b854`, `ee85e1482e3d6322ddb2706392ea0fc97469bd26`, `13585f1092c92fa3f20ffe0d756e40c5720b0de5`, `553d507ea63bc252e815a924c0d2baea961351a1`, `c0bac4d6ced7f78a5464c6e3fd8cfbb43515a9d5`, `c2c54e7c0b84a213848b9ab3dfeb3ae16fb9844d`, `6b8a49a6eed11cc7df19d8b1f2add085b37cf466`, `1949d75e18e59a37de269d88b188fc701f5cf122` |
+| Trunk merge commits | `f04702bdac132662c8496e817bcd850c86e2b854`, `ee85e1482e3d6322ddb2706392ea0fc97469bd26`, `13585f1092c92fa3f20ffe0d756e40c5720b0de5`, `553d507ea63bc252e815a924c0d2baea961351a1`, `c0bac4d6ced7f78a5464c6e3fd8cfbb43515a9d5`, `c2c54e7c0b84a213848b9ab3dfeb3ae16fb9844d`, `6b8a49a6eed11cc7df19d8b1f2add085b37cf466`, `1949d75e18e59a37de269d88b188fc701f5cf122`, `6951b8d5d29d13cac6b89b461104ad03838553de`, `f7035b5644ffc857879b71c39353b2141f17c3f0` |
 | AgentShield merge commits | `f899b27ba3fa60ec7e0dca41cc2dadcb1a1fb75d`, `d1aa5313afd915d0b7296e57aabaeb979b1ea93b`, `908d8f3a52a6a65b21e737339b56906603eb1345`, `69a5e25b675b77666d0c96abc22639a5ba883403` |
 | ECC-Tools merge commits | `6d00d67043e92cadc80f160bfe947115bfef33b1` |
 | Local IOC tests | `node tests/ci/scan-supply-chain-iocs.test.js` passed 15/15 |
 | Unicode safety | `node scripts/ci/check-unicode-safety.js` passed |
-| IOC scan | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` passed with 1241 files inspected |
-| npm registry verification | `npm audit signatures` verified 241 registry signatures and 30 attestations; `npm audit --audit-level=moderate` found 0 vulnerabilities |
+| IOC scan | `node scripts/ci/scan-supply-chain-iocs.js --root <ECC-workspace> --home` passed with 229 files inspected after the no-lifecycle install refresh |
+| npm registry verification | `npm audit signatures` verified 241 registry signatures and 30 attestations; `npm audit --audit-level=high` found 0 vulnerabilities |
+| Actions cache purge | `gh cache delete --all --succeed-on-no-caches` completed and `gh cache list --limit 20` returned no caches |
 | Rust release-surface gate | `cd ecc2 && cargo test` passed 462/462 with the existing 14 dead-code/unused warnings |
 | Root suite | `node tests/run-all.js` passed 2442/2442, 0 failed |
 | Repo sweeps | Targeted persistence path checks found no active `gh-token-monitor`, `pgsql-monitor`, `transformers.pyz`, or `pgmonitor.py` artifacts |
@@ -105,10 +108,12 @@ the extra affected npm package scopes and unscoped packages reported in the
 current Wiz table, rebuilding `dist/action.js` and `dist/index.js`, and passing
 1758/1758 local tests plus the full AgentShield GitHub Actions matrix before
 merge.
-AgentShield PR #85 and trunk PR #1934 extend the response from IOC detection
-into release-path hardening: AgentShield now records registry-signature evidence
-for its action surface, while trunk CI restore-only dependency caches avoid
-writing ordinary test dependency state back into shared caches.
+AgentShield PR #85 and trunk PRs #1934, #1940, and #1941 extend the response
+from IOC detection into release-path hardening: AgentShield now records
+registry-signature evidence for its action surface, trunk has a scheduled IOC
+watch workflow, and trunk CI no longer uses dependency caches or package-manager
+lifecycle scripts in the test install matrix during active supply-chain
+hardening.
 AgentShield PR #86 completes the next evidence-pack provenance slice:
 `agentshield scan --evidence-pack <dir>` now writes `ci-context.json`, includes
 that artifact in the signed bundle digest, documents it in the bundle README,

--- a/docs/releases/2.0.0-rc.1/publication-readiness.md
+++ b/docs/releases/2.0.0-rc.1/publication-readiness.md
@@ -15,9 +15,10 @@ For the May 13 release-readiness evidence refresh, see
 For the May 13 post-hardening evidence refresh after PR #1850 and PR #1851, see
 [`publication-evidence-2026-05-13-post-hardening.md`](publication-evidence-2026-05-13-post-hardening.md).
 For the May 15 queue, discussion, Linear roadmap, Mini Shai-Hulud/TanStack
-follow-up, restore-only cache, AgentShield release-verification, billing-gate,
+follow-up, scheduled supply-chain watch, no-lifecycle CI install hardening,
+GitHub Actions cache purge, AgentShield release-verification, billing-gate,
 AgentShield #86 evidence-pack provenance, and `ecc2` current-dir guard evidence
-refresh through PR #1936, see
+refresh through PR #1941, see
 [`publication-evidence-2026-05-15.md`](publication-evidence-2026-05-15.md).
 For the operator-facing prompt-to-artifact readiness dashboard from the same
 May 15 pass, see


### PR DESCRIPTION
## Summary
- refresh May 15 publication evidence for PRs #1940 and #1941
- record the stronger no-lifecycle CI install hardening, Actions cache purge, current main commit, and current audit/signature counts
- update the preview-pack manifest and publication-readiness pointer so the rc.1 pack references evidence through PR #1941

## Validation
- node tests/docs/ecc2-release-surface.test.js
- git diff --check
- rg -n "6887f295|213 verified|17 verified|restore-only cache|restore-only CI cache|through PR #1936|200 files inspected|1241 files inspected" docs/ECC-2.0-GA-ROADMAP.md docs/releases/2.0.0-rc.1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the May 15 release evidence and rc.1 docs after CI hardening. It documents the no‑lifecycle CI install policy, purges GitHub Actions dependency caches (no more `actions/cache`), adds scheduled supply‑chain watch coverage, updates dashboard metrics and `npm` signature/attestation counts, and points the preview pack and publication‑readiness to evidence through PR #1941.

<sup>Written for commit d23657f66f7df765adca226783c42d6aac603080. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1942?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ECC 2.0 GA Roadmap with refreshed security evidence timeline.
  * Updated publication readiness and operator readiness documentation with current metrics and evidence records.
  * Refreshed preview pack manifest and publication evidence for version 2.0.0-rc.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->