### PR TITLE
fix(session-start): prefer CWD-matched session on resume

### DIFF
--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -35,12 +35,26 @@ async function main() {
   const recentSessions = findFiles(sessionsDir, '*-session.tmp', { maxAge: 7 });
 
   if (recentSessions.length > 0) {
-    const latest = recentSessions[0];
     log(`[SessionStart] Found ${recentSessions.length} recent session(s)`);
-    log(`[SessionStart] Latest: ${latest.path}`);
 
-    // Read and inject the latest session content into Claude's context
-    const content = stripAnsi(readFile(latest.path));
+    // Prefer a session whose Worktree matches the current working directory.
+    // This prevents parallel sessions in different dirs from cross-contaminating
+    // on resume. Fall back to the most-recent session if no CWD match is found.
+    const cwd = process.cwd();
+    let best = recentSessions[0]; // default: most recent
+    for (const s of recentSessions) {
+      const raw = readFile(s.path) || '';
+      const m = raw.match(/\*\*Worktree:\*\*\s*(.+)/);
+      if (m && m[1].trim() === cwd) {
+        best = s;
+        break; // recentSessions is newest-first, so first match = most recent CWD match
+      }
+    }
+
+    log(`[SessionStart] Resuming: ${best.path}${best === recentSessions[0] && recentSessions.length > 1 ? ' (no CWD match — using most recent)' : ' (CWD match)'}`);
+
+    // Read and inject the selected session content into Claude's context
+    const content = stripAnsi(readFile(best.path));
     if (content && !content.includes('[Session context goes here]')) {
       // Only inject if the session has actual content (not the blank template)
       output(`Previous session summary:\n${content}`);


### PR DESCRIPTION
## Problem

When multiple Claude sessions run in parallel in different working directories, the `SessionStart` hook loads the **most-recently-modified** session file regardless of which project the new session belongs to.

This causes context from one project to bleed into a completely unrelated project on resume. For example: a Devops session writes its summary, then a CircuitForge session starts — and loads the Devops summary instead of the CircuitForge one.

## Root Cause

`session-start.js` line 38:
```js
const latest = recentSessions[0]; // always most-recent, no CWD filter
```

`recentSessions` is sorted newest-first by mtime. With a single session this works fine. With parallel sessions in different dirs, whichever session wrote last wins.

## Fix

Scan recent session files for a `**Worktree:**` header that matches `process.cwd()`, and prefer that match over raw recency. Falls back to the existing most-recent behaviour if no CWD match is found — so single-session users and users without worktree metadata are unaffected.

The `**Worktree:**` field is already written by `session-end.js` on every Stop event (`worktree: process.cwd()`), so no session format changes are needed.

## Behaviour after fix

Log output now confirms which path was taken:
```
[SessionStart] Resuming: 2026-05-25-CircuitForge-session.tmp (CWD match)
[SessionStart] Resuming: 2026-05-25-Devops-session.tmp (no CWD match — using most recent)
```

## Testing

Tested with two simultaneous sessions:
- `/Library/Development/CircuitForge` (kiwi logo work)
- `/Library/Development/devl/Devops` (yt-dlp setup)

After fix, each session resumes its own context correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session resume to prefer the session whose `Worktree` matches the current working directory, preventing cross-project context bleed when multiple sessions run in parallel. Falls back to the most recent session if no CWD match is found.

- **Bug Fixes**
  - Scans recent session files for a `**Worktree:**` header that matches `process.cwd()`, choosing the first (newest) match.
  - Logs whether the resume used a CWD match or the most recent file.
  - No format changes; `session-end.js` already writes `Worktree` metadata.

<sup>Written for commit 955127da9a4cb17ee0e11fecdc599f892138b82e. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2056?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions are now intelligently selected based on your current working directory when resuming, with fallback to the most recent session if no matching session is found. Enhanced logging displays how each session was chosen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->