### PR TITLE
fix(nextjs-turbopack): document proxy.ts as the correct Next.js 16 middleware filename

### DIFF
--- a/skills/nextjs-turbopack/SKILL.md
+++ b/skills/nextjs-turbopack/SKILL.md
@@ -39,16 +39,14 @@ Run `next dev` for local development with Turbopack. Use the Bundle Analyzer (se
 
 ## Middleware File Naming
 
-Next.js 16 + Turbopack changed the middleware filename convention:
+Next.js 16 introduced `proxy.ts` as the middleware filename, replacing the older `middleware.ts` convention:
 
-| Mode | Correct filename |
-|------|-----------------|
-| Next.js 16 + Turbopack (default) | `proxy.ts` |
-| Legacy / webpack mode | `middleware.ts` |
+- **Next.js 16+**: use `proxy.ts` at the project root
+- **Pre-Next.js 16**: use `middleware.ts` at the project root
 
-Both files must live at the **project root** (same level as `app/` or `pages/`).
+The filename change is tied to the **Next.js version**, not to which bundler (Turbopack or webpack) is in use. Always check the official docs for the version you are reviewing.
 
-**Do not flag `proxy.ts` as a misnamed or missing middleware file in Next.js 16 + Turbopack projects.** The file is correct and intentional. Renaming it to `middleware.ts` will break middleware execution in Turbopack mode.
+**Do not flag `proxy.ts` as a misnamed or missing middleware file in Next.js 16 projects.** The file is correct and intentional. Suggesting a rename to `middleware.ts` will break middleware execution.
 
 Reference: https://nextjs.org/docs/app/getting-started/proxy
 

--- a/skills/nextjs-turbopack/SKILL.md
+++ b/skills/nextjs-turbopack/SKILL.md
@@ -37,6 +37,21 @@ next start
 
 Run `next dev` for local development with Turbopack. Use the Bundle Analyzer (see Next.js docs) to optimize code-splitting and trim large dependencies. Prefer App Router and server components where possible.
 
+## Middleware File Naming
+
+Next.js 16 + Turbopack changed the middleware filename convention:
+
+| Mode | Correct filename |
+|------|-----------------|
+| Next.js 16 + Turbopack (default) | `proxy.ts` |
+| Legacy / webpack mode | `middleware.ts` |
+
+Both files must live at the **project root** (same level as `app/` or `pages/`).
+
+**Do not flag `proxy.ts` as a misnamed or missing middleware file in Next.js 16 + Turbopack projects.** The file is correct and intentional. Renaming it to `middleware.ts` will break middleware execution in Turbopack mode.
+
+Reference: https://nextjs.org/docs/app/getting-started/proxy
+
 ## Best Practices
 
 - Stay on a recent Next.js 16.x for stable Turbopack and caching behavior.


### PR DESCRIPTION
## Problem

The `nextjs-turbopack` skill says nothing about middleware file naming. Other ECC skills reference `middleware.ts` throughout, which causes a **false-positive security finding** when reviewing a Next.js 16 + Turbopack codebase that correctly uses `proxy.ts`.

This was discovered during a real code review: Claude flagged a working `proxy.ts` auth middleware as a critical security issue ("the auth gate was silently bypassed") and opened a PR to rename it to `middleware.ts`. The project maintainer correctly closed it as "Won't fix" pointing to the Next.js docs.

## Root Cause

Next.js 16 introduced `proxy.ts` as the middleware filename for Turbopack mode:
https://nextjs.org/docs/app/getting-started/proxy

ECC has no record of this convention change, so any security or code review skill operating on a Next.js 16 + Turbopack project will misidentify `proxy.ts` as an incorrectly named file.

## Fix

Add a **Middleware File Naming** section to `skills/nextjs-turbopack/SKILL.md` with:
- A table mapping Turbopack vs webpack mode to the correct filename
- An explicit warning not to flag `proxy.ts` during reviews
- A link to the official Next.js proxy docs

Closes #2032

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document `proxy.ts` as the correct middleware filename for Next.js 16 in `skills/nextjs-turbopack/SKILL.md` to stop false-positive security flags (closes #2032). Clarifies the filename is version-based (16+: `proxy.ts`, pre-16: `middleware.ts`), adds a “do not flag `proxy.ts`” warning, and links to the official docs.

<sup>Written for commit e91109d3eefb739981b4afa57b78537420bbbc13. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2033?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified middleware file naming conventions for Next.js 16+ and Turbopack, added guidance on which filename/location to use for different deployment modes, and included an explicit warning that renaming or relocating the middleware file will prevent middleware from running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->