### PR TITLE
Fix operator legacy salvage detection

### DIFF
--- a/scripts/operator-readiness-dashboard.js
+++ b/scripts/operator-readiness-dashboard.js
@@ -243,6 +243,14 @@ function includesAll(text, needles) {
   return needles.every(needle => text.includes(needle));
 }
 
+function hasLegacySalvageTracking({ stalePrSalvage, legacyInventory, roadmap }) {
+  return stalePrSalvage.includes('Manual review tail')
+    || stalePrSalvage.includes('Remaining Manual-Review Backlog')
+    || stalePrSalvage.includes('Translator/manual review')
+    || legacyInventory.includes('Translator/manual review')
+    || roadmap.includes('ITO-55');
+}
+
 function runCommand(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd,
@@ -286,6 +294,7 @@ function buildRequirements(rootDir, platformReport) {
   const progressSync = readText(rootDir, 'docs/architecture/progress-sync-contract.md');
   const observabilityReadiness = readText(rootDir, 'docs/architecture/observability-readiness.md');
   const stalePrSalvage = readText(rootDir, 'docs/stale-pr-salvage-ledger.md');
+  const legacyInventory = readText(rootDir, 'docs/legacy-artifact-inventory.md');
   const supplyChainRunbook = readText(rootDir, 'docs/security/supply-chain-incident-response.md');
   const supplyChainWorkflow = readText(rootDir, '.github/workflows/supply-chain-watch.yml');
   const packageJson = readPackage(rootDir);
@@ -412,7 +421,7 @@ function buildRequirements(rootDir, platformReport) {
       'legacy-salvage',
       'Audit, prune, or attach legacy work',
       'docs/stale-pr-salvage-ledger.md and legacy inventory',
-      stalePrSalvage.includes('Manual review tail') || roadmap.includes('ITO-55')
+      hasLegacySalvageTracking({ stalePrSalvage, legacyInventory, roadmap })
         ? 'in_progress'
         : 'not_complete',
       'legacy salvage ledger and ITO-55 tracking are present',

--- a/tests/scripts/operator-readiness-dashboard.test.js
+++ b/tests/scripts/operator-readiness-dashboard.test.js
@@ -190,6 +190,51 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('legacy salvage recognizes the real manual-review backlog heading', () => {
+    const rootDir = createTempDir('operator-dashboard-legacy-salvage-');
+
+    try {
+      seedRepo(rootDir, {
+        'docs/ECC-2.0-GA-ROADMAP.md': [
+          'https://linear.app/itomarkets/project/ecc-platform-roadmap-52b328ee03e1',
+          'Linear ITO-44 ITO-59',
+          'AgentShield PR #90 #78-#90',
+          'AgentShield Enterprise Iteration',
+          'ECC-Tools PR #78',
+          'hosted promotion',
+          'announcementGate'
+        ].join('\n'),
+        'docs/stale-pr-salvage-ledger.md': [
+          '# Stale PR Salvage Ledger',
+          '',
+          '## Remaining Manual-Review Backlog',
+          '',
+          '- #1609 Persian README translation',
+          '- #1563 zh-TW README sync'
+        ].join('\n')
+      });
+
+      const report = buildReport({
+        allowUntracked: [],
+        exitCode: false,
+        format: 'json',
+        generatedAt: '2026-05-15T00:00:00.000Z',
+        help: false,
+        repos: [],
+        root: rootDir,
+        skipGithub: true,
+        thresholds: { maxOpenPrs: 20, maxOpenIssues: 20, maxDirtyFiles: 0 },
+        useEnvGithubToken: false,
+        writePath: null
+      });
+
+      const legacySalvage = report.requirements.find(item => item.id === 'legacy-salvage');
+      assert.strictEqual(legacySalvage.status, 'in_progress');
+    } finally {
+      cleanup(rootDir);
+    }
+  })) passed++; else failed++;
+
   if (test('markdown output can be written as the dashboard artifact', () => {
     const rootDir = createTempDir('operator-dashboard-markdown-');
     const outputPath = path.join(rootDir, 'artifacts', 'dashboard.md');


### PR DESCRIPTION
## Summary
- Recognize the real stale-salvage ledger heading `Remaining Manual-Review Backlog`
- Include legacy artifact inventory evidence in the legacy-salvage dashboard requirement
- Add regression coverage so the operator dashboard does not downgrade tracked legacy salvage to `not_complete`

## Validation
- `node tests/scripts/operator-readiness-dashboard.test.js`
- `npm run lint`
- `npm test` (2471/2471)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes legacy salvage detection in the operator readiness dashboard so tracked salvage shows as in_progress instead of not_complete. Recognizes the real ledger heading and includes legacy inventory evidence; also continues to honor roadmap tracking via ITO-55.

- **Bug Fixes**
  - Detects the actual ledger heading: “Remaining Manual-Review Backlog”.
  - Counts legacy artifact inventory mentions of “Translator/manual review” as evidence.
  - Centralizes logic in hasLegacySalvageTracking for consistent checks (ledger, legacy inventory, roadmap ITO-55).
  - Adds regression test to prevent downgrading valid legacy salvage to not_complete.

<sup>Written for commit e600109aa0ff64b7eceb6f3a4296945ad4d39ee7. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1949?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of readiness assessment logic for better maintainability.

* **Tests**
  * Added test coverage for readiness evaluation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->