### PR TITLE
fix: filter internal session summary messages

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -29,6 +29,31 @@ const {
 const SUMMARY_START_MARKER = '<!-- ECC:SUMMARY:START -->';
 const SUMMARY_END_MARKER = '<!-- ECC:SUMMARY:END -->';
 const SESSION_SEPARATOR = '\n---\n';
+const INTERNAL_COMMAND_TAG_PATTERN = /^<(?:local-command-|command-|task-notification\b)/;
+
+function getTextContent(rawContent) {
+  if (typeof rawContent === 'string') {
+    return rawContent;
+  }
+
+  if (Array.isArray(rawContent)) {
+    return rawContent.map(c => (c && c.text) || '').join(' ');
+  }
+
+  return '';
+}
+
+function isInternalTranscriptEntry(entry, cleanedText) {
+  if (entry.isMeta === true) {
+    return true;
+  }
+
+  if (entry.type === 'system' && entry.subtype === 'local_command') {
+    return true;
+  }
+
+  return INTERNAL_COMMAND_TAG_PATTERN.test(cleanedText);
+}
 
 /**
  * Extract a meaningful summary from the session transcript.
@@ -55,13 +80,9 @@ function extractSessionSummary(transcriptPath) {
       if (entry.type === 'user' || entry.role === 'user' || entry.message?.role === 'user') {
         // Support both direct content and nested message.content (Claude Code JSONL format)
         const rawContent = entry.message?.content ?? entry.content;
-        const text = typeof rawContent === 'string'
-          ? rawContent
-          : Array.isArray(rawContent)
-            ? rawContent.map(c => (c && c.text) || '').join(' ')
-            : '';
+        const text = getTextContent(rawContent);
         const cleaned = stripAnsi(text).trim();
-        if (cleaned) {
+        if (cleaned && !isInternalTranscriptEntry(entry, cleaned)) {
           userMessages.push(cleaned.slice(0, 200));
         }
       }

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -35,6 +35,7 @@ const DEFAULT_SESSION_START_CONTEXT_MAX_CHARS = 8000;
 const DEFAULT_SESSION_RETENTION_DAYS = 30;
 const SESSION_START_MODE_INVALID = 'invalid';
 const SESSION_START_MODE_SKIP = 'skip';
+const INTERNAL_COMMAND_BULLET_PATTERN = /^-\s*<(?:local-command-|command-|task-notification\b)/;
 
 /**
  * Resolve a filesystem path to its canonical (real) form.
@@ -255,6 +256,13 @@ function selectMatchingSession(sessions, cwd, currentProject) {
     ? '[SessionStart] No worktree/project session match found'
     : '[SessionStart] All session files were unreadable');
   return null;
+}
+
+function sanitizeSessionContext(content) {
+  return String(content || '')
+    .split('\n')
+    .filter(line => !INTERNAL_COMMAND_BULLET_PATTERN.test(line.trim()))
+    .join('\n');
 }
 
 function parseInstinctFile(content) {
@@ -580,7 +588,7 @@ async function main() {
           log(`[SessionStart] Selected: ${result.session.path} (match: ${result.matchReason})`);
 
           // Use the already-read content from selectMatchingSession (no duplicate I/O)
-          const content = stripAnsi(result.content);
+          const content = sanitizeSessionContext(stripAnsi(result.content));
           if (content && !content.includes('[Session context goes here]')) {
             // STALE-REPLAY GUARD: wrap the summary in a historical-only marker so
             // the model does not re-execute stale skill invocations / ARGUMENTS

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -475,6 +475,49 @@ async function runTests() {
   else failed++;
 
   if (
+    await asyncTest('omits internal control-tag bullets from injected session content', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-internal-start-${Date.now()}`);
+      const sessionsDir = getLegacySessionsDir(isoHome);
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
+
+      const sessionFile = path.join(sessionsDir, '2026-02-11-internal-session.tmp');
+      fs.writeFileSync(
+        sessionFile,
+        buildSessionStartFixture(
+          [
+            '### Tasks',
+            '- Keep this user request',
+            '- <local-command-caveat>Caveat: hidden</local-command-caveat>',
+            '- <command-name>/clear</command-name>',
+            '- <task-notification>hidden</task-notification>',
+            '- Keep this follow-up'
+          ].join('\n'),
+          { title: '# Real Session' }
+        )
+      );
+
+      try {
+        const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome
+        });
+        assert.strictEqual(result.code, 0);
+        const additionalContext = getSessionStartAdditionalContext(result.stdout);
+        assert.ok(additionalContext.includes('Keep this user request'), 'Should preserve real session content');
+        assert.ok(additionalContext.includes('Keep this follow-up'), 'Should preserve later real session content');
+        assert.ok(!additionalContext.includes('local-command-caveat'), 'Should omit local command caveats');
+        assert.ok(!additionalContext.includes('<command-name>'), 'Should omit slash command metadata');
+        assert.ok(!additionalContext.includes('task-notification'), 'Should omit task notification metadata');
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     await asyncTest('caps very large session-start context by default', async () => {
       const isoHome = path.join(os.tmpdir(), `ecc-large-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);
@@ -2028,6 +2071,50 @@ async function runTests() {
       const result = await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson);
       assert.strictEqual(result.code, 0, 'Should handle array content without crash');
       cleanupTestDir(testDir);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('omits Claude internal control messages from session summaries', async () => {
+      const testDir = createTestDir();
+      const transcriptPath = path.join(testDir, 'transcript.jsonl');
+
+      const lines = [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'Fix the display issue' } }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: '<local-command-caveat>Caveat: hidden</local-command-caveat>' },
+          isMeta: true
+        }),
+        JSON.stringify({ type: 'user', message: { role: 'user', content: '<command-name>/clear</command-name>\n<command-message>clear</command-message>' } }),
+        JSON.stringify({ type: 'system', subtype: 'local_command', content: '<local-command-stdout>Done</local-command-stdout>' }),
+        JSON.stringify({ type: 'user', message: { role: 'user', content: '<task-notification>hidden</task-notification>' } }),
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'Add regression coverage' } })
+      ];
+      fs.writeFileSync(transcriptPath, lines.join('\n'));
+
+      try {
+        const stdinJson = JSON.stringify({ transcript_path: transcriptPath });
+        const result = await runScript(path.join(scriptsDir, 'session-end.js'), stdinJson, {
+          HOME: testDir,
+          USERPROFILE: testDir
+        });
+        assert.strictEqual(result.code, 0, 'Should handle internal control messages without crashing');
+
+        const files = fs.readdirSync(getCanonicalSessionsDir(testDir)).filter(f => f.endsWith('-session.tmp'));
+        assert.ok(files.length > 0, 'Should create a session file');
+        const content = fs.readFileSync(path.join(getCanonicalSessionsDir(testDir), files[0]), 'utf8');
+        assert.ok(content.includes('Fix the display issue'), 'Should include real user message');
+        assert.ok(content.includes('Add regression coverage'), 'Should include later real user message');
+        assert.ok(!content.includes('local-command-caveat'), 'Should omit local command caveats');
+        assert.ok(!content.includes('<command-name>'), 'Should omit slash command metadata');
+        assert.ok(!content.includes('local-command-stdout'), 'Should omit local command stdout');
+        assert.ok(!content.includes('task-notification'), 'Should omit task notification metadata');
+      } finally {
+        cleanupTestDir(testDir);
+      }
     })
   )
     passed++;


### PR DESCRIPTION
## Summary

Filters Claude internal control messages out of ECC session continuity summaries.

1. Exclude `isMeta`, local command, slash command, and task notification transcript entries when `session-end.js` builds the generated Tasks list.
2. Sanitize previously persisted session summary bullets before `session-start.js` injects prior context into a new session.
3. Add regression coverage for both newly generated summaries and already persisted summary content.

## Test plan

- [x] `node --check scripts/hooks/session-end.js && node --check scripts/hooks/session-start.js`
- [x] `node tests/hooks/hooks.test.js`
- [x] `npm run lint`
- [x] `npm test`

## Notes

- `npm install` reported 2 existing dependency audit findings (1 moderate, 1 high); no dependency changes are included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters internal control messages from ECC session summaries and injected prior context so tasks reflect only real user content. Adds tests to prevent regressions.

- **Bug Fixes**
  - In `session-end.js`, skip transcript entries that are meta (`isMeta`), system local commands (`type: system` + `subtype: local_command`), or start with `<local-command-…>`, `<command-…>`, or `<task-notification>`; handles array content via `getTextContent`.
  - In `session-start.js`, sanitize persisted summaries to remove bullets like `- <local-command-…>`, `- <command-…>`, and `- <task-notification>` before injecting context.
  - Added tests to confirm both summary generation and context injection ignore these internal tags.

<sup>Written for commit 381cbca8250c27a252933282b177a22524279783. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2038?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session summaries now correctly exclude internal system metadata and control tags, ensuring cleaner session context.
  * Previous session context injection now filters out internal command markers and system artifacts.

* **Tests**
  * Added edge-case tests for session handling with internal metadata to verify proper filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->