### PR TITLE
fix(metrics-bridge): take latest cumulative snapshot instead of summing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ ecc2/target/
 .opencode/package-lock.json
 .opencode/node_modules/
 assets/images/security/badrudi-exploit.mp4
+.claude/*.local.*

--- a/rules/swift/testing.md
+++ b/rules/swift/testing.md
@@ -9,7 +9,7 @@ paths:
 
 ## Framework
 
-Use **Swift Testing** (`import Testing`) for new tests. Use `@Test` and `#expect`:
+Use **Swift Testing** (`import Testing`) for new unit and integration tests when the minimum deployment target supports it (iOS 16+, macOS 13+, Xcode 15+). Use `@Test` and `#expect`:
 
 ```swift
 @Test("User creation validates email")
@@ -19,6 +19,15 @@ func userCreationValidatesEmail() throws {
     }
 }
 ```
+
+**Continue using XCTest for:**
+
+- UI tests — XCUITest is XCTest-based and has no Swift Testing equivalent
+- Performance tests — `measure {}` / `XCTMetric` have no equivalent in Swift Testing
+- Targets with deployment targets below iOS 16 / macOS 13
+- Existing XCTest suites — do not migrate unless there is a clear reason
+
+Swift Testing and XCTest can coexist in the same test target.
 
 ## Test Isolation
 

--- a/rules/typescript/coding-style.md
+++ b/rules/typescript/coding-style.md
@@ -134,6 +134,39 @@ export function formatUser(user) {
 }
 ```
 
+### `null` vs `undefined`
+
+Use each for a distinct semantic meaning — mixing them forces callers to check both every time.
+
+| Value | Meaning |
+|-------|---------|
+| `undefined` | Value was never set / property does not exist |
+| `null` | Value was explicitly cleared / intentionally absent |
+
+Rules:
+
+- Use `undefined` as the default "not present" signal — it is what TypeScript and JavaScript use natively (missing props, optional parameters, uninitialised variables)
+- Use `null` only when you need to **explicitly communicate** "this was set to nothing" (e.g. clearing a foreign key, an API field that distinguishes "not provided" from "removed")
+- Never mix both for the same concept in one codebase area — pick one and stay consistent
+- Enable `strictNullChecks` (included in `strict: true`) so the compiler enforces the distinction
+- Prefer optional chaining (`?.`) and nullish coalescing (`??`) over manual `=== null || === undefined` checks
+
+```typescript
+// WRONG: returning null for "not found" when the rest of the codebase uses undefined
+function findUser(id: string): User | null { ... }
+
+// CORRECT: consistent with JS/TS conventions for "not found"
+function findUser(id: string): User | undefined { ... }
+
+// CORRECT: null signals intentional removal (e.g. clearing a DB foreign key)
+interface Profile {
+  avatarUrl: string | null  // null = user explicitly removed their avatar
+}
+
+// CORRECT: optional chaining + nullish coalescing
+const name = user?.profile?.displayName ?? 'Anonymous'
+```
+
 ## Immutability
 
 Use spread operator for immutable updates:

--- a/rules/typescript/coding-style.md
+++ b/rules/typescript/coding-style.md
@@ -60,6 +60,27 @@ type UserWithRole = User & {
 - Use `unknown` for external or untrusted input, then narrow it safely
 - Use generics when a value's type depends on the caller
 
+### Avoid `as` Type Assertions
+
+`as` tells the compiler "trust me" and bypasses type checking — the same risk as `any`.
+
+- Avoid `as SomeType` when TypeScript can infer or narrow the type itself
+- Never use `as any` — it is `any` in disguise
+- Prefer a type guard (`instanceof`, `typeof`, custom predicate) over `as`
+- Only use `as` when bridging library types you cannot change (e.g. DOM APIs, third-party responses), and add a comment explaining why
+
+```typescript
+// WRONG: silences the compiler without verifying the shape
+const user = response.data as User
+
+// CORRECT: validate before narrowing
+const user = userSchema.parse(response.data) // Zod throws if shape is wrong
+
+// ACCEPTABLE: DOM API returns Element | null; we have already checked
+const canvas = document.getElementById('chart') as HTMLCanvasElement
+// ↑ only safe after confirming the element exists and is a canvas
+```
+
 ```typescript
 // WRONG: any removes type safety
 function getErrorMessage(error: any) {
@@ -80,7 +101,7 @@ function getErrorMessage(error: unknown): string {
 
 - Define component props with a named `interface` or `type`
 - Type callback props explicitly
-- Do not use `React.FC` unless there is a specific reason to do so
+- Do not use `React.FC` — it adds an implicit `children` prop you didn't ask for, hides the return type from callers, and offers no advantage over a plain function with typed props
 
 ```typescript
 interface User {
@@ -158,9 +179,11 @@ function getErrorMessage(error: unknown): string {
   return 'Unexpected error'
 }
 
+// ⚠️ MUST REPLACE: swap this stub with your real logger (e.g. pino, winston).
+// Leaving it as-is silently swallows errors in production.
 const logger = {
   error: (message: string, error: unknown) => {
-    // Replace with your production logger (for example, pino or winston).
+    // e.g. pinoLogger.error({ err: error }, message)
   }
 }
 

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -78,35 +78,41 @@ function extractFilePaths(toolName, toolInput) {
 
 /**
  * Read cumulative cost for a session from the tail of costs.jsonl.
- * Reads last 8KB to avoid scanning entire file.
+ * Reads last 64KB to give long sessions enough room to find their latest row.
+ *
+ * Each row in costs.jsonl is itself a cumulative snapshot (cost-tracker.js
+ * re-scans the entire transcript on every Stop event), so we take the LATEST
+ * row per session — never sum, or we double-count every prior snapshot.
  */
 function readSessionCost(sessionId) {
   try {
     const costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
     const stat = fs.statSync(costsPath);
-    const readSize = Math.min(stat.size, 8192);
+    const readSize = Math.min(stat.size, 65536);
     const fd = fs.openSync(costsPath, 'r');
     try {
       const buf = Buffer.alloc(readSize);
       fs.readSync(fd, buf, 0, readSize, Math.max(0, stat.size - readSize));
       const lines = buf.toString('utf8').split('\n').filter(Boolean);
 
-      let totalCost = 0;
-      let totalIn = 0;
-      let totalOut = 0;
+      let latest = null;
       for (const line of lines) {
         try {
           const row = JSON.parse(line);
-          if (row.session_id === sessionId) {
-            totalCost += toNumber(row.estimated_cost_usd);
-            totalIn += toNumber(row.input_tokens);
-            totalOut += toNumber(row.output_tokens);
+          if (row.session_id !== sessionId) continue;
+          if (!latest || (row.timestamp || '') > (latest.timestamp || '')) {
+            latest = row;
           }
         } catch {
           /* skip malformed lines */
         }
       }
-      return { totalCost, totalIn, totalOut };
+      if (!latest) return { totalCost: 0, totalIn: 0, totalOut: 0 };
+      return {
+        totalCost: toNumber(latest.estimated_cost_usd),
+        totalIn: toNumber(latest.input_tokens),
+        totalOut: toNumber(latest.output_tokens)
+      };
     } finally {
       fs.closeSync(fd);
     }

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -179,6 +179,75 @@ function runTests() {
     passed++;
   else failed++;
 
+  if (
+    test('readSessionCost returns latest cumulative snapshot, not sum (regression)', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        // cost-tracker writes one row per Stop, each a cumulative snapshot
+        // for the same session. Bridge must take the latest, not sum them.
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          [
+            JSON.stringify({ timestamp: '2026-05-18T01:00:00.000Z', session_id: 's1', estimated_cost_usd: 1.00, input_tokens: 10, output_tokens: 20 }),
+            JSON.stringify({ timestamp: '2026-05-18T01:01:00.000Z', session_id: 's1', estimated_cost_usd: 2.50, input_tokens: 25, output_tokens: 50 }),
+            JSON.stringify({ timestamp: '2026-05-18T01:02:00.000Z', session_id: 's1', estimated_cost_usd: 4.75, input_tokens: 40, output_tokens: 90 })
+          ].join('\n') + '\n',
+          'utf8'
+        );
+        const result = readSessionCost('s1');
+        assert.strictEqual(result.totalCost, 4.75, 'should be latest row, not 8.25 sum');
+        assert.strictEqual(result.totalIn, 40);
+        assert.strictEqual(result.totalOut, 90);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost handles out-of-order timestamps correctly', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          [
+            JSON.stringify({ timestamp: '2026-05-18T01:02:00.000Z', session_id: 's2', estimated_cost_usd: 4.75, input_tokens: 40, output_tokens: 90 }),
+            JSON.stringify({ timestamp: '2026-05-18T01:00:00.000Z', session_id: 's2', estimated_cost_usd: 1.00, input_tokens: 10, output_tokens: 20 })
+          ].join('\n') + '\n',
+          'utf8'
+        );
+        const result = readSessionCost('s2');
+        assert.strictEqual(result.totalCost, 4.75);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
   // run tests
   console.log('\nrun:');
 


### PR DESCRIPTION
## Problem

`readSessionCost` in `scripts/hooks/ecc-metrics-bridge.js` summed every row in `costs.jsonl` that matched the session id. But `cost-tracker.js` writes a **cumulative snapshot** on every Stop event (it re-scans the entire transcript each time), so each row is the running total up to that point, not an increment.

Summing those rows triple/quadruple/30×-counts a session's cost. Symptom: the status line `$cost` and the PostToolUse `COST WARNING` hook show numbers far above real usage.

## Evidence

Against my live `~/.claude/metrics/costs.jsonl` (16 sessions, mostly Opus 4.7):

| | sum (current code) | latest (this fix) | ratio |
|---|---:|---:|---:|
| Total | $1456.96 | $230.33 | **6.33×** |
| Worst single session (12 rows) | $613.37 | $20.68 | **29.7×** |
| Sessions with 1 row | unchanged | unchanged | 1.0× |

Per-session breakdown attached in the commit message context.

## Fix

`readSessionCost` now picks the row with the latest `timestamp` per session_id instead of summing. Same change applies to `totalIn` / `totalOut`. Tail-read window bumped from 8 KB → 64 KB so long sessions can still find their latest row when other sessions interleave.

```js
// before
totalCost += toNumber(row.estimated_cost_usd);

// after
if (!latest || (row.timestamp || '') > (latest.timestamp || '')) {
  latest = row;
}
```

ISO-8601 timestamps sort lexicographically = chronologically, so a string `>` compare is sufficient and avoids `Date` parsing in a hot path.

## Tests

Added two regression tests in `tests/hooks/ecc-metrics-bridge.test.js`:

1. `readSessionCost returns latest cumulative snapshot, not sum` — three rows for one session, asserts `$4.75` (latest) not `$8.25` (sum).
2. `readSessionCost handles out-of-order timestamps correctly` — rows in file order ≠ chronological order; assert latest by timestamp wins.

`node tests/hooks/ecc-metrics-bridge.test.js` → 16/16 passing.

## Not addressed in this PR

The rate table at `cost-tracker.js:34-38` is still hardcoded approximations (Opus = $15/$75 per 1M, cache write/read at 1.25× / 0.1× input rate, no 5m vs 1h cache tier split, no `server_tool_use` pricing). After this fix the numbers align with what `cost-tracker.js` writes, but that itself remains an estimate vs real Anthropic billing. Worth a follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated session cost reporting by taking the latest cumulative snapshot per session instead of summing. Status `$cost` and PostToolUse `COST WARNING` now match real usage.

- Bug Fixes
  - `scripts/hooks/ecc-metrics-bridge.js`: pick the newest `timestamp` per `session_id` and use its `estimated_cost_usd`, `input_tokens`, and `output_tokens`.
  - Expand tail read window from 8 KB to 64 KB to find the latest row in long, interleaved logs.
  - Add tests for cumulative snapshots and out-of-order timestamps.

- Refactors
  - Clarify Swift Testing vs XCTest usage in `rules/swift/testing.md`.
  - Tighten TypeScript style rules: avoid `as` assertions; add `null` vs `undefined` guidance; improve logger note.
  - Ignore local Claude config files in `.gitignore`.

<sup>Written for commit c6d576abcf21a070c0b72af3ca71aabfc1e3f055. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1975?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Swift testing guidance to clarify Swift Testing vs. XCTest usage based on deployment targets and tooling requirements.
  * Added TypeScript/JavaScript style guidelines covering type assertions, React props conventions, and null/undefined semantics.

* **Bug Fixes**
  * Fixed session cost aggregation to accurately reflect latest totals and prevent double-counting across cumulative snapshots.

* **Tests**
  * Added regression tests for session cost calculation accuracy.

* **Chores**
  * Updated configuration to ignore local credential files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->