### PR TITLE
feat(install-targets): add claude-project (per-project Claude Code) adapter

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -10,6 +10,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codebuddy",
@@ -33,6 +34,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -55,6 +57,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "opencode",
@@ -79,6 +82,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "opencode",
         "codebuddy"
@@ -106,6 +110,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -177,6 +182,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -210,6 +216,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -255,6 +262,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -294,6 +302,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -326,6 +335,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -360,6 +370,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -402,6 +413,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -428,6 +440,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -459,6 +472,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "codex",
         "opencode",
@@ -490,6 +504,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "codex",
         "opencode"
       ],
@@ -515,6 +530,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -559,6 +575,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -592,6 +609,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -617,6 +635,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -653,6 +672,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -679,6 +699,7 @@
       ],
       "targets": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",
@@ -703,7 +724,8 @@
         "docs/ja-JP"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -718,7 +740,8 @@
         "docs/zh-CN"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -733,7 +756,8 @@
         "docs/ko-KR"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -748,7 +772,8 @@
         "docs/pt-BR"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -763,7 +788,8 @@
         "docs/ru"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -778,7 +804,8 @@
         "docs/tr"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -793,7 +820,8 @@
         "docs/vi-VN"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,
@@ -808,7 +836,8 @@
         "docs/zh-TW"
       ],
       "targets": [
-        "claude"
+        "claude",
+        "claude-project"
       ],
       "dependencies": [],
       "defaultInstall": false,

