### PR TITLE
fix: let users disable context monitor cost warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,15 @@ export ECC_SESSION_START_MAX_CHARS=4000
 
 # Disable SessionStart additional context entirely for low-context/local-model setups
 export ECC_SESSION_START_CONTEXT=off
+
+# Keep context/scope/loop warnings but suppress API-rate cost estimates
+export ECC_CONTEXT_MONITOR_COST_WARNINGS=off
+```
+
+Windows PowerShell:
+
+```powershell
+[Environment]::SetEnvironmentVariable('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'off', 'User')
 ```
 
 ---
@@ -1610,6 +1619,7 @@ Add to `~/.claude/settings.json`:
 | `model` | opus | **sonnet** | ~60% cost reduction; handles 80%+ of coding tasks |
 | `MAX_THINKING_TOKENS` | 31,999 | **10,000** | ~70% reduction in hidden thinking cost per request |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | 95 | **50** | Compacts earlier — better quality in long sessions |
+| `ECC_CONTEXT_MONITOR_COST_WARNINGS` | on | **off for subscription users** | Suppresses agent-facing API-rate estimate warnings while keeping context/scope/loop warnings |
 
 Switch to Opus only when you need deep architectural reasoning:
 ```
@@ -1625,6 +1635,8 @@ Switch to Opus only when you need deep architectural reasoning:
 | `/clear` | Between unrelated tasks (free, instant reset) |
 | `/compact` | At logical task breakpoints (research done, milestone complete) |
 | `/cost` | Monitor token spending during session |
+
+If you use a Claude subscription and the context monitor's API-rate estimates are not useful, set `ECC_CONTEXT_MONITOR_COST_WARNINGS=off`. This only suppresses the agent-facing cost warnings; it does not disable context exhaustion, scope, or loop warnings.
 
 ### Strategic Compaction
 

--- a/docs/token-optimization.md
+++ b/docs/token-optimization.md
@@ -29,6 +29,7 @@ Add to your `~/.claude/settings.json`:
 | `model` | opus | **sonnet** | Sonnet handles ~80% of coding tasks well. Switch to Opus with `/model opus` for complex reasoning. ~60% cost reduction. |
 | `MAX_THINKING_TOKENS` | 31,999 | **10,000** | Extended thinking reserves up to 31,999 output tokens per request for internal reasoning. Reducing this cuts hidden cost by ~70%. Set to `0` to disable for trivial tasks. |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | _(inherits main)_ | **haiku** | Subagents (Task tool) run on this model. Haiku is ~80% cheaper and sufficient for exploration, file reading, and test running. |
+| `ECC_CONTEXT_MONITOR_COST_WARNINGS` | on | **off for subscription users** | Suppresses agent-facing API-rate estimate warnings while keeping context exhaustion, scope, and loop warnings. |
 
 ### Community note on auto-compaction overrides
 
@@ -70,6 +71,22 @@ Switch models mid-session:
 | `/clear` | Between unrelated tasks. Stale context wastes tokens on every subsequent message. |
 | `/compact` | At logical task breakpoints (after planning, after debugging, before switching focus). |
 | `/cost` | Check token spending for the current session. |
+
+### API-rate cost estimate warnings
+
+ECC's context monitor can emit API-rate cost estimates from local hook telemetry. If you are on a Claude subscription and those estimates do not reflect your actual bill, disable only the agent-facing cost warnings:
+
+```bash
+export ECC_CONTEXT_MONITOR_COST_WARNINGS=off
+```
+
+Windows PowerShell:
+
+```powershell
+[Environment]::SetEnvironmentVariable('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'off', 'User')
+```
+
+This does not disable context exhaustion warnings, scope warnings, loop warnings, `/cost`, or cost telemetry files.
 
 ### Strategic compaction
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -110,6 +110,15 @@ export ECC_SESSION_START_MAX_CHARS=4000
 
 # Disable SessionStart additional context entirely
 export ECC_SESSION_START_CONTEXT=off
+
+# Keep context/scope/loop warnings but suppress API-rate cost estimates
+export ECC_CONTEXT_MONITOR_COST_WARNINGS=off
+```
+
+Windows PowerShell:
+
+```powershell
+[Environment]::SetEnvironmentVariable('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'off', 'User')
 ```
 
 Profiles:

--- a/scripts/hooks/ecc-context-monitor.js
+++ b/scripts/hooks/ecc-context-monitor.js
@@ -24,6 +24,20 @@ const LOOP_THRESHOLD = 3;
 const STALE_SECONDS = 60;
 const DEBOUNCE_CALLS = 5;
 
+function isEnabledEnv(value, defaultValue = true) {
+  if (value === undefined || value === null || String(value).trim() === '') {
+    return defaultValue;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['0', 'false', 'no', 'off', 'disabled'].includes(normalized)) return false;
+  if (['1', 'true', 'yes', 'on', 'enabled'].includes(normalized)) return true;
+  return defaultValue;
+}
+
+function costWarningsEnabled(env = process.env) {
+  return isEnabledEnv(env.ECC_CONTEXT_MONITOR_COST_WARNINGS, true);
+}
+
 /**
  * Get debounce state file path.
  * @param {string} sessionId
@@ -84,7 +98,7 @@ function detectLoop(recentTools) {
  * Evaluate all warning conditions against bridge data.
  * Returns array of {severity, type, message} sorted by severity desc.
  */
-function evaluateConditions(bridge) {
+function evaluateConditions(bridge, options = {}) {
   const warnings = [];
   const remaining = bridge.context_remaining_pct;
 
@@ -109,25 +123,27 @@ function evaluateConditions(bridge) {
   }
 
   // Cost warnings
-  const cost = bridge.total_cost_usd || 0;
-  if (cost > COST_CRITICAL_USD) {
-    warnings.push({
-      severity: 3,
-      type: 'cost',
-      message: `COST CRITICAL: Session cost is $${cost.toFixed(2)}. ` + 'Stop and inform the user about high cost before continuing.'
-    });
-  } else if (cost > COST_WARNING_USD) {
-    warnings.push({
-      severity: 2,
-      type: 'cost',
-      message: `COST WARNING: Session cost is $${cost.toFixed(2)}. ` + 'Review whether the current approach justifies the expense.'
-    });
-  } else if (cost > COST_NOTICE_USD) {
-    warnings.push({
-      severity: 1,
-      type: 'cost',
-      message: `COST NOTICE: Session cost is $${cost.toFixed(2)}. ` + 'Consider whether the current approach is efficient.'
-    });
+  if (options.costWarnings !== false) {
+    const cost = bridge.total_cost_usd || 0;
+    if (cost > COST_CRITICAL_USD) {
+      warnings.push({
+        severity: 3,
+        type: 'cost',
+        message: `COST CRITICAL: Session cost is $${cost.toFixed(2)}. ` + 'Stop and inform the user about high cost before continuing.'
+      });
+    } else if (cost > COST_WARNING_USD) {
+      warnings.push({
+        severity: 2,
+        type: 'cost',
+        message: `COST WARNING: Session cost is $${cost.toFixed(2)}. ` + 'Review whether the current approach justifies the expense.'
+      });
+    } else if (cost > COST_NOTICE_USD) {
+      warnings.push({
+        severity: 1,
+        type: 'cost',
+        message: `COST NOTICE: Session cost is $${cost.toFixed(2)}. ` + 'Consider whether the current approach is efficient.'
+      });
+    }
   }
 
   // File scope warning
@@ -185,7 +201,7 @@ function run(rawInput) {
     // If bridge is stale, null out context data (still check cost/scope/loop)
     const evalBridge = isStale ? { ...bridge, context_remaining_pct: null } : bridge;
 
-    const warnings = evaluateConditions(evalBridge);
+    const warnings = evaluateConditions(evalBridge, { costWarnings: costWarningsEnabled() });
     if (warnings.length === 0) return rawInput;
 
     // Debounce logic
@@ -239,4 +255,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { run, evaluateConditions, detectLoop, severityLabel };
+module.exports = { run, evaluateConditions, detectLoop, severityLabel, costWarningsEnabled };

--- a/tests/hooks/ecc-context-monitor.test.js
+++ b/tests/hooks/ecc-context-monitor.test.js
@@ -5,8 +5,12 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-const { run, evaluateConditions, detectLoop, severityLabel } = require('../../scripts/hooks/ecc-context-monitor');
+const { run, evaluateConditions, detectLoop, severityLabel, costWarningsEnabled } = require('../../scripts/hooks/ecc-context-monitor');
+const { getBridgePath, writeBridgeAtomic } = require('../../scripts/lib/session-bridge');
 
 // Test helper
 function test(name, fn) {
@@ -18,6 +22,18 @@ function test(name, fn) {
     console.log(`  \u2717 ${name}`);
     console.log(`    Error: ${err.message}`);
     return false;
+  }
+}
+
+function withEnv(name, value, fn) {
+  const original = process.env[name];
+  try {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+    return fn();
+  } finally {
+    if (original === undefined) delete process.env[name];
+    else process.env[name] = original;
   }
 }
 
@@ -108,6 +124,53 @@ function runTests() {
       const warnings = evaluateConditions({ total_cost_usd: 2 });
       const cost = warnings.find(w => w.type === 'cost');
       assert.strictEqual(cost, undefined);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('cost warnings can be suppressed without hiding context warnings', () => {
+      const warnings = evaluateConditions({ total_cost_usd: 55, context_remaining_pct: 20 }, { costWarnings: false });
+      assert.strictEqual(warnings.find(w => w.type === 'cost'), undefined);
+      const ctx = warnings.find(w => w.type === 'context');
+      assert.ok(ctx, 'Expected context warning to remain enabled');
+      assert.strictEqual(ctx.severity, 3);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('ECC_CONTEXT_MONITOR_COST_WARNINGS=off disables only run-time cost warnings', () => {
+      const sessionId = `ctx-monitor-cost-off-${process.pid}-${Date.now()}`;
+      const input = JSON.stringify({ session_id: sessionId, tool_name: 'Bash' });
+      const warnPath = path.join(os.tmpdir(), `ecc-ctx-warn-${sessionId}.json`);
+      try {
+        writeBridgeAtomic(sessionId, {
+          context_remaining_pct: 20,
+          total_cost_usd: 55,
+          last_timestamp: new Date().toISOString()
+        });
+        const result = withEnv('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'off', () => JSON.parse(run(input)));
+        const message = result.hookSpecificOutput.additionalContext;
+        assert.ok(message.includes('CONTEXT CRITICAL'), 'Expected context warning to remain');
+        assert.ok(!message.includes('COST CRITICAL'), 'Expected cost warning to be suppressed');
+      } finally {
+        fs.rmSync(getBridgePath(sessionId), { force: true });
+        fs.rmSync(warnPath, { force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('cost warning env defaults on and accepts false-like values', () => {
+      assert.strictEqual(withEnv('ECC_CONTEXT_MONITOR_COST_WARNINGS', undefined, () => costWarningsEnabled()), true);
+      assert.strictEqual(withEnv('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'false', () => costWarningsEnabled()), false);
+      assert.strictEqual(withEnv('ECC_CONTEXT_MONITOR_COST_WARNINGS', '0', () => costWarningsEnabled()), false);
+      assert.strictEqual(withEnv('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'yes', () => costWarningsEnabled()), true);
     })
   )
     passed++;


### PR DESCRIPTION
## Summary
- add `ECC_CONTEXT_MONITOR_COST_WARNINGS=off` to suppress agent-facing API-rate cost warnings
- keep context exhaustion, scope, and loop warnings enabled when cost warnings are off
- document Bash and Windows PowerShell setup paths for subscription users

Fixes #1958.

## Validation
- `node tests/hooks/ecc-context-monitor.test.js`
- `node tests/scripts/manual-hook-install-docs.test.js`
- `node tests/ci/scan-supply-chain-iocs.test.js`
- `node scripts/ci/scan-supply-chain-iocs.js --root /Users/affoon/GitHub/ECC --home`
- `git diff --check`
- `node scripts/ci/validate-hooks.js`
- `npm run lint`
- `npm test` (2473/2473)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users turn off agent-facing API-rate cost warnings in the context monitor without disabling context, scope, or loop warnings. Adds the `ECC_CONTEXT_MONITOR_COST_WARNINGS=off` opt-out and documents setup for Bash and Windows PowerShell.

- New Features
  - Added `ECC_CONTEXT_MONITOR_COST_WARNINGS` (default on). False-like values (`off`, `false`, `0`, etc.) suppress only cost warnings.
  - Kept context exhaustion, scope, loop warnings, `/cost`, and telemetry unchanged.
  - Updated README, hooks README, and token-optimization docs with Bash and Windows PowerShell examples.
  - Implemented `costWarningsEnabled()` and plumbed option through `evaluateConditions`/`run`; added tests for env parsing and runtime behavior.
  - Fixes #1958.

<sup>Written for commit 9b15c6fec8ce17bf7095a9234f7ca42ce732ea96. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1965?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now suppress API-rate cost estimate warnings while preserving context exhaustion and other critical warnings.

* **Documentation**
  * Added environment variable documentation and setup instructions for disabling cost warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->