### PR TITLE
fix(hooks): cost-tracker prefer harness cost.total_cost_usd when statusline writes it

### DIFF
--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -20,14 +20,53 @@
  * Each row therefore represents the cumulative session total up to that point.
  * To get per-session cost, take the last row per session_id. To get per-day
  * spend, aggregate.
+ *
+ * Harness-cost contract (optional, opt-in by the statusline):
+ *   If the user's statusline (which receives `cost.total_cost_usd` directly
+ *   from Claude Code) writes `{ts, cost_usd}` to
+ *   `<os.tmpdir()>/harness-cost-<session_id>.json` on each render, this hook
+ *   prefers that authoritative value over the transcript-sum estimate when
+ *   the cache is fresh (≤ 300s). The transcript-sum is kept as a safe
+ *   fallback because:
+ *     - the hard-coded rate table cannot represent Opus 4.7's >200K-token
+ *       2x tier or the 1h-cache 2x tier (under-counts on long sessions);
+ *     - summing the full transcript double-counts work done across
+ *       `--resume` boundaries while `cost.total_cost_usd` is per-process.
+ *   Absent a writer, behavior is unchanged.
  */
 
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { ensureDir, appendFile, getClaudeDir } = require('../lib/utils');
 const { sanitizeSessionId } = require('../lib/session-bridge');
+
+const HARNESS_COST_MAX_AGE_SECONDS = 300;
+
+/**
+ * Read authoritative harness cost from the per-session cache file.
+ * @param {string} sessionId
+ * @param {number} maxAgeSeconds
+ * @returns {number|null} cost in USD, or null on miss / stale / parse error
+ */
+function readHarnessCost(sessionId, maxAgeSeconds) {
+  if (!sessionId) return null;
+  try {
+    const fp = path.join(os.tmpdir(), `harness-cost-${sessionId}.json`);
+    if (!fs.existsSync(fp)) return null;
+    const obj = JSON.parse(fs.readFileSync(fp, 'utf8'));
+    const ts = Number(obj && obj.ts);
+    const cost = Number(obj && obj.cost_usd);
+    if (!Number.isFinite(ts) || !Number.isFinite(cost) || cost < 0) return null;
+    const age = Math.floor(Date.now() / 1000) - ts;
+    if (age < 0 || age > maxAgeSeconds) return null;
+    return cost;
+  } catch {
+    return null;
+  }
+}
 
 // Approximate per-1M-token billing rates (USD).
 // Cache creation: 1.25x input rate. Cache read: 0.1x input rate.
