### PR TITLE
feat(skills): add trustboost-pii-sanitizer community skill

### DIFF
--- a/skills/trustboost-pii-sanitizer/SKILL.md
+++ b/skills/trustboost-pii-sanitizer/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: trustboost-pii-sanitizer
+description: Sanitize PII from text before sending to LLMs or external APIs. Use when handling user data, building APIs that process personal information, preparing data for external services, or when privacy compliance is required (GDPR, HIPAA, LGPD, EU AI Act).
+origin: community
+---
+
+# TrustBoost PII Sanitizer
+
+Context-aware PII sanitization for autonomous AI agent pipelines. Sanitizes emails, phone numbers, national IDs, private keys, passwords, and financial data before text reaches LLMs or external services.
+
+## When to Activate
+
+- Processing user-generated text that may contain personal data
+- Building APIs or agents that handle customer information
+- Preparing data for external LLM providers (Claude, GPT, Gemini)
+- Privacy compliance requirements (GDPR, HIPAA, LGPD, EU AI Act)
+- Autonomous agent pipelines where human review is not possible
+- Files containing credentials, API keys, or secrets before sharing
+
+## Core Concepts
+
+### Context-Aware Sanitization
+
+TrustBoost adjusts sanitization depth based on context:
+
+- `legal` — maximum sanitization, all PII redacted
+- `financial` — high sanitization + LATAM identifiers (RFC, CPF, CUIT)
+- `medical` — HIPAA-grade, names + diagnoses + IDs
+- `code` — only API keys and passwords, not technical emails
+- `general` — standard sanitization (default)
+
+### Fail-Closed Behavior
+
+If the API is unreachable, TrustBoost returns `risk_category: CRITICAL` — input never passes through unflagged.
+
+### Multilingual Support
+
+Detects PII in EN, ES (LATAM), PT (BR/PT), DE, JA including country-specific patterns:
+- RFC (Mexico), CUIT (Argentina), RUT (Chile)
+- CPF, CNPJ (Brazil)
+- Personalausweis, IBAN (Germany)
+- マイナンバー, 運転免許証 (Japan)
+
+## Code Examples
+
+### Basic sanitization (preview — no wallet required)
+
+```bash
+curl -X POST https://api.trustboost.dev/sanitize/preview \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Contact john@example.com or call +1-555-0123"}'
+```
+
+Response:
+```json
+{
+  "sanitized_content": "Contact [REDACTED] or call [REDACTED]",
+  "safety_score": 0.4,
+  "risk_category": "PRIVATE"
+}
+```
+
+### Context-aware sanitization (TRIAL — 50 free requests)
+
+```bash
+curl -X POST https://api.trustboost.dev/sanitize \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Cliente RFC: LOPJ850101ABC, monto: $50,000",
+    "tx_hash": "TRIAL",
+    "wallet_address": "my-agent",
+    "context": "financial"
+  }'
+```
+
+Response:
+```json
+{
+  "status": "success",
+  "data": {
+    "sanitized_content": "Cliente RFC: [REDACTED], monto: $50,000",
+    "safety_score": 0.6,
+    "risk_category": "PRIVATE",
+    "context_applied": "financial"
+  }
+}
+```
+
+### Python integration
+
+```python
+import requests
+
+def sanitize_before_llm(text: str, context: str = "general") -> str:
+    """Sanitize PII before sending to any LLM. Fail-closed on error."""
+    try:
+        r = requests.post(
+            "https://api.trustboost.dev/sanitize/preview",
+            json={"text": text},
+            timeout=30
+        )
+        r.raise_for_status()
+        return r.json().get("sanitized_content", text)
+    except Exception:
+        return "[BLOCKED: sanitization failed]"
+
+# Use before any LLM call
+clean_text = sanitize_before_llm(user_input, context="legal")
+response = llm.invoke(clean_text)
+```
+
+### MCP integration (Claude Code, Cursor, Windsurf)
+
+```json
+{
+  "mcpServers": {
+    "trustboost": {
+      "url": "https://api.trustboost.dev/mcp"
+    }
+  }
+}
+```
+
+## Anti-Patterns
+
+```python
+# BAD: Sending raw user input directly to LLM
+response = llm.invoke(user_message)
+
+# GOOD: Sanitize first
+clean = sanitize_before_llm(user_message)
+response = llm.invoke(clean)
+```
+
+```python
+# BAD: Fail-open on sanitization error
+try:
+    clean = sanitize(text)
+except:
+    clean = text  # PII passes through
+
+# GOOD: Fail-closed
+try:
+    clean = sanitize(text)
+except:
+    clean = "[BLOCKED: sanitization failed]"
+```
+
+## Best Practices
+
+- Always sanitize before LLM calls in production pipelines
+- Use context-specific modes for better accuracy (legal, financial, medical)
+- Monitor `risk_category` — if CRITICAL appears frequently, review your data pipeline
+- Use `safety_score` for audit trails and compliance reporting
+- Set `wallet_address` to your agent ID for per-agent quota tracking
+- Treat TRIAL as evaluation only — use paid mode for production workloads
+
+## Related Skills
+
+- `security-review` — comprehensive security audit workflow
+- `coding-standards` — code quality and validation patterns
+
+## Resources
+
+- API health: https://api.trustboost.dev/health
+- MCP Server: https://api.trustboost.dev/mcp
+- GitHub: https://github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer
+- ClawHub: https://clawhub.ai/teodorofodocrispin-cmyk/trustboost-pii-sanitizer

