### PR TITLE
fix(ci): close two validate-workflow-security bypasses (write-all + refs/pull)

### DIFF
--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -21,6 +21,15 @@ const RULES = [
     eventPattern: /\bpull_request_target\s*:/m,
     description: 'pull_request_target must not checkout an untrusted pull_request head ref/repository',
     expressionPattern: /\$\{\{\s*github\.event\.pull_request\.head\.(?:ref|sha|repo\.full_name)\s*\}\}/g,
+    // Even without the standard `github.event.pull_request.head.*` expression,
+    // a checkout under `pull_request_target` that fetches a `refs/pull/<N>/{head,merge}`
+    // ref pulls attacker-controlled code into a workflow with write-scoped
+    // tokens. GitHub's security guidance treats both forms equivalently;
+    // we match the ref value directly so any interpolation that resolves
+    // to such a ref (`refs/pull/${{ github.event.pull_request.number }}/merge`,
+    // a hardcoded `refs/pull/123/head`, a `${{ env.X }}` that the maintainer
+    // assumes is safe, etc.) trips the same rule.
+    refPattern: /^\s*ref:\s*['"]?[^'"\n]*refs\/(?:remotes\/)?pull\/[^'"\n\s]+/m,
   },
 ];
 
@@ -126,6 +135,18 @@ function findViolations(filePath, source) {
           expression: match[0],
           line: step.startLine + getLineNumber(step.text, match.index) - 1,
         });