--- a/schemas/ecc-install-config.schema.json
+++ b/schemas/ecc-install-config.schema.json
@@ -19,6 +19,7 @@
       "type": "string",
       "enum": [
         "claude",
+        "claude-project",
         "cursor",
         "antigravity",
         "codex",

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -49,6 +49,7 @@
               "type": "string",
               "enum": [
                 "claude",
+                "claude-project",
                 "cursor",
                 "antigravity",
                 "codex",

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -27,11 +27,12 @@ Usage: install.sh [--target <${LEGACY_INSTALL_TARGETS.join('|')}>] [--dry-run] [
        install.sh [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--dry-run] [--json] --profile <name> [--with <component>]... [--without <component>]...
        install.sh [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--dry-run] [--json] --modules <id,id,...> [--with <component>]... [--without <component>]...
        install.sh [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--dry-run] [--json] --skills <skill-id[,skill-id...]>
-       install.sh [--target claude] [--dry-run] [--json] --locale <locale-code>
+       install.sh [--target claude|claude-project] [--dry-run] [--json] --locale <locale-code>
        install.sh [--dry-run] [--json] --config <path>
 
 Targets:
   claude       (default) - Install ECC into ~/.claude/ with managed rules/skills under rules/ecc and skills/ecc
+  claude-project - Install ECC into ./.claude/ (per-project) with managed rules/skills under rules/ecc and skills/ecc
   cursor       - Install rules, hooks, and bundled Cursor configs to ./.cursor/
   antigravity  - Install rules, workflows, skills, and agents to ./.agent/
   codex        - Install shared agents/config into ~/.codex/
@@ -49,8 +50,8 @@ Options:
   --skills <ids>      Install one or more skill directories by ID, e.g. continuous-learning-v2
   --without <component>
                       Exclude a user-facing install component
-  --locale <code>     Install translated docs to ~/.claude/docs/<locale>/
-                      (claude target only; can be combined with --profile or --with)
+  --locale <code>     Install translated docs to ~/.claude/docs/<locale>/ (or ./.claude/docs/<locale>/ for claude-project)
+                      (claude or claude-project target only; can be combined with --profile or --with)
   --config <path>     Load install intent from ecc-install.json
   --dry-run    Show the install plan without copying files
   --json       Emit machine-readable plan/result JSON

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['claude', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed'];
+const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',
@@ -36,6 +36,14 @@ function listSupportedLocales() {
 }
 const LEGACY_COMPAT_BASE_MODULE_IDS_BY_TARGET = Object.freeze({
   claude: [
+    'rules-core',
+    'agents-core',
+    'commands-core',
+    'hooks-runtime',
+    'platform-configs',
+    'workflow-quality',
+  ],
+  'claude-project': [
     'rules-core',
     'agents-core',
     'commands-core',

--- a/scripts/lib/install-targets/claude-project.js
+++ b/scripts/lib/install-targets/claude-project.js
@@ -1,0 +1,91 @@
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createRemappedOperation,
+  isForeignPlatformPath,
+  normalizeRelativePath,
+} = require('./helpers');
+
+const CLAUDE_ECC_NAMESPACE = 'ecc';
+
+function getClaudeManagedDestinationPath(adapter, sourceRelativePath, input) {
+  const normalizedSourcePath = normalizeRelativePath(sourceRelativePath);
+  const targetRoot = adapter.resolveRoot(input);
+
+  if (normalizedSourcePath === 'rules') {
+    return path.join(targetRoot, 'rules', CLAUDE_ECC_NAMESPACE);
+  }
+
+  if (normalizedSourcePath.startsWith('rules/')) {
+    return path.join(
+      targetRoot,
+      'rules',
+      CLAUDE_ECC_NAMESPACE,
+      normalizedSourcePath.slice('rules/'.length)
+    );
+  }
+
+  if (normalizedSourcePath === 'skills') {
+    return path.join(targetRoot, 'skills', CLAUDE_ECC_NAMESPACE);
+  }
+
+  if (normalizedSourcePath.startsWith('skills/')) {
+    return path.join(
+      targetRoot,
+      'skills',
+      CLAUDE_ECC_NAMESPACE,
+      normalizedSourcePath.slice('skills/'.length)
+    );
+  }
+
+  if (normalizedSourcePath === 'docs' || normalizedSourcePath.startsWith('docs/')) {
+    return path.join(targetRoot, normalizedSourcePath);
+  }
+
+  return null;
+}
+
+module.exports = createInstallTargetAdapter({
+  id: 'claude-project',
+  target: 'claude-project',
+  kind: 'project',
+  rootSegments: ['.claude'],
+  installStatePathSegments: ['ecc', 'install-state.json'],
+  nativeRootRelativePath: '.claude-plugin',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, 'claude'))
+        .map(sourceRelativePath => {
+          const managedDestinationPath = getClaudeManagedDestinationPath(
+            adapter,
+            sourceRelativePath,
+            planningInput
+          );
+
+          if (managedDestinationPath) {
+            return createRemappedOperation(
+              adapter,
+              module.id,
+              sourceRelativePath,
+              managedDestinationPath,
+              { strategy: 'preserve-relative-path' }
+            );
+          }
+
+          return adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput);
+        });
+    });
+  },
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -1,5 +1,6 @@
 const antigravityProject = require('./antigravity-project');
 const claudeHome = require('./claude-home');
+const claudeProject = require('./claude-project');
 const codebuddyProject = require('./codebuddy-project');
 const codexHome = require('./codex-home');
 const cursorProject = require('./cursor-project');
@@ -11,6 +12,7 @@ const zedProject = require('./zed-project');
 
 const ADAPTERS = Object.freeze([
   claudeHome,
+  claudeProject,
   cursorProject,
   antigravityProject,
   codexHome,

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -89,7 +89,7 @@ function isMcpConfigPath(filePath) {
 }
 
 function buildResolvedClaudeHooks(plan) {
-  if (!plan.adapter || plan.adapter.target !== 'claude') {
+  if (!plan.adapter || (plan.adapter.target !== 'claude' && plan.adapter.target !== 'claude-project')) {
     return null;
   }
 

--- a/scripts/lib/install/request.js
+++ b/scripts/lib/install/request.js
@@ -100,8 +100,8 @@ function normalizeInstallRequest(options = {}) {
       `Unsupported locale: "${locale}". Supported locales: ${listSupportedLocales().join(', ')}`
     );
   }
-  if (locale && target !== 'claude') {
-    throw new Error('--locale can only be used with --target claude');
+  if (locale && target !== 'claude' && target !== 'claude-project') {
+    throw new Error('--locale can only be used with --target claude or --target claude-project');
   }
   const requestedIncludeComponentIds = dedupeStrings([
     ...(config?.includeComponentIds || []),

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -944,6 +944,13 @@ function runTests() {
     });
 
     assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'rules'
+        && operation.destinationPath === path.join(projectRoot, '.claude', 'rules', 'ecc')
+      )),
+      'Should still include non-foreign rules path (guards against empty-plan regression)'
+    );
+    assert.ok(
       !plan.operations.some(operation => (
         normalizedRelativePath(operation.sourceRelativePath) === '.cursor'
         || normalizedRelativePath(operation.sourceRelativePath).startsWith('.cursor/')

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -37,6 +37,7 @@ function runTests() {
     const adapters = listInstallTargetAdapters();
     const targets = adapters.map(adapter => adapter.target);
     assert.ok(targets.includes('claude'), 'Should include claude target');
+    assert.ok(targets.includes('claude-project'), 'Should include claude-project target');
     assert.ok(targets.includes('cursor'), 'Should include cursor target');
     assert.ok(targets.includes('antigravity'), 'Should include antigravity target');
     assert.ok(targets.includes('codex'), 'Should include codex target');
@@ -863,6 +864,99 @@ function runTests() {
         `Supported: ${SUPPORTED_INSTALL_TARGETS.join(', ')}`
       );
     }
+  })) passed++; else failed++;
+
+  if (test('resolves claude-project adapter root and install-state path from project root', () => {
+    const adapter = getInstallTargetAdapter('claude-project');
+    const projectRoot = '/workspace/app';
+    const root = adapter.resolveRoot({ projectRoot });
+    const statePath = adapter.getInstallStatePath({ projectRoot });
+
+    assert.strictEqual(adapter.id, 'claude-project');
+    assert.strictEqual(adapter.target, 'claude-project');
+    assert.strictEqual(adapter.kind, 'project');
+    assert.strictEqual(root, path.join(projectRoot, '.claude'));
+    assert.strictEqual(statePath, path.join(projectRoot, '.claude', 'ecc', 'install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('claude-project adapter supports lookup by target and adapter id', () => {
+    const byTarget = getInstallTargetAdapter('claude-project');
+    const byId = getInstallTargetAdapter('claude-project');
+
+    assert.strictEqual(byTarget.id, 'claude-project');
+    assert.strictEqual(byId.id, 'claude-project');
+    assert.ok(byTarget.supports('claude-project'));
+  })) passed++; else failed++;
+
+  if (test('plans claude-project rules and skills under project-scope ECC-managed subdirectories', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'claude-project',
+      repoRoot,
+      projectRoot,
+      modules: [
+        {
+          id: 'rules-core',
+          paths: ['rules'],
+        },
+        {
+          id: 'workflow-quality',
+          paths: ['skills/tdd-workflow'],
+        },
+      ],
+    });
+
+    assert.strictEqual(plan.adapter.id, 'claude-project');
+    assert.strictEqual(plan.targetRoot, path.join(projectRoot, '.claude'));
+    assert.strictEqual(plan.installStatePath, path.join(projectRoot, '.claude', 'ecc', 'install-state.json'));
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'rules'
+        && operation.destinationPath === path.join(projectRoot, '.claude', 'rules', 'ecc')
+      )),
+      'Should install bundled rules under project-scope rules/ecc'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'skills/tdd-workflow'
+        && operation.destinationPath === path.join(projectRoot, '.claude', 'skills', 'ecc', 'tdd-workflow')
+      )),
+      'Should install bundled skills under project-scope skills/ecc'
+    );
+  })) passed++; else failed++;
+
+  if (test('claude-project skips foreign platform source paths', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const projectRoot = '/workspace/app';
+
+    const plan = planInstallTargetScaffold({
+      target: 'claude-project',
+      repoRoot,
+      projectRoot,
+      modules: [
+        {
+          id: 'platform-configs',
+          paths: ['.cursor', '.zed', 'rules'],
+        },
+      ],
+    });
+
+    assert.ok(
+      !plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === '.cursor'
+        || normalizedRelativePath(operation.sourceRelativePath).startsWith('.cursor/')
+      )),
+      'Should skip foreign Cursor platform paths'
+    );
+    assert.ok(
+      !plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === '.zed'
+        || normalizedRelativePath(operation.sourceRelativePath).startsWith('.zed/')
+      )),
+      'Should skip foreign Zed platform paths'
+    );
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Adds a new `claude-project` install target — a project-scope counterpart to the existing user-scope `claude` target. Installs ECC into `<projectRoot>/.claude/` instead of `~/.claude/`, with the same `rules/ecc` and `skills/ecc` namespacing.

