### PR TITLE
docs(gateguard): warn that ECC_GATEGUARD / ECC_DISABLED_HOOKS need a restart

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -693,7 +693,8 @@ function withRecoveryHint(message, hookIds = [EDIT_WRITE_HOOK_ID]) {
   return [
     message,
     '',
-    `Recovery: if GateGuard is blocking setup or repair work, run this session with \`ECC_GATEGUARD=off\` or add ${disableTargets} to \`ECC_DISABLED_HOOKS\`.`
+    `Recovery: if GateGuard is blocking setup or repair work, set \`ECC_GATEGUARD=off\` or add ${disableTargets} to \`ECC_DISABLED_HOOKS\`.`,
+    'Set these in your shell before launching Claude Code, or add them to `~/.claude/settings.json` `env` and restart Claude Code — the `env` block is snapshotted into the Claude Code process at session start, so mid-session edits do NOT propagate to a running session.'
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary

The GateGuard recovery hint tells users they can disable the gate by setting `ECC_GATEGUARD=off` or adding the hook id to `ECC_DISABLED_HOOKS`, but doesn't warn that either env var has to be in the Claude Code **process env at the time the hook runs**. `~/.claude/settings.json` `env` is loaded once at session start, so a mid-session edit doesn't propagate to the running process — the hook keeps firing despite the new value being on disk.

I hit this for ~an hour during a long refactor session, and the recovery hint kept telling me my correct settings.json change should work, so I assumed the disable mechanism was broken. Investigation traced it back to `process.env` already being snapshot, and a restart was the actual fix.

This PR appends one sentence to `withRecoveryHint()` naming the two paths that actually work:
- Export the env var in the parent shell before launching Claude Code, OR
- Edit `~/.claude/settings.json` `env` AND restart Claude Code.

## Change

A single function in `scripts/hooks/gateguard-fact-force.js`:

```diff
 function withRecoveryHint(message, hookIds = [EDIT_WRITE_HOOK_ID]) {
   const disableTargets = hookIds.map(hookId => `\`${hookId}\``).join(' or ');
   return [
     message,
     '',
-    `Recovery: if GateGuard is blocking setup or repair work, run this session with \`ECC_GATEGUARD=off\` or add ${disableTargets} to \`ECC_DISABLED_HOOKS\`.`
+    `Recovery: if GateGuard is blocking setup or repair work, set \`ECC_GATEGUARD=off\` or add ${disableTargets} to \`ECC_DISABLED_HOOKS\`.`,
+    'Set these in your shell before launching Claude Code, or add them to `~/.claude/settings.json` `env` and restart Claude Code — the `env` block is snapshotted into the Claude Code process at session start, so mid-session edits do NOT propagate to a running session.'
   ].join('\n');
 }
```

No behavior change. No signature change. The first sentence is preserved verbatim so test assertions on literal substrings (`ECC_GATEGUARD=off`, `ECC_DISABLED_HOOKS`, `pre:bash:gateguard-fact-force` / not `pre:edit-write:gateguard-fact-force` for routine Bash) continue to hold.

## Test plan

- [x] All 90 cases in `tests/hooks/gateguard-fact-force.test.js` pass locally on `node tests/hooks/gateguard-fact-force.test.js`.
- [x] Manually verified the existing recovery-hint test (`denial messages include direct recovery escape hatch`) and the routine-Bash test (`routine Bash denials include Bash hook disable id`) both still pass with the new two-line message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the GateGuard recovery hint: `ECC_GATEGUARD=off` or entries in `ECC_DISABLED_HOOKS` must be in the Claude Code process env when the hook runs. Adds a sentence telling users to set them in the shell before launch, or update `~/.claude/settings.json` `env` and restart, since the env is snapshotted at session start.

<sup>Written for commit b21a8ac716e0f71d06a065311432dfd8b1c2163d. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1952?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved error recovery instructions in denial responses to provide clearer guidance on disabling gateguard and clarified that environment settings are applied at session start.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->