### PR TITLE
fix(install-targets): validate compiled OpenCode plugin before install

### DIFF
--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -57,6 +57,19 @@ cd ECC
 opencode
 ```
 
+If you also want to apply the ECC home install
+(`node scripts/install-apply.js --target opencode --profile full`), build the
+plugin first so the compiled payload at `.opencode/dist/` exists:
+
+```bash
+node scripts/build-opencode.js   # or: npm run build:opencode
+node scripts/install-apply.js --target opencode --profile full
+```
+
+Without `.opencode/dist/index.js`, OpenCode will detect the slash commands
+but silently skip plugin hooks and tools. The installer now fails fast with
+a pointer to this command if the build step is missing.
+
 ## Features
 
 ### Agents (12)

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -8,12 +8,25 @@ const {
 } = require('./helpers');
 
 const COMPILED_PLUGIN_DIST_DIR = path.join('.opencode', 'dist');
-const REQUIRED_COMPILED_RELATIVE_PATHS = Object.freeze([
-  path.join(COMPILED_PLUGIN_DIST_DIR, 'index.js'),
-  path.join(COMPILED_PLUGIN_DIST_DIR, 'plugins'),
-  path.join(COMPILED_PLUGIN_DIST_DIR, 'tools'),
+const REQUIRED_COMPILED_ARTEFACTS = Object.freeze([
+  { relativePath: path.join(COMPILED_PLUGIN_DIST_DIR, 'index.js'), expectedType: 'file' },
+  { relativePath: path.join(COMPILED_PLUGIN_DIST_DIR, 'plugins'), expectedType: 'directory' },
+  { relativePath: path.join(COMPILED_PLUGIN_DIST_DIR, 'tools'), expectedType: 'directory' },
 ]);
 const BUILD_COMMAND_HINT = 'node scripts/build-opencode.js (or: npm run build:opencode)';
+
+function isExpectedType(absolutePath, expectedType) {
+  let stat;
+  try {
+    stat = fs.statSync(absolutePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  return expectedType === 'file' ? stat.isFile() : stat.isDirectory();
+}
 
 function defaultValidateOpencodeHome(input = {}) {
   if (!input.homeDir && !os.homedir()) {
@@ -30,12 +43,13 @@ function defaultValidateOpencodeHome(input = {}) {
     return [];
   }
 
-  const missingPaths = REQUIRED_COMPILED_RELATIVE_PATHS
-    .map(relativePath => ({
-      relativePath,
-      absolutePath: path.join(input.repoRoot, relativePath),
+  const missingPaths = REQUIRED_COMPILED_ARTEFACTS
+    .map(artefact => ({
+      relativePath: artefact.relativePath,
+      absolutePath: path.join(input.repoRoot, artefact.relativePath),
+      expectedType: artefact.expectedType,
     }))
-    .filter(entry => !fs.existsSync(entry.absolutePath));
+    .filter(entry => !isExpectedType(entry.absolutePath, entry.expectedType));
 
   if (missingPaths.length > 0) {
     const missingList = missingPaths.map(entry => entry.relativePath).join(', ');
@@ -44,12 +58,14 @@ function defaultValidateOpencodeHome(input = {}) {
         'error',
         'opencode-plugin-not-built',
         'OpenCode install requires the compiled plugin payload under '
-          + `${COMPILED_PLUGIN_DIST_DIR}, but the following artefact(s) were not found: `
-          + `${missingList}. Run ${BUILD_COMMAND_HINT} from the repo root before `
-          + 're-running the installer.',
+          + `${COMPILED_PLUGIN_DIST_DIR}, but the following artefact(s) were `
+          + `missing or had the wrong type: ${missingList}. Run `
+          + `${BUILD_COMMAND_HINT} from the repo root before re-running the `
+          + 'installer.',
         {
           missingPaths: missingPaths.map(entry => entry.absolutePath),
           missingRelativePaths: missingPaths.map(entry => entry.relativePath),
+          expectedTypes: missingPaths.map(entry => entry.expectedType),
         }
       ),
     ];

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -7,7 +7,12 @@ const {
   createInstallTargetAdapter,
 } = require('./helpers');
 
-const COMPILED_PLUGIN_RELATIVE_PATH = path.join('.opencode', 'dist', 'index.js');
+const COMPILED_PLUGIN_DIST_DIR = path.join('.opencode', 'dist');
+const REQUIRED_COMPILED_RELATIVE_PATHS = Object.freeze([
+  path.join(COMPILED_PLUGIN_DIST_DIR, 'index.js'),
+  path.join(COMPILED_PLUGIN_DIST_DIR, 'plugins'),
+  path.join(COMPILED_PLUGIN_DIST_DIR, 'tools'),
+]);
 const BUILD_COMMAND_HINT = 'node scripts/build-opencode.js (or: npm run build:opencode)';
 
 function defaultValidateOpencodeHome(input = {}) {
@@ -25,16 +30,27 @@ function defaultValidateOpencodeHome(input = {}) {
     return [];
   }
 
-  const compiledPluginPath = path.join(input.repoRoot, COMPILED_PLUGIN_RELATIVE_PATH);
-  if (!fs.existsSync(compiledPluginPath)) {
+  const missingPaths = REQUIRED_COMPILED_RELATIVE_PATHS
+    .map(relativePath => ({
+      relativePath,
+      absolutePath: path.join(input.repoRoot, relativePath),
+    }))
+    .filter(entry => !fs.existsSync(entry.absolutePath));
+
+  if (missingPaths.length > 0) {
+    const missingList = missingPaths.map(entry => entry.relativePath).join(', ');
     return [
       buildValidationIssue(
         'error',
         'opencode-plugin-not-built',
-        'OpenCode install requires the compiled plugin payload at '
-          + `${COMPILED_PLUGIN_RELATIVE_PATH}, but it was not found. Run `
-          + `${BUILD_COMMAND_HINT} from the repo root before re-running the installer.`,
-        { compiledPluginPath }
+        'OpenCode install requires the compiled plugin payload under '
+          + `${COMPILED_PLUGIN_DIST_DIR}, but the following artefact(s) were not found: `
+          + `${missingList}. Run ${BUILD_COMMAND_HINT} from the repo root before `
+          + 're-running the installer.',
+        {
+          missingPaths: missingPaths.map(entry => entry.absolutePath),
+          missingRelativePaths: missingPaths.map(entry => entry.relativePath),
+        }
       ),
     ];
   }

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -1,4 +1,46 @@
-const { createInstallTargetAdapter } = require('./helpers');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  buildValidationIssue,
+  createInstallTargetAdapter,
+} = require('./helpers');
+
+const COMPILED_PLUGIN_RELATIVE_PATH = path.join('.opencode', 'dist', 'index.js');
+const BUILD_COMMAND_HINT = 'node scripts/build-opencode.js (or: npm run build:opencode)';
+
+function defaultValidateOpencodeHome(input = {}) {
+  if (!input.homeDir && !os.homedir()) {
+    return [
+      buildValidationIssue(
+        'error',
+        'missing-home-dir',
+        'homeDir is required for home install targets'
+      ),
+    ];
+  }
+
+  if (!input.repoRoot) {
+    return [];
+  }
+
+  const compiledPluginPath = path.join(input.repoRoot, COMPILED_PLUGIN_RELATIVE_PATH);
+  if (!fs.existsSync(compiledPluginPath)) {
+    return [
+      buildValidationIssue(
+        'error',
+        'opencode-plugin-not-built',
+        'OpenCode install requires the compiled plugin payload at '
+          + `${COMPILED_PLUGIN_RELATIVE_PATH}, but it was not found. Run `
+          + `${BUILD_COMMAND_HINT} from the repo root before re-running the installer.`,
+        { compiledPluginPath }
+      ),
+    ];
+  }
+
+  return [];
+}
 
 module.exports = createInstallTargetAdapter({
   id: 'opencode-home',
@@ -7,4 +49,5 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.opencode'],
   installStatePathSegments: ['ecc-install-state.json'],
   nativeRootRelativePath: '.opencode',
+  validate: defaultValidateOpencodeHome,
 });

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -15,12 +15,17 @@ const REQUIRED_COMPILED_ARTEFACTS = Object.freeze([
 ]);
 const BUILD_COMMAND_HINT = 'node scripts/build-opencode.js (or: npm run build:opencode)';
 
+// Errors that mean "this artefact does not exist at the expected path / type".
+// Anything else (EACCES, EIO, ...) is a genuine system fault we surface to the
+// caller rather than masking as a missing artefact.
+const MISSING_ARTEFACT_ERROR_CODES = new Set(['ENOENT', 'ENOTDIR']);
+
 function isExpectedType(absolutePath, expectedType) {
   let stat;
   try {
     stat = fs.statSync(absolutePath);
   } catch (error) {
-    if (error && error.code === 'ENOENT') {
+    if (error && MISSING_ARTEFACT_ERROR_CODES.has(error.code)) {
       return false;
     }
     throw error;

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -990,13 +990,36 @@ function runTests() {
       assert.strictEqual(issues[0].severity, 'error');
       assert.strictEqual(issues[0].code, 'opencode-plugin-not-built');
       assert.ok(
-        issues[0].message.includes('.opencode/dist/index.js') || issues[0].message.includes('.opencode\\dist\\index.js'),
-        'Validation message should reference the missing compiled plugin path'
+        issues[0].message.includes('.opencode/dist') || issues[0].message.includes('.opencode\\dist'),
+        'Validation message should reference the .opencode/dist payload location'
       );
       assert.ok(
         issues[0].message.includes('build-opencode.js') || issues[0].message.includes('build:opencode'),
         'Validation message should hint at the build command'
       );
+      assert.ok(Array.isArray(issues[0].missingRelativePaths) && issues[0].missingRelativePaths.length >= 1,
+        'Validation issue should expose the list of missing artefacts as metadata');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('opencode adapter validate reports a partial build (entry present, runtime dirs absent)', () => {
+    const adapter = getInstallTargetAdapter('opencode');
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-partial-'));
+    try {
+      const distDir = path.join(repoRoot, '.opencode', 'dist');
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(path.join(distDir, 'index.js'), '// stub\n');
+      // Intentionally omit dist/plugins and dist/tools.
+
+      const issues = adapter.validate({ homeDir: '/Users/example', repoRoot });
+      assert.strictEqual(issues.length, 1, 'Should surface a single validation issue for partial builds');
+      assert.strictEqual(issues[0].code, 'opencode-plugin-not-built');
+      const missing = issues[0].missingRelativePaths.map(p => p.replace(/\\/g, '/'));
+      assert.ok(missing.includes('.opencode/dist/plugins'), 'Missing list should include dist/plugins');
+      assert.ok(missing.includes('.opencode/dist/tools'), 'Missing list should include dist/tools');
+      assert.ok(!missing.includes('.opencode/dist/index.js'), 'Missing list should not include the present entry');
     } finally {
       fs.rmSync(repoRoot, { recursive: true, force: true });
     }
@@ -1007,7 +1030,8 @@ function runTests() {
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-built-'));
     try {
       const distDir = path.join(repoRoot, '.opencode', 'dist');
-      fs.mkdirSync(distDir, { recursive: true });
+      fs.mkdirSync(path.join(distDir, 'plugins'), { recursive: true });
+      fs.mkdirSync(path.join(distDir, 'tools'), { recursive: true });
       fs.writeFileSync(path.join(distDir, 'index.js'), '// stub\n');
 
       const issues = adapter.validate({ homeDir: '/Users/example', repoRoot });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1048,6 +1048,36 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('opencode adapter validate handles ENOTDIR (intermediate path is a file) without throwing', () => {
+    const adapter = getInstallTargetAdapter('opencode');
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-enotdir-'));
+    try {
+      // Create `.opencode/dist` as a regular file. Stat'ing
+      // `.opencode/dist/index.js` then throws ENOTDIR (intermediate component
+      // is a file, not a directory). The validate gate must treat this as a
+      // missing artefact and surface the structured opencode-plugin-not-built
+      // issue, not propagate the raw fs error.
+      const opencodeDir = path.join(repoRoot, '.opencode');
+      fs.mkdirSync(opencodeDir, { recursive: true });
+      fs.writeFileSync(path.join(opencodeDir, 'dist'), 'not-a-dir');
+
+      let issues;
+      assert.doesNotThrow(
+        () => { issues = adapter.validate({ homeDir: '/Users/example', repoRoot }); },
+        'validate should swallow ENOTDIR and surface a structured issue'
+      );
+      assert.strictEqual(issues.length, 1, 'ENOTDIR case should produce exactly one validation issue');
+      assert.strictEqual(issues[0].severity, 'error');
+      assert.strictEqual(issues[0].code, 'opencode-plugin-not-built');
+      const missing = issues[0].missingRelativePaths.map(p => p.replace(/\\/g, '/'));
+      assert.ok(missing.includes('.opencode/dist/index.js'), 'ENOTDIR target should be reported as missing');
+      assert.ok(missing.includes('.opencode/dist/plugins'), 'Sibling artefacts under the bad path should be reported');
+      assert.ok(missing.includes('.opencode/dist/tools'), 'Sibling artefacts under the bad path should be reported');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('opencode adapter validate passes once compiled plugin payload exists', () => {
     const adapter = getInstallTargetAdapter('opencode');
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-built-'));

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -3,6 +3,8 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const {
@@ -964,6 +966,55 @@ function runTests() {
       )),
       'Should skip foreign Zed platform paths'
     );
+  })) passed++; else failed++;
+
+  if (test('resolves opencode adapter root and install-state path from home dir', () => {
+    const adapter = getInstallTargetAdapter('opencode');
+    const homeDir = '/Users/example';
+    const root = adapter.resolveRoot({ homeDir });
+    const statePath = adapter.getInstallStatePath({ homeDir });
+
+    assert.strictEqual(adapter.id, 'opencode-home');
+    assert.strictEqual(adapter.target, 'opencode');
+    assert.strictEqual(adapter.kind, 'home');
+    assert.strictEqual(root, path.join(homeDir, '.opencode'));
+    assert.strictEqual(statePath, path.join(homeDir, '.opencode', 'ecc-install-state.json'));
+  })) passed++; else failed++;
+
+  if (test('opencode adapter validate reports an error when compiled plugin is missing', () => {
+    const adapter = getInstallTargetAdapter('opencode');
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-missing-'));
+    try {
+      const issues = adapter.validate({ homeDir: '/Users/example', repoRoot });
+      assert.strictEqual(issues.length, 1, 'Should surface exactly one validation issue');
+      assert.strictEqual(issues[0].severity, 'error');
+      assert.strictEqual(issues[0].code, 'opencode-plugin-not-built');
+      assert.ok(
+        issues[0].message.includes('.opencode/dist/index.js') || issues[0].message.includes('.opencode\\dist\\index.js'),
+        'Validation message should reference the missing compiled plugin path'
+      );
+      assert.ok(
+        issues[0].message.includes('build-opencode.js') || issues[0].message.includes('build:opencode'),
+        'Validation message should hint at the build command'
+      );
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('opencode adapter validate passes once compiled plugin payload exists', () => {
+    const adapter = getInstallTargetAdapter('opencode');
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-built-'));
+    try {
+      const distDir = path.join(repoRoot, '.opencode', 'dist');
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(path.join(distDir, 'index.js'), '// stub\n');
+
+      const issues = adapter.validate({ homeDir: '/Users/example', repoRoot });
+      assert.deepStrictEqual(issues, [], 'Should not surface validation issues when plugin is built');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -1025,6 +1025,29 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('opencode adapter validate rejects wrong artefact type (file where directory expected)', () => {
+    const adapter = getInstallTargetAdapter('opencode');
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-wrongtype-'));
+    try {
+      const distDir = path.join(repoRoot, '.opencode', 'dist');
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(path.join(distDir, 'index.js'), '// stub\n');
+      // Materialize plugins/tools as files instead of directories.
+      fs.writeFileSync(path.join(distDir, 'plugins'), 'not-a-dir');
+      fs.writeFileSync(path.join(distDir, 'tools'), 'not-a-dir');
+
+      const issues = adapter.validate({ homeDir: '/Users/example', repoRoot });
+      assert.strictEqual(issues.length, 1, 'Wrong-type artefacts should still surface a validation issue');
+      assert.strictEqual(issues[0].code, 'opencode-plugin-not-built');
+      const missing = issues[0].missingRelativePaths.map(p => p.replace(/\\/g, '/'));
+      assert.ok(missing.includes('.opencode/dist/plugins'), 'Should flag plugins file as wrong type');
+      assert.ok(missing.includes('.opencode/dist/tools'), 'Should flag tools file as wrong type');
+      assert.ok(!missing.includes('.opencode/dist/index.js'), 'Should not flag index.js when it is correctly a file');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('opencode adapter validate passes once compiled plugin payload exists', () => {
     const adapter = getInstallTargetAdapter('opencode');
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-targets-opencode-built-'));


### PR DESCRIPTION
## Summary

Fixes #2040.

OpenCode installs through `node scripts/install-apply.js --target opencode
--profile full` end up with `/` slash commands visible in autocomplete but
silently non-functional — the plugin entry point loads, but `.opencode/dist/`
(the compiled JavaScript payload OpenCode actually executes) is missing from
fresh `git clone` checkouts because `scripts/build-opencode.js` only runs as
part of `npm pack`'s `prepack` hook. This PR makes that broken-state install
fail fast with an actionable message instead of installing successfully and
leaving the user with a non-functional plugin surface.

## Root cause

`scripts/build-opencode.js` produces `.opencode/dist/{index.js, plugins/, tools/}`.
That dist is wired into `npm pack` via `prepack` and the `files` array in
`package.json`, so npm-package consumers always get a working payload. But
the installer (`scripts/install-apply.js → opencode-home`) copies straight from
`.opencode/` in the source repo and never checks for the compiled output. A
fresh clone has no `dist/` (it's gitignored), so the installer happily copies
TypeScript sources into `~/.opencode/` and OpenCode then refuses to execute
them.

The reporter's traceback confirms this exact symptom: commands appear in the
autocomplete list (because `commands/*.md` does land), but pressing enter does
nothing (because plugin hooks/tools have no compiled JS to run).

## Fix

`scripts/lib/install-targets/opencode-home.js` now declares a `validate(input)`
override that:

- Returns the existing `missing-home-dir` issue when no home directory is
  resolvable (matches the helper's default behaviour for `kind: 'home'`).
- When `input.repoRoot` is provided, checks that `<repoRoot>/.opencode/dist/index.js`
  exists. If it doesn't, returns a single `error`-severity issue with code
  `opencode-plugin-not-built` whose message names the missing path and the
  exact build command (`node scripts/build-opencode.js` / `npm run build:opencode`).

`registry.planInstallTargetScaffold` already aborts on any `error`-severity
issue, so the user sees a clear, actionable failure instead of an apparently
successful install that breaks at runtime.

No public API changes. No change to install destinations, manifests, schemas,
or runtime behaviour for already-built repos.

## Test plan

- [x] `node tests/lib/install-targets.test.js` — 38/38 passing (35 baseline + 3 new).
  - Adds the previously-missing per-adapter resolution test for `opencode-home`
    (matches the convention every other home adapter follows).
  - Adds a missing-build assertion using a fresh `os.tmpdir()` repoRoot.
  - Adds a built-payload assertion that materializes a stub `dist/index.js` and
    expects `validate` to return `[]`.
- [x] `node tests/scripts/install-apply.test.js` — 28/28 passing (no regression;
  the suite never invokes `--target opencode`, so the new gate is opt-in).
- [x] `node tests/scripts/build-opencode.test.js` — 3/3 passing.
- [x] `node tests/opencode-config.test.js` — 3/3 passing.
- [x] `node tests/docs/ecc2-release-surface.test.js` — 28/28 passing (asserts
  the README content stays in the release surface manifest).
- [x] `node tests/run-all.js` — full suite, 2571/2571 passing.
- [x] `npx markdownlint-cli .opencode/README.md` — exit 0.
- [x] `npx eslint scripts/lib/install-targets/opencode-home.js tests/lib/install-targets.test.js` — clean.

## Out of scope

Open questions I noticed while researching but deliberately did not roll into
this PR — happy to follow up in separate changes if the maintainer agrees:

1. **`opencode-project` adapter** mirroring `claude-project`: would let users
   install ECC into a project-local `.opencode/` (parallel to the recently-
   added `claude-project`). Useful but expands the surface (manifest, schema,
   request-validation), so kept out of this fix.
2. **Switching the home install root from `~/.opencode` to `~/.config/opencode`**
   (the XDG path that upstream `sst/opencode` constructs from `xdg-basedir`):
   the issue reporter's "ATTEMP FIX" patches this. Worth noting that
   `Global.Path.home + .opencode` *is* in OpenCode's search order
   ([`packages/opencode/src/config/paths.ts`](https://github.com/sst/opencode/blob/dev/packages/opencode/src/config/paths.ts)),
   so the existing path is not actually broken — just non-canonical. Changing
   it is a behaviour shift for every existing install-state file and feels
   like maintainer territory.
3. **Auto-running `build-opencode.js` from inside the installer**: would
   require `tsc` to be reachable on every install run, which regresses the
   fast-path. The validate gate keeps the toolchain boundary clean and lets
   `prepack`/CI own the compile step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast when installing the OpenCode plugin from a fresh clone if the compiled payload is missing or the wrong type. The `opencode-home` target now requires `.opencode/dist/index.js` (file), `.opencode/dist/plugins/` (dir), and `.opencode/dist/tools/` (dir), and tells users to build first.

- **Bug Fixes**
  - Added validate() that returns `error` `opencode-plugin-not-built` with missing paths and expected types; hints `node scripts/build-opencode.js` or `npm run build:opencode`; preserves `missing-home-dir`; no change when already built.
  - Treats ENOTDIR (e.g., `.opencode/dist` is a file) as a missing artefact instead of throwing; other I/O errors still surface.
  - Updated `.opencode/README.md`; tests cover adapter resolution, missing/partial builds, wrong types, ENOTDIR, and the built path.

<sup>Written for commit 847584188a195ff5296ce3661fefcabf9286e827. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2041?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenCode home install guide with exact build + install commands and clarified new failure behavior when the build step is missing.
* **Bug Fixes**
  * Added filesystem validation and clearer user-facing errors for missing, incomplete, or mis-typed compiled plugin artifacts under the build output.
* **Tests**
  * Added automated tests covering missing, partial, wrong-type, ENOTDIR, and successful build scenarios for the home install workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->