### PR TITLE
fix(mcp): drop -y flag, pin versions, switch github to official binary

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,12 @@
 {
   "mcpServers": {
     "github": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"]
+      "command": "sh",
+      "args": ["-c", "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) exec /opt/homebrew/bin/github-mcp-server stdio"]
     },
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@2.1.4"]
+      "args": ["@upstash/context7-mcp@2.2.5"]
     },
     "exa": {
       "type": "http",
@@ -14,15 +14,15 @@
     },
     "memory": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"]
+      "args": ["@modelcontextprotocol/server-memory@2026.1.26"]
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@0.0.68", "--extension"]
+      "args": ["@playwright/mcp@0.0.75", "--extension"]
     },
     "sequential-thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+      "args": ["@modelcontextprotocol/server-sequential-thinking@2025.12.18"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Drop `-y` from all `npx`-launched MCP servers. Claude Code's MCP host validates `args[0]` as the package name; the literal `-y` was breaking resolution with `Package '-y' not resolvable`. npm 11.14+ auto-confirms cached packages, so `-y` is unnecessary.
- Pin every MCP server to a specific cooldown-safe version (>24h old) instead of floating tags. Defends against supply-chain compromise via freshly-published malicious releases.
- Replace deprecated `@modelcontextprotocol/server-github` with GitHub's official Go binary (`github-mcp-server`, available via `brew install github-mcp-server`). Token is sourced from `gh auth token` at launch — no hardcoded secret, picks up keyring rotation automatically.

## Pinned versions

| Server | Version |
|---|---|
| context7 | 2.2.5 |
| memory | 2026.1.26 |
| sequential-thinking | 2025.12.18 |
| playwright | 0.0.75 |
| github (brew binary) | 1.0.5 |

## Test plan

- [x] Each pinned server launches cleanly via direct invocation
- [x] Official `github-mcp-server stdio` connects with `GITHUB_PERSONAL_ACCESS_TOKEN` from `gh auth token`
- [ ] Reload Claude Code and confirm all servers show green in MCP panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MCP startup errors and harden the setup. Removed `-y` from `npx`, pinned server versions, and switched GitHub to the official `github-mcp-server` with `gh`-based auth.

- **Dependencies**
  - Pin versions: `@upstash/context7-mcp@2.2.5`, `@modelcontextprotocol/server-memory@2026.1.26`, `@playwright/mcp@0.0.75`, `@modelcontextprotocol/server-sequential-thinking@2025.12.18`.
  - Replace `@modelcontextprotocol/server-github` with Homebrew `github-mcp-server` v1.0.5; token is read from `gh auth token` at launch (no hardcoded secret).

<sup>Written for commit da70124a4b6e3f9d810911afdea582bb5adeaa33. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2025?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration and package versions to enhance compatibility and functionality across multiple services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->