### PR TITLE
fix(docs): update marketplace URL in Chinese README to match repo rename

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@
 
 ```bash
 # 添加市场
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # 安装插件
 /plugin install ecc@ecc
@@ -547,7 +547,7 @@ Claude Code v2.1+ 会**按照约定自动加载**已安装插件中的 `hooks/ho
 
 ```bash
 # 将此仓库添加为市场
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # 安装插件
 /plugin install ecc@ecc


### PR DESCRIPTION
## What Changed
Updated the `/plugin marketplace add` URL in `README.zh-CN.md` from `https://github.com/affaan-m/everything-claude-code` to `https://github.com/affaan-m/ECC` (2 occurrences).

## Why This Change
The repository was renamed from `everything-claude-code` to `ECC`, but the Chinese README still referenced the old URL. This caused a mismatch: when running `/plugin marketplace add` with the old URL, Claude Code registers the marketplace under a name derived from `everything-claude-code`, making `/plugin install ecc@ecc` fail with **"Marketplace 'ecc' not found"** because the installer looks for a marketplace named `ecc`.

The English README already uses the correct URL (`affaan-m/ECC`). This PR brings the Chinese version in sync.

## Testing Done
- [x] Manual verification: both URLs in the rendered README now use `affaan-m/ECC`
- [ ] Automated tests pass locally (`node tests/run-all.js`) — `README.zh-CN.md` is a documentation-only change

## Type of Change
- [ ] `fix:` Bug fix
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `/plugin marketplace add` URL in `README.zh-CN.md` from `https://github.com/affaan-m/everything-claude-code` to `https://github.com/affaan-m/ECC` to match the repo rename. This fixes the install error ("Marketplace 'ecc' not found") when running `/plugin install ecc@ecc`.

<sup>Written for commit 26e69ef89bf167b5d0a411de5ff3ba1d818be2dc. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2050?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosted Claude Code plugin marketplace source URL in installation instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->