### PR TITLE
docs: define ECC 2.0 hypergrowth release lane

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,20 +5,20 @@
     "email": "me@affaanmustafa.com"
   },
   "metadata": {
-    "description": "Battle-tested Claude Code configurations from an Anthropic hackathon winner"
+    "description": "Harness-native ECC skills, hooks, rules, MCP conventions, and operator workflows"
   },
   "plugins": [
     {
       "name": "ecc",
       "source": "./",
-      "description": "The most comprehensive Claude Code plugin — 60 agents, 232 skills, 75 legacy command shims, selective install profiles, and production-ready hooks for TDD, security scanning, code review, and continuous learning",
+      "description": "Harness-native ECC operator layer - 60 agents, 232 skills, 75 legacy command shims, reusable hooks, rules, selective install profiles, and production-ready workflows for Claude Code, Codex, OpenCode, Cursor, and related agent harnesses",
       "version": "2.0.0-rc.1",
       "author": {
         "name": "Affaan Mustafa",
         "email": "me@affaanmustafa.com"
       },
       "homepage": "https://ecc.tools",
-      "repository": "https://github.com/affaan-m/everything-claude-code",
+      "repository": "https://github.com/affaan-m/ECC",
       "license": "MIT",
       "keywords": [
         "agents",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "ecc",
   "version": "2.0.0-rc.1",
-  "description": "Battle-tested Claude Code plugin for engineering teams — 60 agents, 232 skills, 75 legacy command shims, production-ready hooks, and selective install workflows evolved through continuous real-world use",
+  "description": "Harness-native ECC plugin for engineering teams - 60 agents, 232 skills, 75 legacy command shims, reusable hooks, rules, MCP conventions, and operator workflows for Claude Code plus adjacent agent harnesses",
   "author": {
     "name": "Affaan Mustafa",
     "url": "https://x.com/affaanmustafa"
   },
   "homepage": "https://ecc.tools",
-  "repository": "https://github.com/affaan-m/everything-claude-code",
+  "repository": "https://github.com/affaan-m/ECC",
   "license": "MIT",
   "keywords": [
     "claude-code",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
           ### Notes
           - npm package: \`ecc-universal\`
-          - Claude marketplace/plugin identifier: \`everything-claude-code@everything-claude-code\`
+          - Claude marketplace/plugin identifier: \`ecc@ecc\`
           - For migration tips and compatibility notes, see README and CHANGELOG.
           EOF
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -114,7 +114,7 @@ jobs:
 
           ### Package Notes
           - npm package: \`ecc-universal\`
-          - Claude marketplace/plugin identifier: \`everything-claude-code@everything-claude-code\`
+          - Claude marketplace/plugin identifier: \`ecc@ecc\`
           EOF
 
       - name: Pack npm artifact

--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -12,11 +12,29 @@ execution truth is split across:
 - merged PR evidence;
 - handoffs under `~/.cluster-swarm/handoffs/`.
 
+The May 19 release/growth execution map lives at
+[`docs/releases/2.0.0/ecc-2-hypergrowth-release-command-center.md`](releases/2.0.0/ecc-2-hypergrowth-release-command-center.md).
+It is the operator surface for the final ECC 2.0 repo identity, video suite,
+partner/sponsor funnel, consulting/talk funnel, and social launch plan.
+
+## 2026-05-19 Delta
+
+- The public repo identity is now `affaan-m/ECC`; release, package, plugin,
+  workflow, and launch-copy surfaces should use that URL for current public
+  links.
+- The ECC 2.0 release story should lead with the product shape directly:
+  harness-native operator system, reusable skills/rules/hooks/MCP conventions,
+  `ecc2/` alpha control plane, Hermes as optional operator shell, and ECC Tools
+  Pro/Sponsors/consulting as the business surface.
+- Copy should avoid presenting this as a repo rename or config-pack migration.
+  The release proof should show the system through install flow, cross-harness
+  demos, security evidence, hosted product evidence, and the video suite.
+
 ## Current Evidence
 
 As of 2026-05-18:
 
-- GitHub queues are clean across `affaan-m/everything-claude-code`,
+- GitHub queues are clean across `affaan-m/ECC`,
   `affaan-m/agentshield`, `affaan-m/JARVIS`, `ECC-Tools/ECC-Tools`, and
   `ECC-Tools/ECC-website`: the latest `platform-audit` sweep found 0 open PRs,
   0 open issues, 0 discussion maintainer-touch gaps, 0 answerable Q&A missing
@@ -33,7 +51,7 @@ As of 2026-05-18:
   now at 0 open PRs and 0 open issues by live `gh search`. Archived repos
   touched during closure were restored to archived state.
 - GitHub discussions are current across those tracked repos:
-  `affaan-m/everything-claude-code` has 58 total discussions and 0 without
+  `affaan-m/ECC` has 58 total discussions and 0 without
   maintainer touch after May 15 maintainer updates on #73 and #1239; AgentShield,
   JARVIS, ECC Tools, and the ECC Tools website have discussions disabled or 0
   total discussions. `docs/architecture/discussion-response-playbook.md` now
@@ -715,8 +733,8 @@ is not complete unless the evidence column exists and has been freshly verified.
 
 | Prompt requirement | Required artifact or gate | Current evidence | Status |
 | --- | --- | --- | --- |
-| Keep public PRs below 20 | Repo-family PR recheck | 0 open PRs across `everything-claude-code`, AgentShield, JARVIS, `ECC-Tools/ECC-Tools`, and `ECC-Tools/ECC-website` on 2026-05-18 after merging PR #1976 and refreshing platform audit evidence | Complete |
-| Keep public issues below 20 | Repo-family issue recheck | 0 open issues across `everything-claude-code`, AgentShield, JARVIS, `ECC-Tools/ECC-Tools`, and `ECC-Tools/ECC-website` on 2026-05-18 after the live platform audit refresh | Complete |
+| Keep public PRs below 20 | Repo-family PR recheck | 0 open PRs across `ECC`, AgentShield, JARVIS, `ECC-Tools/ECC-Tools`, and `ECC-Tools/ECC-website` on 2026-05-18 after merging PR #1976 and refreshing platform audit evidence | Complete |
+| Keep public issues below 20 | Repo-family issue recheck | 0 open issues across `ECC`, AgentShield, JARVIS, `ECC-Tools/ECC-Tools`, and `ECC-Tools/ECC-website` on 2026-05-18 after the live platform audit refresh | Complete |
 | Manage repository discussions | Repo-family discussion recheck plus response playbook | Platform audit reports 0 discussion maintainer-touch gaps and 0 answerable Q&A missing accepted answers; trunk still has 58 total discussions; `docs/architecture/discussion-response-playbook.md` distinguishes support, maintainer coordination, stale/concluded, release, informational, and security-sensitive response paths | Complete |
 | Manage PR discussions | PR review/comment closure plus merge/close state | ECC #1976 merged after maintainer follow-up validation; no open tracked PRs remain | Complete |
 | Salvage useful stale work | `docs/stale-pr-salvage-ledger.md` plus `docs/legacy-artifact-inventory.md` | Ledger records salvaged, superseded, skipped, and manual-review tails; #1815-#1818 added cost tracking, skill scout, frontend design guidance, code-reviewer false-positive guardrails, and the May 12 gap pass; #1687, #1609, #1563, #1564, and #1565 localization tails are attached to Linear ITO-55 for language-owner review and no automatic import remains release-blocking | Complete; repeat legacy scan before release |

--- a/docs/business/social-launch-copy.md
+++ b/docs/business/social-launch-copy.md
@@ -7,7 +7,8 @@ Use these templates as launch-ready starting points. Review channel tone before 
 ```text
 ECC v2.0.0-rc.1 preview pack is ready for final release review.
 
-The repo is moving from a Claude Code config pack into a cross-harness operating system for agentic work.
+ECC 2.0 is the harness-native operator system for agentic work: skills, hooks,
+rules, MCP conventions, release gates, and an optional Hermes operator shell.
 
 What ships:
 - Hermes setup guide
@@ -15,8 +16,8 @@ What ships:
 - cross-harness architecture docs
 - Hermes import guidance for turning local operator workflows into public ECC skills
 
-Start here: https://github.com/affaan-m/everything-claude-code
-Release notes: https://github.com/affaan-m/everything-claude-code/blob/main/docs/releases/2.0.0-rc.1/release-notes.md
+Start here: https://github.com/affaan-m/ECC
+Release notes: https://github.com/affaan-m/ECC/blob/main/docs/releases/2.0.0-rc.1/release-notes.md
 ```
 
 ## X Post: Proof + Metrics
@@ -57,7 +58,7 @@ ECC v2.0.0-rc.1 pushes that further: reusable skills, thin harness adapters, and
 ```text
 ECC v2.0.0-rc.1 preview pack is ready for final release review.
 
-The practical shift: ECC is no longer just a Claude Code config pack. It is becoming a cross-harness operating system for agentic work.
+ECC 2.0 is the harness-native operator system for agentic work. The same reusable layer now reaches Claude Code, Codex, OpenCode, Cursor, Gemini, Zed, GitHub Copilot workflows, and terminal-only operator lanes.
 
 This release-candidate surface includes:
 - sanitized Hermes setup documentation
@@ -67,6 +68,6 @@ This release-candidate surface includes:
 
 It does not include private workspace state, credentials, raw local exports, or personal datasets.
 
-Repo: https://github.com/affaan-m/everything-claude-code
-Release notes: https://github.com/affaan-m/everything-claude-code/blob/main/docs/releases/2.0.0-rc.1/release-notes.md
+Repo: https://github.com/affaan-m/ECC
+Release notes: https://github.com/affaan-m/ECC/blob/main/docs/releases/2.0.0-rc.1/release-notes.md
 ```

--- a/docs/releases/2.0.0-rc.1/release-name-plugin-publication-checklist-2026-05-18.md
+++ b/docs/releases/2.0.0-rc.1/release-name-plugin-publication-checklist-2026-05-18.md
@@ -1,6 +1,7 @@
 # ECC v2.0.0-rc.1 Release Name And Plugin Publication Checklist
 
-Snapshot date: 2026-05-18.
+Snapshot date: 2026-05-18. Canonical repo decision refreshed 2026-05-19
+after the public repo rename to `affaan-m/ECC`.
 
 This checklist is the operator gate for release naming, package publication,
 and Claude/Codex plugin distribution. It is not a publication action by itself.
@@ -9,20 +10,22 @@ submitting marketplace forms, or posting announcements.
 
 ## Fixed rc.1 Decision
 
-Ship `v2.0.0-rc.1` as **Everything Claude Code (ECC)**.
+Ship `v2.0.0-rc.1` as **ECC**.
 
-- Keep the GitHub repo at `affaan-m/everything-claude-code`.
+- Keep the GitHub repo at `affaan-m/ECC`.
 - Keep the npm package as `ecc-universal`.
 - Keep Claude and Codex plugin slugs as `ecc`.
 - Publish the npm prerelease on the `next` dist-tag, not `latest`.
-- Do not rename to `affaan-m/ecc`, `ecc`, or `@affaan-m/ecc` before rc.1.
+- Do not rename the npm package to `ecc` or `@affaan-m/ecc` before rc.1.
+- Treat `affaan-m/ECC` as the canonical public repo for rc.1 and GA release
+  copy.
 
 Reasons:
 
 - `ecc-universal` is the current working install and package surface.
 - `ecc` on npm is occupied by an unrelated elliptic-curve package.
 - `@affaan-m/ecc` is unclaimed on npm, but would require a migration plan.
-- `affaan-m/ecc` is not available to the current GitHub auth context.
+- `affaan-m/ECC` is now the live public GitHub repo.
 - Claude and Codex already expose the desired short namespace as `ecc`.
 
 ## Current Surface Evidence
@@ -30,8 +33,7 @@ Reasons:
 | Surface | Current value | Evidence command | 2026-05-18 result | Release action |
 | --- | --- | --- | --- | --- |
 | Git commit | `67e63e63f9bfd074bd6a21bf6bac71f3dfefa58b` | `git rev-parse HEAD` | Recorded from clean `main` before this ITO-46 evidence refresh | Re-run from final release commit |
-| GitHub repo | `affaan-m/everything-claude-code` | `git remote get-url origin` | `https://github.com/affaan-m/everything-claude-code.git` | Keep for rc.1 |
-| Possible short repo | `affaan-m/ecc` | `gh repo view affaan-m/ecc --json nameWithOwner,url,isPrivate` | GraphQL could not resolve repository | Do not depend on it for rc.1 |
+| GitHub repo | `affaan-m/ECC` | `git remote get-url origin` | `https://github.com/affaan-m/ECC.git` | Keep for rc.1 and GA |
 | npm package | `ecc-universal@2.0.0-rc.1` local, `1.10.0` registry latest | `node -p "require('./package.json').name + '@' + require('./package.json').version"` and `npm view ecc-universal name version dist-tags --json` | Local rc.1 ready; registry still latest `1.10.0` | Publish rc.1 with `--tag next` after approval |
 | Exact npm short name | `ecc` | `npm view ecc name version description repository.url --json` | Occupied by unrelated `ecc@0.0.2` | Do not use |
 | Scoped npm short name | `@affaan-m/ecc` | `npm view @affaan-m/ecc name version --json` | 404 | Candidate only after migration plan |
@@ -59,7 +61,7 @@ claude plugin validate .claude-plugin/plugin.json
 claude plugin tag .claude-plugin --dry-run
 codex plugin marketplace add --help
 HOME="$(mktemp -d)" codex plugin marketplace add ./
-HOME="$(mktemp -d)" codex plugin marketplace add affaan-m/everything-claude-code --ref "$(git rev-parse HEAD)"
+HOME="$(mktemp -d)" codex plugin marketplace add affaan-m/ECC --ref "$(git rev-parse HEAD)"
 npm pack --dry-run --json
 npm publish --tag next --dry-run
 npm run build:opencode
@@ -96,8 +98,8 @@ keep the related publication action blocked.
   documents a public submission path or confirms the plugin has been listed.
 - Do not announce billing, Marketplace, or native payments until ECC Tools live
   Marketplace account readback returns ready.
-- Do not rename the repo or package until rc.1 is published and a migration
-  guide maps old names to new names.
+- Do not rename the npm package until rc.1 is published and a migration guide
+  maps old install names to new names.
 - Do not post social copy while any release, npm, plugin, or billing URL is
   still approval-gated.
 

--- a/docs/releases/2.0.0/ecc-2-hypergrowth-release-command-center.md
+++ b/docs/releases/2.0.0/ecc-2-hypergrowth-release-command-center.md
@@ -1,0 +1,145 @@
+# ECC 2.0 Hypergrowth Release Command Center
+
+Snapshot date: 2026-05-19.
+
+This is the execution map for turning ECC 2.0 into a complete public release,
+partner funnel, sponsor funnel, consulting surface, and content launch. It is
+written for operators. Use it to decide what ships, what gets announced, and
+what stays blocked until evidence exists.
+
+## Release Claim
+
+ECC 2.0 is the harness-native operator system for agentic work.
+
+The public proof must show the actual system:
+
+- reusable skills, rules, hooks, MCP conventions, and release gates;
+- Claude Code, Codex, OpenCode, Cursor, Gemini, Zed, GitHub Copilot, and
+  terminal-only workflows as supported execution surfaces;
+- `ecc2/` as the alpha control-plane/TUI direction;
+- Hermes as the optional operator shell for chat, cron, handoffs, and daily
+  work routing;
+- ECC Tools Pro, GitHub Sponsors, and consulting as the business surface that
+  funds the OSS layer.
+
+Avoid language that frames this as a rename or a retreat from the old project.
+The release copy should show the 2.0 product shape directly.
+
+## Current Growth Baseline
+
+| Metric | Current | Target | Gap |
+| --- | ---: | ---: | ---: |
+| MRR | `$1,728/mo` | `$10,000/mo` | `$8,272/mo` |
+| Sponsor motion | Active GitHub Sponsors plus open inbound | Repeatable sponsor close loop | Approval-gated outbound |
+| Consulting motion | Open, non-primary | Partner-ready packages | Public proof, talks, and intake |
+| Content motion | Raw ECC 2 media exists | Weekly launch clips and founder proof | Final video suite |
+| Community motion | Discord exists | Useful coding/operator community | Invite, channels, pins, moderation |
+
+MRR growth should come from four lanes at once:
+
+- GitHub Sponsors and OSS partner sponsors;
+- ECC Tools Pro subscriptions;
+- consulting and implementation contracts;
+- talks, podcasts, conference demos, and partner webinars that create inbound.
+
+## Release Gates
+
+| Lane | Done when | Current action |
+| --- | --- | --- |
+| Repo identity | README, package metadata, plugin metadata, release docs, workflows, and launch copy all use `affaan-m/ECC` where public URLs are needed | Canonical URL sweep |
+| Package and plugin publication | `ecc-universal@2.0.0-rc.1` dry-runs clean, npm `next` is approved, Claude plugin tag dry-runs, Codex repo marketplace smoke passes, OpenCode build passes | Refresh publication evidence from final commit |
+| Product proof | Quickstart, cross-harness architecture, demo prompts, `ecc2/` alpha boundary, AgentShield safety proof, and hosted ECC Tools links are consistent | Keep proof surfaces concrete |
+| Revenue proof | Sponsor tiers, Pro pricing, consulting CTA, partner CTA, and billing-readback language are current | Do not announce billing claims before live readback |
+| Content proof | Launch video, short-form clips, screenshots, release notes, GitHub Discussion, X, LinkedIn, and longform post are aligned | Produce video suite from existing raw material |
+| Community proof | Discord invite, rules, channels, onboarding, and sponsor/community routing are ready | Needs invite/token decision before public links |
+
+## Video Suite
+
+The video lane should use the existing ECC video-editing skill plus the
+`browser-use/video-use` model where useful: transcript as the editing surface,
+strategy approval before render, deterministic cuts, timeline/project output
+when available, and self-eval before publication.
+
+Reference pattern: <https://github.com/browser-use/video-use>
+
+Primary source classes already exist in the local ECC media library. Keep raw
+absolute paths out of public docs; use basenames or a private production
+manifest when handing work to an editor or agent.
+
+| Deliverable | Length | Source material | Proof goal |
+| --- | ---: | --- | --- |
+| Primary launch video | 90-150s | `longform-full-wide.mp4`, `sf-longform-full.mp4`, `architecture-2-wide.mp4`, `terminal-scan-2-wide.mp4`, `new_site_raw.mp4` | ECC 2.0 as the operator system |
+| Install proof | 30s | README install, terminal scan, quickstart, plugin install | Fewer-click adoption |
+| What is ECC | 45-60s | `sf-thread-2-whatisecc.mp4`, `vertical-2-whatisecc.mp4`, `architecture-2-*` | Product category clarity |
+| Security proof | 45-60s | `sf-thread-4-security.mp4`, AgentShield evidence, supply-chain gates | Enterprise trust |
+| Money/proof clip | 30-45s | `thread-2-ghapp-money.mp4`, `metrics-ticker-2-*`, `gh_app_*.png` | Sponsor, Pro, and partner credibility |
+| Coverage/social proof | 30-45s | `coverage-montage-wide.mp4`, `100k.png`, `star_history.png`, `x_analytics.png`, coverage screenshots | Distribution leverage |
+
+Production steps:
+
+1. Generate transcripts for the longform and shortform raw clips.
+2. Build an edit decision list with hook, proof, demo, business CTA, and final
+   CTA segments.
+3. Cut deterministically with FFmpeg.
+4. Add overlays and data motion in Remotion or Manim.
+5. Add captions, light color correction, audio normalization, and platform
+   reframes.
+6. Run a self-eval pass for blank frames, bad captions, jump cuts, weak hook,
+   missing product proof, and stale URLs.
+7. Export final MP4s plus the editable timeline/project state.
+
+## Distribution Plan
+
+| Channel | Asset | CTA |
+| --- | --- | --- |
+| GitHub Release | release notes, quickstart, launch video, sponsor link | star, install, sponsor |
+| GitHub Discussion | short announcement and proof bullets | questions, feedback, sponsors |
+| X | launch thread, 30s install clip, proof clips | repo, sponsor, Pro |
+| LinkedIn | partner-friendly product proof, consulting CTA | sponsors, consulting, talks |
+| YouTube/Shorts/Reels/TikTok | primary launch video and clips | repo, site, newsletter/community |
+| Podcasts/talks | one-page pitch, demo outline, founder proof | bookings, partners |
+| Sponsor outbound | direct sponsor note and tier table | GitHub Sponsors or Pro |
+
+## Copy Rules
+
+Use direct product language:
+
+- `ECC 2.0 is the harness-native operator system for agentic work.`
+- `One reusable layer across Claude Code, Codex, OpenCode, Cursor, Gemini, Zed, GitHub Copilot, and terminal workflows.`
+- `OSS stays free. Sponsors and Pro fund the work.`
+- `Use ECC for skills, hooks, rules, MCP conventions, release gates, and operator workflows.`
+
+Avoid:
+
+- `we renamed the repo`;
+- `pivot`;
+- legacy config-pack framing;
+- `Claude-only`;
+- generic founder-journey language;
+- claims about billing, marketplace payments, or official directory listings
+  before live evidence exists.
+
+## First Build Order
+
+1. Land the public repo identity fixes.
+2. Refresh package, plugin, workflow, release, and launch-copy URLs.
+3. Record final publication evidence from the exact release commit.
+4. Produce the video suite manifest and transcripts from existing raw material.
+5. Browser-capture the README, ECC Tools app, install flow, and relevant proof
+   surfaces for b-roll.
+6. Render the primary launch video plus five short clips.
+7. Finalize GitHub release, X thread, LinkedIn post, Discussion announcement,
+   sponsor email copy, and podcast/talk pitch.
+8. Publish only after npm, plugin, release URL, and billing-readback gates are
+   either live or explicitly marked blocked.
+
+## Owner Approvals
+
+These actions need a human approval or credential before they move:
+
+- sending annual-upgrade or sponsor emails;
+- updating LinkedIn profile text;
+- wiring Discord with a bot token and guild ID;
+- publishing npm or creating plugin tags;
+- announcing billing/native payments;
+- posting final social copy from personal accounts.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ecc-universal",
   "version": "2.0.0-rc.1",
-  "description": "Complete collection of battle-tested Claude Code configs — agents, skills, hooks, rules, and legacy command shims evolved over 10+ months of intensive daily use by an Anthropic hackathon winner",
+  "description": "Harness-native agent operating system for Claude Code, Codex, OpenCode, Cursor, Gemini, and terminal workflows - skills, hooks, rules, MCP conventions, and operator control-plane patterns",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/affaan-m/everything-claude-code.git"
+    "url": "git+https://github.com/affaan-m/ECC.git"
   },
-  "homepage": "https://github.com/affaan-m/everything-claude-code#readme",
+  "homepage": "https://github.com/affaan-m/ECC#readme",
   "bugs": {
-    "url": "https://github.com/affaan-m/everything-claude-code/issues"
+    "url": "https://github.com/affaan-m/ECC/issues"
   },
   "files": [
     ".agents/",
@@ -299,7 +299,7 @@
     "ecc-install": "scripts/install-apply.js"
   },
   "scripts": {
-    "postinstall": "echo '\\n  ecc-universal installed!\\n  Run: npx ecc typescript\\n  Compat: npx ecc-install typescript\\n  Docs: https://github.com/affaan-m/everything-claude-code\\n'",
+    "postinstall": "echo '\\n  ecc-universal installed!\\n  Run: npx ecc typescript\\n  Compat: npx ecc-install typescript\\n  Docs: https://github.com/affaan-m/ECC\\n'",
     "catalog:check": "node scripts/ci/catalog.js --text",
     "catalog:sync": "node scripts/ci/catalog.js --write --text",
     "command-registry:generate": "node scripts/ci/generate-command-registry.js",

--- a/tests/docs/ecc2-release-surface.test.js
+++ b/tests/docs/ecc2-release-surface.test.js
@@ -111,12 +111,12 @@ test('business launch copy stays aligned with the rc.1 public surface', () => {
     'business launch copy should stay pre-publication until release URLs exist'
   );
   assert.ok(
-    source.includes('https://github.com/affaan-m/everything-claude-code'),
+    source.includes('https://github.com/affaan-m/ECC'),
     'business launch copy should include the public repo URL'
   );
   assert.ok(
     source.includes(
-      'https://github.com/affaan-m/everything-claude-code/blob/main/docs/releases/2.0.0-rc.1/release-notes.md'
+      'https://github.com/affaan-m/ECC/blob/main/docs/releases/2.0.0-rc.1/release-notes.md'
     ),
     'business launch copy should link to the rc.1 release notes'
   );
@@ -320,15 +320,15 @@ test('release name and plugin publication checklist freezes rc.1 surfaces', () =
   const referenceArchitecture = read('docs/ECC-2.0-REFERENCE-ARCHITECTURE.md');
 
   for (const value of [
-    'Everything Claude Code (ECC)',
-    '`affaan-m/everything-claude-code`',
+    'Ship `v2.0.0-rc.1` as **ECC**',
+    '`affaan-m/ECC`',
     '`ecc-universal`',
     '`ecc` on npm is occupied',
     '`@affaan-m/ecc` is unclaimed on npm',
     'Claude plugin',
     'Codex plugin',
     'do not claim official directory listing until OpenAI publishing path is available',
-    'Do not rename the repo or package until rc.1 is published',
+    'Do not rename the npm package until rc.1 is published',
     'Do not announce billing, Marketplace, or native payments',
   ]) {
     assert.ok(checklist.includes(value), `release name/plugin checklist missing ${value}`);


### PR DESCRIPTION
## Summary
- refresh active package/plugin/workflow metadata for the canonical affaan-m/ECC repo identity
- update rc.1 release checklist and launch copy to lead with ECC 2.0 as a harness-native operator system
- add a 2.0 hypergrowth command-center doc covering release gates, video suite, sponsor/partner/MRR lanes, consulting/talk distribution, and owner approvals

## Validation
- node tests/docs/ecc2-release-surface.test.js
- node tests/plugin-manifest.test.js
- node tests/docs/install-identifiers.test.js
- node_modules/.bin/markdownlint docs/releases/2.0.0/ecc-2-hypergrowth-release-command-center.md docs/ECC-2.0-GA-ROADMAP.md docs/business/social-launch-copy.md docs/releases/2.0.0-rc.1/release-name-plugin-publication-checklist-2026-05-18.md
- node scripts/ci/validate-workflow-security.js
- node tests/scripts/release.test.js
- node tests/scripts/release-publish.test.js
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the ECC 2.0 Hypergrowth Release Command Center and sets `affaan-m/ECC` as the canonical repo across docs, metadata, workflows, and tests. Aligns all messaging to the “harness‑native operator system” story for rc.1.

- **New Features**
  - Added the ECC 2.0 Hypergrowth Release Command Center covering release gates, video suite, distribution plan, partner/sponsor/consulting lanes, and owner approvals.

- **Refactors**
  - Switched all public URLs and references to `affaan-m/ECC` in docs, `package.json`, plugin manifests, workflows, tests, and social copy.
  - Standardized marketplace/plugin identifier to `ecc@ecc` in release workflows.
  - Updated rc.1 checklist to ship as “ECC,” keep npm package `ecc-universal`, plugin slug `ecc`, and publish on the `next` dist-tag; refreshed descriptions to lead with a harness‑native operator system, reusable skills/hooks/rules, MCP conventions, and cross‑harness support.

<sup>Written for commit a90d82e1be03065354d4beadab90c164b3ecc319. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/1988?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated plugin/marketplace metadata, package metadata, and repository URLs to reflect new project branding and identifiers.
  * Adjusted release workflow release-body content to use the new plugin identifier.

* **Documentation**
  * Revised roadmap, launch copy, release command center, and release checklists to reference the new project identity and canonical repo.

* **Tests**
  * Updated test assertions to match revised public-facing text and links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/1988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->