### PR TITLE
fix(ci): cover Unicode Tag block + other invisibles in check-unicode-safety (ASCII smuggling)

### DIFF
--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -122,7 +122,23 @@ function isDangerousInvisibleCodePoint(codePoint) {
     // an attacker hides instructions inside ASCII-looking strings (PR
     // bodies, SKILL.md, frontmatter), the LLM consumes the tag bytes,
     // and the human reviewer sees nothing.
-    (codePoint >= 0xE0000 && codePoint <= 0xE007F)
+    (codePoint >= 0xE0000 && codePoint <= 0xE007F) ||
+    // U+180E MONGOLIAN VOWEL SEPARATOR — formerly classified as a space
+    // separator, reclassified as a format control in Unicode 6.3; renders
+    // as zero-width and routinely abused for homograph / smuggling.
+    codePoint === 0x180E ||
+    // U+115F / U+1160 HANGUL CHOSEONG/JUNGSEONG FILLER — zero-width fillers
+    // used in Korean text shaping; abused as invisible characters.
+    codePoint === 0x115F ||
+    codePoint === 0x1160 ||
+    // U+2061–U+2064 invisible math operators (FUNCTION APPLICATION,
+    // INVISIBLE TIMES, INVISIBLE SEPARATOR, INVISIBLE PLUS). Zero-width
+    // and not used outside math typesetting; legitimate Markdown / source
+    // does not contain them.
+    (codePoint >= 0x2061 && codePoint <= 0x2064) ||
+    // U+3164 HANGUL FILLER — zero-width filler reportedly used in Discord
+    // / Twitter smuggling attacks; not used in legitimate Korean text.
+    codePoint === 0x3164
   );
 }
 

--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -114,7 +114,15 @@ function isDangerousInvisibleCodePoint(codePoint) {
     (codePoint >= 0x202A && codePoint <= 0x202E) ||
     (codePoint >= 0x2066 && codePoint <= 0x2069) ||
     (codePoint >= 0xFE00 && codePoint <= 0xFE0F) ||
-    (codePoint >= 0xE0100 && codePoint <= 0xE01EF)
+    (codePoint >= 0xE0100 && codePoint <= 0xE01EF) ||
+    // Unicode Tag block (U+E0000–U+E007F). Tag characters were proposed
+    // for language tagging in Unicode 3.1 and have been deprecated since
+    // Unicode 5.1, so no legitimate text uses them. They are the canonical
+    // vector for "ASCII smuggling" / "Tag smuggling" prompt injection:
+    // an attacker hides instructions inside ASCII-looking strings (PR
+    // bodies, SKILL.md, frontmatter), the LLM consumes the tag bytes,
+    // and the human reviewer sees nothing.
+    (codePoint >= 0xE0000 && codePoint <= 0xE007F)
   );
 }
 

