### PR TITLE
docs: 新增 fork banner 揭露 upstream PR 貢獻

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> **About this fork:** I forked this repo to contribute upstream bug fixes.
+> My merged contributions to the upstream project (affaan-m/ECC):
+> - [PR #161](https://github.com/affaan-m/ECC/pull/161) — fix: preserve content after frontmatter in `parse_instinct_file()` (merged)
+> - [PR #171](https://github.com/affaan-m/ECC/pull/171) — fix: sync `plugin.json` version with latest tag (merged)
+>
+> These contributions were spec-driven (specs by me, implementation generated via Claude Code, reviewed and submitted by me), and merged by the upstream maintainer — the strongest "external code review" signal in my portfolio. The rest of this README is the upstream maintainer's documentation, kept as-is.
+
+---
+
 **Language:** English | [繁體中文](docs/zh-TW/README.md)
 
 # Everything Claude Code


### PR DESCRIPTION
## Summary

- 在 README 最頂部（Language 行之前）插入 fork banner blockquote
- 明確列出已 merged 到 upstream `affaan-m/ECC` 的兩個 PR（#161 / #171）
- 揭露貢獻為 spec-driven 產出，且上游 maintainer merge 是最強 external code review signal
- 保留原 upstream README 不動（kept as-is），banner 用 `---` 分隔線清楚劃界

## 動機

Eric 求職 portfolio 揭露策略：
- fork 在 ericcai0814 本身 0 commit，若 reviewer 點進來不知道為何釘
- 兩個 merged PR 是 portfolio 內最強的「外部代碼審查通過」signal
- 第一眼可見原則：banner 放最頂部不被 badges / language switcher 蓋過

## 變更

`README.md`: 新增 9 行（fork banner blockquote + `---` 分隔線）

## Test plan

- [ ] 在 GitHub 上 review README 渲染（banner blockquote、PR 連結）
- [ ] 確認與下方 Language switcher、Title、badges 不衝突
- [ ] 點兩個 PR 連結確認 redirect 到 affaan-m/ECC#161 / #171 正確
- [ ] merge 後在 GitHub profile pin 順序檢查（everything-claude-code 在 pin 位置時 banner 正常顯示）

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fork banner at the top of `README.md` to highlight and link to my merged upstream contributions in `affaan-m/ECC` (PR #161, #171). The banner appears before the Language line, is separated by `---`, explains the spec-driven work, and leaves the rest of the upstream README unchanged.

<sup>Written for commit 1cf9b022c7cd000f56f225efe3f4d1f7f2671e38. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2047?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with a new "About this fork" section documenting upstream contributions and clarifying the fork's relationship to the original project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->