--- a/skills/trustboost-pii-sanitizer/SKILL.md
+++ b/skills/trustboost-pii-sanitizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trustboost-pii-sanitizer
-description: Sanitize PII from text before sending to LLMs or external APIs. Use when handling user data, building APIs that process personal information, preparing data for external services, or when privacy compliance is required (GDPR, HIPAA, LGPD, EU AI Act).
+description: Sanitize PII from text before sending to LLMs or external APIs. Use when handling user data, building APIs that process personal information, preparing data for external services, or when privacy compliance is required (GDPR, LGPD, EU AI Act). Note: not recommended for HIPAA zero-transmission environments.
 origin: community
 ---
 
@@ -31,7 +31,7 @@ TrustBoost adjusts sanitization depth based on context:
 
 ### Fail-Closed Behavior
 
-If the API is unreachable, TrustBoost returns `risk_category: CRITICAL` — input never passes through unflagged.
+If the API is unreachable, the caller must fail closed — block forwarding input and treat the event as `CRITICAL`. The client-side error handler returns `[BLOCKED: sanitization failed]` so input never passes through unflagged.
 
 ### Multilingual Support
 
@@ -168,7 +168,7 @@ except:
 | Infrastructure | FastAPI + Supabase + Render (AWS) — NOT Make.com (migrated v2.0, April 2026) |
 | Registry | Glama MCP registry + GitHub Marketplace Action |
 | Data sovereignty | Processed on Render (AWS us-east-1) |
-| Encryption | HTTPS in transit. Supabase at rest encryption. |
+| Encryption | HTTPS in transit. Supabase at-rest encryption. |
 | DPA | Not available — prototype stage. Not recommended for HIPAA zero-transmission environments. |
 | TRIAL quota exhaustion | After 50 requests, API returns 402 with payment instructions. Agent pipeline receives [BLOCKED: sanitization failed] — fail-closed, not silent degradation. Upgrade: send 149 USDC on Solana to obtain 10,000 sanitizations. |
 | Paid tier | 149 USDC on Solana mainnet → 10,000 sanitizations. tx_hash verified on-chain via Helius oracle. |

--- a/skills/trustboost-pii-sanitizer/SKILL.md
+++ b/skills/trustboost-pii-sanitizer/SKILL.md
@@ -158,6 +158,22 @@ except:
 - Set `wallet_address` to your agent ID for per-agent quota tracking
 - Treat TRIAL as evaluation only — use paid mode for production workloads
 
+## Data Handling & Vetting
+
+| Item | Details |
+|------|---------|
+| Retention policy | 90 days. Deleted on request via teodorofodocrispin@gmail.com |
+| Raw input stored | Never — only sanitized output + metadata logged |
+| License | MIT — github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer |
+| Infrastructure | FastAPI + Supabase + Render (AWS) — NOT Make.com (migrated v2.0, April 2026) |
+| Registry | Glama MCP registry + GitHub Marketplace Action |
+| Data sovereignty | Processed on Render (AWS us-east-1) |
+| Encryption | HTTPS in transit. Supabase at rest encryption. |
+| DPA | Not available — prototype stage. Not recommended for HIPAA zero-transmission environments. |
+| TRIAL quota exhaustion | After 50 requests, API returns 402 with payment instructions. Agent pipeline receives [BLOCKED: sanitization failed] — fail-closed, not silent degradation. Upgrade: send 149 USDC on Solana to obtain 10,000 sanitizations. |
+| Paid tier | 149 USDC on Solana mainnet → 10,000 sanitizations. tx_hash verified on-chain via Helius oracle. |
+| Fallback strategy | Use /sanitize/preview (3 req/IP/24h, no quota) for low-volume scenarios while upgrading. |
+
 ## Related Skills
 
 - `security-review` — comprehensive security audit workflow

