### PR TITLE
fix(gateguard): preserve quoted git introspection args

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -119,6 +119,65 @@ function tokenize(segment) {
   return segment.split(/\s+/).filter(Boolean);
 }
 
+
+/**
+ * Tokenize a short allowlisted shell command while preserving quoted
+ * arguments. This is intentionally smaller than a full shell parser: the
+ * caller rejects shell control characters before invoking it, so this only
+ * needs to keep spaces inside quotes together for read-only git commands.
+ *
+ * @param {string} input
+ * @returns {string[] | null}
+ */
+function tokenizeAllowlistedShellWords(input) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let escaped = false;
+
+  for (const char of String(input || '')) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaped) current += '\\';
+  if (quote) return null;
+  if (current) tokens.push(current);
+  return tokens;
+}
+
 /**
  * Strip a leading path and trailing `.exe` from a command token so
  * `/usr/bin/git`, `git.exe`, and `GIT` all normalize to `git`.
@@ -592,8 +651,16 @@ function isReadOnlyGitIntrospection(command) {
     return false;
   }
 
-  const tokens = trimmed.split(/\s+/);
-  if (tokens[0] !== 'git' || tokens.length < 2) {
+  const segments = splitCommandSegments(trimmed);
+  if (segments.length !== 1) {
+    return false;
+  }
+
+  const tokens = tokenizeAllowlistedShellWords(trimmed);
+  if (!tokens) {
+    return false;
+  }
+  if (commandBasename(tokens[0]) !== 'git' || tokens.length < 2) {
     return false;
   }
 
@@ -613,7 +680,7 @@ function isReadOnlyGitIntrospection(command) {
   }
 
   if (subcommand === 'show') {
-    return args.length === 1 && !args[0].startsWith('--') && /^[a-zA-Z0-9._:/-]+$/.test(args[0]);
+    return args.length === 1 && !args[0].startsWith('--') && /^[a-zA-Z0-9._:/ -]+$/.test(args[0]);
   }
 
   if (subcommand === 'branch') {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -769,6 +769,8 @@ function runTests() {
       'git diff --name-only',
       'git log --oneline --max-count=1',
       'git show HEAD:README.md',
+      'git show HEAD:"docs/install guide.md"',
+      '/usr/bin/git status --short',
       'git branch --show-current',
       'git rev-parse --abbrev-ref HEAD',
     ];
@@ -802,7 +804,20 @@ function runTests() {
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('current user request'));
   })) passed++; else failed++;
 
-  // --- Test 23: module-load pruning removes old state files only ---
+  // --- Test 23: quoted shell separators are not read-only git bypasses
+  clearState();
+  if (test('does not treat quoted shell separators as read-only git introspection', () => {
+    const result = runBashHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'git show HEAD:"docs/a;b.md"' }
+    });
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce valid JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('current user request'));
+  })) passed++; else failed++;
+
+  // --- Test 24: module-load pruning removes old state files only ---
   clearState();
   if (test('prunes stale state files while keeping fresh state files', () => {
     const staleFile = path.join(stateDir, 'state-stale-session.json');


### PR DESCRIPTION
## Summary

GateGuard's read-only git bypass currently tokenizes with plain whitespace. That keeps simple commands fast, but it also means safe introspection with quoted pathspecs is not recognized, for example:

```sh
git show HEAD:"docs/install guide.md"
```

This patch keeps the bypass narrow while preserving quoted read-only arguments:

- add a tiny tokenizer for the read-only allowlist path that preserves quoted arguments,
- keep path-prefixed git commands such as `/usr/bin/git status --short` working,
- keep commands with shell separators out of the read-only bypass,
- add regression tests for quoted pathspecs and quoted separators.

## Validation

- `node tests/hooks/gateguard-fact-force.test.js` → 91 passed, 0 failed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GateGuard’s read-only git bypass to correctly handle quoted introspection args while still blocking shell separators. Keeps path-prefixed git binaries working and makes commands like `git show HEAD:"docs/install guide.md"` safe and recognized.

- **Bug Fixes**
  - Added a tiny tokenizer that preserves quoted args and escapes; rejects unclosed quotes.
  - Rejects commands with shell separators by enforcing a single command segment.
  - Normalizes the git binary name so `/usr/bin/git` and `git.exe` are treated as `git`.
  - Allows spaces in `git show` pathspecs inside quotes; keeps flags and unsafe patterns blocked.
  - Added tests for quoted pathspecs and quoted separators.

<sup>Written for commit 2cca4be3699ba94da6849165fc444c6fc6e9d25c. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2011?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git command detection and validation to properly handle quoted file paths containing spaces and special characters.
  * Enhanced shell command tokenizer with better support for complex quoted arguments and edge cases.
  * Expanded allowed character set for git show operations to include spaces in file paths.
  * Added improved validation to detect and properly handle malformed input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->