### PR TITLE
docs(i18n): add German (de-DE) localization scout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Language:** English | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md) | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md)
+**Language:** English | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md) | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md) | [Deutsch](docs/de-DE/README.md)
 
 # ECC
 
@@ -28,7 +28,7 @@
 **Language / 语言 / 語言 / Dil / Язык / Ngôn ngữ**
 
 [**English**](README.md) | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md)
- | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md)
+ | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md) | [Deutsch](docs/de-DE/README.md)
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 
 **Language / 语言 / 語言 / Dil / Язык / Ngôn ngữ**
 
-[**English**](README.md) | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md) | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md)
+[**English**](README.md) | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md) | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md) | [Deutsch](docs/de-DE/README.md)
 
 </div>
 

--- a/docs/de-DE/GLOSSARY.md
+++ b/docs/de-DE/GLOSSARY.md
@@ -1,0 +1,67 @@
+# Glossar / Glossary
+
+Einheitliches Terminologie-Glossar für die deutsche (de-DE) Übersetzung von ECC.
+
+Leitlinie: Etablierte englische Fachbegriffe und ECC-Oberflächennamen (`agents/`, `skills/`,
+`commands/`, `hooks/`, `rules/`) bleiben **englisch** — sie sind im deutschsprachigen
+Entwickleralltag Standard und entsprechen Verzeichnis-/Befehlsnamen im Repo. Begriffe mit
+einer klaren, gebräuchlichen deutschen Entsprechung werden **übersetzt**.
+
+| English | Deutsch | Notiz |
+|---------|---------|-------|
+| Agent | Agent | bleibt englisch — ECC-Oberfläche (`agents/`) |
+| Skill | Skill | bleibt englisch — ECC-Oberfläche (`skills/`) |
+| Hook | Hook | bleibt englisch — ECC-Oberfläche (`hooks/`) |
+| Command | Command | bleibt englisch als ECC-Oberfläche (`commands/`); generisch sonst „Befehl" |
+| Rule | Rule | bleibt englisch als ECC-Oberfläche (`rules/`); generisch sonst „Regel" |
+| Harness | Harness | bleibt englisch — keine etablierte deutsche Entsprechung |
+| Instinct | Instinct | bleibt englisch — ECC-Begriff aus Continuous Learning |
+| Plugin | Plugin | bleibt englisch |
+| Marketplace | Marketplace | bleibt englisch — Anthropic-Produktbegriff |
+| Worktree | Worktree | bleibt englisch — Git-Fachbegriff |
+| Subagent | Subagent | bleibt englisch |
+| Frontmatter | Frontmatter | bleibt englisch; YAML-Feldnamen bleiben englisch |
+| Continuous Learning | Continuous Learning | ECC-Feature-Name bleibt englisch; beschreibend „kontinuierliches Lernen" |
+| Memory | Memory | als ECC-Konzept englisch; generisch „Speicher" |
+| Context window | Kontextfenster | |
+| Token | Token | |
+| Coverage | Coverage | „Testabdeckung", wo beschreibend |
+| Test-Driven Development | testgetriebene Entwicklung | Kürzel TDD beibehalten |
+| Code review | Code-Review | |
+| Refactoring | Refactoring | |
+| Pull request | Pull Request | |
+| Commit | Commit | |
+| Branch | Branch | |
+| Merge | Merge / zusammenführen | je nach Kontext |
+| Build | Build | |
+| Deploy | Deployment / deployen | |
+| Pipeline | Pipeline | |
+| Orchestration | Orchestrierung | |
+| Repository | Repository | kurz „Repo" zulässig |
+| Dependency | Abhängigkeit | |
+| Edge case | Grenzfall | |
+| Best practice | Best Practice | |
+| Anti-pattern | Anti-Pattern | |
+| Middleware | Middleware | |
+| Endpoint | Endpoint | |
+| Schema | Schema | |
+| Payload | Payload | |
+| Callback | Callback | |
+| Checkpoint | Checkpoint | |
+| Linter | Linter | |
+| Formatter | Formatter | |
+| Staging | Staging | |
+| Production | Produktion / Produktivumgebung | je nach Kontext |
+| Debugging | Debugging | |
+| Logging | Logging | |
+| Monitoring | Monitoring | |
+| Rate limit | Rate-Limit | |
+| Retry | Retry / Wiederholung | |
+| Fallback | Fallback | |
+| Graceful degradation | Graceful Degradation | |
+| Sandboxing | Sandboxing | |
+| Sanitization | Sanitisierung | |
+| Selective install | selektive Installation | |
+| Profile | Profil | Installationsprofil |
+| Component | Komponente | Installationskomponente |
+| Module | Modul | Installationsmodul |

--- a/docs/de-DE/GLOSSARY.md
+++ b/docs/de-DE/GLOSSARY.md
@@ -12,8 +12,8 @@ einer klaren, gebräuchlichen deutschen Entsprechung werden **übersetzt**.
 | Agent | Agent | bleibt englisch — ECC-Oberfläche (`agents/`) |
 | Skill | Skill | bleibt englisch — ECC-Oberfläche (`skills/`) |
 | Hook | Hook | bleibt englisch — ECC-Oberfläche (`hooks/`) |
-| Command | Command | bleibt englisch als ECC-Oberfläche (`commands/`); generisch sonst „Befehl" |
-| Rule | Rule | bleibt englisch als ECC-Oberfläche (`rules/`); generisch sonst „Regel" |
+| Command | Command | bleibt englisch als ECC-Oberfläche (`commands/`); generisch sonst „Befehl“ |
+| Rule | Rule | bleibt englisch als ECC-Oberfläche (`rules/`); generisch sonst „Regel“ |
 | Harness | Harness | bleibt englisch — keine etablierte deutsche Entsprechung |
 | Instinct | Instinct | bleibt englisch — ECC-Begriff aus Continuous Learning |
 | Plugin | Plugin | bleibt englisch |
@@ -21,11 +21,11 @@ einer klaren, gebräuchlichen deutschen Entsprechung werden **übersetzt**.
 | Worktree | Worktree | bleibt englisch — Git-Fachbegriff |
 | Subagent | Subagent | bleibt englisch |
 | Frontmatter | Frontmatter | bleibt englisch; YAML-Feldnamen bleiben englisch |
-| Continuous Learning | Continuous Learning | ECC-Feature-Name bleibt englisch; beschreibend „kontinuierliches Lernen" |
-| Memory | Memory | als ECC-Konzept englisch; generisch „Speicher" |
+| Continuous Learning | Continuous Learning | ECC-Feature-Name bleibt englisch; beschreibend „kontinuierliches Lernen“ |
+| Memory | Memory | als ECC-Konzept englisch; generisch „Speicher“ |
 | Context window | Kontextfenster | |
 | Token | Token | |
-| Coverage | Coverage | „Testabdeckung", wo beschreibend |
+| Coverage | Coverage | „Testabdeckung“, wo beschreibend |
 | Test-Driven Development | testgetriebene Entwicklung | Kürzel TDD beibehalten |
 | Code review | Code-Review | |
 | Refactoring | Refactoring | |
@@ -37,7 +37,7 @@ einer klaren, gebräuchlichen deutschen Entsprechung werden **übersetzt**.
 | Deploy | Deployment / deployen | |
 | Pipeline | Pipeline | |
 | Orchestration | Orchestrierung | |
-| Repository | Repository | kurz „Repo" zulässig |
+| Repository | Repository | kurz „Repo“ zulässig |
 | Dependency | Abhängigkeit | |
 | Edge case | Grenzfall | |
 | Best practice | Best Practice | |