+      }
+      if (rule.refPattern) {
+        const refMatch = step.text.match(rule.refPattern);
+        if (refMatch) {
+          violations.push({
+            filePath,
+            event: rule.event,
+            description: rule.description,
+            expression: refMatch[0].trim(),
+            line: step.startLine + getLineNumber(step.text, refMatch.index) - 1,
+          });
+        }
       }
     }
   }

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -38,8 +38,9 @@ const WRITE_PERMISSION_PATTERN = /^\s*(?:contents|issues|pull-requests|actions|c
 // scope write access. The named-scope pattern above misses it because there
 // is no scope name on the left of the colon — just the literal `write-all`
 // value at the permissions key. Treat both as equivalent for the purposes
-// of the persist-credentials and lifecycle-script gates below.
-const WRITE_ALL_PATTERN = /^\s*permissions:\s*write-all\b/m;
+// of the persist-credentials gate below. The optional single/double quotes
+// match valid YAML `permissions: "write-all"` / `'write-all'` forms.
+const WRITE_ALL_PATTERN = /^\s*permissions:\s*["']?write-all["']?\s*$/m;
 const NPM_AUDIT_PATTERN = /\bnpm\s+audit\b(?!\s+signatures\b)/;
 const NPM_AUDIT_SIGNATURES_PATTERN = /\bnpm\s+audit\s+signatures\b/;
 const ACTIONS_CACHE_PATTERN = /uses:\s*['"]?actions\/cache@/m;
@@ -127,6 +128,13 @@ function findViolations(filePath, source) {
     }
 
     for (const step of checkoutSteps) {
+      // Track whether the expression-based rule already produced a
+      // violation for this step. If it did, skip the refPattern fallback
+      // — a `refs/pull/${{ github.event.pull_request.head.sha }}/merge`
+      // value matches both patterns under the same rule, and the second
+      // push would print a duplicate ERROR line that says exactly the
+      // same thing with a different `expression:` echo.
+      let stepFlagged = false;
       for (const match of step.text.matchAll(rule.expressionPattern)) {
         violations.push({
           filePath,
@@ -135,8 +143,9 @@ function findViolations(filePath, source) {
           expression: match[0],
           line: step.startLine + getLineNumber(step.text, match.index) - 1,
         });
+        stepFlagged = true;
       }
-      if (rule.refPattern) {
+      if (rule.refPattern && !stepFlagged) {
         const refMatch = step.text.match(rule.refPattern);
         if (refMatch) {
           violations.push({

--- a/scripts/ci/validate-workflow-security.js
+++ b/scripts/ci/validate-workflow-security.js
@@ -25,6 +25,12 @@ const RULES = [
 ];
 
 const WRITE_PERMISSION_PATTERN = /^\s*(?:contents|issues|pull-requests|actions|checks|deployments|discussions|id-token|packages|pages|repository-projects|security-events|statuses):\s*write\b/m;
+// `permissions: write-all` is GitHub Actions' shorthand for granting every
+// scope write access. The named-scope pattern above misses it because there
+// is no scope name on the left of the colon — just the literal `write-all`
+// value at the permissions key. Treat both as equivalent for the purposes
+// of the persist-credentials and lifecycle-script gates below.
+const WRITE_ALL_PATTERN = /^\s*permissions:\s*write-all\b/m;
 const NPM_AUDIT_PATTERN = /\bnpm\s+audit\b(?!\s+signatures\b)/;
 const NPM_AUDIT_SIGNATURES_PATTERN = /\bnpm\s+audit\s+signatures\b/;
 const ACTIONS_CACHE_PATTERN = /uses:\s*['"]?actions\/cache@/m;
@@ -124,7 +130,7 @@ function findViolations(filePath, source) {
     }
   }
 
-  if (WRITE_PERMISSION_PATTERN.test(source)) {
+  if (WRITE_PERMISSION_PATTERN.test(source) || WRITE_ALL_PATTERN.test(source)) {
     for (const step of checkoutSteps) {
       if (!/persist-credentials:\s*['"]?false['"]?\b/m.test(step.text)) {
         violations.push({

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -99,6 +99,34 @@ function run() {
     assert.match(result.stderr, /pull_request\.head\.sha/);
   })) passed++; else failed++;
 
+  // `refs/pull/<N>/{head,merge}` under `pull_request_target` is the canonical
+  // privilege-escalation pattern that the standard `github.event.pull_request.head.*`
+  // expression check did not cover. Either form pulls attacker-controlled code
+  // into a privileged workflow.
+
+  if (test('rejects pull_request_target checkout fetching refs/pull/N/merge', () => {
+    const result = runValidator({
+      'unsafe-pr-target-merge-ref.yml': `name: Unsafe\non:\n  pull_request_target:\n    types: [opened]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: refs/pull/\${{ github.event.pull_request.number }}/merge\n          persist-credentials: false\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on refs/pull/N/merge under pull_request_target');
+    assert.match(result.stderr, /pull_request_target must not checkout an untrusted pull_request head ref/);
+  })) passed++; else failed++;
+
+  if (test('rejects pull_request_target checkout fetching hardcoded refs/pull/N/head', () => {
+    const result = runValidator({
+      'unsafe-pr-target-head-ref.yml': `name: Unsafe\non:\n  pull_request_target:\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: refs/pull/123/head\n          persist-credentials: false\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on hardcoded refs/pull/N/head');
+    assert.match(result.stderr, /pull_request_target must not checkout an untrusted pull_request head ref/);
+  })) passed++; else failed++;
+
+  if (test('allows pull_request_target checkout of the base ref (no with.ref)', () => {
+    const result = runValidator({
+      'safe-pr-target-base.yml': `name: Safe\non:\n  pull_request_target:\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          persist-credentials: false\n      - run: echo inspecting base\n`,
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
   if (test('rejects shared cache use in pull_request_target workflows', () => {
     const result = runValidator({
       'unsafe-pr-target-cache.yml': `name: Unsafe\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/cache@v5\n        with:\n          path: ~/.npm\n          key: cache\n      - run: echo inspect\n`,

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -127,6 +127,22 @@ function run() {
     assert.strictEqual(result.status, 0, result.stderr || result.stdout);
   })) passed++; else failed++;
 
+  // When a checkout step matches both the expression-based rule
+  // (`github.event.pull_request.head.sha`) and the refPattern fallback
+  // (`refs/pull/...`), only one violation should be emitted — the
+  // expression match is the more specific signal and printing both would
+  // duplicate an otherwise identical ERROR line.
+
+  if (test('emits a single violation when both expressionPattern and refPattern match the same step', () => {
+    const result = runValidator({
+      'unsafe-pr-target-both.yml': `name: Unsafe\non:\n  pull_request_target:\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: refs/pull/\${{ github.event.pull_request.head.sha }}/merge\n          persist-credentials: false\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail');
+    // Count ERROR: lines for this rule's description. Should be exactly 1.
+    const matches = (result.stderr || '').match(/ERROR:.*pull_request_target must not checkout an untrusted pull_request head ref/g) || [];
+    assert.strictEqual(matches.length, 1, `Expected exactly 1 violation, got ${matches.length}: ${result.stderr}`);
+  })) passed++; else failed++;
+
   if (test('rejects shared cache use in pull_request_target workflows', () => {
     const result = runValidator({
       'unsafe-pr-target-cache.yml': `name: Unsafe\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  inspect:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/cache@v5\n        with:\n          path: ~/.npm\n          key: cache\n      - run: echo inspect\n`,
@@ -186,7 +202,10 @@ function run() {
   // `permissions: write-all` is GitHub Actions' shorthand for granting every
   // scope write access. The named-scope pattern only catches `contents: write`,
   // `issues: write`, etc., so workflows that opt into write-all were silently
-  // exempted from the persist-credentials and --ignore-scripts gates.
+  // exempted from the persist-credentials gate (the lifecycle-script gate
+  // already fires unconditionally for every workflow). The tests below
+  // exercise the persist-credentials path specifically — that's the gate the
+  // WRITE_ALL_PATTERN OR-clause newly activates.
 
   if (test('rejects checkout credential persistence in workflows with permissions: write-all', () => {
     const result = runValidator({
@@ -196,15 +215,27 @@ function run() {
     assert.match(result.stderr, /write permissions must disable checkout credential persistence/);
   })) passed++; else failed++;
 
-  if (test('rejects npm ci without ignore-scripts in workflows with permissions: write-all', () => {
+  // Quoted YAML forms (`"write-all"` and `'write-all'`) are valid YAML for the
+  // same scalar value. Verify the WRITE_ALL_PATTERN regex covers them — without
+  // the quote markers it silently slips the same persist-credentials gate.
+
+  if (test('rejects double-quoted permissions: "write-all"', () => {
     const result = runValidator({
-      'unsafe-write-all-install.yml': `name: Unsafe\non:\n  workflow_dispatch:\npermissions: write-all\njobs:\n  audit:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          persist-credentials: false\n      - run: npm ci\n`,
+      'unsafe-write-all-double.yml': `name: Unsafe\non:\n  workflow_dispatch:\npermissions: "write-all"\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm ci --ignore-scripts\n`,
     });
-    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on write-all + npm ci without --ignore-scripts');
-    assert.match(result.stderr, /npm ci must include --ignore-scripts/);
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on quoted write-all + credential-persisting checkout');
+    assert.match(result.stderr, /write permissions must disable checkout credential persistence/);
   })) passed++; else failed++;
 
-  if (test('allows compliant workflow with permissions: write-all', () => {
+  if (test('rejects single-quoted permissions: \'write-all\'', () => {
+    const result = runValidator({
+      'unsafe-write-all-single.yml': `name: Unsafe\non:\n  workflow_dispatch:\npermissions: 'write-all'\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm ci --ignore-scripts\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on single-quoted write-all + credential-persisting checkout');
+    assert.match(result.stderr, /write permissions must disable checkout credential persistence/);
+  })) passed++; else failed++;
+
+  if (test('allows compliant workflow with permissions: write-all (persist-credentials: false)', () => {
     const result = runValidator({
       'safe-write-all.yml': `name: Safe\non:\n  workflow_dispatch:\npermissions: write-all\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          persist-credentials: false\n      - run: npm ci --ignore-scripts\n`,
     });

--- a/tests/ci/validate-workflow-security.test.js
+++ b/tests/ci/validate-workflow-security.test.js
@@ -155,6 +155,34 @@ function run() {
     assert.strictEqual(result.status, 0, result.stderr || result.stdout);
   })) passed++; else failed++;
 
+  // `permissions: write-all` is GitHub Actions' shorthand for granting every
+  // scope write access. The named-scope pattern only catches `contents: write`,
+  // `issues: write`, etc., so workflows that opt into write-all were silently
+  // exempted from the persist-credentials and --ignore-scripts gates.
+
+  if (test('rejects checkout credential persistence in workflows with permissions: write-all', () => {
+    const result = runValidator({
+      'unsafe-write-all-checkout.yml': `name: Unsafe\non:\n  workflow_dispatch:\npermissions: write-all\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm ci --ignore-scripts\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on write-all + credential-persisting checkout');
+    assert.match(result.stderr, /write permissions must disable checkout credential persistence/);
+  })) passed++; else failed++;
+
+  if (test('rejects npm ci without ignore-scripts in workflows with permissions: write-all', () => {
+    const result = runValidator({
+      'unsafe-write-all-install.yml': `name: Unsafe\non:\n  workflow_dispatch:\npermissions: write-all\njobs:\n  audit:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          persist-credentials: false\n      - run: npm ci\n`,
+    });
+    assert.notStrictEqual(result.status, 0, 'Expected validator to fail on write-all + npm ci without --ignore-scripts');
+    assert.match(result.stderr, /npm ci must include --ignore-scripts/);
+  })) passed++; else failed++;
+
+  if (test('allows compliant workflow with permissions: write-all', () => {
+    const result = runValidator({
+      'safe-write-all.yml': `name: Safe\non:\n  workflow_dispatch:\npermissions: write-all\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          persist-credentials: false\n      - run: npm ci --ignore-scripts\n`,
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  })) passed++; else failed++;
+
   if (test('rejects actions/cache in workflows with id-token write', () => {
     const result = runValidator({
       'unsafe-oidc-cache.yml': `name: Unsafe\non:\n  push:\npermissions:\n  contents: read\n  id-token: write\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/cache@v5\n        with:\n          path: ~/.npm\n          key: cache\n`,


### PR DESCRIPTION
## Summary

`scripts/ci/validate-workflow-security.js` is the gatekeeper that's supposed to prevent unsafe GitHub Actions patterns from landing in `.github/workflows/`. Found two independent bypasses where the validator silently passes obviously unsafe configurations:

1. **`permissions: write-all` shorthand misses the named-scope check.** The `WRITE_PERMISSION_PATTERN` enumerates named scopes (`contents: write`, `issues: write`, etc.) but never matches the top-level shorthand `permissions: write-all`, which is *strictly broader*. As a result, a workflow that opts into write-all silently slips the persist-credentials and lifecycle-script gates.
2. **`pull_request_target` + `refs/pull/<N>/{head,merge}` checkout not flagged.** The rule's `expressionPattern` only matches `github.event.pull_request.head.{ref,sha,repo.full_name}` interpolations. The canonical second form of the same exploit — checking out `refs/pull/<N>/merge` (the PR's merge commit) or `refs/pull/<N>/head` directly — bypasses the rule. This is the highest-severity primitive in GitHub's own `pull_request_target` security guidance.

Both bypasses reproduce in a single short YAML file.

## Bypass 1 — `permissions: write-all` (before → after)

Repro on `main` at `b113edac`:

```
$ cat /tmp/bad.yml
name: bad
on: [push]
permissions: write-all
jobs:
  do:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

$ ECC_WORKFLOWS_DIR=/tmp node scripts/ci/validate-workflow-security.js; echo $?
Validated workflow security for 1 workflow files
0
```

Expected: violation flagging the missing `persist-credentials: false` on a checkout running in a write-scoped workflow.
Actual: passes silently.

After this PR:

```
ERROR: bad.yml:8 - workflows with write permissions must disable checkout credential persistence
exit 1
```

Fix: add `WRITE_ALL_PATTERN = /^\s*permissions:\s*write-all\b/m` and OR it with the existing `WRITE_PERMISSION_PATTERN` at the single gate. Both top-level and job-level `permissions:` blocks satisfy the `^\s*` prefix.

## Bypass 2 — `pull_request_target` + `refs/pull/N/merge` (before → after)

Repro on `main` at `b113edac`:

```
$ cat /tmp/bad.yml
name: bad
on:
  pull_request_target:
    types: [opened]
permissions:
  contents: read
jobs:
  do:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          ref: refs/pull/${{ github.event.pull_request.number }}/merge
          persist-credentials: false

$ ECC_WORKFLOWS_DIR=/tmp node scripts/ci/validate-workflow-security.js; echo $?
Validated workflow security for 1 workflow files
0
```

Expected: violation flagging the untrusted PR ref checkout under `pull_request_target`.
Actual: passes silently — the most dangerous pattern in GitHub's own security guidance.

After this PR:

```
ERROR: bad.yml:13 - pull_request_target must not checkout an untrusted pull_request head ref/repository
  Unsafe expression: ref: refs/pull/${{
exit 1
```

Fix: add a `refPattern` field to the existing `pull_request_target` rule that matches the ref VALUE (`/^\s*ref:\s*['"]?[^'"\n]*refs\/(?:remotes\/)?pull\/[^'"\n\s]+/m`). The pattern catches every interpolation shape — `refs/pull/123/head`, `refs/pull/${{ github.event.pull_request.number }}/merge`, `${{ env.FOO }}/refs/pull/N/head` — without enumerating possible expressions.

Scoping: already gated on the workflow containing `pull_request_target:`, so non-privileged `pull_request` workflows that legitimately check out a PR ref are unaffected.

## Commit layout

Two reviewable commits, one per bypass, each with its own fixture coverage:

1. `fix(ci): treat 'permissions: write-all' as a write-permission gate` — adds `WRITE_ALL_PATTERN` and ORs into the existing gate. Includes 3 fixtures: write-all + credential-persisting checkout (REJECT), write-all + `npm ci` (REJECT), write-all compliant (ALLOW).
2. `fix(ci): flag refs/pull checkouts under pull_request_target` — adds `refPattern` and applies in the per-checkout-step loop. Includes 3 fixtures: `refs/pull/N/merge` (REJECT), `refs/pull/N/head` (REJECT), pull_request_target base-ref checkout (ALLOW — GitHub's official safe pattern).

## Tests

`tests/ci/validate-workflow-security.test.js`: 14 → 22 cases (8 new). Full `yarn test` green; `yarn lint` clean.

## Compatibility with `f7035b56`

This branch was rebased against `main` after `f7035b56 Harden CI installs against supply-chain lifecycle hooks` landed. That commit reshaped `npm ci` enforcement into the new `UNSAFE_INSTALL_PATTERNS` array but did not touch either of the two bypasses fixed here. Verified by reproducing both bypasses on `main` HEAD (`b113edac`) and confirming both still slip the validator pre-fix.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] Manual: each bypass reproduction above returns exit 1 with the expected ERROR line
- [ ] Manual: each ALLOW fixture in the new tests stays exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes two gaps in our workflow security validator: it now treats `permissions: write-all` (including quoted forms) as write scope and blocks `pull_request_target` checkouts of `refs/pull/*/{head,merge}`. Also prevents duplicate error lines when a checkout matches both detection patterns.

- **Bug Fixes**
  - Treat `permissions: write-all` (bare, single-quoted, double-quoted) as write; require `persist-credentials: false` on `actions/checkout`.
  - In `pull_request_target` workflows, flag any checkout `ref` pointing to `refs/pull/...` (hardcoded or interpolated), and dedupe when both expression and ref patterns match the same step.
  - Added tests covering quoted `write-all`, `refs/pull` detection, and duplicate suppression.

<sup>Written for commit cff581b457211828cbb1e4c7534896289c6c1833. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1970?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced workflow security validator to detect unsafe pull-request-target checkouts that reference pull request heads/merges.
  * Broadened handling of broad write permissions to enforce the same credential persistence restrictions as scoped write permissions.

* **Tests**
  * Expanded test coverage for pull-request-target checkout checks and for variations of broad write-permission configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->