### PR TITLE
docs(rules): resolve ambiguities surfaced in a real-world session

### DIFF
--- a/rules/common/agents.md
+++ b/rules/common/agents.md
@@ -28,10 +28,12 @@ No user prompt needed:
 
 ## Parallel Task Execution
 
-ALWAYS use parallel Task execution for independent operations:
+**Scope:** parallel dispatch applies to **research, review, and analysis** agents whose outputs are independent reports. It does NOT apply to **implementation** agents that write to disk — those serialize to avoid merge conflicts on shared files.
+
+ALWAYS use parallel Task execution for independent **read-only** operations:
 
 ```markdown
-# GOOD: Parallel execution
+# GOOD: Parallel execution (reviewers / analyzers)
 Launch 3 agents in parallel:
 1. Agent 1: Security analysis of auth module
 2. Agent 2: Performance review of cache system
@@ -40,6 +42,19 @@ Launch 3 agents in parallel:
 # BAD: Sequential when unnecessary
 First agent 1, then agent 2, then agent 3
 ```
+
+```markdown
+# BAD: Parallel implementation agents on the same codebase
+Launch 2 agents in parallel:
+1. Agent 1: Implement endpoint X (modifies api.php)
+2. Agent 2: Implement endpoint Y (modifies api.php)
+# → merge conflict on api.php
+
+# GOOD: Serialize implementation agents, OR pre-partition the work
+# so each agent touches a disjoint file set.
+```
+
+This resolves the apparent conflict with `superpowers:subagent-driven-development`'s "never dispatch multiple implementation subagents in parallel" rule — both rules are now consistent: parallel reviewers yes, parallel implementers no.
 
 ## Multi-Perspective Analysis
 

--- a/rules/common/code-review.md
+++ b/rules/common/code-review.md
@@ -18,9 +18,9 @@ Code review ensures quality, security, and maintainability before code is merged
 
 Before requesting review, ensure:
 
-- All automated checks (CI/CD) are passing
+- All automated checks (CI/CD) are passing — if the project has CI/CD configured; otherwise: tests pass locally and linters report clean
 - Merge conflicts are resolved
-- Branch is up to date with target branch
+- Branch is up to date with target branch (skip if not using a branch-based workflow)
 
 ## Review Checklist
 

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -40,6 +40,8 @@ MANY SMALL FILES > FEW LARGE FILES:
 - Extract utilities from large modules
 - Organize by feature/domain, not by type
 
+**Existing-codebase precedence:** When working in a project whose existing files routinely exceed these limits (e.g., monolithic dispatchers, framework-defined large files), follow the in-file conventions. Do not unilaterally split a file you're modifying unless the user asks for it or the file's growth is directly caused by your change. The "follow existing patterns" rule below wins over the abstract size targets in that case.
+
 ## Error Handling
 
 ALWAYS handle errors comprehensively:
@@ -82,9 +84,9 @@ Split large functions into focused pieces with clear responsibilities.
 
 Before marking work complete:
 - [ ] Code is readable and well-named
-- [ ] Functions are small (<50 lines)
-- [ ] Files are focused (<800 lines)
-- [ ] No deep nesting (>4 levels)
+- [ ] Functions are small (<50 lines of executable code, excluding blank lines, comments, docstrings)
+- [ ] Files are focused (<800 lines, OR the file already exceeded this when you arrived)
+- [ ] No deep nesting (>4 levels of indentation in any one function body; each `if`/`for`/`while`/`try` block counts as one level)
 - [ ] Proper error handling
-- [ ] No hardcoded values (use constants or config)
-- [ ] No mutation (immutable patterns used)
+- [ ] No hardcoded values (use constants or config) — except trivial literals like `0`, `1`, port `8080`, etc.
+- [ ] No mutation (immutable patterns used) — see language-specific overrides where mutation is idiomatic

--- a/rules/common/testing.md
+++ b/rules/common/testing.md
@@ -2,10 +2,12 @@
 
 ## Minimum Test Coverage: 80%
 
-Test Types (ALL required):
+Test Types (applies if the project already has the corresponding test infrastructure):
 1. **Unit Tests** - Individual functions, utilities, components
 2. **Integration Tests** - API endpoints, database operations
 3. **E2E Tests** - Critical user flows (framework chosen per language)
+
+**Project-aware application:** If the project has no e2e harness configured (no Playwright/Cypress/etc.), do NOT block shipping on missing e2e tests — instead, flag the gap once per session and continue. The 80% target applies to whichever test types the project actually runs. Adding new test infrastructure is its own task and requires user approval, not a side effect of feature work.
 
 ## Test-Driven Development
 