@@ -125,12 +164,22 @@ process.stdin.on('end', () => {
     } = usageTotals || {};
 
     const rates = getRates(model);
-    const estimatedCostUsd = Math.round((
+    const transcriptCostUsd = Math.round((
       (inputTokens      / 1e6) * rates.in +
       (outputTokens     / 1e6) * rates.out +
       (cacheWriteTokens / 1e6) * rates.cacheWrite +
       (cacheReadTokens  / 1e6) * rates.cacheRead
     ) * 1e6) / 1e6;
+
+    // Prefer the harness's authoritative `cost.total_cost_usd` when the
+    // statusline has written it to the per-session cache (see contract in
+    // the file header). The harness number reflects API-billed truth
+    // (correct rates, 1h-cache 2x, >200K tier 2x) and is per-process so it
+    // does not drift across `--resume`. Cache miss → transcript-sum.
+    const harnessCost = readHarnessCost(sessionId, HARNESS_COST_MAX_AGE_SECONDS);
+    const estimatedCostUsd = harnessCost !== null
+      ? Math.round(harnessCost * 1e6) / 1e6
+      : transcriptCostUsd;
 
     const metricsDir = path.join(getClaudeDir(), 'metrics');
     ensureDir(metricsDir);

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -215,6 +215,93 @@ function runTests() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
+  // 8. Prefers harness-cost cache value over transcript-sum when fresh
+  (test('prefers fresh harness-cost cache over transcript estimate', () => {
+    const tmpHome = makeTempDir();
+    const sessionId = 'harness-fresh-' + Date.now();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-opus-4-20250514',
+          usage: {
+            input_tokens: 10000,
+            output_tokens: 5000,
+            cache_creation_input_tokens: 200000,
+            cache_read_input_tokens: 1000000,
+          },
+        },
+      },
+    ]);
+    const harnessCachePath = path.join(os.tmpdir(), `harness-cost-${sessionId}.json`);
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    fs.writeFileSync(
+      harnessCachePath,
+      JSON.stringify({ ts: nowEpoch, cost_usd: 1.23 }),
+      'utf8'
+    );
+
+    try {
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 1.23, 'Expected harness cost to win');
+      // Token totals still reflect the transcript scan
+      assert.strictEqual(row.input_tokens, 10000, 'Token totals should still come from transcript');
+      assert.strictEqual(row.output_tokens, 5000, 'Token totals should still come from transcript');
+    } finally {
+      try { fs.unlinkSync(harnessCachePath); } catch { /* best-effort */ }
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
+  // 9. Ignores stale harness-cost cache and falls back to transcript estimate
+  (test('ignores stale harness-cost cache (>300s) and uses transcript estimate', () => {
+    const tmpHome = makeTempDir();
+    const sessionId = 'harness-stale-' + Date.now();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-4-20250514',
+          usage: { input_tokens: 1000, output_tokens: 500 },
+        },
+      },
+    ]);
+    const harnessCachePath = path.join(os.tmpdir(), `harness-cost-${sessionId}.json`);
+    const staleEpoch = Math.floor(Date.now() / 1000) - 3600;
+    fs.writeFileSync(
+      harnessCachePath,
+      JSON.stringify({ ts: staleEpoch, cost_usd: 999.99 }),
+      'utf8'
+    );
+
+    try {
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.notStrictEqual(row.estimated_cost_usd, 999.99, 'Stale cache must not win');
+      assert.ok(row.estimated_cost_usd > 0, 'Expected fallback transcript estimate to be positive');
+      // Sonnet rates: 1000/1e6*3 + 500/1e6*15 ≈ $0.011 — well below the 999.99 stale value
+      assert.ok(row.estimated_cost_usd < 1, 'Expected small transcript estimate, not the stale 999.99');
+    } finally {
+      try { fs.unlinkSync(harnessCachePath); } catch { /* best-effort */ }
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary

  `cost-tracker.js` re-prices the whole transcript at a fixed Opus rate table on every `Stop`. On long sessions and after `--resume` the resulting `estimated_cost_usd` diverges sharply from the harness's API-billed
  `cost.total_cost_usd`. The bridge file picks up that inflated number and `ecc-context-monitor` then injects `COST CRITICAL: ... Stop and inform the user about high cost before continuing` once the value crosses `$50`, which
   makes the agent halt prematurely.

  Reproduced live: statusline reported `$15.61 sess` while the hook chain told the agent `Стоимость сессии — $73.99. Останавливаюсь.` End-to-end verification on the affected session:

  | source | cost |
  | --- | --- |
  | harness `cost.total_cost_usd` (truth) | $4.45 |
  | `readHarnessCost` (this PR) → `costs.jsonl` | $4.26 |
  | transcript-sum fallback (current behaviour) | $27.21 |

  Root causes the transcript-sum cannot fix on its own:

  - The hard-coded `RATE_TABLE` cannot represent Opus 4.7's `>200K` token 2x tier or the 1h-cache 2x tier (under-counts on long sessions).
  - Summing all assistant entries in the transcript file double-counts work done across `--resume` boundaries, while `cost.total_cost_usd` is per-process.

  ## Change

  Adds an opt-in contract: if the user's statusline writes `{ts, cost_usd}` to `<os.tmpdir()>/harness-cost-<session_id>.json` on each render, `cost-tracker.js` prefers that authoritative value when fresh (`≤ 300s`). Cache
  miss → unchanged transcript-sum path. Strictly additive — users without a statusline-side writer see no behaviour change.

  The contract is documented in the file header of `scripts/hooks/cost-tracker.js` so any statusline (PowerShell, bash, Node) can opt in.

  ## Type

  - [ ] Skill
  - [ ] Agent
  - [x] Hook
  - [ ] Command

  ## Testing

  ```
  $ node tests/hooks/cost-tracker.test.js

  === Testing cost-tracker.js ===

    ✓ passes through input on stdout
    ✓ creates metrics file when given transcript usage data
    ✓ handles empty input gracefully
    ✓ handles invalid JSON gracefully
    ✓ handles missing usage fields gracefully
    ✓ prefers ECC_SESSION_ID over CLAUDE_SESSION_ID when both are present
    ✓ uses input session_id for session correlation when env vars are absent
    ✓ prefers fresh harness-cost cache over transcript estimate
    ✓ ignores stale harness-cost cache (>300s) and uses transcript estimate

  Results: Passed: 9, Failed: 0
  ```

  Full suite `node tests/run-all.js` — 2513/2523 passing; the 10 pre-existing failures are unrelated (Windows broken-symlink handling in `lib/`, `ci/validators`, `harness-audit`, `instinct-cli-projects` — none reference
  `cost-tracker`). ESLint clean on both touched files.

  Also exercised manually end-to-end against a live affected session: with the cache present the recorded `estimated_cost_usd` matches the harness's `cost.total_cost_usd`; with the cache removed it falls back to the existing
  transcript-sum.

  ## Checklist

  - [x] Follows format guidelines
  - [x] Tested with Claude Code
  - [x] No sensitive info (API keys, paths)
  - [x] Clear descriptions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated session cost by preferring the harness’s `cost.total_cost_usd` when available, preventing false “COST CRITICAL” halts. Falls back to the transcript estimate when the cache is missing or stale.

- **Bug Fixes**
  - Read `{ts, cost_usd}` from `<tmp>/harness-cost-<session_id>.json` and use it when fresh (≤300s).
  - Keep transcript-sum as fallback; no behavior change without a writer.
  - Safely ignore stale, missing, or invalid cache values.
  - Added tests for fresh and stale cache paths; existing tests remain green.

<sup>Written for commit 46e2d58795856f9c988d9b502cbf2e8b0bef7a92. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2054?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved cost estimation logic to leverage cached authoritative cost data when available, with automatic fallback to transcript-based calculation if the cache is unavailable or outdated.

* **Tests**
  * Added test coverage for cached cost data validation and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->