### PR TITLE
fix: guard against empty choices in OpenAI and AstraFlow LLM providers

### DIFF
--- a/src/llm/providers/astraflow.py
+++ b/src/llm/providers/astraflow.py
@@ -79,6 +79,8 @@ class _AstraflowBaseProvider(LLMProvider):
                 params["tools"] = [tool.to_openai_tool() for tool in llm_input.tools]
 
             response = self.client.chat.completions.create(**params)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             choice = response.choices[0]
 
             tool_calls = None

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -70,6 +70,8 @@ class OpenAIProvider(LLMProvider):
                 params["tools"] = [tool.to_openai_tool() for tool in input.tools]
 
             response = self.client.chat.completions.create(**params)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             choice = response.choices[0]
 
             tool_calls = None


### PR DESCRIPTION
## What

Add a guard in `OpenAIProvider.generate()` and `AstraFlowProvider.generate()` before accessing `response.choices[0]`.

## Why

The OpenAI-compatible API spec allows HTTP 200 responses with:
- An **empty `choices` list** — content-filtered responses on some providers (e.g. Gemini returns `choices=[]` on `PROHIBITED_CONTENT`)
- **`choices[0].message = None`** — documented in the OpenAI spec as possible when the response is filtered

Both cases currently crash with `IndexError` or `AttributeError` at the point of access, bypassing the provider's exception handling entirely.

## Change

```python
# before
response = self.client.chat.completions.create(**params)
choice = response.choices[0]  # IndexError if choices=[]

# after
response = self.client.chat.completions.create(**params)
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
choice = response.choices[0]
```

Applied identically to both `openai.py` and `astraflow.py` providers.

## Proof

This crash is confirmed by:
- Gemini's documentation on `PROHIBITED_CONTENT` responses (HTTP 200 with empty `choices`)
- A [live test](https://github.com/qizwiz/pact) reproducing `choices[0].message = None` against `gemini-2.5-flash-preview`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when OpenAI-compatible APIs return empty or filtered chat completions. `OpenAI` and `AstraFlow` providers now validate `response.choices` and raise a clear error instead of IndexError/AttributeError.

- **Bug Fixes**
  - Add guard in `generate()` for empty `choices` or `choices[0].message` is `None`.
  - Raise `ValueError("LLM returned empty or filtered response")` to surface filtered outputs.
  - Aligns with OpenAI spec and providers like Gemini that may return HTTP 200 with empty choices.

<sup>Written for commit cc62e89152fea0f858f0b2fdd9b23ecc539f43e3. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1976?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of language model API responses to properly detect and handle empty or filtered responses, enhancing error reporting and system reliability across providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->