### PR TITLE
docs(security-guide): add LLM Safe Haven to References (re: #1585)

### DIFF
--- a/the-security-guide.md
+++ b/the-security-guide.md
@@ -438,6 +438,7 @@ Scan your setup: [github.com/affaan-m/agentshield](https://github.com/affaan-m/a
 - Microsoft Security, "AI Recommendation Poisoning" (February 10, 2026): [microsoft.com](https://www.microsoft.com/en-us/security/blog/2026/02/10/ai-recommendation-poisoning/)
 - Snyk, "ToxicSkills: Malicious AI Agent Skills in the Wild": [snyk.io](https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/)
 - Snyk `agent-scan`: [github.com/snyk/agent-scan](https://github.com/snyk/agent-scan)
+- LLM Safe Haven (fail-closed runtime hooks, threat model, hardening guides for Claude Code/Cursor/Windsurf/Copilot/Codex/Aider/Cline): [github.com/pleasedodisturb/llm-safe-haven](https://github.com/pleasedodisturb/llm-safe-haven)
 - Hunt.io, "CVE-2026-25253 OpenClaw AI Agent Exposure" (February 3, 2026): [hunt.io](https://hunt.io/blog/cve-2026-25253-openclaw-ai-agent-exposure)
 - OpenAI, "Designing AI agents to resist prompt injection" (March 11, 2026): [openai.com](https://openai.com/index/designing-agents-to-resist-prompt-injection/)
 - OpenAI Codex docs, "Agent network access": [platform.openai.com](https://platform.openai.com/docs/codex/agent-network)


### PR DESCRIPTION
Concrete patch per the close note on #1585 ("reopen welcome with a... concrete patch").

Adds one line to the References section of `the-security-guide.md`, placed next to the existing `Snyk agent-scan` entry since both are agent-security tools. No promotional copy — same factual format as the surrounding entries.

LLM Safe Haven complements AgentShield: AgentShield scans ECC skills/hooks/MCP configs for risk, LLM Safe Haven installs runtime hooks (bash firewall, secret guard, audit log) and ships a threat model + per-agent hardening guides. Both projects address parts of the same problem space called out in the "Tooling Landscape" section of this guide.

Most relevant for ECC users:
- Fail-closed hook install pattern (`npx llm-safe-haven`) for Claude Code, Cursor, Windsurf, Copilot, Codex, Aider, Cline
- Threat model with OWASP Agentic Top 10 mapping + real incidents timeline. Currently covers the Shai-Hulud npm worm campaign including the May 11 TanStack wave and May 19 AntV wave that both weaponize `.claude/settings.json` SessionStart hooks — directly relevant to the supply-chain section of this guide.
- Per-agent hardening guides with CVE annotations

Happy to adjust framing, drop to a single repo link, or move placement if you prefer it elsewhere in the document.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LLM Safe Haven to the Security Guide references, next to `Snyk agent-scan`. It links to fail-closed runtime hooks, a threat model, and hardening guides for Claude Code, Cursor, Windsurf, Copilot, Codex, Aider, and Cline.

<sup>Written for commit 5708c40b76917a524299856effb83d4cdc8be2e3. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2034?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "LLM Safe Haven" reference link to the security guide's References section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->