--- a/rules/php/coding-style.md
+++ b/rules/php/coding-style.md
@@ -10,7 +10,7 @@ paths:
 ## Standards
 
 - Follow **PSR-12** formatting and naming conventions.
-- Prefer `declare(strict_types=1);` in application code.
+- Prefer `declare(strict_types=1);` in **new files**. When editing an existing file that does not declare it, leave the file's existing convention intact — adding `declare(strict_types=1);` mid-file is itself a behavior change and out of scope for incidental edits. See `common/coding-style.md` "follow existing patterns" guidance.
 - Use scalar type hints, return types, and typed properties everywhere new code permits.
 
 ## Immutability

--- a/rules/web/performance.md
+++ b/rules/web/performance.md
@@ -14,6 +14,10 @@
 
 ## Bundle Budget
 
+These are targets for **new** projects and for projects that already enforce bundle budgets via tooling (`vite build --report`, `next build` size output, webpack-bundle-analyzer, etc.).
+
+For existing projects that have shipped without budgets — especially vanilla-JS monoliths or legacy SPAs — these numbers are aspirational, not gates. Do not block a feature ship on bundle size in a project that has never enforced one; flag the gap as a follow-up improvement.
+
 | Page Type | JS Budget (gzipped) | CSS Budget |
 |-----------|---------------------|------------|
 | Landing page | < 150kb | < 30kb |


### PR DESCRIPTION
## Summary

Six rule clarifications based on contradictions and ambiguities hit during a multi-task session (cockpit redesign + PayPal import recovery, ~13 hours of agent work across ~50 commits, 10 pre-mortem findings, ~100 test assertions).

Each change resolves a specific friction I hit:

- **`common/agents.md`** — The "ALWAYS use parallel Task execution" rule directly contradicts `superpowers:subagent-driven-development`'s "Never dispatch multiple implementation subagents in parallel." Scoped the common rule to research/review agents; added explicit guidance + example that implementation agents serialize.

- **`common/coding-style.md`** — Added "existing-codebase precedence" note to the 800-line file limit (projects like 9k-line monolithic dispatchers shouldn't trigger ship-blocking on size). Tightened the checklist: function-length counting policy, nesting-level counting policy, hardcoded-value exceptions, mutation override.

- **`common/testing.md`** — "Unit + integration + e2e ALL required" is unrealistic for projects with no e2e harness. Made the rule project-aware: applies if the infrastructure exists, flag the gap once if not; don't block ship.

- **`common/code-review.md`** — "All CI/CD checks passing" requires CI/CD to exist. Added the otherwise-clause: tests pass locally + linters clean.

- **`php/coding-style.md`** — `declare(strict_types=1);` "prefer in application code" conflicts with the "follow existing patterns" common rule for files that don't have it. Disambiguated: new files yes, existing files leave the convention.

- **`web/performance.md`** — Bundle budgets framed as universal gates broke for projects without bundler tooling. Added "aspirational vs enforced" note.

## Test plan

- [x] All edits are markdown-only; no code or schema changes
- [x] No conflicts with existing rule cross-references (the common/agents.md change references the existing superpowers skill, which is already in the ECC ecosystem)
- [x] Each change has a clear, specific real-world failure mode it resolves
- [ ] Maintainer sanity-check that the "implementation serialize / review parallel" framing matches your intent for the agents rule

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies six rules to remove contradictions and make gates project-aware. Sets clear guidance for agent parallelism, legacy file size norms, and when tests/CI/bundle budgets block a ship.

- **Refactors**
  - Agents: parallel for research/review; implementation agents serialize or touch disjoint files.
  - Coding style: existing-codebase precedence on 800-line/file limits; clarified function line counting, nesting, literals, mutation overrides.
  - Testing: require unit/integration/E2E only if infra exists; flag missing E2E once; 80% applies to active suites.
  - Code review: CI/CD required only if configured; else local tests + linters; branch workflow optional.
  - PHP: `declare(strict_types=1);` in new files only; keep existing files’ convention.
  - Web performance: bundle budgets enforced when tooling exists; otherwise aspirational, not gates.

<sup>Written for commit bfa0cfa2f2110faa96003dbfbc5145da1e47c790. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2027?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidelines for parallel task execution in independent read-only operations.
  * Updated code review pre-flight checklist requirements for automated checks and CI/CD status.
  * Expanded coding standards guidance with detailed code quality checklist and existing codebase conventions.
  * Made test requirements conditional based on project infrastructure and test harness availability.
  * Refined PHP strict-types handling for new vs. existing files.
  * Clarified web bundle budget targets as goals for new projects, aspirational for existing projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->