ECC currently has **6 project-scope adapters** (cursor, antigravity, gemini, codebuddy, joycode, zed) and **4 user-scope adapters** (claude, codex, opencode, qwen). Claude Code is the only one of the project-scope-capable editors without a project-scope target. This PR closes that gap.

## Why

Use cases this enables:

- **Monorepos / polyglot workspaces** with multiple independently-configured projects, where contaminating `~/.claude/` with one project's skills/rules would bleed into other projects.
- **Per-project skill isolation** for teams that want ECC scoped to a repo without affecting the developer's global Claude Code config.
- **Reproducible per-project ECC installs** that can be committed to the repo (or `.gitignored`) without coupling to the developer's home directory.

### Concrete use case — Flow

This PR is driven by [Flow](https://github.com/mhd-ghaith-abtah/flow) ([npm](https://www.npmjs.com/package/@mhd-ghaith-abtah/flow)), an opinionated workflow orchestrator that composes ECC, [BMAD](https://github.com/bmad-code-org/BMAD-METHOD), and [Caveman](https://github.com/JuliusBrussee/caveman) into a per-project setup via `flow init`.

Flow's \"team profile\" wants ECC scoped to the project (not to `~/.claude/`) so that:

- Non-Flow projects on the same machine don't see Flow's curated ECC selection
- Different Flow-managed repos can pick different ECC profiles/skills without conflicting
- The ECC install is reproducible per-repo and survives a clean machine

Today the only workaround is a `HOME=$PROJECT/.flow-vendor ./install.sh` shim, which is fragile and surprises tools that resolve `~/.claude/` directly. This PR removes that need by letting Flow (or any consumer with the same requirement) call ECC with `--target claude-project` and get a clean per-project install.

Symmetric benefit for any consumer that wants per-project ECC without needing to know about Flow.

## Design

`claude-project` is **symmetric with `claude`** — same destination mapping, same locale handling, same hooks placeholder substitution, same `rules/ecc` + `skills/ecc` namespacing. The only difference is the resolved root:

| Adapter         | kind    | Root resolution                            | install-state path                                   |
|-----------------|---------|--------------------------------------------|------------------------------------------------------|
| `claude`        | home    | `~/.claude/`                               | `~/.claude/ecc/install-state.json`                   |
| `claude-project`| project | `<projectRoot>/.claude/`                   | `<projectRoot>/.claude/ecc/install-state.json`       |

Implementation mirrors `cursor-project.js` (project-scope adapter) with `claude-home.js`'s destination-mapping logic to keep the namespacing consistent.

## Backwards compatibility

**No breaking change.** Existing `--target claude` continues to route to `claude-home` (user-scope) unchanged. The new target is fully opt-in via `--target claude-project`.

`LEGACY_INSTALL_TARGETS` (the bash-installer compat list: `claude`, `cursor`, `antigravity`) is **not** extended — `claude-project` participates only in the modern manifest-driven path. Defaults remain `claude`.

## Changes

- New: `scripts/lib/install-targets/claude-project.js` — adapter (mirrors claude-home pattern with `kind: 'project'`)
- Register: `scripts/lib/install-targets/registry.js`
- Extend: `SUPPORTED_INSTALL_TARGETS` + `LEGACY_COMPAT_BASE_MODULE_IDS_BY_TARGET` in `scripts/lib/install-manifests.js`
- Schema: `schemas/ecc-install-config.schema.json` target enum
- Manifests: `manifests/install-modules.json` — add `claude-project` to every module that already supports `claude` (rules-core, agents-core, commands-core, hooks-runtime, platform-configs, workflow-quality, mcp-management, all skill modules, all docs-<locale> modules)
- Gates: `buildResolvedClaudeHooks` (apply.js) and `--locale` gate (request.js) extended to accept either `claude` or `claude-project`
- Help text: `scripts/install-apply.js` — document the new target and updated locale guidance
- Tests: 4 new cases in `tests/lib/install-targets.test.js`

## Test plan

- [x] `node tests/lib/install-targets.test.js` — 35/35 pass (4 new)
- [x] `node tests/lib/install-manifests.test.js` — 39/39 pass
- [x] `node tests/lib/selective-install.test.js` — 46/46 pass
- [x] `node tests/lib/locale-install.test.js` — 5/5 pass
- [x] Schema / SUPPORTED_INSTALL_TARGETS regression guards — pass
- [x] End-to-end smoke: `node scripts/install-apply.js --target claude-project --profile minimal --dry-run --json` emits 359 operations, all destinations rooted at `<projectRoot>/.claude/` (parity with `--target claude` which emits 359 ops rooted at `~/.claude/`)
- [x] Foreign-platform filter verified — `.cursor`, `.zed`, etc. correctly skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a project-local install target ("claude-project") so modules can be installed into a project-scoped location alongside the existing global target.
  * Installer and install flows now recognize and handle the new target.

* **Documentation**
  * CLI help and install docs updated to document the new target, its install paths, and locale behavior.

* **Tests**
  * Test coverage expanded to include the new target and project-scoped install scenarios.

* **Schema**
  * Install/configuration schemas updated to allow the new target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->