### PR TITLE
fix(hooks): fix cost-reporting bugs in ecc-metrics-bridge (double-count + tail truncation)

### DIFF
--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -91,6 +91,13 @@ function readSessionCost(sessionId) {
       fs.readSync(fd, buf, 0, readSize, Math.max(0, stat.size - readSize));
       const lines = buf.toString('utf8').split('\n').filter(Boolean);
 
+      // Each row in costs.jsonl is *already* a cumulative session total — see
+      // scripts/hooks/cost-tracker.js: "Each row therefore represents the
+      // cumulative session total up to that point. To get per-session cost,
+      // take the last row per session_id." Summing every matching row
+      // therefore double-counts: for N rows of the same session it over-
+      // reports by roughly N(N+1)/2 / N = (N+1)/2 ×. Take the last matching
+      // row instead.
       let totalCost = 0;
       let totalIn = 0;
       let totalOut = 0;
@@ -98,9 +105,9 @@ function readSessionCost(sessionId) {
         try {
           const row = JSON.parse(line);
           if (row.session_id === sessionId) {
-            totalCost += toNumber(row.estimated_cost_usd);
-            totalIn += toNumber(row.input_tokens);
-            totalOut += toNumber(row.output_tokens);
+            totalCost = toNumber(row.estimated_cost_usd);
+            totalIn = toNumber(row.input_tokens);
+            totalOut = toNumber(row.output_tokens);
           }
         } catch {
           /* skip malformed lines */

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -77,46 +77,44 @@ function extractFilePaths(toolName, toolInput) {
 }
 
 /**
- * Read cumulative cost for a session from the tail of costs.jsonl.
- * Reads last 8KB to avoid scanning entire file.
+ * Read cumulative cost for a session from costs.jsonl.
+ *
+ * Scans the full file because each row is a cumulative session total
+ * (see cost-tracker.js docblock) and the row we need is the last one
+ * matching `sessionId`. The previous implementation read only the
+ * trailing 8 KiB; any session whose latest cumulative row was pushed
+ * past that window by newer rows from other sessions silently dropped
+ * to zero — the opposite sign of the double-count bug fixed in the
+ * previous commit.
+ *
+ * costs.jsonl is append-only and unbounded today (no rotation in
+ * cost-tracker.js). At a typical ~150 bytes per row, even 100k rows
+ * is ~15 MB and a single sync read on every PreToolUse hook is in
+ * the low milliseconds. If rotation lands later, this scan becomes
+ * even cheaper.
  */
 function readSessionCost(sessionId) {
   try {
     const costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
-    const stat = fs.statSync(costsPath);
-    const readSize = Math.min(stat.size, 8192);
-    const fd = fs.openSync(costsPath, 'r');
-    try {
-      const buf = Buffer.alloc(readSize);
-      fs.readSync(fd, buf, 0, readSize, Math.max(0, stat.size - readSize));
-      const lines = buf.toString('utf8').split('\n').filter(Boolean);
+    const content = fs.readFileSync(costsPath, 'utf8');
+    const lines = content.split('\n').filter(Boolean);
 
-      // Each row in costs.jsonl is *already* a cumulative session total — see
-      // scripts/hooks/cost-tracker.js: "Each row therefore represents the
-      // cumulative session total up to that point. To get per-session cost,
-      // take the last row per session_id." Summing every matching row
-      // therefore double-counts: for N rows of the same session it over-
-      // reports by roughly N(N+1)/2 / N = (N+1)/2 ×. Take the last matching
-      // row instead.
-      let totalCost = 0;
-      let totalIn = 0;
-      let totalOut = 0;
-      for (const line of lines) {
-        try {
-          const row = JSON.parse(line);
-          if (row.session_id === sessionId) {
-            totalCost = toNumber(row.estimated_cost_usd);
-            totalIn = toNumber(row.input_tokens);
-            totalOut = toNumber(row.output_tokens);
-          }
-        } catch {
-          /* skip malformed lines */
+    let totalCost = 0;
+    let totalIn = 0;
+    let totalOut = 0;
+    for (const line of lines) {
+      try {
+        const row = JSON.parse(line);
+        if (row.session_id === sessionId) {
+          totalCost = toNumber(row.estimated_cost_usd);
+          totalIn = toNumber(row.input_tokens);
+          totalOut = toNumber(row.output_tokens);
         }
+      } catch {
+        /* skip malformed lines */
       }
-      return { totalCost, totalIn, totalOut };
-    } finally {
-      fs.closeSync(fd);
     }
+    return { totalCost, totalIn, totalOut };
   } catch {
     return { totalCost: 0, totalIn: 0, totalOut: 0 };
   }

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -89,7 +89,7 @@ function extractFilePaths(toolName, toolInput) {
  *
  * costs.jsonl is append-only and unbounded today (no rotation in
  * cost-tracker.js). At a typical ~150 bytes per row, even 100k rows
- * is ~15 MB and a single sync read on every PreToolUse hook is in
+ * is ~15 MB and a single sync read on every PostToolUse hook is in
  * the low milliseconds. If rotation lands later, this scan becomes
  * even cheaper.
  */

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -94,14 +94,15 @@ function extractFilePaths(toolName, toolInput) {
  * even cheaper.
  */
 function readSessionCost(sessionId) {
+  const costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
   try {
-    const costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
     const content = fs.readFileSync(costsPath, 'utf8');
     const lines = content.split('\n').filter(Boolean);
 
     let totalCost = 0;
     let totalIn = 0;
     let totalOut = 0;
+    let malformed = 0;
     for (const line of lines) {
       try {
         const row = JSON.parse(line);
@@ -111,11 +112,23 @@ function readSessionCost(sessionId) {
           totalOut = toNumber(row.output_tokens);
         }
       } catch {
-        /* skip malformed lines */
+        malformed += 1;
       }
     }
+    // One aggregated breadcrumb per call rather than one per bad row, so a
+    // log-flooded costs.jsonl stays diagnosable without overwhelming stderr.
+    if (malformed > 0) {
+      process.stderr.write(`[ecc-metrics-bridge] skipped ${malformed} malformed line(s) in ${costsPath}\n`);
+    }
     return { totalCost, totalIn, totalOut };
-  } catch {
+  } catch (err) {
+    // ENOENT is the common case (no Stop event has fired yet this session)
+    // and is not actually a failure — stay silent on it. Anything else
+    // (permission, EISDIR, malformed read) deserves a breadcrumb because
+    // the bridge will silently report zero cost otherwise.
+    if (err && err.code !== 'ENOENT') {
+      process.stderr.write(`[ecc-metrics-bridge] failing open after ${err.name || 'error'} reading ${costsPath}: ${err.message || String(err)}\n`);
+    }
     return { totalCost: 0, totalIn: 0, totalOut: 0 };
   }
 }

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -19,6 +19,7 @@ const MAX_STDIN = 1024 * 1024;
 const MAX_FILES_TRACKED = 200;
 const RECENT_TOOLS_SIZE = 5;
 const HASH_INPUT_LIMIT = 2048;
+const costWarningSignatures = new Map();
 
 function toNumber(value) {
   const n = Number(value);
@@ -76,6 +77,13 @@ function extractFilePaths(toolName, toolInput) {
   return paths;
 }
 
+function writeCostWarningOnce(kind, costsPath, signature, message) {
+  const key = `${kind}:${costsPath}`;
+  if (costWarningSignatures.get(key) === signature) return;
+  costWarningSignatures.set(key, signature);
+  process.stderr.write(message);
+}
+
 /**
  * Read cumulative cost for a session from costs.jsonl.
  *
@@ -117,8 +125,15 @@ function readSessionCost(sessionId) {
     }
     // One aggregated breadcrumb per call rather than one per bad row, so a
     // log-flooded costs.jsonl stays diagnosable without overwhelming stderr.
+    // Suppress repeats for the same malformed-line count; this hook runs after
+    // every tool invocation, so a persistent bad row should not spam stderr.
     if (malformed > 0) {
-      process.stderr.write(`[ecc-metrics-bridge] skipped ${malformed} malformed line(s) in ${costsPath}\n`);
+      writeCostWarningOnce(
+        'malformed',
+        costsPath,
+        String(malformed),
+        `[ecc-metrics-bridge] skipped ${malformed} malformed line(s) in ${costsPath}\n`
+      );
     }
     return { totalCost, totalIn, totalOut };
   } catch (err) {
@@ -127,7 +142,12 @@ function readSessionCost(sessionId) {
     // (permission, EISDIR, malformed read) deserves a breadcrumb because
     // the bridge will silently report zero cost otherwise.
     if (err && err.code !== 'ENOENT') {
-      process.stderr.write(`[ecc-metrics-bridge] failing open after ${err.name || 'error'} reading ${costsPath}: ${err.message || String(err)}\n`);
+      writeCostWarningOnce(
+        'read-error',
+        costsPath,
+        err.code || err.name || 'error',
+        `[ecc-metrics-bridge] failing open after ${err.name || 'error'} reading ${costsPath}: ${err.message || String(err)}\n`
+      );
     }
     return { totalCost: 0, totalIn: 0, totalOut: 0 };
   }

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -11,6 +11,7 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { sanitizeSessionId, readBridge, writeBridgeAtomic } = require('../lib/session-bridge');
 const { getClaudeDir } = require('../lib/utils');
@@ -19,7 +20,7 @@ const MAX_STDIN = 1024 * 1024;
 const MAX_FILES_TRACKED = 200;
 const RECENT_TOOLS_SIZE = 5;
 const HASH_INPUT_LIMIT = 2048;
-const costWarningSignatures = new Map();
+const WARNING_CACHE_PREFIX = 'ecc-metrics-cost-warnings-';
 
 function toNumber(value) {
   const n = Number(value);
@@ -77,11 +78,34 @@ function extractFilePaths(toolName, toolInput) {
   return paths;
 }
 
-function writeCostWarningOnce(kind, costsPath, signature, message) {
-  const key = `${kind}:${costsPath}`;
-  if (costWarningSignatures.get(key) === signature) return;
-  costWarningSignatures.set(key, signature);
+function getCostWarningCachePath(costsPath) {
+  const hash = crypto.createHash('sha256').update(costsPath).digest('hex').slice(0, 16);
+  return path.join(os.tmpdir(), `${WARNING_CACHE_PREFIX}${hash}.json`);
+}
+
+function readCostWarningCache(cachePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeCostWarningIfChanged(kind, costsPath, signature, message) {
+  const cachePath = getCostWarningCachePath(costsPath);
+  const cache = readCostWarningCache(cachePath);
+  if (cache[kind] === signature) return;
+
   process.stderr.write(message);
+  try {
+    const next = { ...cache, [kind]: signature };
+    const tmp = `${cachePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(next), 'utf8');
+    fs.renameSync(tmp, cachePath);
+  } catch {
+    // Warning-cache persistence is best effort; never block hook execution.
+  }
 }
 
 /**
@@ -102,8 +126,9 @@ function writeCostWarningOnce(kind, costsPath, signature, message) {
  * even cheaper.
  */
 function readSessionCost(sessionId) {
-  const costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
+  let costsPath = path.join('metrics', 'costs.jsonl');
   try {
+    costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
     const content = fs.readFileSync(costsPath, 'utf8');
     const lines = content.split('\n').filter(Boolean);
 
@@ -111,6 +136,7 @@ function readSessionCost(sessionId) {
     let totalIn = 0;
     let totalOut = 0;
     let malformed = 0;
+    const malformedHasher = crypto.createHash('sha256');
     for (const line of lines) {
       try {
         const row = JSON.parse(line);
@@ -121,17 +147,18 @@ function readSessionCost(sessionId) {
         }
       } catch {
         malformed += 1;
+        malformedHasher.update(line).update('\0');
       }
     }
     // One aggregated breadcrumb per call rather than one per bad row, so a
     // log-flooded costs.jsonl stays diagnosable without overwhelming stderr.
-    // Suppress repeats for the same malformed-line count; this hook runs after
-    // every tool invocation, so a persistent bad row should not spam stderr.
+    // Suppress repeats for the same malformed-line signature across hook
+    // subprocesses, so a persistent bad row should not spam stderr.
     if (malformed > 0) {
-      writeCostWarningOnce(
+      writeCostWarningIfChanged(
         'malformed',
         costsPath,
-        String(malformed),
+        `${malformed}:${malformedHasher.digest('hex').slice(0, 16)}`,
         `[ecc-metrics-bridge] skipped ${malformed} malformed line(s) in ${costsPath}\n`
       );
     }
@@ -142,10 +169,10 @@ function readSessionCost(sessionId) {
     // (permission, EISDIR, malformed read) deserves a breadcrumb because
     // the bridge will silently report zero cost otherwise.
     if (err && err.code !== 'ENOENT') {
-      writeCostWarningOnce(
+      writeCostWarningIfChanged(
         'read-error',
         costsPath,
-        err.code || err.name || 'error',
+        `${err.code || err.name || 'error'}:${err.message || String(err)}`,
         `[ecc-metrics-bridge] failing open after ${err.name || 'error'} reading ${costsPath}: ${err.message || String(err)}\n`
       );
     }

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -226,6 +226,89 @@ function runTests() {
   else failed++;
 
   if (
+    test('readSessionCost writes a stderr breadcrumb when malformed lines are skipped', () => {
+      // Reviewer (coderabbitai) asked for diagnosability when the inner
+      // catch silently skips malformed JSON rows. Verify the aggregated
+      // "skipped N malformed line(s)" breadcrumb appears on stderr while
+      // the function still recovers the last valid matching row.
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      const originalStderrWrite = process.stderr.write.bind(process.stderr);
+      let captured = '';
+      process.stderr.write = chunk => {
+        captured += String(chunk);
+        return true;
+      };
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          [
+            JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.5, input_tokens: 500, output_tokens: 250 }),
+            'NOT_JSON',
+            '{"truncated":',
+            JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.7, input_tokens: 700, output_tokens: 350 }),
+          ].join('\n') + '\n',
+          'utf8'
+        );
+        const result = readSessionCost('S1');
+        assert.strictEqual(result.totalCost, 0.7, 'last valid row should still win');
+        assert.ok(/skipped 2 malformed line\(s\)/.test(captured),
+          `expected aggregated malformed-line breadcrumb on stderr, got: ${captured}`);
+      } finally {
+        process.stderr.write = originalStderrWrite;
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost stays silent when costs.jsonl does not exist (ENOENT)', () => {
+      // ENOENT is the common case before any Stop event has fired — it is
+      // not a failure and should not produce stderr noise. Other errors
+      // (permission, EISDIR, etc.) DO produce a breadcrumb, covered by the
+      // malformed-line test above's surrounding harness.
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      const originalStderrWrite = process.stderr.write.bind(process.stderr);
+      let captured = '';
+      process.stderr.write = chunk => {
+        captured += String(chunk);
+        return true;
+      };
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        // Do NOT create the metrics dir or file — readSessionCost should
+        // hit ENOENT and return zeros silently.
+        const result = readSessionCost('S1');
+        assert.deepStrictEqual(result, { totalCost: 0, totalIn: 0, totalOut: 0 });
+        assert.strictEqual(captured, '', `expected no stderr on ENOENT, got: ${captured}`);
+      } finally {
+        process.stderr.write = originalStderrWrite;
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('readSessionCost does not include unrelated default-session rows', () => {
       const tmpHome = makeTempHome();
       const originalHome = process.env.HOME;

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -146,6 +146,45 @@ function runTests() {
   else failed++;
 
   if (
+    test('readSessionCost returns the LAST cumulative row, not the sum (cost-tracker contract)', () => {
+      // cost-tracker.js writes one row per Stop event; each row is already
+      // a cumulative session total ("To get per-session cost, take the
+      // last row per session_id."). Summing across rows over-counts:
+      // 0.01 + 0.02 + 0.03 = 0.06, but the correct answer is 0.03.
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          [
+            JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.01, input_tokens: 333, output_tokens: 166 }),
+            JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.02, input_tokens: 666, output_tokens: 333 }),
+            JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.03, input_tokens: 1000, output_tokens: 500 })
+          ].join('\n') + '\n',
+          'utf8'
+        );
+        const result = readSessionCost('S1');
+        assert.strictEqual(result.totalCost, 0.03, `expected last-row 0.03, got ${result.totalCost} (was the bug: 0.06)`);
+        assert.strictEqual(result.totalIn, 1000);
+        assert.strictEqual(result.totalOut, 500);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('readSessionCost does not include unrelated default-session rows', () => {
       const tmpHome = makeTempHome();
       const originalHome = process.env.HOME;

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -185,6 +185,47 @@ function runTests() {
   else failed++;
 
   if (
+    test('readSessionCost finds session row beyond the old 8 KiB tail boundary', () => {
+      // The previous implementation read only the trailing 8 KiB of
+      // costs.jsonl. A long-running deployment where the target session's
+      // most recent cumulative row sat further back than that — e.g.
+      // pushed past by many rows from OTHER sessions — silently saw
+      // cost=0. This test wedges the S1 row at the file start, fills
+      // ~16 KiB of OTHER-session noise after it, and asserts the S1 row
+      // is still found.
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        const otherRow = JSON.stringify({ session_id: 'OTHER', estimated_cost_usd: 1, input_tokens: 100, output_tokens: 50 });
+        const s1Row = JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.5, input_tokens: 500, output_tokens: 250 });
+        const rows = [s1Row, ...Array(200).fill(otherRow)];
+        fs.writeFileSync(path.join(metricsDir, 'costs.jsonl'), rows.join('\n') + '\n', 'utf8');
+        // Confirm we're actually past the old 8 KiB ceiling so the test
+        // would have failed under the previous implementation.
+        const size = fs.statSync(path.join(metricsDir, 'costs.jsonl')).size;
+        assert.ok(size > 8192, `setup: expected costs.jsonl > 8 KiB, got ${size} bytes`);
+        const result = readSessionCost('S1');
+        assert.strictEqual(result.totalCost, 0.5);
+        assert.strictEqual(result.totalIn, 500);
+        assert.strictEqual(result.totalOut, 250);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('readSessionCost does not include unrelated default-session rows', () => {
       const tmpHome = makeTempHome();
       const originalHome = process.env.HOME;

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -226,11 +226,13 @@ function runTests() {
   else failed++;
 
   if (
-    test('readSessionCost writes a stderr breadcrumb when malformed lines are skipped', () => {
+    test('readSessionCost writes one stderr breadcrumb when malformed lines persist across calls', () => {
       // Reviewer (coderabbitai) asked for diagnosability when the inner
       // catch silently skips malformed JSON rows. Verify the aggregated
       // "skipped N malformed line(s)" breadcrumb appears on stderr while
-      // the function still recovers the last valid matching row.
+      // the function still recovers the last valid matching row. Because
+      // this hook runs after every tool invocation, the same bad rows should
+      // not emit the same warning on every call.
       const tmpHome = makeTempHome();
       const originalHome = process.env.HOME;
       const originalUserProfile = process.env.USERPROFILE;
@@ -257,8 +259,11 @@ function runTests() {
         );
         const result = readSessionCost('S1');
         assert.strictEqual(result.totalCost, 0.7, 'last valid row should still win');
-        assert.ok(/skipped 2 malformed line\(s\)/.test(captured),
-          `expected aggregated malformed-line breadcrumb on stderr, got: ${captured}`);
+        const secondResult = readSessionCost('S1');
+        assert.deepStrictEqual(secondResult, result);
+        const matches = captured.match(/skipped 2 malformed line\(s\)/g) || [];
+        assert.strictEqual(matches.length, 1,
+          `expected one aggregated malformed-line breadcrumb on stderr, got: ${captured}`);
       } finally {
         process.stderr.write = originalStderrWrite;
         if (originalHome === undefined) delete process.env.HOME;

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -5,6 +5,7 @@
  */
 
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -266,6 +267,48 @@ function runTests() {
           `expected one aggregated malformed-line breadcrumb on stderr, got: ${captured}`);
       } finally {
         process.stderr.write = originalStderrWrite;
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost suppresses repeated malformed breadcrumbs across hook subprocesses', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          [
+            JSON.stringify({ session_id: 'S1', estimated_cost_usd: 0.7, input_tokens: 700, output_tokens: 350 }),
+            'NOT_JSON',
+            '{"truncated":'
+          ].join('\n') + '\n',
+          'utf8'
+        );
+
+        const bridgePath = path.resolve(__dirname, '../../scripts/hooks/ecc-metrics-bridge');
+        const code = "const { readSessionCost } = require(process.argv[1]); readSessionCost('S1');";
+        const env = { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome };
+        const first = spawnSync(process.execPath, ['-e', code, bridgePath], { env, encoding: 'utf8' });
+        const second = spawnSync(process.execPath, ['-e', code, bridgePath], { env, encoding: 'utf8' });
+
+        assert.strictEqual(first.status, 0, first.stderr || first.stdout);
+        assert.strictEqual(second.status, 0, second.stderr || second.stdout);
+        assert.match(first.stderr, /skipped 2 malformed line\(s\)/);
+        assert.strictEqual(second.stderr, '', `expected repeat subprocess warning suppression, got: ${second.stderr}`);
+      } finally {
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;
         if (originalUserProfile === undefined) delete process.env.USERPROFILE;


### PR DESCRIPTION
## Summary

`scripts/hooks/ecc-metrics-bridge.js#readSessionCost` has two opposite-sign bugs that both produce a wrong cost number, then feed it into `ecc-context-monitor.js` and from there into the live model turn as `additionalContext`:

1. **Over-count** — sum of cumulative rows reports ~(N+1)/2 × the real cost (~2× over-count at 3 Stop events for a session). Threshold alarms (`COST_NOTICE_USD`, `COST_WARNING_USD`, `COST_CRITICAL_USD`) trip on phantom spend, and the agent itself is told a wrong number.
2. **Under-count** — 8 KiB tail-only read silently drops the target session's row once newer rows from other sessions push past the window; reports zero. On any non-trivial workstation this happens within minutes of normal use because `cost-tracker.js` has no rotation policy.

Both bugs reproduce in a few lines of fixture.

## Bug 1 — Over-count (cumulative double-counting)

`cost-tracker.js`'s module docblock explicitly states:

> Cumulative behavior: Stop fires per assistant response, not per session. Each row therefore represents the cumulative session total up to that point. To get per-session cost, take the last row per session_id.

`readSessionCost` then violates that contract by summing across rows. For 3 cumulative rows at 0.01, 0.02, 0.03 USD (true running total: 0.03), the bridge today reports 0.06 USD.

Repro on `main` at `b113edac`:

```
$ python3 -c '
import json
with open("/tmp/eccc/.claude/metrics/costs.jsonl", "w") as f:
    for cost, inp, out in [(0.01, 333, 166), (0.02, 666, 333), (0.03, 1000, 500)]:
        json.dump({"session_id": "S1", "estimated_cost_usd": cost,
                   "input_tokens": inp, "output_tokens": out}, f)
        f.write(chr(10))'
$ HOME=/tmp/eccc node -e 'const m = require("./scripts/hooks/ecc-metrics-bridge.js"); \
    console.log(JSON.stringify(m.readSessionCost("S1")))'
{"totalCost":0.06,"totalIn":1999,"totalOut":999}
```

Expected: `{"totalCost":0.03,"totalIn":1000,"totalOut":500}` (the last cumulative row).
Actual: 2× over-count.

Fix: replace `+=` with `=` in the matching branch so the assignment reflects the most recent row encountered. Iteration is in file order, which is event time order, so the last assignment wins — exactly the contract `cost-tracker.js` writes against.

## Bug 2 — Under-count (8 KiB tail truncation)

The function reads only the trailing 8 KiB of `~/.claude/metrics/costs.jsonl`. Once the target session's most recent cumulative row gets pushed past that window by newer rows from other sessions, the bridge silently sees zero matching rows and returns `{totalCost: 0}`. Same false signal to `ecc-context-monitor.js`, opposite sign.

Repro (S1 row at file start, 200 rows of OTHER-session noise after, total ~16 KiB):

```
$ HOME=/tmp/eccc node -e '
    const fs = require("fs");
    fs.mkdirSync("/tmp/eccc/.claude/metrics", { recursive: true });
    const s1 = JSON.stringify({session_id:"S1",estimated_cost_usd:0.5,input_tokens:500,output_tokens:250});
    const other = JSON.stringify({session_id:"OTHER",estimated_cost_usd:1,input_tokens:100,output_tokens:50});
    fs.writeFileSync("/tmp/eccc/.claude/metrics/costs.jsonl",
        [s1, ...Array(200).fill(other)].join("\\n") + "\\n");
    const m = require("./scripts/hooks/ecc-metrics-bridge.js");
    console.log(JSON.stringify(m.readSessionCost("S1")))'
{"totalCost":0,"totalIn":0,"totalOut":0}
```

Expected: `{"totalCost":0.5, "totalIn":500, "totalOut":250}` (the S1 row that exists in the file).
Actual: zero — the row is past the 8 KiB tail.

Fix: drop the `fs.openSync` + bounded `fs.readSync` + position arithmetic in favour of `fs.readFileSync(costsPath, 'utf8')` and iterate every line. Each row is ~150 bytes; even 100k rows is ~15 MB and a single sync read on PreToolUse is in the low ms. If file rotation lands in `cost-tracker.js` later, this scan becomes proportionally cheaper.

## Commit layout

Two commits, one fix each, with paired regression tests:

1. `fix(hooks): use last cumulative row for session cost in metrics bridge` — `+=` → `=`. Test: `readSessionCost returns the LAST cumulative row, not the sum (cost-tracker contract)` with three cumulative rows so the two formulas (sum vs. last-row) diverge.
2. `fix(hooks): scan full costs.jsonl when locating session row` — drop 8 KiB ceiling. Test: `readSessionCost finds session row beyond the old 8 KiB tail boundary` with the file deliberately exceeding 8 KiB before the read.

## Tests

`tests/hooks/ecc-metrics-bridge.test.js`: 13 → 15 cases (2 new). Existing `readSessionCost does not include unrelated default-session rows` test happened to pass under both bugs because it used only single-row sessions. The new tests use multi-row + multi-session fixtures so the two bugs become assertable.

Full `yarn test` green; `yarn lint` clean.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] Manual: bug-1 repro returns `totalCost: 0.03` (was `0.06`)
- [ ] Manual: bug-2 repro returns `totalCost: 0.5` (was `0`)
- [ ] Manual: existing `readSessionCost does not include unrelated default-session rows` test still passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cost reporting in `ecc-metrics-bridge`: use the last cumulative row per session and scan the full `costs.jsonl`. This removes double-counting and tail truncation so thresholds and `additionalContext` use the right numbers, and adds aggregated, deduplicated (persisted) breadcrumbs for malformed lines or read errors.

- **Bug Fixes**
  - Use the last cumulative row per `session_id` in `readSessionCost` (stop summing across rows).
  - Read the full `~/.claude/metrics/costs.jsonl` (drop the 8 KiB tail read).
  - Aggregate and deduplicate stderr breadcrumbs for malformed lines and non-ENOENT read errors; persist dedup across hook subprocesses; stay silent on `ENOENT`.
  - Add regression tests for both bugs, malformed-line aggregation, ENOENT silence, and cross-process dedup; tests and lint pass.

<sup>Written for commit f6d7067ff5c89726d4603dec3b1cc77673ea0d12. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1971?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use the latest cumulative entry per session (last matching row) when computing session costs; malformed metric lines are skipped and produce a single deduplicated aggregated warning. Missing metric files return zero totals without warnings. Cross-process deduplication ensures repeated stderr warnings are suppressed.

* **Tests**
  * Expanded tests for large files, boundary reads, malformed-entry handling, cross-process suppression, and missing-file behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->