### PR TITLE
Fix supply-chain IOC package version matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Works across **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Gemini**, *
 
 ECC v2.0.0-rc.1 adds the public Hermes operator story on top of that reusable layer: start with the [Hermes setup guide](docs/HERMES-SETUP.md), then review the [rc.1 release notes](docs/releases/2.0.0-rc.1/release-notes.md) and [cross-harness architecture](docs/architecture/cross-harness.md).
 
-
 ---
 
 <table>

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -54,7 +54,7 @@ Thank you to everyone funding ECC's open-source work. Your sponsorship is what l
 
 [**Become a Sponsor →**](https://github.com/sponsors/affaan-m)
 
-For corporate sponsorship inquiries, custom partnerships, or PR integrations, email **affaan@ecc.tools** with your company name and intended tier. We'll move fast — most agreements close within 48 hours.
+For corporate sponsorship inquiries, custom partnerships, or PR integrations, email **[affaan@ecc.tools](mailto:affaan@ecc.tools)** with your company name and intended tier. We'll move fast — most agreements close within 48 hours.
 
 ---
 

--- a/scripts/ci/scan-supply-chain-iocs.js
+++ b/scripts/ci/scan-supply-chain-iocs.js
@@ -493,6 +493,65 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function versionSpecifierMatches(value, version) {
+  if (value === undefined || value === null) return false;
+  const specifier = String(value);
+  const versionPattern = new RegExp(`(^|[^0-9A-Za-z.])${escapeRegExp(version)}([^0-9A-Za-z.]|$)`, 'i');
+  return specifier === version || versionPattern.test(specifier);
+}
+
+function packageKeyMatches(key, packageName) {
+  return key === packageName
+    || key === `node_modules/${packageName}`
+    || key.endsWith(`/node_modules/${packageName}`);
+}
+
+function jsonReferencesPackageVersion(value, packageName, version) {
+  if (!value || typeof value !== 'object') return false;
+
+  if (value.name === packageName && versionSpecifierMatches(value.version, version)) {
+    return true;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (packageKeyMatches(key, packageName)) {
+      if (typeof child === 'string' && versionSpecifierMatches(child, version)) {
+        return true;
+      }
+      if (child && typeof child === 'object' && versionSpecifierMatches(child.version, version)) {
+        return true;
+      }
+    }
+
+    if (child && typeof child === 'object' && jsonReferencesPackageVersion(child, packageName, version)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function textReferencesPackageVersion(text, packageName, version) {
+  const escapedPackage = escapeRegExp(packageName);
+  const escapedVersion = escapeRegExp(version);
+  const packageToken = `${escapedPackage}(?![A-Za-z0-9._/-])`;
+  const sameLinePattern = new RegExp(`${packageToken}[^\\n]{0,200}${escapedVersion}(?![0-9A-Za-z.])`, 'i');
+  const requirementsPattern = new RegExp(`^\\s*${packageToken}\\s*(?:==|===|~=|>=|<=|>|<)\\s*${escapedVersion}(?![0-9A-Za-z.])`, 'im');
+  const poetryNamePattern = new RegExp(`name\\s*=\\s*["']${escapedPackage}["'][\\s\\S]{0,300}?version\\s*=\\s*["']${escapedVersion}["']`, 'i');
+
+  return sameLinePattern.test(text)
+    || requirementsPattern.test(text)
+    || poetryNamePattern.test(text);
+}
+
+function dependencyFileReferencesPackageVersion(text, packageName, version) {
+  try {
+    return jsonReferencesPackageVersion(JSON.parse(text), packageName, version);
+  } catch {
+    return textReferencesPackageVersion(text, packageName, version);
+  }
+}
+
 function addFinding(findings, severity, filePath, line, indicator, message) {
   findings.push({ severity, filePath, line, indicator, message });
 }
@@ -543,17 +602,14 @@ function scanFile(filePath, rootDir, findings) {
   if (!DEPENDENCY_FILENAMES.has(base)) return;
 
   for (const [packageName, versions] of Object.entries(MALICIOUS_PACKAGE_VERSIONS)) {
-    const packageIndex = lowerText.indexOf(normalizeForMatch(packageName));
-    if (packageIndex === -1) continue;
-
     for (const version of versions) {
-      const versionPattern = new RegExp(`(^|[^0-9a-z.])${escapeRegExp(version)}([^0-9a-z.]|$)`, 'i');
-      if (versionPattern.test(text) || lowerText.includes(`@${version}`)) {
+      if (dependencyFileReferencesPackageVersion(text, packageName, version)) {
+        const packageIndex = lowerText.indexOf(normalizeForMatch(packageName));
         addFinding(
           findings,
           'critical',
           relativePath,
-          lineForIndex(text, packageIndex),
+          lineForIndex(text, packageIndex === -1 ? 0 : packageIndex),
           `${packageName}@${version}`,
           'Dependency manifest or lockfile references a known compromised package version',
         );

--- a/scripts/platform-audit.js
+++ b/scripts/platform-audit.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const {

--- a/skills/recsys-pipeline-architect/SKILL.md
+++ b/skills/recsys-pipeline-architect/SKILL.md
@@ -8,7 +8,7 @@ origin: community
 
 A spec-and-scaffold skill for building composable recommendation, ranking, and feed pipelines. It encodes the **six-stage pattern** — Source → Hydrator → Filter → Scorer → Selector → SideEffect — popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm) (Apache 2.0). This skill is an independent reimplementation of the pattern (MIT) — no code copied from the original.
 
-Upstream: https://github.com/mturac/recsys-pipeline-architect
+Upstream: <https://github.com/mturac/recsys-pipeline-architect>
 
 ## When to Use
 
@@ -100,7 +100,7 @@ Default to isolation. Joint only when there's a specific reason (e.g., explicit 
 
 ## Upstream contents
 
-The upstream repository at https://github.com/mturac/recsys-pipeline-architect ships:
+The upstream repository at <https://github.com/mturac/recsys-pipeline-architect> ships:
 
 - Full `SKILL.md` with the complete 8-step workflow
 - 5 load-on-demand reference docs: interfaces in 4 languages (TS/Go/Python/Rust), multi-action scoring pattern, candidate isolation, filter cookbook (12 patterns), scorer cookbook (weighted sum, MMR, diversity penalty, position debiasing)

--- a/tests/ci/scan-supply-chain-iocs.test.js
+++ b/tests/ci/scan-supply-chain-iocs.test.js
@@ -154,6 +154,30 @@ function run() {
     });
   })) passed++; else failed++;
 
+  if (test('does not combine package-name substrings with unrelated versions', () => {
+    withFixture({
+      'package-lock.json': JSON.stringify({
+        packages: {
+          'node_modules/react-remove-scroll': {
+            version: '2.6.3',
+          },
+          'node_modules/@tailwindcss/node': {
+            version: '4.2.1',
+            dependencies: {
+              lightningcss: '1.31.1',
+            },
+          },
+          'node_modules/lightningcss': {
+            version: '1.31.1',
+          },
+        },
+      }, null, 2),
+    }, rootDir => {
+      const result = scanSupplyChainIocs({ rootDir });
+      assert.deepStrictEqual(result.findings, []);
+    });
+  })) passed++; else failed++;
+
   if (test('does not flag benign substrings in clean package scripts', () => {
     withFixture({
       'node_modules/uuid/package.json': JSON.stringify({


### PR DESCRIPTION
## Summary
- tighten supply-chain IOC dependency matching so package-name substrings do not combine with unrelated versions
- add regression coverage for lightningcss plus unrelated 2.6.3 lockfile entries
- preserve detection for TanStack, Mistral, OpenSearch, Squawk, UiPath, Guardrails, node-ipc, persistence, and dead-man-switch indicators

## Verification
- node tests/ci/scan-supply-chain-iocs.test.js
- node tests/ci/supply-chain-advisory-sources.test.js
- node tests/ci/supply-chain-watch-workflow.test.js
- node tests/scripts/npm-publish-surface.test.js
- npm test
- npm audit signatures
- node scripts/ci/scan-supply-chain-iocs.js --root /Users/affoon/GitHub --home --json
- node scripts/ci/scan-supply-chain-iocs.js --root /Users/affoon/Documents/GitHub --home --json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false positives in the supply-chain IOC scanner by requiring exact package+version matches in manifests and lockfiles, not mixing substrings with unrelated versions. Preserves existing indicators and also fixes minor lint issues in platform audit and docs.

- **Bug Fixes**
  - Parse JSON manifests/lockfiles; match on package keys (including nested node_modules paths) and version fields.
  - Improve text matching with strict token/semver boundaries; support common `requirements.txt` and Poetry patterns.
  - Add regression tests so `lightningcss` isn’t flagged by unrelated `2.6.3`, and to prevent substring+version combining.

<sup>Written for commit 8e5094a5638af5a704f0a4601bacf1ea2302c6cf. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1948?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced supply-chain scanner to detect compromised packages across JSON and plain-text manifests, with improved version matching to reduce false positives and better handling of nested/varied package references.
* **Tests**
  * Added coverage for edge cases to prevent incorrect matches in lockfile layouts.
* **Documentation**
  * Minor README and sponsor/contact formatting updates.
* **Chores**
  * Removed an unused import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->