### PR TITLE
chore: update statusline ANSI color palette

### DIFF
--- a/scripts/hooks/ecc-statusline.js
+++ b/scripts/hooks/ecc-statusline.js
@@ -52,7 +52,7 @@ function buildContextBar(remaining) {
   if (used < 50) return ` \x1b[32m${bar} ${used}%\x1b[0m`;
   if (used < 65) return ` \x1b[33m${bar} ${used}%\x1b[0m`;
   if (used < 80) return ` \x1b[38;5;208m${bar} ${used}%\x1b[0m`;
-  return ` \x1b[5;31m${bar} ${used}%\x1b[0m`;
+  return ` \x1b[1;31m${bar} ${used}%\x1b[0m`;
 }
 
 /**
@@ -137,7 +137,7 @@ function runStatusline() {
           parts.push(dur);
         }
         if (parts.length > 0) {
-          metricsStr = `\x1b[36m${parts.join(' ')}\x1b[0m`;
+          metricsStr = `\x1b[38;5;117m${parts.join(' ')}\x1b[0m`;
         }
       }
 
@@ -149,7 +149,7 @@ function runStatusline() {
       const segments = [`\x1b[2m${model}\x1b[0m`];
 
       if (task) {
-        segments.push(`\x1b[1m${task}\x1b[0m`);
+        segments.push(`\x1b[1;97m${task}\x1b[0m`);
       }
       if (metricsStr) {
         segments.push(metricsStr);

--- a/tests/hooks/ecc-statusline.test.js
+++ b/tests/hooks/ecc-statusline.test.js
@@ -131,9 +131,9 @@ function runTests() {
   else failed++;
 
   if (
-    test('20% remaining contains red blink ANSI code', () => {
+    test('20% remaining contains bold red ANSI code', () => {
       const bar = buildContextBar(20);
-      assert.ok(bar.includes('\x1b[5;31m'), `Expected red blink ANSI in: ${JSON.stringify(bar)}`);
+      assert.ok(bar.includes('\x1b[1;31m'), `Expected bold red ANSI in: ${JSON.stringify(bar)}`);
     })
   )
     passed++;


### PR DESCRIPTION
## Summary

- Replace blinking red (`\x1b[5;31m`) with bold red (`\x1b[1;31m`) for critical context bar — blink is jarring in daily use
- Replace cyan metrics (`\x1b[36m`) with sky blue (`\x1b[38;5;117m`) for a softer, more cohesive look
- Replace plain bold task text (`\x1b[1m`) with bold bright white (`\x1b[1;97m`) for better contrast against dim segments
- Update `tests/hooks/ecc-statusline.test.js` assertion to match new bold red code

## Test plan

- [x] `node tests/hooks/ecc-statusline.test.js` — 16/16 passing
- [x] `node tests/run-all.js` — full suite green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the statusline ANSI color palette to reduce visual noise and improve contrast. Blinking red is now bold red; metrics use a softer blue; task text is brighter for clarity.

- **Refactors**
  - Context bar: `\x1b[5;31m` → `\x1b[1;31m`
  - Metrics: `\x1b[36m` → `\x1b[38;5;117m`
  - Task label: `\x1b[1m` → `\x1b[1;97m`
  - Updated `tests/hooks/ecc-statusline.test.js` to expect bold red code

<sup>Written for commit 03f3c0834fbc369cd34477150f5183bd7509a567. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1944?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Enhanced status display visual styling throughout the interface:
  * Progress bar updated with bolder formatting for improved visibility when usage is below threshold
  * Metrics display color refined with enhanced contrast for better readability at a glance
  * Current task text formatting enhanced with brighter styling for increased prominence and visibility
  * Test coverage updated and verified to match new styling specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->