--- a/docs/de-DE/README.md
+++ b/docs/de-DE/README.md
@@ -1,0 +1,1762 @@
+**Sprache:** [English](../../README.md) | [Deutsch](README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+
+# ECC
+
+![ECC - das Harness-native Operator-System für agentische Arbeit](../../assets/hero.png)
+
+[![Stars](https://img.shields.io/github/stars/affaan-m/ECC?style=flat)](https://github.com/affaan-m/ECC/stargazers)
+[![Forks](https://img.shields.io/github/forks/affaan-m/ECC?style=flat)](https://github.com/affaan-m/ECC/network/members)
+[![Contributors](https://img.shields.io/github/contributors/affaan-m/ECC?style=flat)](https://github.com/affaan-m/ECC/graphs/contributors)
+[![npm ecc-universal](https://img.shields.io/npm/dw/ecc-universal?label=ecc-universal%20weekly%20downloads&logo=npm)](https://www.npmjs.com/package/ecc-universal)
+[![npm ecc-agentshield](https://img.shields.io/npm/dw/ecc-agentshield?label=ecc-agentshield%20weekly%20downloads&logo=npm)](https://www.npmjs.com/package/ecc-agentshield)
+[![GitHub App Install](https://img.shields.io/badge/GitHub%20App-150%20installs-2ea44f?logo=github)](https://github.com/marketplace/ecc-tools)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+![Shell](https://img.shields.io/badge/-Shell-4EAA25?logo=gnu-bash&logoColor=white)
+![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?logo=typescript&logoColor=white)
+![Python](https://img.shields.io/badge/-Python-3776AB?logo=python&logoColor=white)
+![Go](https://img.shields.io/badge/-Go-00ADD8?logo=go&logoColor=white)
+![Java](https://img.shields.io/badge/-Java-ED8B00?logo=openjdk&logoColor=white)
+![Perl](https://img.shields.io/badge/-Perl-39457E?logo=perl&logoColor=white)
+![Markdown](https://img.shields.io/badge/-Markdown-000000?logo=markdown&logoColor=white)
+
+> **182K+ Stars** | **28K+ Forks** | **170+ Contributors** | **12+ Sprach-Ökosysteme** | **Gewinner eines Anthropic-Hackathons**
+
+---
+
+<div align="center">
+
+**Language / 语言 / 語言 / Dil / Язык / Ngôn ngữ**
+
+[English](../../README.md) | [**Deutsch**](README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md)
+ | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+
+</div>
+
+---
+
+**Das Harness-native Operator-System für agentische Arbeit. Von einem Gewinner eines Anthropic-Hackathons.**
+
+Nicht nur Konfigurationen. Ein vollständiges System: Skills, Instincts, Speicheroptimierung, Continuous Learning, Security-Scanning und research-first-Entwicklung. Produktionsreife Agents, Skills, Hooks, Rules, MCP-Konfigurationen und Legacy-Command-Shims, die über mehr als 10 Monate intensiver täglicher Nutzung beim Bau echter Produkte entstanden sind.
+
+Funktioniert über **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Gemini**, **Zed**, **GitHub Copilot** und andere KI-Agent-Harnesses hinweg.
+
+ECC v2.0.0-rc.1 ergänzt diese wiederverwendbare Schicht um die öffentliche Hermes-Operator-Story: Beginne mit dem [Hermes-Setup-Leitfaden](../../docs/HERMES-SETUP.md), prüfe anschließend die [rc.1-Release-Notes](../../docs/releases/2.0.0-rc.1/release-notes.md) und die [Cross-Harness-Architektur](../../docs/architecture/cross-harness.md).
+
+---
+
+<table>
+<tr>
+<td width="25%" align="center">
+  <a href="https://ecc.tools/pricing">
+    <strong> ECC Pro</strong><br />
+    <sub>Private Repos · GitHub App · 19 $/Platz/Monat</sub>
+  </a>
+</td>
+<td width="25%" align="center">
+  <a href="https://github.com/sponsors/affaan-m">
+    <strong> Sponsor</strong><br />
+    <sub>Finanziere das OSS · Ab 5 $/Monat</sub>
+  </a>
+</td>
+<td width="25%" align="center">
+  <a href="https://github.com/affaan-m/ECC/discussions">
+    <strong>Community</strong>
+    <br />
+    <sub>Discussions · Q&amp;A · Show & Tell</sub>
+  </a>
+</td>
+<td width="25%" align="center">
+  <a href="https://github.com/apps/ecc-tools">
+    <strong> GitHub App</strong><br />
+    <sub>Installieren · PR-Audits · Free-Tier</sub>
+  </a>
+</td>
+</tr>
+</table>
+
+<sub>**OSS bleibt kostenlos.** Dieses Repo ist für immer MIT-lizenziert. ECC Pro ist die gehostete GitHub App für private Repos. <a href="https://github.com/sponsors/affaan-m">Sponsoren</a> und <a href="https://ecc.tools/pricing">Pro-Abonnenten</a> finanzieren die Arbeit — deshalb liefert ein einzelner Maintainer wöchentlich über 7 Harnesses hinweg aus.</sub>
+
+---
+
+## Die Leitfäden
+
+Dieses Repo enthält ausschließlich den rohen Code. Die Leitfäden erklären alles.
+
+<table>
+<tr>
+<td width="33%">
+<a href="https://x.com/affaanmustafa/status/2012378465664745795">
+<img src="../../assets/images/guides/shorthand-guide.png" alt="The Shorthand Guide to Everything Claude Code" />
+</a>
+</td>
+<td width="33%">
+<a href="https://x.com/affaanmustafa/status/2014040193557471352">
+<img src="../../assets/images/guides/longform-guide.png" alt="The Longform Guide to Everything Claude Code" />
+</a>
+</td>
+<td width="33%">
+<a href="https://x.com/affaanmustafa/status/2033263813387223421">
+<img src="../../assets/images/security/security-guide-header.png" alt="The Shorthand Guide to Everything Agentic Security" />
+</a>
+</td>
+</tr>
+<tr>
+<td align="center"><b>Kurzleitfaden</b><br/>Setup, Grundlagen, Philosophie. <b>Lies das zuerst.</b></td>
+<td align="center"><b>Langleitfaden</b><br/>Token-Optimierung, Memory-Persistenz, Evals, Parallelisierung.</td>
+<td align="center"><b>Security-Leitfaden</b><br/>Angriffsvektoren, Sandboxing, Sanitisierung, CVEs, AgentShield.</td>
+</tr>
+</table>
+
+| Thema | Was du lernst |
+|-------|-------------------|
+| Token-Optimierung | Modellauswahl, Verschlankung des Systemprompts, Hintergrundprozesse |
+| Memory-Persistenz | Hooks, die Kontext über Sessions hinweg automatisch speichern/laden |
+| Continuous Learning | Automatisches Extrahieren von Mustern aus Sessions in wiederverwendbare Skills |
+| Verifikationsschleifen | Checkpoint- vs. kontinuierliche Evals, Grader-Typen, pass@k-Metriken |
+| Parallelisierung | Git-Worktrees, Cascade-Methode, wann Instanzen skaliert werden |
+| Subagent-Orchestrierung | Das Kontextproblem, das Iterative-Retrieval-Muster |
+
+---
+
+## Was ist neu
+
+### v2.0.0-rc.1 — Oberflächen-Refresh, Operator-Workflows und ECC 2.0 Alpha (April 2026)
+
+- **Dashboard-GUI** — Neue Tkinter-basierte Desktop-Anwendung (`ecc_dashboard.py` oder `npm run dashboard`) mit Umschalter für dunkles/helles Theme, Schriftanpassung und Projektlogo in Kopfzeile und Taskleiste.
+- **Öffentliche Oberfläche mit dem Live-Repo synchronisiert** — Metadaten, Katalogzahlen, Plugin-Manifeste und Install-bezogene Dokumentation entsprechen jetzt der tatsächlichen OSS-Oberfläche: 60 Agents, 232 Skills und 75 Legacy-Command-Shims.
+- **Erweiterung von Operator- und Outbound-Workflows** — `brand-voice`, `social-graph-ranker`, `connections-optimizer`, `customer-billing-ops`, `ecc-tools-cost-audit`, `google-workspace-ops`, `project-flow-ops` und `workspace-surface-audit` runden die Operator-Spur ab.
+- **Medien- und Launch-Tooling** — `manim-video`, `remotion-video-creation` und verbesserte Social-Publishing-Oberflächen machen technische Erklärinhalte und Launch-Content zum Teil desselben Systems.
+- **Wachstum der Framework- und Produktoberfläche** — `nestjs-patterns`, reichhaltigere Codex/OpenCode-Install-Oberflächen und erweitertes Cross-Harness-Packaging halten das Repo auch über Claude Code allein hinaus nutzbar.
+- **ECC 2.0 Alpha ist im Tree** — der Rust-Control-Plane-Prototyp in `ecc2/` baut jetzt lokal und stellt die Befehle `dashboard`, `start`, `sessions`, `status`, `stop`, `resume` und `daemon` bereit. Er ist als Alpha nutzbar, aber noch kein allgemeines Release.
+- **Operator-Status-Snapshots** — `ecc status --markdown --write status.md` verwandelt den lokalen State Store in eine portable Übergabe, die Bereitschaft, aktive Sessions, Skill-Run-Gesundheit, Install-Gesundheit, ausstehende Governance-Events und verknüpfte Arbeitselemente aus Linear/GitHub/Handovers abdeckt. Nutze `ecc work-items upsert ...` für manuelle Einträge, `ecc work-items sync-github --repo owner/repo` für den Queue-Status von PRs/Issues und `ecc status --exit-code`, um Automatisierung scheitern zu lassen, wenn die Bereitschaft Aufmerksamkeit erfordert.
+- **Ökosystem-Härtung** — AgentShield, ECC-Tools-Kostenkontrollen, Arbeiten am Billing-Portal und Website-Refreshes werden weiterhin rund um das Kern-Plugin ausgeliefert, statt in separate Silos abzudriften.
+
+### v1.9.0 — Selektive Installation & Spracherweiterung (März 2026)
+
+- **Architektur für selektive Installation** — Manifest-gesteuerte Install-Pipeline mit `install-plan.js` und `install-apply.js` für gezielte Komponenteninstallation. Der State Store verfolgt, was installiert ist, und ermöglicht inkrementelle Updates.
+- **6 neue Agents** — `typescript-reviewer`, `pytorch-build-resolver`, `java-build-resolver`, `java-reviewer`, `kotlin-reviewer`, `kotlin-build-resolver` erweitern die Sprachabdeckung auf 10 Sprachen.
+- **Neue Skills** — `pytorch-patterns` für Deep-Learning-Workflows, `documentation-lookup` für API-Referenzrecherche, `bun-runtime` und `nextjs-turbopack` für moderne JS-Toolchains sowie 8 operative Domänen-Skills und `mcp-server-patterns`.
+- **Session- & State-Infrastruktur** — SQLite-State-Store mit Query-CLI, Session-Adapter für strukturierte Aufzeichnung, Grundlage für Skill-Evolution für sich selbst verbessernde Skills.
+- **Orchestrierungsüberarbeitung** — Harness-Audit-Scoring deterministisch gemacht, Orchestrierungsstatus und Launcher-Kompatibilität gehärtet, Verhinderung von Observer-Loops mit 5-Schichten-Schutz.
+- **Observer-Zuverlässigkeit** — Fix für Memory-Explosion mit Throttling und Tail-Sampling, Fix für Sandbox-Zugriff, Lazy-Start-Logik und Re-Entrancy-Guard.
+- **12 Sprach-Ökosysteme** — Neue Rules für Java, PHP, Perl, Kotlin/Android/KMP, C++ und Rust treten zu den bestehenden Rules für TypeScript, Python, Go und den common-Rules hinzu.
+- **Community-Beiträge** — Koreanische und chinesische Übersetzungen, Optimierung des biome-Hooks, Skills zur Videoverarbeitung, operative Skills, PowerShell-Installer, Antigravity-IDE-Unterstützung.
+- **CI-Härtung** — 19 Fixes für Testfehler, Durchsetzung der Katalogzahlen, Validierung des Install-Manifests und vollständige Test-Suite grün.
+
+### v1.8.0 — Harness-Performance-System (März 2026)
+
+- **Harness-First-Release** — ECC ist nun ausdrücklich als Performance-System für Agent-Harnesses positioniert, nicht nur als Config-Paket.
+- **Überarbeitung der Hook-Zuverlässigkeit** — SessionStart-Root-Fallback, Session-Zusammenfassungen in der Stop-Phase und skriptbasierte Hooks, die fragile Inline-Einzeiler ersetzen.
+- **Hook-Laufzeitsteuerung** — `ECC_HOOK_PROFILE=minimal|standard|strict` und `ECC_DISABLED_HOOKS=...` für Laufzeit-Gating ohne Bearbeitung von Hook-Dateien.
+- **Neue Harness-Befehle** — `/harness-audit`, `/loop-start`, `/loop-status`, `/quality-gate`, `/model-route`.
+- **NanoClaw v2** — Modell-Routing, Skill-Hot-Load, Session-Branch/-Search/-Export/-Compact/-Metriken.
+- **Cross-Harness-Parität** — Verhalten über Claude Code, Cursor, OpenCode und Codex-App/-CLI hinweg verschärft.
+- **997 interne Tests bestanden** — vollständige Suite grün nach Hook-/Laufzeit-Refactoring und Kompatibilitätsupdates.
+
+### v1.7.0 — Cross-Platform-Erweiterung & Präsentations-Builder (Februar 2026)
+
+- **Codex-App- + CLI-Unterstützung** — Direkte `AGENTS.md`-basierte Codex-Unterstützung, Installer-Targeting und Codex-Dokumentation
+- **`frontend-slides`-Skill** — Abhängigkeitsfreier HTML-Präsentations-Builder mit Anleitung zur PPTX-Konvertierung und strengen Viewport-Fit-Regeln
+- **5 neue generische Business-/Content-Skills** — `article-writing`, `content-engine`, `market-research`, `investor-materials`, `investor-outreach`
+- **Breitere Tool-Abdeckung** — Cursor-, Codex- und OpenCode-Unterstützung verschärft, sodass dasselbe Repo sauber über alle großen Harnesses hinweg ausgeliefert wird
+- **992 interne Tests** — Erweiterte Validierung und Regressionsabdeckung über Plugin, Hooks, Skills und Packaging
+
+### v1.6.0 — Codex CLI, AgentShield & Marketplace (Februar 2026)
+
+- **Codex-CLI-Unterstützung** — Neuer Befehl `/codex-setup` erzeugt `codex.md` für die Kompatibilität mit der OpenAI Codex CLI
+- **7 neue Skills** — `search-first`, `swift-actor-persistence`, `swift-protocol-di-testing`, `regex-vs-llm-structured-text`, `content-hash-cache-pattern`, `cost-aware-llm-pipeline`, `skill-stocktake`
+- **AgentShield-Integration** — Der `/security-scan`-Skill führt AgentShield direkt aus Claude Code aus; 1282 Tests, 102 Rules
+- **GitHub Marketplace** — ECC-Tools-GitHub-App live unter [github.com/marketplace/ecc-tools](https://github.com/marketplace/ecc-tools) mit Free-/Pro-/Enterprise-Stufen
+- **30+ Community-PRs gemergt** — Beiträge von 30 Contributors über 6 Sprachen hinweg
+- **978 interne Tests** — Erweiterte Validierungs-Suite über Agents, Skills, Commands, Hooks und Rules
+
+### v1.4.1 — Bugfix (Februar 2026)
+
+- **Inhaltsverlust beim Instinct-Import behoben** — `parse_instinct_file()` verwarf während `/instinct-import` stillschweigend sämtlichen Inhalt nach dem Frontmatter (Abschnitte Action, Evidence, Examples). ([#148](https://github.com/affaan-m/ECC/issues/148), [#161](https://github.com/affaan-m/ECC/pull/161))
+
+### v1.4.0 — Mehrsprachige Rules, Installationsassistent & PM2 (Februar 2026)
+
+- **Interaktiver Installationsassistent** — Der neue `configure-ecc`-Skill bietet ein geführtes Setup mit Merge-/Überschreiben-Erkennung
+- **PM2 & Multi-Agent-Orchestrierung** — 6 neue Befehle (`/pm2`, `/multi-plan`, `/multi-execute`, `/multi-backend`, `/multi-frontend`, `/multi-workflow`) zur Verwaltung komplexer Multi-Service-Workflows
+- **Architektur für mehrsprachige Rules** — Rules von Flat-Dateien in die Verzeichnisse `common/` + `typescript/` + `python/` + `golang/` umstrukturiert. Installiere nur die Sprachen, die du brauchst
+- **Chinesische (zh-CN) Übersetzungen** — Vollständige Übersetzung aller Agents, Commands, Skills und Rules (80+ Dateien)
+- **GitHub-Sponsors-Unterstützung** — Unterstütze das Projekt über GitHub Sponsors
+- **Erweiterte CONTRIBUTING.md** — Detaillierte PR-Vorlagen für jeden Beitragstyp
+
+### v1.3.0 — OpenCode-Plugin-Unterstützung (Februar 2026)
+
+- **Vollständige OpenCode-Integration** — 12 Agents, 24 Commands, 16 Skills mit Hook-Unterstützung über das Plugin-System von OpenCode (20+ Event-Typen)
+- **3 native Custom Tools** — run-tests, check-coverage, security-audit
+- **LLM-Dokumentation** — `llms.txt` für umfassende OpenCode-Dokumentation
+
+### v1.2.0 — Vereinheitlichte Commands & Skills (Februar 2026)
+
+- **Python/Django-Unterstützung** — Skills für Django-Patterns, Sicherheit, TDD und Verifikation
+- **Java-Spring-Boot-Skills** — Patterns, Sicherheit, TDD und Verifikation für Spring Boot
+- **Session-Verwaltung** — `/sessions`-Befehl für den Session-Verlauf
+- **Continuous Learning v2** — Instinct-basiertes Lernen mit Konfidenz-Scoring, Import/Export, Evolution
+
+Den vollständigen Changelog findest du unter [Releases](https://github.com/affaan-m/ECC/releases).
+
+---
+
+## Schnellstart
+
+In unter 2 Minuten einsatzbereit:
+
+### Wähle nur einen Pfad
+
+Die meisten Claude-Code-Nutzer sollten genau einen Installationspfad verwenden:
+
+- **Empfohlene Voreinstellung:** Installiere das Claude-Code-Plugin und kopiere dann nur die Rule-Ordner, die du tatsächlich willst.
+- **Verwende den manuellen Installer nur dann, wenn** du feinere Kontrolle wünschst, den Plugin-Pfad ganz vermeiden willst oder dein Claude-Code-Build Probleme hat, den selbst gehosteten Marketplace-Eintrag aufzulösen.
+- **Stapele Installationsmethoden nicht.** Das häufigste kaputte Setup ist: zuerst `/plugin install`, danach `install.sh --profile full` oder `npx ecc-install --profile full`.
+
+Falls du bereits mehrere Installationen übereinandergelegt hast und Dinge doppelt aussehen, springe direkt zu [ECC zurücksetzen / deinstallieren](#ecc-zurücksetzen--deinstallieren).
+
+### Low-Context-/No-Hooks-Pfad
+
+Falls sich Hooks zu global anfühlen oder du nur ECCs Rules, Agents, Commands und Kern-Workflow-Skills willst, überspringe das Plugin und nutze das minimale manuelle Profil:
+
+```bash
+./install.sh --profile minimal --target claude
+```
+
+```powershell
+.\install.ps1 --profile minimal --target claude
+# oder
+npx ecc-install --profile minimal --target claude
+```
+
+Dieses Profil schließt `hooks-runtime` absichtlich aus.
+
+Falls du das normale core-Profil willst, aber Hooks deaktiviert brauchst, verwende:
+
+```bash
+./install.sh --profile core --without baseline:hooks --target claude
+```
+
+Füge Hooks später nur hinzu, wenn du Laufzeit-Durchsetzung willst:
+
+```bash
+./install.sh --target claude --modules hooks-runtime
+```
+
+### Finde zuerst die richtigen Komponenten
+
+Falls du nicht sicher bist, welches ECC-Profil oder welche Komponente du installieren sollst, frage den mitgelieferten Advisor aus jedem beliebigen Projekt:
+
+```bash
+npx ecc consult "security reviews" --target claude
+```
+
+Er liefert passende Komponenten, verwandte Profile sowie Preview-/Install-Befehle zurück. Verwende den Preview-Befehl vor der Installation, falls du den exakten Dateiplan inspizieren willst.
+
+Halte die Installation für produktive ML-/MLOps-Workflows opt-in und komponentenbezogen:
+
+```bash
+npx ecc consult "mlops training model deployment" --target claude
+npx ecc install --profile minimal --target claude --with capability:machine-learning
+```
+
+### Schritt 1: Plugin installieren (empfohlen)
+
+> NOTE: Das Plugin ist bequem, aber der OSS-Installer unten ist weiterhin der zuverlässigste Pfad, falls dein Claude-Code-Build Probleme hat, selbst gehostete Marketplace-Einträge aufzulösen.
+
+```bash
+# Marketplace hinzufügen
+/plugin marketplace add https://github.com/affaan-m/ECC
+
+# Plugin installieren
+/plugin install ecc@ecc
+```
+
+### Hinweis zu Benennung + Migration
+
+ECC hat jetzt drei öffentliche Bezeichner, und sie sind nicht austauschbar:
+
+- GitHub-Quell-Repo: `affaan-m/ECC`
+- Claude-Marketplace-/Plugin-Bezeichner: `ecc@ecc`
+- npm-Paket: `ecc-universal`
+
+Das ist beabsichtigt. Anthropic-Marketplace-/Plugin-Installationen werden über einen kanonischen Plugin-Bezeichner gekeyt, daher verwendet ECC `ecc@ecc`, um Tool-Namen und Slash-Command-Namespaces kurz genug für strenge Desktop-/API-Validatoren zu halten. Ältere Beiträge zeigen möglicherweise noch den früheren langen Marketplace-Bezeichner; behandle diesen lediglich als Legacy-Alias. Das npm-Paket blieb davon getrennt bei `ecc-universal`, daher verwenden npm-Installationen und Marketplace-Installationen absichtlich unterschiedliche Namen.
+
+### Schritt 2: Rules nur installieren, wenn du sie brauchst
+
+> WARNING: **Wichtig:** Claude-Code-Plugins können `rules` nicht automatisch verteilen.
+>
+> Falls du ECC bereits über `/plugin install` installiert hast, **führe danach nicht `./install.sh --profile full`, `.\install.ps1 --profile full` oder `npx ecc-install --profile full` aus**. Das Plugin lädt ECC-Skills, -Commands und -Hooks bereits. Wird der vollständige Installer nach einer Plugin-Installation ausgeführt, kopiert er dieselben Oberflächen in deine Benutzerverzeichnisse und kann doppelte Skills sowie doppeltes Laufzeitverhalten erzeugen.
+>
+> Kopiere für Plugin-Installationen manuell nur die `rules/`-Verzeichnisse, die du willst, nach `~/.claude/rules/ecc/`. Beginne mit `rules/common` plus einem Sprach- oder Framework-Paket, das du tatsächlich verwendest. Kopiere nicht jedes Rules-Verzeichnis, es sei denn, du willst diesen gesamten Kontext ausdrücklich in Claude haben.
+>
+> Verwende den vollständigen Installer nur dann, wenn du eine vollständig manuelle ECC-Installation statt des Plugin-Pfads durchführst.
+>
+> Falls dein lokales Claude-Setup gelöscht oder zurückgesetzt wurde, bedeutet das nicht, dass du ECC erneut kaufen musst. Beginne mit `node scripts/ecc.js list-installed`, führe dann `node scripts/ecc.js doctor` und `node scripts/ecc.js repair` aus, bevor du irgendetwas neu installierst. Das stellt ECC-verwaltete Dateien üblicherweise wieder her, ohne dein Setup neu aufzubauen. Falls das Problem im Konto- oder Marketplace-Zugriff für ECC Tools liegt, behandle die Konto-/Abrechnungswiederherstellung separat.
+
+```bash
+# Zuerst das Repo klonen
+git clone https://github.com/affaan-m/ECC.git
+cd ECC
+
+# Abhängigkeiten installieren (wähle deinen Paketmanager)
+npm install        # oder: pnpm install | yarn install | bun install
+
+# Plugin-Installationspfad: nur ECC-Rules in einen ECC-eigenen Namespace kopieren
+mkdir -p ~/.claude/rules/ecc
+cp -R rules/common ~/.claude/rules/ecc/
+cp -R rules/typescript ~/.claude/rules/ecc/
+
+# Vollständig manueller ECC-Installationspfad (nutze diesen statt /plugin install)
+# ./install.sh --profile full
+```
+
+```powershell
+# Windows PowerShell
+
+# Plugin-Installationspfad: nur ECC-Rules in einen ECC-eigenen Namespace kopieren
+New-Item -ItemType Directory -Force -Path "$HOME/.claude/rules/ecc" | Out-Null
+Copy-Item -Recurse rules/common "$HOME/.claude/rules/ecc/"
+Copy-Item -Recurse rules/typescript "$HOME/.claude/rules/ecc/"
+
+# Vollständig manueller ECC-Installationspfad (nutze diesen statt /plugin install)
+# .\install.ps1 --profile full
+# npx ecc-install --profile full
+```
+
+Anweisungen zur manuellen Installation findest du in der README im `rules/`-Ordner. Kopiere Rules manuell stets als ganzes Sprachverzeichnis (zum Beispiel `rules/common` oder `rules/golang`), nicht die darin enthaltenen Dateien, damit relative Verweise weiterhin funktionieren und Dateinamen nicht kollidieren.
+
+### Vollständig manuelle Installation (Fallback)
+
+Verwende dies nur, wenn du den Plugin-Pfad absichtlich überspringst:
+
+```bash
+./install.sh --profile full
+```
+
+```powershell
+.\install.ps1 --profile full
+# oder
+npx ecc-install --profile full
+```
+
+Wenn du diesen Pfad wählst, höre dort auf. Führe nicht zusätzlich `/plugin install` aus.
+
+### ECC zurücksetzen / deinstallieren
+
+Falls sich ECC doppelt, aufdringlich oder kaputt anfühlt, installiere es nicht weiter über sich selbst.
+
+- **Plugin-Pfad:** Entferne das Plugin aus Claude Code, lösche dann die konkreten Rule-Ordner, die du manuell unter `~/.claude/rules/ecc/` kopiert hast.
+- **Manueller Installer / CLI-Pfad:** Sieh dir die Entfernung vom Repo-Root aus zuerst in der Vorschau an:
+
+```bash
+node scripts/uninstall.js --dry-run
+```
+
+Entferne anschließend ECC-verwaltete Dateien:
+
+```bash
+node scripts/uninstall.js
+```
+
+Du kannst auch den Lifecycle-Wrapper verwenden:
+
+```bash
+node scripts/ecc.js list-installed
+node scripts/ecc.js doctor
+node scripts/ecc.js repair
+node scripts/ecc.js uninstall --dry-run
+```
+
+ECC entfernt nur Dateien, die in seinem Install-State erfasst sind. Es löscht keine fremden Dateien, die es nicht installiert hat.
+
+Falls du Methoden gestapelt hast, räume in dieser Reihenfolge auf:
+
+1. Entferne die Claude-Code-Plugin-Installation.
+2. Führe den ECC-Uninstall-Befehl vom Repo-Root aus, um über den Install-State verwaltete Dateien zu entfernen.
+3. Lösche alle zusätzlichen Rule-Ordner, die du manuell kopiert hast und nicht mehr willst.
+4. Installiere einmal neu, über einen einzigen Pfad.
+
+### Schritt 3: Loslegen
+
+```bash
+# Skills sind die primäre Workflow-Oberfläche.
+# Bestehende Slash-artige Command-Namen funktionieren weiterhin, während ECC von commands/ wegmigriert.
+
+# Die Plugin-Installation verwendet die kanonische Namespace-Form
+/ecc:plan "Benutzerauthentifizierung hinzufügen"
+
+# Die manuelle Installation behält die kürzere Slash-Form bei:
+# /plan "Benutzerauthentifizierung hinzufügen"
+
+# Verfügbare Commands prüfen
+/plugin list ecc@ecc
+```
+
+**Das war's!** Du hast nun Zugriff auf 60 Agents, 232 Skills und 75 Legacy-Command-Shims.
+
+### Dashboard-GUI
+
+Starte das Desktop-Dashboard, um ECC-Komponenten visuell zu erkunden:
+
+```bash
+npm run dashboard
+# oder
+python3 ./ecc_dashboard.py
+```
+
+**Funktionen:**
+- Oberfläche mit Reitern: Agents, Skills, Commands, Rules, Settings
+- Umschalter für dunkles/helles Theme
+- Schriftanpassung (Familie & Größe)
+- Projektlogo in Kopfzeile und Taskleiste
+- Suche und Filter über alle Komponenten
+
+### Multi-Modell-Befehle erfordern zusätzliches Setup
+
+> WARNING: `multi-*`-Befehle sind durch die obige Basis-Plugin-/Rules-Installation **nicht** abgedeckt.
+>
+> Um `/multi-plan`, `/multi-execute`, `/multi-backend`, `/multi-frontend` und `/multi-workflow` zu nutzen, musst du zusätzlich die `ccg-workflow`-Runtime installieren.
+>
+> Initialisiere sie mit `npx ccg-workflow`.
+>
+> Diese Runtime stellt die externen Abhängigkeiten bereit, die diese Befehle erwarten, darunter:
+> - `~/.claude/bin/codeagent-wrapper`
+> - `~/.claude/.ccg/prompts/*`
+>
+> Ohne `ccg-workflow` laufen diese `multi-*`-Befehle nicht korrekt.
+
+---
+
+## Cross-Platform-Unterstützung
+
+Dieses Plugin unterstützt nun vollständig **Windows, macOS und Linux**, neben enger Integration über große IDEs (Cursor, Zed, OpenCode, Antigravity) und CLI-Harnesses hinweg. Alle Hooks und Skripte wurden für maximale Kompatibilität in Node.js neu geschrieben.
+
+### Paketmanager-Erkennung
+
+Das Plugin erkennt deinen bevorzugten Paketmanager (npm, pnpm, yarn oder bun) automatisch mit folgender Priorität:
+
+1. **Umgebungsvariable**: `CLAUDE_PACKAGE_MANAGER`
+2. **Projektkonfiguration**: `.claude/package-manager.json`
+3. **package.json**: Feld `packageManager`
+4. **Lock-Datei**: Erkennung aus package-lock.json, yarn.lock, pnpm-lock.yaml oder bun.lockb
+5. **Globale Konfiguration**: `~/.claude/package-manager.json`
+6. **Fallback**: Erster verfügbarer Paketmanager
+
+So legst du deinen bevorzugten Paketmanager fest:
+
+```bash
+# Über Umgebungsvariable
+export CLAUDE_PACKAGE_MANAGER=pnpm
+
+# Über globale Konfiguration
+node scripts/setup-package-manager.js --global pnpm
+
+# Über Projektkonfiguration
+node scripts/setup-package-manager.js --project bun
+
+# Aktuelle Einstellung erkennen
+node scripts/setup-package-manager.js --detect
+```
+
+Oder verwende den `/setup-pm`-Befehl in Claude Code.
+
+### Hook-Laufzeitsteuerung
+
+Verwende Laufzeit-Flags, um die Strenge anzupassen oder bestimmte Hooks vorübergehend zu deaktivieren:
+
+```bash
+# Hook-Strenge-Profil (Standard: standard)
+export ECC_HOOK_PROFILE=standard
+
+# Komma-getrennte Hook-IDs, die deaktiviert werden sollen
+export ECC_DISABLED_HOOKS="pre:bash:tmux-reminder,post:edit:typecheck"
+
+# Zusatzkontext bei SessionStart begrenzen (Standard: 8000 Zeichen)
+export ECC_SESSION_START_MAX_CHARS=4000
+
+# Zusatzkontext bei SessionStart für Low-Context-/lokale-Modell-Setups vollständig deaktivieren
+export ECC_SESSION_START_CONTEXT=off
+
+# Kontext-/Scope-/Loop-Warnungen behalten, aber API-Rate-Kostenschätzungen unterdrücken
+export ECC_CONTEXT_MONITOR_COST_WARNINGS=off
+```
+
+Windows PowerShell:
+
+```powershell
+[Environment]::SetEnvironmentVariable('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'off', 'User')
+```
+
+---
+
+## Was ist enthalten
+
+Dieses Repo ist ein **Claude-Code-Plugin** - installiere es direkt oder kopiere Komponenten manuell.
+
+```
+ECC/
+|-- .claude-plugin/   # Plugin- und Marketplace-Manifeste
+|   |-- plugin.json         # Plugin-Metadaten und Komponentenpfade
+|   |-- marketplace.json    # Marketplace-Katalog für /plugin marketplace add
+|
+|-- agents/           # 60 spezialisierte Subagents für Delegation
+|   |-- planner.md           # Planung der Feature-Implementierung
+|   |-- architect.md         # Systemdesign-Entscheidungen
+|   |-- tdd-guide.md         # Testgetriebene Entwicklung
+|   |-- code-reviewer.md     # Qualitäts- und Sicherheitsreview
+|   |-- security-reviewer.md # Schwachstellenanalyse
+|   |-- build-error-resolver.md
+|   |-- e2e-runner.md        # Playwright-E2E-Tests
+|   |-- refactor-cleaner.md  # Beseitigung von totem Code
+|   |-- doc-updater.md       # Dokumentationssynchronisierung
+|   |-- docs-lookup.md       # Dokumentations-/API-Nachschlagen
+|   |-- chief-of-staff.md    # Kommunikations-Triage und Entwürfe
+|   |-- loop-operator.md     # Autonome Loop-Ausführung
+|   |-- harness-optimizer.md # Tuning der Harness-Konfiguration
+|   |-- cpp-reviewer.md      # C++-Code-Review
+|   |-- cpp-build-resolver.md # C++-Build-Fehlerbehebung
+|   |-- fsharp-reviewer.md   # F#-Funktionscode-Review
+|   |-- go-reviewer.md       # Go-Code-Review
+|   |-- go-build-resolver.md # Go-Build-Fehlerbehebung
+|   |-- python-reviewer.md   # Python-Code-Review
+|   |-- database-reviewer.md # Datenbank-/Supabase-Review
+|   |-- typescript-reviewer.md # TypeScript-/JavaScript-Code-Review
+|   |-- java-reviewer.md     # Java-/Spring-Boot-Code-Review
+|   |-- java-build-resolver.md # Java-/Maven-/Gradle-Build-Fehler
+|   |-- kotlin-reviewer.md   # Kotlin-/Android-/KMP-Code-Review
+|   |-- kotlin-build-resolver.md # Kotlin-/Gradle-Build-Fehler
+|   |-- harmonyos-app-resolver.md # HarmonyOS-/ArkTS-App-Entwicklung
+|   |-- rust-reviewer.md     # Rust-Code-Review
+|   |-- rust-build-resolver.md # Rust-Build-Fehlerbehebung
+|   |-- pytorch-build-resolver.md # PyTorch-/CUDA-Trainingsfehler
+|   |-- mle-reviewer.md      # Review von produktiver ML-Pipeline, Eval, Serving und Monitoring
+|
+|-- skills/           # Workflow-Definitionen und Domänenwissen
+|   |-- coding-standards/           # Sprach-Best-Practices
+|   |-- clickhouse-io/              # ClickHouse-Analytics, Queries, Data Engineering
+|   |-- backend-patterns/           # API-, Datenbank-, Caching-Patterns
+|   |-- frontend-patterns/          # React-, Next.js-Patterns
+|   |-- frontend-slides/            # HTML-Foliendecks und PPTX-zu-Web-Präsentations-Workflows (NEU)
+|   |-- article-writing/            # Langform-Texte in einer vorgegebenen Stimme ohne generischen KI-Ton (NEU)
+|   |-- content-engine/             # Multi-Plattform-Social-Content und Repurposing-Workflows (NEU)
+|   |-- market-research/            # Quellenbelegte Markt-, Wettbewerber- und Investorenrecherche (NEU)
+|   |-- investor-materials/         # Pitch-Decks, One-Pager, Memos und Finanzmodelle (NEU)
+|   |-- investor-outreach/          # Personalisierte Fundraising-Ansprache und Follow-up (NEU)
+|   |-- continuous-learning/        # Legacy-v1-Stop-Hook-Musterextraktion
+|   |-- continuous-learning-v2/     # Instinct-basiertes Lernen mit Konfidenz-Scoring
+|   |-- iterative-retrieval/        # Progressive Kontextverfeinerung für Subagents
+|   |-- strategic-compact/          # Manuelle Compaction-Vorschläge (Langleitfaden)
+|   |-- tdd-workflow/               # TDD-Methodik
+|   |-- security-review/            # Sicherheits-Checkliste
+|   |-- eval-harness/               # Evaluation der Verifikationsschleife (Langleitfaden)
+|   |-- verification-loop/          # Kontinuierliche Verifikation (Langleitfaden)
+|   |-- videodb/                   # Video und Audio: Ingest, Suche, Bearbeitung, Generierung, Streaming (NEU)
+|   |-- golang-patterns/            # Go-Idiome und Best Practices
+|   |-- golang-testing/             # Go-Test-Patterns, TDD, Benchmarks
+|   |-- cpp-coding-standards/         # C++-Coding-Standards aus den C++ Core Guidelines (NEU)
+|   |-- cpp-testing/                # C++-Tests mit GoogleTest, CMake/CTest (NEU)
+|   |-- django-patterns/            # Django-Patterns, Models, Views (NEU)
+|   |-- django-security/            # Django-Sicherheits-Best-Practices (NEU)
+|   |-- django-tdd/                 # Django-TDD-Workflow (NEU)
+|   |-- django-verification/        # Django-Verifikationsschleifen (NEU)
+|   |-- laravel-patterns/           # Laravel-Architektur-Patterns (NEU)
+|   |-- laravel-security/           # Laravel-Sicherheits-Best-Practices (NEU)
+|   |-- laravel-tdd/                # Laravel-TDD-Workflow (NEU)
+|   |-- laravel-verification/       # Laravel-Verifikationsschleifen (NEU)
+|   |-- python-patterns/            # Python-Idiome und Best Practices (NEU)
+|   |-- python-testing/             # Python-Tests mit pytest (NEU)
+|   |-- quarkus-patterns/            # Java-Quarkus-Patterns (NEU)
+|   |-- quarkus-security/            # Quarkus-Sicherheit (NEU)
+|   |-- quarkus-tdd/                 # Quarkus-TDD (NEU)
+|   |-- quarkus-verification/        # Quarkus-Verifikation (NEU)
+|   |-- springboot-patterns/        # Java-Spring-Boot-Patterns (NEU)
+|   |-- springboot-security/        # Spring-Boot-Sicherheit (NEU)
+|   |-- springboot-tdd/             # Spring-Boot-TDD (NEU)
+|   |-- springboot-verification/    # Spring-Boot-Verifikation (NEU)
+|   |-- configure-ecc/              # Interaktiver Installationsassistent (NEU)
+|   |-- security-scan/              # Integration des AgentShield-Security-Auditors (NEU)
+|   |-- java-coding-standards/     # Java-Coding-Standards (NEU)
+|   |-- jpa-patterns/              # JPA-/Hibernate-Patterns (NEU)
+|   |-- postgres-patterns/         # PostgreSQL-Optimierungs-Patterns (NEU)
+|   |-- nutrient-document-processing/ # Dokumentenverarbeitung mit der Nutrient-API (NEU)
+|   |-- docs/examples/project-guidelines-template.md  # Vorlage für projektspezifische Skills
+|   |-- database-migrations/         # Migrations-Patterns (Prisma, Drizzle, Django, Go) (NEU)
+|   |-- api-design/                  # REST-API-Design, Pagination, Fehlerantworten (NEU)
+|   |-- deployment-patterns/         # CI/CD, Docker, Health-Checks, Rollbacks (NEU)
+|   |-- docker-patterns/            # Docker Compose, Netzwerk, Volumes, Container-Sicherheit (NEU)
+|   |-- e2e-testing/                 # Playwright-E2E-Patterns und Page Object Model (NEU)
+|   |-- content-hash-cache-pattern/  # SHA-256-Content-Hash-Caching für Dateiverarbeitung (NEU)
+|   |-- cost-aware-llm-pipeline/     # LLM-Kostenoptimierung, Modell-Routing, Budget-Tracking (NEU)
+|   |-- regex-vs-llm-structured-text/ # Entscheidungsrahmen: Regex vs. LLM für Text-Parsing (NEU)
+|   |-- swift-actor-persistence/     # Thread-sichere Swift-Datenpersistenz mit Actors (NEU)
+|   |-- swift-protocol-di-testing/   # Protokollbasierte DI für testbaren Swift-Code (NEU)
+|   |-- search-first/               # Research-vor-Coding-Workflow (NEU)
+|   |-- skill-stocktake/            # Auditieren von Skills und Commands auf Qualität (NEU)
+|   |-- liquid-glass-design/         # iOS-26-Liquid-Glass-Designsystem (NEU)
+|   |-- foundation-models-on-device/ # Apple-On-Device-LLM mit FoundationModels (NEU)
+|   |-- swift-concurrency-6-2/       # Swift 6.2 Approachable Concurrency (NEU)
+|   |-- mle-workflow/               # Produktive ML-Datenverträge, Evals, Deployment, Monitoring (NEU)
+|   |-- perl-patterns/             # Moderne Perl-5.36+-Idiome und Best Practices (NEU)
+|   |-- perl-security/             # Perl-Sicherheits-Patterns, Taint-Mode, sicheres I/O (NEU)
+|   |-- perl-testing/              # Perl-TDD mit Test2::V0, prove, Devel::Cover (NEU)
+|   |-- autonomous-loops/           # Patterns für autonome Loops: sequentielle Pipelines, PR-Loops, DAG-Orchestrierung (NEU)
+|   |-- plankton-code-quality/      # Durchsetzung der Code-Qualität zur Schreibzeit mit Plankton-Hooks (NEU)
+|
+|-- commands/         # Gepflegte Slash-Entry-Kompatibilität; skills/ bevorzugen
+|   |-- plan.md             # /plan - Implementierungsplanung
+|   |-- code-review.md      # /code-review - Qualitätsreview
+|   |-- build-fix.md        # /build-fix - Build-Fehler beheben
+|   |-- refactor-clean.md   # /refactor-clean - Entfernen von totem Code
+|   |-- quality-gate.md     # /quality-gate - Verifikations-Gate
+|   |-- learn.md            # /learn - Muster mitten in der Session extrahieren (Langleitfaden)
+|   |-- learn-eval.md       # /learn-eval - Muster extrahieren, evaluieren und speichern (NEU)
+|   |-- checkpoint.md       # /checkpoint - Verifikationsstatus speichern (Langleitfaden)
+|   |-- setup-pm.md         # /setup-pm - Paketmanager konfigurieren
+|   |-- go-review.md        # /go-review - Go-Code-Review (NEU)
+|   |-- go-test.md          # /go-test - Go-TDD-Workflow (NEU)
+|   |-- go-build.md         # /go-build - Go-Build-Fehler beheben (NEU)
+|   |-- skill-create.md     # /skill-create - Skills aus Git-Historie generieren (NEU)
+|   |-- instinct-status.md  # /instinct-status - Gelernte Instincts anzeigen (NEU)
+|   |-- instinct-import.md  # /instinct-import - Instincts importieren (NEU)
+|   |-- instinct-export.md  # /instinct-export - Instincts exportieren (NEU)
+|   |-- evolve.md           # /evolve - Instincts zu Skills clustern
+|   |-- prune.md            # /prune - Abgelaufene ausstehende Instincts löschen (NEU)
+|   |-- pm2.md              # /pm2 - PM2-Service-Lifecycle-Verwaltung (NEU)
+|   |-- multi-plan.md       # /multi-plan - Multi-Agent-Aufgabenzerlegung (NEU)
+|   |-- multi-execute.md    # /multi-execute - Orchestrierte Multi-Agent-Workflows (NEU)
+|   |-- multi-backend.md    # /multi-backend - Backend-Multi-Service-Orchestrierung (NEU)
+|   |-- multi-frontend.md   # /multi-frontend - Frontend-Multi-Service-Orchestrierung (NEU)
+|   |-- multi-workflow.md   # /multi-workflow - Allgemeine Multi-Service-Workflows (NEU)
+|   |-- sessions.md         # /sessions - Verwaltung des Session-Verlaufs
+|   |-- test-coverage.md    # /test-coverage - Analyse der Testabdeckung
+|   |-- update-docs.md      # /update-docs - Dokumentation aktualisieren
+|   |-- update-codemaps.md  # /update-codemaps - Codemaps aktualisieren
+|   |-- python-review.md    # /python-review - Python-Code-Review (NEU)
+|-- legacy-command-shims/   # Opt-in-Archiv für ausgemusterte Shims wie /tdd und /eval
+|   |-- tdd.md              # /tdd - Bevorzuge den tdd-workflow-Skill
+|   |-- e2e.md              # /e2e - Bevorzuge den e2e-testing-Skill
+|   |-- eval.md             # /eval - Bevorzuge den eval-harness-Skill
+|   |-- verify.md           # /verify - Bevorzuge den verification-loop-Skill
+|   |-- orchestrate.md      # /orchestrate - Bevorzuge dmux-workflows oder multi-workflow
+|
+|-- rules/            # Stets zu befolgende Richtlinien (nach ~/.claude/rules/ecc/ kopieren)
+|   |-- README.md            # Strukturübersicht und Installationsanleitung
+|   |-- common/              # Sprachunabhängige Prinzipien
+|   |   |-- coding-style.md    # Immutabilität, Dateiorganisation
+|   |   |-- git-workflow.md    # Commit-Format, PR-Prozess
+|   |   |-- testing.md         # TDD, 80 % Coverage-Anforderung
+|   |   |-- performance.md     # Modellauswahl, Kontextverwaltung
+|   |   |-- patterns.md        # Design-Patterns, Skelett-Projekte
+|   |   |-- hooks.md           # Hook-Architektur, TodoWrite
+|   |   |-- agents.md          # Wann an Subagents delegiert wird
+|   |   |-- security.md        # Verpflichtende Sicherheitsprüfungen
+|   |-- typescript/          # TypeScript-/JavaScript-spezifisch
+|   |-- python/              # Python-spezifisch
+|   |-- golang/              # Go-spezifisch
+|   |-- swift/               # Swift-spezifisch
+|   |-- php/                 # PHP-spezifisch (NEU)
+|   |-- arkts/               # HarmonyOS / ArkTS-spezifisch
+|
+|-- hooks/            # Trigger-basierte Automatisierungen
+|   |-- README.md                 # Hook-Dokumentation, Rezepte und Anpassungsanleitung
+|   |-- hooks.json                # Konfiguration aller Hooks (PreToolUse, PostToolUse, Stop usw.)
+|   |-- memory-persistence/       # Session-Lifecycle-Hooks (Langleitfaden)
+|   |-- strategic-compact/        # Compaction-Vorschläge (Langleitfaden)
+|
+|-- scripts/          # Cross-Platform-Node.js-Skripte (NEU)
+|   |-- lib/                     # Gemeinsame Utilities
+|   |   |-- utils.js             # Cross-Platform-Datei-/Pfad-/System-Utilities
+|   |   |-- package-manager.js   # Paketmanager-Erkennung und -Auswahl
+|   |-- hooks/                   # Hook-Implementierungen
+|   |   |-- session-start.js     # Kontext bei Session-Start laden
+|   |   |-- session-end.js       # Status bei Session-Ende speichern
+|   |   |-- pre-compact.js       # Statusspeicherung vor der Compaction
+|   |   |-- suggest-compact.js   # Strategische Compaction-Vorschläge
+|   |   |-- evaluate-session.js  # Muster aus Sessions extrahieren
+|   |-- setup-package-manager.js # Interaktives PM-Setup
+|
+|-- tests/            # Test-Suite (NEU)
+|   |-- lib/                     # Bibliothekstests
+|   |-- hooks/                   # Hook-Tests
+|   |-- run-all.js               # Alle Tests ausführen
+|
+|-- contexts/         # Kontexte für dynamische Systemprompt-Injektion (Langleitfaden)
+|   |-- dev.md              # Kontext für den Entwicklungsmodus
+|   |-- review.md           # Kontext für den Code-Review-Modus
+|   |-- research.md         # Kontext für den Recherche-/Erkundungsmodus
+|
+|-- examples/         # Beispielkonfigurationen und -sessions
+|   |-- CLAUDE.md             # Beispielkonfiguration auf Projektebene
+|   |-- user-CLAUDE.md        # Beispielkonfiguration auf Benutzerebene
+|   |-- saas-nextjs-CLAUDE.md   # Praxisnahes SaaS (Next.js + Supabase + Stripe)
+|   |-- go-microservice-CLAUDE.md # Praxisnaher Go-Microservice (gRPC + PostgreSQL)
+|   |-- django-api-CLAUDE.md      # Praxisnahe Django-REST-API (DRF + Celery)
+|   |-- laravel-api-CLAUDE.md     # Praxisnahe Laravel-API (PostgreSQL + Redis) (NEU)
+|   |-- rust-api-CLAUDE.md        # Praxisnahe Rust-API (Axum + SQLx + PostgreSQL) (NEU)
+|
+|-- mcp-configs/      # MCP-Server-Konfigurationen
+|   |-- mcp-servers.json    # GitHub, Supabase, Vercel, Railway usw.
+|
+|-- ecc_dashboard.py  # Desktop-GUI-Dashboard (Tkinter)
+|
+|-- assets/           # Assets für das Dashboard
+|   |-- images/
+|       |-- ecc-logo.png
+|
+|-- marketplace.json  # Konfiguration des selbst gehosteten Marketplace (für /plugin marketplace add)
+```
+
+---
+
+## Ökosystem-Tools
+
+### Skill Creator
+
+Zwei Wege, um Claude-Code-Skills aus deinem Repository zu generieren:
+
+#### Option A: Lokale Analyse (eingebaut)
+
+Verwende den `/skill-create`-Befehl für lokale Analyse ohne externe Dienste:
+
+```bash
+/skill-create                    # Aktuelles Repo analysieren
+/skill-create --instincts        # Zusätzlich Instincts für continuous-learning-v2 generieren
+```
+
+Dies analysiert deine Git-Historie lokal und generiert SKILL.md-Dateien.
+
+#### Option B: GitHub App (fortgeschritten)
+
+Für fortgeschrittene Funktionen (10k+ Commits, Auto-PRs, Team-Sharing):
+
+[GitHub App installieren](https://github.com/apps/skill-creator) | [ecc.tools](https://ecc.tools)
+
+```bash
+# Kommentiere auf einem beliebigen Issue:
+/skill-creator analyze
+
+# Oder löst automatisch bei einem Push auf den Default-Branch aus
+```
+
+Beide Optionen erzeugen:
+- **SKILL.md-Dateien** - sofort einsatzbereite Skills für Claude Code
+- **Instinct-Sammlungen** - für continuous-learning-v2
+- **Musterextraktion** - lernt aus deiner Commit-Historie
+
+### AgentShield — Security-Auditor
+
+> Gebaut beim Claude Code Hackathon (Cerebral Valley x Anthropic, Februar 2026). 1282 Tests, 98 % Coverage, 102 statische Analyse-Rules.
+
+Scanne deine Claude-Code-Konfiguration auf Schwachstellen, Fehlkonfigurationen und Injection-Risiken.
+
+```bash
+# Schneller Scan (keine Installation nötig)
+npx ecc-agentshield scan
+
+# Sichere Probleme automatisch beheben
+npx ecc-agentshield scan --fix
+
+# Tiefenanalyse mit drei Opus-4.6-Agents
+npx ecc-agentshield scan --opus --stream
+
+# Sichere Konfiguration von Grund auf generieren
+npx ecc-agentshield init
+```
+
+**Was es scannt:** CLAUDE.md, settings.json, MCP-Konfigurationen, Hooks, Agent-Definitionen und Skills über 5 Kategorien — Secrets-Erkennung (14 Muster), Berechtigungs-Audit, Analyse von Hook-Injection, Risikoprofilierung von MCP-Servern und Review der Agent-Konfiguration.
+
+**Das `--opus`-Flag** führt drei Claude-Opus-4.6-Agents in einer Red-Team-/Blue-Team-/Auditor-Pipeline aus. Der Angreifer findet Exploit-Ketten, der Verteidiger bewertet die Schutzmaßnahmen, und der Auditor synthetisiert beides zu einer priorisierten Risikobewertung. Adversariales Schlussfolgern, nicht nur Mustererkennung.
+
+**Ausgabeformate:** Terminal (farblich nach A-F abgestuft), JSON (CI-Pipelines), Markdown, HTML. Exit-Code 2 bei kritischen Befunden für Build-Gates.
+
+Verwende `/security-scan` in Claude Code, um es auszuführen, oder füge es per [GitHub Action](https://github.com/affaan-m/agentshield) zur CI hinzu.
+
+[GitHub](https://github.com/affaan-m/agentshield) | [npm](https://www.npmjs.com/package/ecc-agentshield)
+
+### Continuous Learning v2
+
+Das Instinct-basierte Lernsystem lernt deine Muster automatisch:
+
+```bash
+/instinct-status        # Gelernte Instincts mit Konfidenz anzeigen
+/instinct-import <file> # Instincts von anderen importieren
+/instinct-export        # Eigene Instincts zum Teilen exportieren
+/evolve                 # Verwandte Instincts zu Skills clustern
+```
+
+Die vollständige Dokumentation findest du unter `skills/continuous-learning-v2/`.
+Behalte `continuous-learning/` nur dann, wenn du den Legacy-v1-Stop-Hook-Flow für gelernte Skills ausdrücklich willst.
+
+---
+
+## Voraussetzungen
+
+### Version der Claude Code CLI
+
+**Mindestversion: v2.1.0 oder neuer**
+
+Dieses Plugin erfordert die Claude Code CLI v2.1.0+ aufgrund von Änderungen daran, wie das Plugin-System Hooks verarbeitet.
+
+Prüfe deine Version:
+```bash
+claude --version
+```
+
+### Wichtig: Verhalten beim automatischen Laden von Hooks
+
+> WARNING: **Für Contributors:** Füge KEIN `"hooks"`-Feld zu `.claude-plugin/plugin.json` hinzu. Das wird durch einen Regressionstest erzwungen.
+
+Claude Code v2.1+ **lädt automatisch** `hooks/hooks.json` aus jedem installierten Plugin per Konvention. Es explizit in `plugin.json` zu deklarieren, verursacht einen Fehler durch Duplikaterkennung:
+
+```
+Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
+```
+
+**Historie:** Dies hat in diesem Repo wiederholte Fix-/Revert-Zyklen verursacht ([#29](https://github.com/affaan-m/ECC/issues/29), [#52](https://github.com/affaan-m/ECC/issues/52), [#103](https://github.com/affaan-m/ECC/issues/103)). Das Verhalten änderte sich zwischen Claude-Code-Versionen, was zu Verwirrung führte. Wir haben jetzt einen Regressionstest, der verhindert, dass dies erneut eingeführt wird.
+
+---
+
+## Installation
+
+### Option 1: Als Plugin installieren (empfohlen)
+
+Der einfachste Weg, dieses Repo zu nutzen - als Claude-Code-Plugin installieren:
+
+```bash
+# Dieses Repo als Marketplace hinzufügen
+/plugin marketplace add https://github.com/affaan-m/ECC
+
+# Das Plugin installieren
+/plugin install ecc@ecc
+```
+
+Oder füge es direkt zu deiner `~/.claude/settings.json` hinzu:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "ecc": {
+      "source": {
+        "source": "github",
+        "repo": "affaan-m/ECC"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ecc@ecc": true
+  }
+}
+```
+
+Dies gibt dir sofortigen Zugriff auf alle Commands, Agents, Skills und Hooks.
+
+> **Hinweis:** Das Claude-Code-Plugin-System unterstützt das Verteilen von `rules` über Plugins nicht ([Upstream-Einschränkung](https://code.claude.com/docs/en/plugins-reference)). Du musst Rules manuell installieren:
+>
+> ```bash
+> # Zuerst das Repo klonen
+> git clone https://github.com/affaan-m/ECC.git
+> cd ECC
+>
+> # Option A: Rules auf Benutzerebene (gilt für alle Projekte)
+> mkdir -p ~/.claude/rules/ecc
+> cp -r rules/common ~/.claude/rules/ecc/
+> cp -r rules/typescript ~/.claude/rules/ecc/   # wähle deinen Stack
+> cp -r rules/python ~/.claude/rules/ecc/
+> cp -r rules/golang ~/.claude/rules/ecc/
+> cp -r rules/php ~/.claude/rules/ecc/
+>
+> # Option B: Rules auf Projektebene (gilt nur für das aktuelle Projekt)
+> mkdir -p .claude/rules/ecc
+> cp -r rules/common .claude/rules/ecc/
+> cp -r rules/typescript .claude/rules/ecc/     # wähle deinen Stack
+> ```
+
+---
+
+### Option 2: Manuelle Installation
+
+Falls du manuelle Kontrolle darüber bevorzugst, was installiert wird:
+
+```bash
+# Das Repo klonen
+git clone https://github.com/affaan-m/ECC.git
+cd ECC
+
+# Agents in deine Claude-Konfiguration kopieren
+cp agents/*.md ~/.claude/agents/
+
+# Rules-Verzeichnisse kopieren (common + sprachspezifisch)
+mkdir -p ~/.claude/rules/ecc
+cp -r rules/common ~/.claude/rules/ecc/
+cp -r rules/typescript ~/.claude/rules/ecc/   # wähle deinen Stack
+cp -r rules/python ~/.claude/rules/ecc/
+cp -r rules/golang ~/.claude/rules/ecc/
+cp -r rules/php ~/.claude/rules/ecc/
+cp -r rules/arkts ~/.claude/rules/ecc/
+
+# Zuerst Skills kopieren (primäre Workflow-Oberfläche)
+# Empfohlen (neue Nutzer): nur Kern-/allgemeine Skills
+mkdir -p ~/.claude/skills/ecc
+cp -r .agents/skills/* ~/.claude/skills/ecc/
+cp -r skills/search-first ~/.claude/skills/ecc/
+
+# Optional: nischen-/framework-spezifische Skills nur bei Bedarf hinzufügen
+# for s in django-patterns django-tdd laravel-patterns springboot-patterns quarkus-patterns; do
+# cp -r skills/$s ~/.claude/skills/ecc/
+# done
+
+# Optional: gepflegte Slash-Command-Kompatibilität während der Migration behalten
+mkdir -p ~/.claude/commands
+cp commands/*.md ~/.claude/commands/
+
+# Ausgemusterte Shims liegen in legacy-command-shims/commands/.
+# Kopiere einzelne Dateien von dort nur, wenn du alte Namen wie /tdd noch brauchst.
+```
+
+#### Hooks installieren
+
+Kopiere die rohe Repo-Datei `hooks/hooks.json` nicht in `~/.claude/settings.json` oder `~/.claude/hooks/hooks.json`. Diese Datei ist plugin-/repo-orientiert und dafür gedacht, über den ECC-Installer installiert oder als Plugin geladen zu werden, daher ist rohes Kopieren kein unterstützter manueller Installationspfad.
+
+Verwende den Installer, um nur die Claude-Hook-Runtime zu installieren, damit Command-Pfade korrekt umgeschrieben werden:
+
+```bash
+# macOS / Linux
+bash ./install.sh --target claude --modules hooks-runtime
+```
+
+```powershell
+# Windows PowerShell
+pwsh -File .\install.ps1 --target claude --modules hooks-runtime
+```
+
+Das schreibt aufgelöste Hooks nach `~/.claude/hooks/hooks.json` und lässt eine bestehende `~/.claude/settings.json` unberührt.
+
+Falls du ECC über `/plugin install` installiert hast, kopiere diese Hooks nicht in `settings.json`. Claude Code v2.1+ lädt Plugin-`hooks/hooks.json` bereits automatisch, und sie in `settings.json` zu duplizieren, verursacht doppelte Ausführung und Cross-Platform-Hook-Konflikte.
+
+Windows-Hinweis: Das Claude-Konfigurationsverzeichnis ist `%USERPROFILE%\\.claude`, nicht `~/claude`.
+
+#### MCPs konfigurieren
+
+Claude-Plugin-Installationen aktivieren die mitgelieferten MCP-Server-Definitionen von ECC absichtlich nicht automatisch. Das vermeidet überlange Plugin-MCP-Tool-Namen auf strengen Drittanbieter-Gateways und hält gleichzeitig das manuelle MCP-Setup verfügbar.
+
+Verwende den `/mcp`-Befehl von Claude Code oder das CLI-verwaltete MCP-Setup für Live-Änderungen an Claude-Code-Servern. Verwende `/mcp` für Laufzeit-Deaktivierungen in Claude Code; Claude Code speichert diese Entscheidungen in `~/.claude.json`.
+
+Für repo-lokalen MCP-Zugriff kopiere die gewünschten MCP-Server-Definitionen aus `mcp-configs/mcp-servers.json` in eine projektbezogene `.mcp.json`.
+
+Falls du bereits eigene Kopien der von ECC mitgelieferten MCPs betreibst, setze:
+
+```bash
+export ECC_DISABLED_MCPS="github,context7,exa,playwright,sequential-thinking,memory"
+```
+
+ECC-verwaltete Install- und Codex-Sync-Flows überspringen oder entfernen diese mitgelieferten Server, statt Duplikate erneut hinzuzufügen. `ECC_DISABLED_MCPS` ist ein ECC-Install-/Sync-Filter, kein Live-Toggle für Claude Code.
+
+**Wichtig:** Ersetze die `YOUR_*_HERE`-Platzhalter durch deine tatsächlichen API-Keys.
+
+---
+
+## Kernkonzepte
+
+### Agents
+
+Subagents bearbeiten delegierte Aufgaben mit begrenztem Umfang. Beispiel:
+
+```markdown
+---
+name: code-reviewer
+description: Reviews code for quality, security, and maintainability
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+You are a senior code reviewer...
+```
+
+### Skills
+
+Skills sind die primäre Workflow-Oberfläche. Sie können direkt aufgerufen, automatisch vorgeschlagen und von Agents wiederverwendet werden. ECC liefert während der Migration weiterhin gepflegte `commands/` aus, während ausgemusterte Kurznamen-Shims unter `legacy-command-shims/` nur zur ausdrücklichen Opt-in-Nutzung liegen. Neue Workflow-Entwicklung sollte zuerst in `skills/` landen.
+
+```markdown
+# TDD Workflow
+
+1. Define interfaces first
+2. Write failing tests (RED)
+3. Implement minimal code (GREEN)
+4. Refactor (IMPROVE)
+5. Verify 80%+ coverage
+```
+
+### Hooks
+
+Hooks feuern bei Tool-Events. Beispiel - Warnung vor console.log:
+
+```json
+{
+  "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+  "hooks": [{
+    "type": "command",
+    "command": "#!/bin/bash\ngrep -n 'console\\.log' \"$file_path\" && echo '[Hook] Remove console.log' >&2"
+  }]
+}
+```
+
+### Rules
+
+Rules sind stets zu befolgende Richtlinien, organisiert in `common/` (sprachunabhängig) + sprachspezifische Verzeichnisse:
+
+```
+rules/
+  common/          # Universelle Prinzipien (immer installieren)
+  typescript/      # TS/JS-spezifische Patterns und Tools
+  python/          # Python-spezifische Patterns und Tools
+  golang/          # Go-spezifische Patterns und Tools
+  swift/           # Swift-spezifische Patterns und Tools
+  php/             # PHP-spezifische Patterns und Tools
+  arkts/           # HarmonyOS / ArkTS-Patterns und -Beschränkungen
+```
+
+Details zu Installation und Struktur findest du in [`rules/README.md`](../../rules/README.md).
+
+---
+
+## Welchen Agent sollte ich verwenden?
+
+Nicht sicher, wo du anfangen sollst? Verwende diese Kurzreferenz. Skills sind die kanonische Workflow-Oberfläche; gepflegte Slash-Einträge bleiben für command-first-Workflows verfügbar.
+
+| Ich möchte… | Diese Oberfläche verwenden | Verwendeter Agent |
+|--------------|-----------------|------------|
+| Ein neues Feature planen | `/ecc:plan "Add auth"` | planner |
+| Systemarchitektur entwerfen | `/ecc:plan` + architect-Agent | architect |
+| Code zuerst mit Tests schreiben | `tdd-workflow`-Skill | tdd-guide |
+| Gerade geschriebenen Code reviewen | `/code-review` | code-reviewer |
+| Einen fehlschlagenden Build beheben | `/build-fix` | build-error-resolver |
+| End-to-End-Tests ausführen | `e2e-testing`-Skill | e2e-runner |
+| Sicherheitslücken finden | `/security-scan` | security-reviewer |
+| Toten Code entfernen | `/refactor-clean` | refactor-cleaner |
+| Dokumentation aktualisieren | `/update-docs` | doc-updater |
+| Go-Code reviewen | `/go-review` | go-reviewer |
+| Python-Code reviewen | `/python-review` | python-reviewer |
+| F#-Code reviewen | *(`fsharp-reviewer` direkt aufrufen)* | fsharp-reviewer |
+| TypeScript-/JavaScript-Code reviewen | *(`typescript-reviewer` direkt aufrufen)* | typescript-reviewer |
+| HarmonyOS-Apps entwickeln | *(`harmonyos-app-resolver` direkt aufrufen)* | harmonyos-app-resolver |
+| Datenbank-Queries auditieren | *(automatisch delegiert)* | database-reviewer |
+| Produktive ML-Änderungen reviewen | `mle-workflow`-Skill + `mle-reviewer`-Agent | mle-reviewer |
+
+### Häufige Workflows
+
+Die Slash-Formen unten werden dort gezeigt, wo sie Teil der gepflegten Command-Oberfläche bleiben. Ausgemusterte Kurznamen-Shims wie `/tdd` und `/eval` liegen in `legacy-command-shims/` nur zur ausdrücklichen Opt-in-Nutzung.
+
+**Ein neues Feature beginnen:**
+```
+/ecc:plan "Add user authentication with OAuth"
+                                              → planner erstellt Implementierungs-Blueprint
+tdd-workflow skill                            → tdd-guide erzwingt write-tests-first
+/code-review                                  → code-reviewer prüft deine Arbeit
+```
+
+**Einen Bug beheben:**
+```
+tdd-workflow skill                            → tdd-guide: schreibe einen fehlschlagenden Test, der ihn reproduziert
+                                              → implementiere den Fix, verifiziere, dass der Test besteht
+/code-review                                  → code-reviewer: fängt Regressionen ab
+```
+
+**Vorbereitung für die Produktion:**
+```
+/security-scan                                → security-reviewer: OWASP-Top-10-Audit
+e2e-testing skill                             → e2e-runner: Tests kritischer Benutzerflüsse
+/test-coverage                                → 80 %+ Coverage verifizieren
+```
+
+---
+
+## FAQ
+
+<details>
+<summary><b>Wie prüfe ich, welche Agents/Commands installiert sind?</b></summary>
+
+```bash
+/plugin list ecc@ecc
+```
+
+Dies zeigt alle verfügbaren Agents, Commands und Skills aus dem Plugin.
+</details>
+
+<details>
+<summary><b>Meine Hooks funktionieren nicht / ich sehe „Duplicate hooks file"-Fehler</b></summary>
+
+Das ist das häufigste Problem. **Füge KEIN `"hooks"`-Feld zu `.claude-plugin/plugin.json` hinzu.** Claude Code v2.1+ lädt `hooks/hooks.json` aus installierten Plugins automatisch. Es explizit zu deklarieren, verursacht Fehler durch Duplikaterkennung. Siehe [#29](https://github.com/affaan-m/ECC/issues/29), [#52](https://github.com/affaan-m/ECC/issues/52), [#103](https://github.com/affaan-m/ECC/issues/103).
+</details>
+
+<details>
+<summary><b>Kann ich ECC mit Claude Code an einem benutzerdefinierten API-Endpoint oder Modell-Gateway verwenden?</b></summary>
+
+Ja. ECC hat keine Anthropic-gehosteten Transporteinstellungen fest verdrahtet. Es läuft lokal über die normale CLI-/Plugin-Oberfläche von Claude Code, daher funktioniert es mit:
+
+- Anthropic-gehostetem Claude Code
+- Offiziellen Claude-Code-Gateway-Setups mit `ANTHROPIC_BASE_URL` und `ANTHROPIC_AUTH_TOKEN`
+- Kompatiblen benutzerdefinierten Endpoints, die die von Claude Code erwartete Anthropic-API sprechen
+
+Minimalbeispiel:
+
+```bash
+export ANTHROPIC_BASE_URL=https://your-gateway.example.com
+export ANTHROPIC_AUTH_TOKEN=your-token
+claude
+```
+
+Falls dein Gateway Modellnamen umbildet, konfiguriere das in Claude Code statt in ECC. ECCs Hooks, Skills, Commands und Rules sind modellanbieter-agnostisch, sobald die `claude`-CLI bereits funktioniert.
+
+Offizielle Referenzen:
+- [Claude-Code-LLM-Gateway-Dokumentation](https://docs.anthropic.com/en/docs/claude-code/llm-gateway)
+- [Claude-Code-Modellkonfigurations-Dokumentation](https://docs.anthropic.com/en/docs/claude-code/model-config)
+
+</details>
+
+<details>
+<summary><b>Mein Kontextfenster schrumpft / Claude geht der Kontext aus</b></summary>
+
+Zu viele MCP-Server fressen deinen Kontext. Jede MCP-Tool-Beschreibung verbraucht Token aus deinem 200k-Fenster und reduziert es möglicherweise auf ~70k. Der SessionStart-Kontext ist standardmäßig auf 8000 Zeichen begrenzt; senke ihn mit `ECC_SESSION_START_MAX_CHARS=4000` oder deaktiviere ihn mit `ECC_SESSION_START_CONTEXT=off` für Setups mit lokalem Modell oder wenig Kontext.
+
+**Lösung:** Deaktiviere ungenutzte MCPs aus Claude Code mit `/mcp`. Claude Code schreibt diese Laufzeitentscheidungen nach `~/.claude.json`; `.claude/settings.json` und `.claude/settings.local.json` sind keine zuverlässigen Toggles für bereits geladene MCP-Server.
+
+Halte unter 10 MCPs aktiviert und unter 80 Tools aktiv.
+</details>
+
+<details>
+<summary><b>Kann ich nur einige Komponenten verwenden (z. B. nur Agents)?</b></summary>
+
+Ja. Verwende Option 2 (manuelle Installation) und kopiere nur, was du brauchst:
+
+```bash
+# Nur Agents
+cp agents/*.md ~/.claude/agents/
+
+# Nur Rules
+mkdir -p ~/.claude/rules/ecc/
+cp -r rules/common ~/.claude/rules/ecc/
+```
+
+Jede Komponente ist vollständig unabhängig.
+</details>
+
+<details>
+<summary><b>Funktioniert das mit Cursor / OpenCode / Codex / Antigravity / GitHub Copilot?</b></summary>
+
+Ja. ECC ist Cross-Platform:
+- **Cursor**: Vorübersetzte Konfigurationen in `.cursor/`. Siehe [Cursor-IDE-Unterstützung](#cursor-ide-unterstützung).
+- **Gemini CLI**: Experimentelle projektlokale Unterstützung über `.gemini/GEMINI.md` und gemeinsam genutzte Installer-Verdrahtung.
+- **OpenCode**: Vollständige Plugin-Unterstützung in `.opencode/`. Siehe [OpenCode-Unterstützung](#opencode-unterstützung).
+- **Codex**: Erstklassige Unterstützung sowohl für die macOS-App als auch die CLI, mit Adapter-Drift-Guards und SessionStart-Fallback. Siehe PR [#257](https://github.com/affaan-m/ECC/pull/257).
+- **GitHub Copilot (VS Code)**: Instruction- und Prompt-Schicht über `.github/copilot-instructions.md`, `.vscode/settings.json` und `.github/prompts/`. Siehe [GitHub-Copilot-Unterstützung](#github-copilot-unterstützung).
+- **Antigravity**: Eng integriertes Setup für Workflows, Skills und abgeflachte Rules in `.agent/`. Siehe [Antigravity-Leitfaden](../../docs/ANTIGRAVITY-GUIDE.md).
+- **JoyCode / CodeBuddy**: Projektlokale Adapter für selektive Installation von Commands, Agents, Skills und abgeflachten Rules. Siehe [JoyCode-Adapter-Leitfaden](../../docs/JOYCODE-GUIDE.md).
+- **Qwen CLI**: Adapter für selektive Installation im Home-Verzeichnis für Commands, Agents, Skills, Rules und Qwen-Konfiguration. Siehe [Qwen-CLI-Adapter-Leitfaden](../../docs/QWEN-GUIDE.md).
+- **Zed**: Projektlokaler Adapter für selektive Installation von `.zed/settings.json`, abgeflachten Rules, Commands, Agents und Skills.
+- **Nicht-native Harnesses**: Manueller Fallback-Pfad für Grok und ähnliche Oberflächen. Siehe [Leitfaden zur manuellen Anpassung](../../docs/MANUAL-ADAPTATION-GUIDE.md).
+- **Claude Code**: Nativ — dies ist das primäre Ziel.
+</details>
+
+<details>
+<summary><b>Wie steuere ich einen neuen Skill oder Agent bei?</b></summary>
+
+Siehe [CONTRIBUTING.md](../../CONTRIBUTING.md). Die Kurzfassung:
+1. Forke das Repo
+2. Erstelle deinen Skill in `skills/your-skill-name/SKILL.md` (mit YAML-Frontmatter)
+3. Oder erstelle einen Agent in `agents/your-agent.md`
+4. Reiche einen PR mit einer klaren Beschreibung ein, was er tut und wann er zu verwenden ist
+</details>
+
+---
+
+## Tests ausführen
+
+Das Plugin enthält eine umfassende Test-Suite:
+
+```bash
+# Alle Tests ausführen
+node tests/run-all.js
+
+# Einzelne Testdateien ausführen
+node tests/lib/utils.test.js
+node tests/lib/package-manager.test.js
+node tests/hooks/hooks.test.js
+```
+
+---
+
+## Beitragen
+
+**Beiträge sind willkommen und erwünscht.**
+
+Dieses Repo soll eine Community-Ressource sein. Falls du Folgendes hast:
+- Nützliche Agents oder Skills
+- Clevere Hooks
+- Bessere MCP-Konfigurationen
+- Verbesserte Rules
+
+Bitte trage bei! Richtlinien findest du in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+### Ideen für Beiträge
+
+- Sprachspezifische Skills (Rust, C#, Kotlin, Java) — Go, Python, Perl, Swift, TypeScript und HarmonyOS/ArkTS sind bereits enthalten
+- Framework-spezifische Konfigurationen (Rails, FastAPI) — Django, NestJS, Spring Boot und Laravel sind bereits enthalten
+- DevOps-Agents (Kubernetes, Terraform, AWS, Docker)
+- Teststrategien (verschiedene Frameworks, visuelle Regression)
+- Domänenspezifisches Wissen (ML, Data Engineering, Mobile)
+
+### Hinweise zum Community-Ökosystem
+
+Diese werden nicht mit ECC mitgeliefert und nicht von diesem Repo auditiert, aber sie sind wissenswert, falls du das breitere Claude-Code-Skills-Ökosystem erkundest:
+
+- [claude-seo](https://github.com/AgriciDaniel/claude-seo) — SEO-fokussierte Skill- und Agent-Sammlung
+- [claude-ads](https://github.com/AgriciDaniel/claude-ads) — Sammlung von Ad-Audit- und Paid-Growth-Workflows
+- [claude-cybersecurity](https://github.com/AgriciDaniel/claude-cybersecurity) — sicherheitsorientierte Skill- und Agent-Sammlung
+
+---
+
+## Cursor-IDE-Unterstützung
+
+ECC bietet Cursor-IDE-Unterstützung mit Hooks, Rules, Agents, Skills, Commands und MCP-Konfigurationen, die an Cursors Projektlayout angepasst sind.
+
+### Schnellstart (Cursor)
+
+```bash
+# macOS/Linux
+./install.sh --target cursor typescript
+./install.sh --target cursor python golang swift php
+```
+
+```powershell
+# Windows PowerShell
+.\install.ps1 --target cursor typescript
+.\install.ps1 --target cursor python golang swift php
+```
+
+### Was ist enthalten
+
+| Komponente | Anzahl | Details |
+|-----------|-------|---------|
+| Hook-Events | 15 | sessionStart, beforeShellExecution, afterFileEdit, beforeMCPExecution, beforeSubmitPrompt und 10 weitere |
+| Hook-Skripte | 16 | Schlanke Node.js-Skripte, die über einen gemeinsamen Adapter an `scripts/hooks/` delegieren |
+| Rules | 34 | 9 common (alwaysApply) + 25 sprachspezifisch (TypeScript, Python, Go, Swift, PHP) |
+| Agents | 48 | `.cursor/agents/ecc-*.md` bei Installation; präfixiert, um Kollisionen mit Benutzer- oder Marketplace-Agents zu vermeiden |
+| Skills | Gemeinsam + mitgeliefert | `.cursor/skills/` für übersetzte Ergänzungen |
+| Commands | Gemeinsam | `.cursor/commands/` falls installiert |
+| MCP-Konfiguration | Gemeinsam | `.cursor/mcp.json` falls installiert |
+
+### Hinweise zum Laden in Cursor
+
+ECC installiert keine Root-`AGENTS.md` in `.cursor/`. Cursor behandelt verschachtelte `AGENTS.md`-Dateien als Verzeichniskontext, daher würde das Kopieren von ECCs Repo-Identität in ein Host-Projekt dieses Projekt verunreinigen.
+
+Das Cursor-native Ladeverhalten kann je nach Cursor-Build variieren. ECC installiert Agents als `.cursor/agents/ecc-*.md`; falls dein Cursor-Build keine Projekt-Agents bereitstellt, funktionieren diese Dateien weiterhin als explizite Referenzdefinitionen statt als versteckter globaler Prompt-Kontext.
+
+### Hook-Architektur (DRY-Adapter-Muster)
+
+Cursor hat **mehr Hook-Events als Claude Code** (20 vs. 8). Das Modul `.cursor/hooks/adapter.js` transformiert Cursors stdin-JSON in das Format von Claude Code und erlaubt so die Wiederverwendung bestehender `scripts/hooks/*.js` ohne Duplizierung.
+
+```
+Cursor stdin JSON → adapter.js → transforms → scripts/hooks/*.js
+                                              (shared with Claude Code)
+```
+
+Wichtige Hooks:
+- **beforeShellExecution** — Blockiert Dev-Server außerhalb von tmux (exit 2), git-push-Review
+- **afterFileEdit** — Auto-Formatierung + TypeScript-Prüfung + console.log-Warnung
+- **beforeSubmitPrompt** — Erkennt Secrets (sk-, ghp_, AKIA-Muster) in Prompts
+- **beforeTabFileRead** — Blockiert, dass Tab .env-, .key-, .pem-Dateien liest (exit 2)
+- **beforeMCPExecution / afterMCPExecution** — MCP-Audit-Logging
+
+### Rules-Format
+
+Cursor-Rules verwenden YAML-Frontmatter mit `description`, `globs` und `alwaysApply`:
+
+```yaml
+---
+description: "TypeScript coding style extending common rules"
+globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
+alwaysApply: false
+---
+```
+
+---
+
+## Codex-macOS-App- + CLI-Unterstützung
+
+ECC bietet **erstklassige Codex-Unterstützung** sowohl für die macOS-App als auch die CLI, mit einer Referenzkonfiguration, einem Codex-spezifischen AGENTS.md-Zusatz und gemeinsam genutzten Skills.
+
+### Schnellstart (Codex-App + CLI)
+
+```bash
+# Codex CLI im Repo ausführen — AGENTS.md und .codex/ werden automatisch erkannt
+codex
+
+# Automatisches Setup: ECC-Assets (AGENTS.md, Skills, MCP-Server) nach ~/.codex synchronisieren
+npm install && bash scripts/sync-ecc-to-codex.sh
+# oder: pnpm install && bash scripts/sync-ecc-to-codex.sh
+# oder: yarn install && bash scripts/sync-ecc-to-codex.sh
+# oder: bun install && bash scripts/sync-ecc-to-codex.sh
+
+# Oder manuell: die Referenzkonfiguration in dein Home-Verzeichnis kopieren
+cp .codex/config.toml ~/.codex/config.toml
+```
+
+Das Sync-Skript merged ECC-MCP-Server sicher in deine bestehende `~/.codex/config.toml` mit einer **add-only**-Strategie — es entfernt oder verändert deine bestehenden Server nie. Führe es mit `--dry-run` aus, um Änderungen in der Vorschau zu sehen, oder mit `--update-mcp`, um ein erzwungenes Refresh der ECC-Server auf die neueste empfohlene Konfiguration zu erzwingen.
+
+Für Context7 verwendet ECC den kanonischen Codex-Abschnittsnamen `[mcp_servers.context7]`, startet aber weiterhin das Paket `@upstash/context7-mcp`. Falls du bereits einen veralteten `[mcp_servers.context7-mcp]`-Eintrag hast, migriert `--update-mcp` ihn auf den kanonischen Abschnittsnamen.
+
+Codex-macOS-App:
+- Öffne dieses Repository als deinen Workspace.
+- Die Root-`AGENTS.md` wird automatisch erkannt.
+- `.codex/config.toml` und `.codex/agents/*.toml` funktionieren am besten, wenn sie projektlokal gehalten werden.
+- Die Referenz-`.codex/config.toml` pinnt `model` oder `model_provider` absichtlich nicht, sodass Codex seine eigene aktuelle Voreinstellung verwendet, sofern du sie nicht überschreibst.
+- Optional: Kopiere `.codex/config.toml` nach `~/.codex/config.toml` für globale Voreinstellungen; halte die Multi-Agent-Rollendateien projektlokal, sofern du nicht auch `.codex/agents/` kopierst.
+
+### Was ist enthalten
+
+| Komponente | Anzahl | Details |
+|-----------|-------|---------|
+| Konfiguration | 1 | `.codex/config.toml` — Top-Level-Approvals/-Sandbox/-web_search, MCP-Server, Benachrichtigungen, Profile |
+| AGENTS.md | 2 | Root (universell) + `.codex/AGENTS.md` (Codex-spezifischer Zusatz) |
+| Skills | 32 | `.agents/skills/` — SKILL.md + agents/openai.yaml pro Skill |
+| MCP-Server | 6 | GitHub, Context7, Exa, Memory, Playwright, Sequential Thinking (7 mit Supabase über `--update-mcp`-Sync) |
+| Profile | 2 | `strict` (read-only-Sandbox) und `yolo` (vollständiges Auto-Approve) |
+| Agent-Rollen | 3 | `.codex/agents/` — explorer, reviewer, docs-researcher |
+
+### Skills
+
+Skills unter `.agents/skills/` werden von Codex automatisch geladen:
+
+Kanonische Anthropic-Skills wie `claude-api`, `frontend-design` und `skill-creator` werden hier absichtlich nicht erneut mitgeliefert. Installiere diese aus [`anthropics/skills`](https://github.com/anthropics/skills), wenn du die offiziellen Versionen willst.
+
+| Skill | Beschreibung |
+|-------|-------------|
+| agent-introspection-debugging | Agent-Verhalten, -Routing und Prompt-Grenzen debuggen |
+| agent-sort | Agent-Kataloge und Zuweisungsoberflächen sortieren |
+| api-design | REST-API-Design-Patterns |
+| article-writing | Langform-Texte aus Notizen und Stimm-Referenzen |
+| backend-patterns | API-Design, Datenbank, Caching |
+| brand-voice | Quellenbasierte Schreibstil-Profile aus echtem Content |
+| bun-runtime | Bun als Runtime, Paketmanager, Bundler und Test-Runner |
+| coding-standards | Universelle Coding-Standards |
+| content-engine | Plattform-nativer Social-Content und Repurposing |
+| crosspost | Multi-Plattform-Content-Verteilung über X, LinkedIn, Threads |
+| deep-research | Recherche aus mehreren Quellen mit Synthese und Quellenangabe |
+| dmux-workflows | Multi-Agent-Orchestrierung mit tmux-Pane-Manager |
+| documentation-lookup | Aktuelle Bibliotheks- und Framework-Dokumentation über Context7 MCP |
+| e2e-testing | Playwright-E2E-Tests |
+| eval-harness | Eval-getriebene Entwicklung |
+| everything-claude-code | Entwicklungskonventionen und -Patterns für das Projekt |
+| exa-search | Neural Search über Exa MCP für Web-, Code-, Unternehmensrecherche |
+| fal-ai-media | Vereinheitlichte Mediengenerierung für Bilder, Video und Audio |
+| frontend-patterns | React-/Next.js-Patterns |
+| frontend-slides | HTML-Präsentationen, PPTX-Konvertierung, Erkundung visueller Stile |
+| investor-materials | Decks, Memos, Modelle und One-Pager |
+| investor-outreach | Personalisierte Ansprache, Follow-ups und Intro-Blurbs |
+| market-research | Quellenbelegte Markt- und Wettbewerberrecherche |
+| mcp-server-patterns | MCP-Server mit Node-/TypeScript-SDK bauen |
+| nextjs-turbopack | Next.js 16+ und inkrementelles Turbopack-Bundling |
+| product-capability | Produktziele in abgegrenzte Capability-Maps übersetzen |
+| security-review | Umfassende Sicherheits-Checkliste |
+| strategic-compact | Kontextverwaltung |
+| tdd-workflow | Testgetriebene Entwicklung mit 80 %+ Coverage |
+| verification-loop | Build, Test, Lint, Typecheck, Sicherheit |
+| video-editing | KI-unterstützte Videobearbeitungs-Workflows mit FFmpeg und Remotion |
+| x-api | X-/Twitter-API-Integration für Posting und Analytics |
+
+### Wesentliche Einschränkung
+
+Codex bietet **noch keine Claude-artige Parität bei der Hook-Ausführung**. Die ECC-Durchsetzung dort ist instruction-basiert über `AGENTS.md`, optionale `model_instructions_file`-Overrides sowie Sandbox-/Approval-Einstellungen.
+
+### Multi-Agent-Unterstützung
+
+Aktuelle Codex-Builds unterstützen stabile Multi-Agent-Workflows.
+
+- Aktiviere `features.multi_agent = true` in `.codex/config.toml`
+- Definiere Rollen unter `[agents.<name>]`
+- Verweise jede Rolle auf eine Datei unter `.codex/agents/`
+- Verwende `/agent` in der CLI, um Kind-Agents zu inspizieren oder zu steuern
+
+ECC liefert drei Beispiel-Rollenkonfigurationen aus:
+
+| Rolle | Zweck |
+|------|---------|
+| `explorer` | Read-only-Sammlung von Codebase-Belegen vor Bearbeitungen |
+| `reviewer` | Review von Korrektheit, Sicherheit und fehlenden Tests |
+| `docs_researcher` | Dokumentations- und API-Verifikation vor Release-/Docs-Änderungen |
+
+---
+
+## Zed-Unterstützung
+
+ECC bietet Zed-Projektunterstützung über einen konservativen `.zed`-Adapter für projektlokale Einstellungen, abgeflachte Rules, Agents, Commands und Skills.
+
+```bash
+./install.sh --profile minimal --target zed
+```
+
+```powershell
+.\install.ps1 --profile minimal --target zed
+```
+
+Der Adapter schreibt ECC-verwaltete Dateien unter `.zed/` und hält BYOK-/OpenRouter-Credentials aus dem Repo heraus. Konfiguriere das Zed-Konto oder API-Keys über Zeds eigene Einstellungs-UI oder deine lokalen Benutzereinstellungen.
+
+---
+
+## OpenCode-Unterstützung
+
+ECC bietet **vollständige OpenCode-Unterstützung** einschließlich Plugins und Hooks.
+
+### Schnellstart
+
+```bash
+# OpenCode installieren
+npm install -g opencode
+
+# Im Repository-Root ausführen
+opencode
+```
+
+Die Konfiguration wird automatisch aus `.opencode/opencode.json` erkannt.
+
+### Feature-Parität
+
+| Feature | Claude Code | OpenCode | Status |
+|---------|-------------|----------|--------|
+| Agents | PASS: 60 Agents | PASS: 12 Agents | **Claude Code führt** |
+| Commands | PASS: 75 Commands | PASS: 35 Commands | **Claude Code führt** |
+| Skills | PASS: 232 Skills | PASS: 37 Skills | **Claude Code führt** |
+| Hooks | PASS: 8 Event-Typen | PASS: 11 Events | **OpenCode hat mehr!** |
+| Rules | PASS: 29 Rules | PASS: 13 Instructions | **Claude Code führt** |
+| MCP-Server | PASS: 14 Server | PASS: Vollständig | **Vollständige Parität** |
+| Custom Tools | PASS: Über Hooks | PASS: 6 native Tools | **OpenCode ist besser** |
+
+### Hook-Unterstützung über Plugins
+
+Das Plugin-System von OpenCode ist AUSGEFEILTER als das von Claude Code mit 20+ Event-Typen:
+
+| Claude-Code-Hook | OpenCode-Plugin-Event |
+|-----------------|----------------------|
+| PreToolUse | `tool.execute.before` |
+| PostToolUse | `tool.execute.after` |
+| Stop | `session.idle` |
+| SessionStart | `session.created` |
+| SessionEnd | `session.deleted` |
+
+**Zusätzliche OpenCode-Events**: `file.edited`, `file.watcher.updated`, `message.updated`, `lsp.client.diagnostics`, `tui.toast.show` und mehr.
+
+### Gepflegte Slash-Einträge
+
+| Command | Beschreibung |
+|---------|-------------|
+| `/plan` | Implementierungsplan erstellen |
+| `/code-review` | Code-Änderungen reviewen |
+| `/build-fix` | Build-Fehler beheben |
+| `/refactor-clean` | Toten Code entfernen |
+| `/learn` | Muster aus der Session extrahieren |
+| `/checkpoint` | Verifikationsstatus speichern |
+| `/quality-gate` | Das gepflegte Verifikations-Gate ausführen |
+| `/update-docs` | Dokumentation aktualisieren |
+| `/update-codemaps` | Codemaps aktualisieren |
+| `/test-coverage` | Coverage analysieren |
+| `/go-review` | Go-Code-Review |
+| `/go-test` | Go-TDD-Workflow |
+| `/go-build` | Go-Build-Fehler beheben |
+| `/python-review` | Python-Code-Review (PEP 8, Type Hints, Sicherheit) |
+| `/multi-plan` | Kollaborative Multi-Modell-Planung |
+| `/multi-execute` | Kollaborative Multi-Modell-Ausführung |
+| `/multi-backend` | Backend-fokussierter Multi-Modell-Workflow |
+| `/multi-frontend` | Frontend-fokussierter Multi-Modell-Workflow |
+| `/multi-workflow` | Vollständiger Multi-Modell-Entwicklungs-Workflow |
+| `/pm2` | PM2-Service-Commands automatisch generieren |
+| `/sessions` | Session-Verlauf verwalten |
+| `/skill-create` | Skills aus Git generieren |
+| `/instinct-status` | Gelernte Instincts anzeigen |
+| `/instinct-import` | Instincts importieren |
+| `/instinct-export` | Instincts exportieren |
+| `/evolve` | Instincts zu Skills clustern |
+| `/promote` | Projekt-Instincts auf globalen Geltungsbereich heben |
+| `/projects` | Bekannte Projekte und Instinct-Statistiken auflisten |
+| `/prune` | Abgelaufene ausstehende Instincts löschen (30 Tage TTL) |
+| `/learn-eval` | Muster vor dem Speichern extrahieren und evaluieren |
+| `/setup-pm` | Paketmanager konfigurieren |
+| `/harness-audit` | Harness-Zuverlässigkeit, Eval-Bereitschaft und Risikolage auditieren |
+| `/loop-start` | Kontrolliertes agentisches Loop-Ausführungsmuster starten |
+| `/loop-status` | Aktiven Loop-Status und Checkpoints inspizieren |
+| `/quality-gate` | Quality-Gate-Prüfungen für Pfade oder das gesamte Repo ausführen |
+| `/model-route` | Aufgaben nach Komplexität und Budget an Modelle routen |
+
+### Plugin-Installation
+
+**Option 1: Direkt verwenden**
+```bash
+cd ECC
+opencode
+```
+
+**Option 2: Als npm-Paket installieren**
+```bash
+npm install ecc-universal
+```
+
+Füge es dann zu deiner `opencode.json` hinzu:
+```json
+{
+  "plugin": ["ecc-universal"]
+}
+```
+
+Dieser npm-Plugin-Eintrag aktiviert ECCs veröffentlichtes OpenCode-Plugin-Modul (Hooks/Events und Plugin-Tools).
+Er fügt **nicht** automatisch ECCs vollständigen Command-/Agent-/Instruction-Katalog zu deiner Projektkonfiguration hinzu.
+
+Für das vollständige ECC-OpenCode-Setup entweder:
+- OpenCode innerhalb dieses Repositorys ausführen, oder
+- die mitgelieferten `.opencode/`-Konfigurations-Assets in dein Projekt kopieren und die `instructions`-, `agent`- und `command`-Einträge in `opencode.json` verdrahten
+
+### Dokumentation
+
+- **Migrationsleitfaden**: `.opencode/MIGRATION.md`
+- **OpenCode-Plugin-README**: `.opencode/README.md`
+- **Konsolidierte Rules**: `.opencode/instructions/INSTRUCTIONS.md`
+- **LLM-Dokumentation**: `llms.txt` (vollständige OpenCode-Dokumentation für LLMs)
+
+---
+
+## GitHub-Copilot-Unterstützung
+
+ECC bietet **GitHub-Copilot-Unterstützung** für VS Code über das native Instruction- und Prompt-Datei-System von Copilot Chat — kein zusätzliches Tooling erforderlich.
+
+### Was ist enthalten
+
+| Komponente | Datei | Zweck |
+|-----------|------|---------|
+| Kern-Instructions | `.github/copilot-instructions.md` | Stets geladene Rules: Coding-Style, Sicherheit, Testing, Git-Workflow |
+| VS-Code-Einstellungen | `.vscode/settings.json` | Aufgabenspezifische Instruction-Dateien für Codegenerierung, Testgenerierung, Review und Commit-Nachrichten |
+| Plan-Prompt | `.github/prompts/plan.prompt.md` | Phasenweise Implementierungsplanung |
+| TDD-Prompt | `.github/prompts/tdd.prompt.md` | Red-Green-Improve-Zyklus |
+| Code-Review-Prompt | `.github/prompts/code-review.prompt.md` | Qualitäts- und Sicherheitsreview |
+| Security-Review-Prompt | `.github/prompts/security-review.prompt.md` | Tiefe, OWASP-orientierte Sicherheitsanalyse |
+| Build-Fix-Prompt | `.github/prompts/build-fix.prompt.md` | Systematische Behebung von Build- und CI-Fehlern |
+| Refactor-Prompt | `.github/prompts/refactor.prompt.md` | Beseitigung von totem Code und Vereinfachung |
+
+### Schnellstart (GitHub Copilot)
+
+Die Dateien sind bereits vorhanden — öffne ein beliebiges Repo, das dieses Projekt enthält, und GitHub Copilot Chat nimmt `.github/copilot-instructions.md` automatisch auf.
+Die eingecheckte `.vscode/settings.json` aktiviert `chat.promptFiles`, sodass VS Code die wiederverwendbaren Prompts aus `.github/prompts/` laden kann.
+
+So verwendest du die Workflow-Prompts in Copilot Chat:
+1. Öffne das Copilot-Chat-Panel in VS Code.
+2. Klicke auf das **Büroklammer-/Anhängen-Symbol** und wähle **Prompt...**, oder tippe `/` und wähle einen Prompt.
+3. Wähle den Prompt aus (z. B. `plan`, `tdd`, `code-review`).
+
+### Wie es funktioniert
+
+GitHub Copilot in VS Code liest zwei Dateitypen automatisch:
+
+- **`.github/copilot-instructions.md`** — Instructions auf Repository-Ebene, die in jede Copilot-Chat-Anfrage injiziert werden. Enthält ECCs Kern-Coding-Standards, Sicherheits-Checkliste, Testanforderungen und Git-Workflow.
+- **`.github/prompts/*.prompt.md`** — wiederverwendbare Prompt-Dateien, die Nutzer bei Bedarf aufrufen. Jeder Prompt führt Copilot durch einen bestimmten ECC-Workflow (plan → TDD → review → ship).
+
+Die **`.vscode/settings.json`** fügt aufgabenspezifische Instruction-Overlays hinzu, sodass Copilot je nachdem, ob du Code generierst, Tests schreibst, eine Auswahl reviewst oder eine Commit-Nachricht entwirfst, den richtigen Kontext erhält.
+
+### Feature-Abdeckung
+
+| ECC-Feature | Copilot-Entsprechung |
+|-------------|-------------------|
+| Coding-Standards | Stets aktiv über `copilot-instructions.md` |
+| Sicherheits-Checkliste | Stets aktiv + `security-review`-Prompt |
+| Testing / TDD | Stets aktiv + `tdd`-Prompt |
+| Implementierungsplanung | `plan`-Prompt |
+| Code-Review | `code-review`-Prompt |
+| Behebung von Build-Fehlern | `build-fix`-Prompt |
+| Refactoring | `refactor`-Prompt |
+| Commit-Nachrichten-Format | Aufgabenspezifische Instruction in `settings.json` |
+| Hooks / Automatisierung | Nicht unterstützt (Copilot hat kein Hook-System) |
+| Agents / Delegation | Nicht unterstützt (Copilot hat keine Subagent-API) |
+
+### Einschränkungen
+
+GitHub Copilot hat kein Hook-System und keine Subagent-API, daher sind ECCs Hook-Automatisierungen (Auto-Formatierung, TypeScript-Prüfung, Session-Persistenz, Dev-Server-Guard) sowie die Agent-Delegation nicht verfügbar. Die Instruction- und Prompt-Schicht bringt dennoch die vollständige ECC-Coding-Philosophie — Standards, Sicherheit, TDD und Workflow — in jede Copilot-Chat-Session.
+
+---
+
+## Cross-Tool-Feature-Parität
+
+ECC ist das **erste Plugin, das jedes große KI-Coding-Tool ausreizt**. So vergleicht sich jeder Harness:
+
+| Feature | Claude Code | Cursor IDE | Codex CLI | OpenCode | GitHub Copilot |
+|---------|------------|------------|-----------|----------|----------------|
+| **Agents** | 60 | Gemeinsam (AGENTS.md) | Gemeinsam (AGENTS.md) | 12 | Nicht verfügbar |
+| **Commands** | 75 | Gemeinsam | Instruction-basiert | 35 | 6 Prompts |
+| **Skills** | 232 | Gemeinsam | 10 (natives Format) | 37 | Über Instructions |
+| **Hook-Events** | 8 Typen | 15 Typen | Noch keine | 11 Typen | Keine |
+| **Hook-Skripte** | 20+ Skripte | 16 Skripte (DRY-Adapter) | Nicht verfügbar | Plugin-Hooks | Nicht verfügbar |
+| **Rules** | 34 (common + Sprache) | 34 (YAML-Frontmatter) | Instruction-basiert | 13 Instructions | 1 stets aktive Datei |
+| **Custom Tools** | Über Hooks | Über Hooks | Nicht verfügbar | 6 native Tools | Nicht verfügbar |
+| **MCP-Server** | 14 | Gemeinsam (mcp.json) | 7 (automatisch gemergt über TOML-Parser) | Vollständig | Nicht verfügbar |
+| **Konfigurationsformat** | settings.json | hooks.json + rules/ | config.toml | opencode.json | copilot-instructions.md + settings.json |
+| **Kontextdatei** | CLAUDE.md + AGENTS.md | AGENTS.md | AGENTS.md | AGENTS.md | copilot-instructions.md |
+| **Secret-Erkennung** | Hook-basiert | beforeSubmitPrompt-Hook | Sandbox-basiert | Hook-basiert | Instruction-basiert |
+| **Auto-Formatierung** | PostToolUse-Hook | afterFileEdit-Hook | Nicht verfügbar | file.edited-Hook | Nicht verfügbar |
+| **Version** | Plugin | Plugin | Referenzkonfiguration | 2.0.0-rc.1 | Instruction-Schicht |
+
+**Wesentliche architektonische Entscheidungen:**
+- **AGENTS.md** im Root ist die universelle Cross-Tool-Datei (gelesen von Claude Code, Cursor, Codex und OpenCode — GitHub Copilot verwendet stattdessen `.github/copilot-instructions.md`)
+- Das **DRY-Adapter-Muster** lässt Cursor die Hook-Skripte von Claude Code ohne Duplizierung wiederverwenden
+- Das **Skills-Format** (SKILL.md mit YAML-Frontmatter) funktioniert über Claude Code, Codex und OpenCode hinweg
+- Codex' fehlende Hooks werden durch `AGENTS.md`, optionale `model_instructions_file`-Overrides und Sandbox-Berechtigungen kompensiert
+
+---
+
+## Hintergrund
+
+Ich nutze Claude Code seit dem experimentellen Rollout. Habe im September 2025 den Anthropic-x-Forum-Ventures-Hackathon mit [@DRodriguezFX](https://x.com/DRodriguezFX) gewonnen — [zenith.chat](https://zenith.chat) wurde vollständig mit Claude Code gebaut.
+
+Diese Konfigurationen sind über mehrere produktive Anwendungen hinweg im Praxiseinsatz erprobt.
+
+---
+
+## Token-Optimierung
+
+Die Nutzung von Claude Code kann teuer werden, wenn du den Token-Verbrauch nicht steuerst. Diese Einstellungen senken die Kosten erheblich, ohne die Qualität zu opfern.
+
+### Empfohlene Einstellungen
+
+Füge zu `~/.claude/settings.json` hinzu:
+
+```json
+{
+  "model": "sonnet",
+  "env": {
+    "MAX_THINKING_TOKENS": "10000",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"
+  }
+}
+```
+
+| Einstellung | Standard | Empfohlen | Auswirkung |
+|---------|---------|-------------|--------|
+| `model` | opus | **sonnet** | ~60 % Kostensenkung; bewältigt 80 %+ der Coding-Aufgaben |
+| `MAX_THINKING_TOKENS` | 31.999 | **10.000** | ~70 % Reduktion der versteckten Thinking-Kosten pro Anfrage |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | 95 | **50** | Kompaktiert früher — bessere Qualität in langen Sessions |
+| `ECC_CONTEXT_MONITOR_COST_WARNINGS` | on | **off für Abonnement-Nutzer** | Unterdrückt agentenseitige API-Rate-Schätzwarnungen, behält aber Kontext-/Scope-/Loop-Warnungen |
+
+Wechsle nur dann zu Opus, wenn du tiefes architektonisches Schlussfolgern brauchst:
+```
+/model opus
+```
+
+### Befehle für den Arbeitsalltag
+
+| Command | Wann verwenden |
+|---------|-------------|
+| `/model sonnet` | Standard für die meisten Aufgaben |
+| `/model opus` | Komplexe Architektur, Debugging, tiefes Schlussfolgern |
+| `/clear` | Zwischen voneinander unabhängigen Aufgaben (kostenlos, sofortiges Zurücksetzen) |
+| `/compact` | An logischen Aufgaben-Bruchstellen (Recherche fertig, Meilenstein abgeschlossen) |
+| `/cost` | Token-Ausgaben während der Session überwachen |
+
+Falls du ein Claude-Abonnement nutzt und die API-Rate-Schätzungen des Kontext-Monitors nicht nützlich sind, setze `ECC_CONTEXT_MONITOR_COST_WARNINGS=off`. Das unterdrückt nur die agentenseitigen Kostenwarnungen; es deaktiviert keine Warnungen zu Kontexterschöpfung, Scope oder Loops.
+
+### Strategische Compaction
+
+Der `strategic-compact`-Skill (in diesem Plugin enthalten) schlägt `/compact` an logischen Bruchstellen vor, statt sich auf die Auto-Compaction bei 95 % Kontext zu verlassen. Den vollständigen Entscheidungsleitfaden findest du in `skills/strategic-compact/SKILL.md`.
+
+**Wann kompaktieren:**
+- Nach Recherche/Erkundung, vor der Implementierung
+- Nach Abschluss eines Meilensteins, vor Beginn des nächsten
+- Nach dem Debugging, vor der Fortsetzung der Feature-Arbeit
+- Nach einem gescheiterten Ansatz, vor dem Versuch eines neuen
+
+**Wann NICHT kompaktieren:**
+- Mitten in der Implementierung (du verlierst Variablennamen, Dateipfade, partiellen Zustand)
+
+### Kontextfenster-Verwaltung
+
+**Kritisch:** Aktiviere nicht alle MCPs auf einmal. Jede MCP-Tool-Beschreibung verbraucht Token aus deinem 200k-Fenster und reduziert es möglicherweise auf ~70k.
+
+- Halte unter 10 MCPs pro Projekt aktiviert
+- Halte unter 80 Tools aktiv
+- Verwende `/mcp`, um ungenutzte Claude-Code-MCP-Server zu deaktivieren; diese Laufzeitentscheidungen bleiben in `~/.claude.json` erhalten
+- Verwende `ECC_DISABLED_MCPS` nur, um ECC-generierte MCP-Konfigurationen während der Install-/Sync-Flows zu filtern
+
+### Kostenwarnung zu Agent-Teams
+
+Agent-Teams erzeugen mehrere Kontextfenster. Jeder Teammate verbraucht Token unabhängig. Verwende sie nur für Aufgaben, bei denen Parallelität einen klaren Mehrwert bietet (Arbeit über mehrere Module, parallele Reviews). Für einfache sequentielle Aufgaben sind Subagents token-effizienter.
+
+---
+
+## WARNING: Wichtige Hinweise
+
+### Token-Optimierung
+
+Erreichst du die Tageslimits? Siehe den **[Token-Optimierungs-Leitfaden](../../docs/token-optimization.md)** für empfohlene Einstellungen und Workflow-Tipps.
+
+Schnelle Gewinne:
+
+```json
+// ~/.claude/settings.json
+{
+  "model": "sonnet",
+  "env": {
+    "MAX_THINKING_TOKENS": "10000",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "haiku"
+  }
+}
+```
+
+Verwende `/clear` zwischen voneinander unabhängigen Aufgaben, `/compact` an logischen Bruchstellen und `/cost`, um die Ausgaben zu überwachen.
+
+### Anpassung
+
+Diese Konfigurationen funktionieren für meinen Workflow. Du solltest:
+1. Mit dem beginnen, was dich anspricht
+2. Für deinen Stack anpassen
+3. Entfernen, was du nicht nutzt
+4. Eigene Patterns hinzufügen
+
+---
+
+## Community-Projekte
+
+Projekte, die auf ECC aufbauen oder davon inspiriert sind:
+
+| Projekt | Beschreibung |
+|---------|-------------|
+| [EVC](https://github.com/SaigonXIII/evc) | Marketing-Agent-Workspace — 42 Commands für Content-Operatoren, Brand-Governance und Multi-Channel-Publishing. [Visuelle Übersicht](https://saigonxiii.github.io/evc). |
+| [trading-skills](https://github.com/VictorVVedtion/trading-skills) | 68 trading-thematische Claude-Code-Skills mit Pre-Trade-Review-Prompts und Risiko-Gates, inspiriert von Marktteilnehmern. |
+
+Etwas mit ECC gebaut? Öffne einen PR, um es hier hinzuzufügen.
+
+---
+
+## Sponsoren
+
+Dieses Projekt ist kostenlos und Open Source. Sponsoren helfen, es gepflegt und wachsend zu halten.
+
+[**Sponsor werden**](https://github.com/sponsors/affaan-m) | [Sponsor-Stufen](../../SPONSORS.md) | [Sponsoring-Programm](../../SPONSORING.md)
+
+---
+
+## Star-Verlauf
+
+[![Star History Chart](https://api.star-history.com/svg?repos=affaan-m/ECC&type=Date)](https://star-history.com/#affaan-m/ECC&Date)
+
+---
+
+## Links
+
+- **Kurzleitfaden (Hier starten):** [The Shorthand Guide to Everything Claude Code](https://x.com/affaanmustafa/status/2012378465664745795)
+- **Langleitfaden (fortgeschritten):** [The Longform Guide to Everything Claude Code](https://x.com/affaanmustafa/status/2014040193557471352)
+- **Security-Leitfaden:** [Security-Leitfaden](../../the-security-guide.md) | [Thread](https://x.com/affaanmustafa/status/2033263813387223421)
+- **Folgen:** [@affaanmustafa](https://x.com/affaanmustafa)
+
+---
+
+## Lizenz
+
+MIT - Frei verwenden, nach Bedarf anpassen, zurückgeben, wenn du kannst.
+
+---
+
+**Vergib einen Star für dieses Repo, falls es hilft. Lies beide Leitfäden. Bau etwas Großartiges.**

--- a/docs/de-DE/README.md
+++ b/docs/de-DE/README.md
@@ -1083,7 +1083,7 @@ Dies zeigt alle verfügbaren Agents, Commands und Skills aus dem Plugin.
 </details>
 
 <details>
-<summary><b>Meine Hooks funktionieren nicht / ich sehe „Duplicate hooks file"-Fehler</b></summary>
+<summary><b>Meine Hooks funktionieren nicht / ich sehe den Fehler "Duplicate hooks file"</b></summary>
 
 Das ist das häufigste Problem. **Füge KEIN `"hooks"`-Feld zu `.claude-plugin/plugin.json` hinzu.** Claude Code v2.1+ lädt `hooks/hooks.json` aus installierten Plugins automatisch. Es explizit zu deklarieren, verursacht Fehler durch Duplikaterkennung. Siehe [#29](https://github.com/affaan-m/ECC/issues/29), [#52](https://github.com/affaan-m/ECC/issues/52), [#103](https://github.com/affaan-m/ECC/issues/103).
 </details>

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -1,4 +1,4 @@
-**言語:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+**言語:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 # Everything Claude Code
 
@@ -21,7 +21,7 @@
 
 **言語 / Language / 語言 / Dil / Язык / Ngôn ngữ**
 
-[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -1,4 +1,4 @@
-**언어:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | 한국어 | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+**언어:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | 한국어 | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 # Everything Claude Code
 
@@ -24,7 +24,7 @@
 
 **Language / 语言 / 語言 / 언어 / Dil / Язык / Ngôn ngữ**
 
-[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -1,4 +1,4 @@
-**Idioma:** [English](../../README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | Português (Brasil) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+**Idioma:** [English](../../README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | Português (Brasil) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 # Everything Claude Code
 
@@ -24,7 +24,7 @@
 
 **Idioma / Language / 语言 / Dil / Язык / Ngôn ngữ**
 
-[**English**](../../README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Português (Brasil)](README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+[**English**](../../README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Português (Brasil)](README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,4 +1,4 @@
-**Язык:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | **Русский** | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+**Язык:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | **Русский** | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 # Everything Claude Code
 
@@ -27,7 +27,7 @@
 
 **Язык / 语言 / 語言 / Dil / Ngôn ngữ**
 
-[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | **Русский** | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | **Русский** | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/th/README.md
+++ b/docs/th/README.md
@@ -1,4 +1,4 @@
-**ภาษา:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | **ไทย**
+**ภาษา:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | **ไทย** | [Deutsch](../de-DE/README.md)
 
 # Everything Claude Code
 
@@ -18,7 +18,7 @@
 
 **ภาษา / Language / 语言 / 語言 / Dil / Язык / Ngôn ngữ**
 
-[English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | **ไทย**
+[English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | **ไทย** | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -23,7 +23,7 @@
 
 **Dil / Language / 语言 / 語言 / Язык / Ngôn ngữ**
 
-[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [**Türkçe**](README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [**Türkçe**](README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/vi-VN/README.md
+++ b/docs/vi-VN/README.md
@@ -1,4 +1,4 @@
-**Ngôn ngữ:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | **Tiếng Việt** | [ไทย](../th/README.md)
+**Ngôn ngữ:** [English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | **Tiếng Việt** | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 # Everything Claude Code
 
@@ -18,7 +18,7 @@
 
 **Ngôn ngữ / Language / 语言 / 語言 / Dil / Язык**
 
-[English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | **Tiếng Việt** | [ไทย](../th/README.md)
+[English](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | [繁體中文](../zh-TW/README.md) | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | **Tiếng Việt** | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -13,7 +13,7 @@
 
 **Language / 语言 / 語言 / Dil / Язык / Ngôn ngữ**
 
-[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | **繁體中文** | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md)
+[**English**](../../README.md) | [Português (Brasil)](../pt-BR/README.md) | [简体中文](../../README.zh-CN.md) | **繁體中文** | [日本語](../ja-JP/README.md) | [한국어](../ko-KR/README.md) | [Türkçe](../tr/README.md) | [Русский](../ru/README.md) | [Tiếng Việt](../vi-VN/README.md) | [ไทย](../th/README.md) | [Deutsch](../de-DE/README.md)
 
 </div>
 

--- a/manifests/install-components.json
+++ b/manifests/install-components.json
@@ -589,6 +589,14 @@
       "modules": [
         "docs-zh-tw"
       ]
+    },
+    {
+      "id": "locale:de-de",
+      "family": "locale",
+      "description": "German (de-DE) translated reference docs installed to ~/.claude/docs/de-DE/.",
+      "modules": [
+        "docs-de-de"
+      ]
     }
   ]
 }

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -843,6 +843,22 @@
       "defaultInstall": false,
       "cost": "heavy",
       "stability": "stable"
+    },
+    {
+      "id": "docs-de-de",
+      "kind": "docs",
+      "description": "German (de-DE) translated reference docs for agents, commands, skills, and rules.",
+      "paths": [
+        "docs/de-DE"
+      ],
+      "targets": [
+        "claude",
+        "claude-project"
+      ],
+      "dependencies": [],
+      "defaultInstall": false,
+      "cost": "heavy",
+      "stability": "stable"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "agent.yaml",
     "agents/",
     "commands/",
+    "docs/de-DE/",
     "docs/ja-JP/",
     "docs/ko-KR/",
     "docs/pt-BR/",

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -14,7 +14,7 @@ const COMPONENT_FAMILY_PREFIXES = {
   skill: 'skill:',
   locale: 'locale:',
 };
-const SUPPORTED_LOCALES = Object.freeze(['ja', 'zh-CN', 'ko-KR', 'pt-BR', 'ru', 'tr', 'vi-VN', 'zh-TW']);
+const SUPPORTED_LOCALES = Object.freeze(['ja', 'zh-CN', 'ko-KR', 'pt-BR', 'ru', 'tr', 'vi-VN', 'zh-TW', 'de-DE']);
 const LOCALE_ALIAS_TO_COMPONENT_ID = Object.freeze({
   'ja': 'locale:ja',
   'ja-JP': 'locale:ja',
@@ -29,6 +29,8 @@ const LOCALE_ALIAS_TO_COMPONENT_ID = Object.freeze({
   'vi-VN': 'locale:vi-vn',
   'vi': 'locale:vi-vn',
   'zh-TW': 'locale:zh-tw',
+  'de-DE': 'locale:de-de',
+  'de': 'locale:de-de',
 });
 
 function listSupportedLocales() {

--- a/tests/lib/locale-install.test.js
+++ b/tests/lib/locale-install.test.js
@@ -50,6 +50,7 @@ function runTests() {
     const components = listInstallComponents({ family: 'locale' });
     assert.ok(components.some(component => component.id === 'locale:ja'));
     assert.ok(components.some(component => component.id === 'locale:zh-cn'));
+    assert.ok(components.some(component => component.id === 'locale:de-de'));
     assert.ok(components.every(component => component.family === 'locale'));
   })) passed++; else failed++;
 
@@ -72,6 +73,59 @@ function runTests() {
       );
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('locale:de-de resolves to the German translated docs module', () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'locale-plan-de-'));
+    try {
+      const plan = resolveInstallPlan({
+        includeComponentIds: ['locale:de-de'],
+        target: 'claude',
+        homeDir,
+      });
+
+      assert.deepStrictEqual(plan.selectedModuleIds, ['docs-de-de']);
+      assert.ok(
+        plan.operations.some(operation => (
+          normalizePlanPath(operation.sourceRelativePath) === 'docs/de-DE'
+          && normalizePlanPath(operation.destinationPath).endsWith('/.claude/docs/de-DE')
+        )),
+        'Should map docs/de-DE to ~/.claude/docs/de-DE'
+      );
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('end-to-end: --locale de dry-run includes docs-de-de operations', () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'locale-dry-run-de-'));
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'locale-dry-run-de-project-'));
+
+    try {
+      const output = runInstallApply([
+        '--locale', 'de',
+        '--dry-run',
+        '--json',
+      ], {
+        cwd: projectDir,
+        env: { HOME: homeDir },
+      });
+      const json = JSON.parse(output);
+
+      assert.strictEqual(json.plan.mode, 'manifest');
+      assert.deepStrictEqual(json.plan.includedComponentIds, ['locale:de-de']);
+      assert.deepStrictEqual(json.plan.selectedModuleIds, ['docs-de-de']);
+      assert.ok(
+        json.plan.operations.some(operation => (
+          normalizePlanPath(operation.sourceRelativePath) === 'docs/de-DE/README.md'
+          && normalizePlanPath(operation.destinationPath).endsWith('/.claude/docs/de-DE/README.md')
+        )),
+        'Should copy translated README into ~/.claude/docs/de-DE'
+      );
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(projectDir, { recursive: true, force: true });
     }
   })) passed++; else failed++;
 


### PR DESCRIPTION
## What Changed

German (de-DE) localization scout, following the maintainer guidance in #1980.

**New files**
- `docs/de-DE/README.md` — full German translation of the English root `README.md`. English source: `1e8c7e7` (main HEAD when this branch was cut). Scope: the complete root README — all sections, the full changelog, every install path, key concepts, all per-harness sections, the FAQ. Relative links rewritten for the `docs/de-DE/` depth; both language-selector tables list every locale including Deutsch.
- `docs/de-DE/GLOSSARY.md` — German terminology, modelled on `docs/ja-JP/GLOSSARY.md`. Explicitly records which ECC terms stay English (Agent, Skill, Hook, Command, Rule, Harness, Instinct, Plugin, Marketplace, Worktree, Subagent, Frontmatter) and which take German forms.

**Installer registration** (kept in this PR since it stays small, per the issue)
- `manifests/install-modules.json` — `docs-de-de` module.
- `manifests/install-components.json` — `locale:de-de` component.
- `scripts/lib/install-manifests.js` — `de-DE` in `SUPPORTED_LOCALES`; `de-DE` + `de` aliases in `LOCALE_ALIAS_TO_COMPONENT_ID`, so `--locale de` and `--locale de-DE` both resolve.
- `package.json` — `docs/de-DE/` added to the `files` publish surface (required by `npm-publish-surface.test.js`, which aligns `files` with the module graph).
- `tests/lib/locale-install.test.js` — focused de-DE coverage (catalog entry, plan resolution, `--locale de` dry-run).

**Discoverability**
- `Deutsch` added to the language selector tables in the root `README.md`, `README.zh-CN.md`, and all 8 `docs/<locale>/README.md` files.

**One deviation from the issue, flagged:** the issue listed `targets: ["claude"]`, but all eight existing docs modules (`docs-ja-jp` … `docs-zh-tw`) use `targets: ["claude", "claude-project"]`. Following "the module should follow the existing docs modules", I matched the existing eight. Glad to switch to `["claude"]` only if you'd prefer.

## Why This Change

#1980 confirmed German is wanted and the locale set is not capped. This is the scout PR requested there. Per-domain `docs/de-DE/{agents,commands,rules,skills}/` translations are intentionally left for incremental follow-up PRs to avoid a 300-file localization PR.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

`node tests/run-all.js` → **2570 passed, 0 failed.**

Installer-backed checks named in the issue:
- `node tests/lib/locale-install.test.js` → 7 passed (2 new de-DE tests)
- `node tests/lib/install-manifests.test.js` → 39 passed
- `node scripts/ci/validate-install-manifests.js` → clean (30 modules, 74 components, 6 profiles)
- `npx markdownlint-cli 'docs/de-DE/**/*.md'` → clean

## Type of Change
- [x] `docs:` Documentation
- [x] `feat:` New feature — installer locale registration

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable) — N/A, no shell scripts changed
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [x] Added comments for complex logic — N/A
- [x] README updated — language selectors updated across all 10 READMEs

Refs #1980

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds German (de-DE) docs and installer support, including a full translated README and a glossary. Addresses #1980’s scout localization and makes German available via the installer.

- **New Features**
  - Docs: `docs/de-DE/README.md` (full translation) and `docs/de-DE/GLOSSARY.md`.
  - Installer: `docs-de-de` module and `locale:de-de` component; `de`/`de-DE` aliases; `de-DE` in `SUPPORTED_LOCALES`; targets `["claude", "claude-project"]`.
  - Publishing: add `docs/de-DE/` to `package.json` files.
  - Discoverability: add “Deutsch” to language selectors in the root and all localized `README.md`s.
  - Tests: de-DE checks in `tests/lib/locale-install.test.js` for plan resolution and catalog.

- **Bug Fixes**
  - Fixed German quotation marks in `docs/de-DE/GLOSSARY.md`; normalized one quoted error string in `docs/de-DE/README.md`.

<sup>Written for commit 2b847406dc9a1faeca7abd2b2a96a068cfbd1e52. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2029?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive German (Deutsch) documentation and made German available as an installable locale/component.

* **Documentation**
  * Updated language navigation across multiple README pages to include additional translations (Türkçe, Русский, Tiếng Việt, ไทย, Deutsch, etc.).
  * Added a German terminology glossary and a full German README.

* **Tests**
  * Extended locale-install tests to cover the new German locale and install planning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->