--- a/skills/trustboost-pii-sanitizer/SKILL.md
+++ b/skills/trustboost-pii-sanitizer/SKILL.md
@@ -13,7 +13,7 @@ Context-aware PII sanitization for autonomous AI agent pipelines. Sanitizes emai
 - Processing user-generated text that may contain personal data
 - Building APIs or agents that handle customer information
 - Preparing data for external LLM providers (Claude, GPT, Gemini)
-- Privacy compliance requirements (GDPR, HIPAA, LGPD, EU AI Act)
+- Privacy compliance requirements (GDPR, LGPD, EU AI Act) — see DPA note for HIPAA environments
 - Autonomous agent pipelines where human review is not possible
 - Files containing credentials, API keys, or secrets before sharing
 

--- a/skills/trustboost-pii-sanitizer/SKILL.md
+++ b/skills/trustboost-pii-sanitizer/SKILL.md
@@ -96,11 +96,14 @@ def sanitize_before_llm(text: str, context: str = "general") -> str:
     try:
         r = requests.post(
             "https://api.trustboost.dev/sanitize/preview",
-            json={"text": text},
+            json={"text": text, "context": context},
             timeout=30
         )
         r.raise_for_status()
-        return r.json().get("sanitized_content", text)
+        result = r.json()
+        if "sanitized_content" not in result:
+            return "[BLOCKED: unexpected response shape]"
+        return result["sanitized_content"]
     except Exception:
         return "[BLOCKED: sanitization failed]"
 


### PR DESCRIPTION
Context-aware PII sanitization for Claude Code agents. Activates when handling user data, building APIs, or preparing data for external LLM providers.

- 5 context modes: legal/financial/medical/code/general
- Multilingual: EN, ES-LATAM, PT-BR, DE, JA
- LATAM identifiers: RFC, CPF, CUIT, RUT
- Fail-closed behavior on API error
- MCP compatible: api.trustboost.dev/mcp
- origin: community

## What Changed
Added skills/trustboost-pii-sanitizer/SKILL.md — a community skill for context-aware PII sanitization before LLM calls.

## Why This Change
Claude Code agents frequently process user data containing PII — emails, phone numbers, national IDs, API keys — before sending to external LLMs. This skill provides a reusable pattern for sanitizing that data with TrustBoost, including LATAM identifiers (RFC, CPF, CUIT) not covered by standard regex approaches.

## Testing Done
- curl https://api.trustboost.dev/health → {"status":"ok","version":"2.5.0"}
- Preview endpoint returns [REDACTED] output correctly
- Context modes (financial/legal/medical) tested and verified
- Fail-closed behavior confirmed on unreachable endpoint

## Type of Change
- [x] feat: New feature

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] Follows conventional commits format
- [x] No sensitive data exposed in logs or output

## Documentation
- [x] SKILL.md follows skill guidelines with clear activation triggers
- [x] Examples tested against live API

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `trustboost-pii-sanitizer` community skill for context-aware PII sanitization before sending data to LLMs or external APIs. Improves privacy for Claude Code agents with fail-closed behavior, MCP support, and clearer data handling, quota, and HIPAA guidance.

- **New Features**
  - Context modes: legal, financial, medical, code, general.
  - Multilingual (EN, ES-LATAM, PT-BR, DE, JA); supports LATAM IDs (RFC, CPF, CUIT, RUT).
  - Fails closed if the sanitization API is unreachable; MCP compatible at https://api.trustboost.dev/mcp.
  - Adds `skills/trustboost-pii-sanitizer/SKILL.md` with activation triggers, examples, and Data Handling & Vetting (90-day retention, infra/region, encryption, TRIAL quota/purchase flow, preview fallback).

- **Bug Fixes**
  - Clarifies fail-closed wording and blocked response behavior.
  - Adds explicit `context` parameter usage in examples.
  - Resolves HIPAA guidance contradiction, ensures consistent positioning across sections, and fixes at-rest encryption typo.

<sup>Written for commit 7b52038910d298a36a91b5f12cfa0cd38c27f4b7. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/1981?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive TrustBoost PII sanitizer documentation: details context-aware sanitization modes (legal, financial, medical, code, general), fail-closed behavior on errors, multilingual and country-specific PII detection, preview/trial API examples and integration snippets (sanitize before LLM calls), anti-patterns and best practices, data handling/retention and encryption notes, quota/fallback behavior, paid-tier guidance, and related resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/1981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->