--- a/tests/scripts/check-unicode-safety.test.js
+++ b/tests/scripts/check-unicode-safety.test.js
@@ -109,6 +109,74 @@ if (
   passed++;
 else failed++;
 
+// Invisible code points newly covered by the denylist. These were missing
+// from the previous denylist and silently passed through both detection and
+// `--write` mode. Each is a documented LLM-prompt-injection vector
+// (Tag block "ASCII smuggling"; the other invisibles are widely cited in
+// homograph / Discord / Twitter smuggling references).
+
+const NEWLY_COVERED_RANGES = [
+  { codePoint: 0xE0041, label: 'Tag block U+E0041 (TAG LATIN CAPITAL LETTER A)' },
+  { codePoint: 0xE007F, label: 'Tag block U+E007F (CANCEL TAG, range end)' },
+  { codePoint: 0x180E, label: 'U+180E MONGOLIAN VOWEL SEPARATOR' },
+  { codePoint: 0x115F, label: 'U+115F HANGUL CHOSEONG FILLER' },
+  { codePoint: 0x1160, label: 'U+1160 HANGUL JUNGSEONG FILLER' },
+  { codePoint: 0x2061, label: 'U+2061 FUNCTION APPLICATION' },
+  { codePoint: 0x2064, label: 'U+2064 INVISIBLE PLUS (range end)' },
+  { codePoint: 0x3164, label: 'U+3164 HANGUL FILLER' },
+];
+
+for (const { codePoint, label } of NEWLY_COVERED_RANGES) {
+  if (
+    test(`detects ${label}`, () => {
+      const root = makeTempRoot('ecc-unicode-newly-covered-');
+      fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+      const hex = codePoint.toString(16).toUpperCase().padStart(4, '0');
+      fs.writeFileSync(
+        path.join(root, 'docs', `probe-${hex}.md`),
+        `# Probe\n\nBenign${String.fromCodePoint(codePoint)}text\n`
+      );
+      const result = runCheck(root);
+      assert.notStrictEqual(result.status, 0,
+        `expected exit non-zero on U+${hex}, got ${result.status}: ${result.stderr}`);
+      assert.match(result.stderr, new RegExp(`dangerous-invisible U\\+${hex}`),
+        `expected violation message for U+${hex}, got: ${result.stderr}`);
+    })
+  )
+    passed++;
+  else failed++;
+}
+
+if (
+  test('write mode strips newly-covered invisibles from markdown', () => {
+    const root = makeTempRoot('ecc-unicode-newly-covered-write-');
+    fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+    const tagHidden = [...Array(5)].map((_, i) => String.fromCodePoint(0xE0041 + i)).join('');
+    const mongolianHidden = String.fromCodePoint(0x180E);
+    const filePath = path.join(root, 'docs', 'mixed.md');
+    fs.writeFileSync(filePath, `# Title\n\nBenign${tagHidden}${mongolianHidden}text.\n`);
+
+    const writeResult = runCheck(root, ['--write']);
+    assert.strictEqual(writeResult.status, 0,
+      `expected --write to succeed, got ${writeResult.status}: ${writeResult.stderr}`);
+
+    const sanitized = fs.readFileSync(filePath, 'utf8');
+    assert.doesNotMatch(sanitized, /[\u{E0000}-\u{E007F}]/u,
+      'expected tag block characters stripped');
+    assert.doesNotMatch(sanitized, /\u{180E}/u,
+      'expected U+180E stripped');
+    assert.strictEqual(sanitized, '# Title\n\nBenigntext.\n',
+      'expected only the invisible characters removed, surrounding text preserved');
+
+    // Re-run without --write; should now pass cleanly.
+    const clean = runCheck(root);
+    assert.strictEqual(clean.status, 0,
+      `expected post-sanitize re-run to pass, got: ${clean.stderr}`);
+  })
+)
+  passed++;
+else failed++;
+
 if (
   test('skips Python virtual environments', () => {
     const root = makeTempRoot('ecc-unicode-venv-');


### PR DESCRIPTION
## Summary

`scripts/ci/check-unicode-safety.js` is the repo's last line of defence before contributor content reaches agent context. It also runs in `--write` auto-sanitize mode on `.md` / `.mdx` / `.txt`. Found two classes of invisible code points the denylist silently passes through.

### 1. Unicode Tag block (U+E0000–U+E007F)

Tag characters were proposed for language tagging in Unicode 3.1 and have been **deprecated since Unicode 5.1**, so no legitimate text uses them. They are the canonical vector for "ASCII Smuggling" / "Tag Smuggling" LLM prompt injection, demonstrated against multiple LLM assistants during 2024–2025: an attacker hides instructions inside an ASCII-looking string (PR body, SKILL.md, frontmatter), the model reads the tag bytes, the human reviewer sees nothing.

### 2. Other widely-cited invisibles the denylist also missed

| Code point | Name | Notes |
| --- | --- | --- |
| U+180E | MONGOLIAN VOWEL SEPARATOR | Reclassified Zs → Cf in Unicode 6.3; renders zero-width |
| U+115F | HANGUL CHOSEONG FILLER | Zero-width Korean shaping filler |
| U+1160 | HANGUL JUNGSEONG FILLER | Zero-width Korean shaping filler |
| U+2061–U+2064 | FUNCTION APPLICATION, INVISIBLE TIMES/SEPARATOR/PLUS | Math typesetting only |
| U+3164 | HANGUL FILLER | Discord / Twitter smuggling references |

## Reproduction (before this PR)

```
$ mkdir -p /tmp/uni-test && node -e "
    const fs = require('fs');
    const hidden = [...Array(5)].map((_,i) => String.fromCodePoint(0xE0041 + i)).join('');
    fs.writeFileSync('/tmp/uni-test/innocent.md',
      '# Title\n\nBenign text' + hidden + ' more.\n');"

$ ECC_UNICODE_SCAN_ROOT=/tmp/uni-test node scripts/ci/check-unicode-safety.js
Unicode safety check passed.
$ echo $?
0
```

Expected: tag-block characters reported as `dangerous-invisible` violations (exit 1) and stripped under `--write`.
Actual: validator passes; `--write` leaves the bytes intact.

## After this PR

```
$ ECC_UNICODE_SCAN_ROOT=/tmp/uni-test node scripts/ci/check-unicode-safety.js
Unicode safety violations detected:
innocent.md:3:12 dangerous-invisible U+E0041
innocent.md:3:14 dangerous-invisible U+E0042
innocent.md:3:16 dangerous-invisible U+E0043
innocent.md:3:18 dangerous-invisible U+E0044
innocent.md:3:20 dangerous-invisible U+E0045
exit=1
```

`--write` mode strips the bytes (file length 47 → 42, regex `/[\u{E0000}-\u{E007F}]/u` no longer matches).

## Commit layout

Three reviewable commits:

1. `fix(ci): cover Unicode Tag block (U+E0000–U+E007F) in check-unicode-safety` — single new range in `isDangerousInvisibleCodePoint`. Primary security fix.
2. `fix(ci): cover other widely-cited invisible code points in check-unicode-safety` — five additional code points / ranges (U+180E, U+115F, U+1160, U+2061–U+2064, U+3164). Each documented with its specific abuse pattern.
3. `test(ci): regression coverage for newly-covered invisible code points` — 9 new test cases (detection for each newly-covered code point + a `--write` integration test that strips Tag block + U+180E from a mixed-content fixture).

## Tests

- `tests/scripts/check-unicode-safety.test.js`: 5 → 14 cases
- Full `yarn test` green; `yarn lint` clean
- ECC self-scan (`node scripts/ci/check-unicode-safety.js`) reports only the pre-existing `U+2605` BLACK STAR warnings (unchanged) — no new in-repo violations introduced.

## Risk

Very low. The change is purely additive to a denylist; no legitimate text uses any of these code points. Reviewer concern would be "are we sure?" — answer for the Tag block is deprecation since Unicode 5.1; the other invisibles are zero-width and either obsolete (Mongolian VS) or math-only (U+2061–U+2064) or Korean shaping fillers that should not appear in source / markdown / PR bodies.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] Manual: tag-block fixture reproduction exits 1 with 5 violations
- [ ] Manual: `--write` mode on the same fixture strips bytes and leaves surrounding text intact
- [ ] Manual: ECC self-scan still exits with the same status (only pre-existing emoji warnings)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks Unicode Tag block and other invisible code points in the Unicode safety check to prevent ASCII/tag smuggling. Detection now fails on these, and --write strips them.

- **Bug Fixes**
  - Denylist adds U+E0000–U+E007F (Tag block), U+180E, U+115F, U+1160, U+2061–U+2064, U+3164.
  - Violations reported as dangerous-invisible; --write sanitizes .md/.mdx/.txt.
  - Regression tests increased from 5 to 14, including a write-mode integration test; no new in-repo violations.

<sup>Written for commit 24695693d234a288eb2829ccecf0c430a94eb7ad. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/everything-claude-code/pull/1982?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved Unicode safety checks to detect and sanitize a broader range of invisible Unicode characters that could affect content integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/everything-claude-code/pull/1982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->