### PR TITLE
fix(continuous-learning): bump observer MAX_TURNS default to 50 (#2035)

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -205,17 +205,20 @@ PROMPT
   fi
 
   timeout_seconds="${ECC_OBSERVER_TIMEOUT_SECONDS:-120}"
-  max_turns="${ECC_OBSERVER_MAX_TURNS:-20}"
+  # Default MAX_TURNS=50 to pair with the MAX_ANALYSIS_LINES=500 default (#2035).
+  # A 500-observation batch consistently exhausted the previous 20-turn budget,
+  # forcing every first-cycle analysis to fail with "Reached max turns".
+  max_turns="${ECC_OBSERVER_MAX_TURNS:-50}"
   exit_code=0
 
   case "$max_turns" in
     ''|*[!0-9]*)
-      max_turns=20
+      max_turns=50
       ;;
   esac
 
   if [ "$max_turns" -lt 4 ]; then
-    max_turns=20
+    max_turns=50
   fi
 
   # Ensure CWD is PROJECT_DIR so the relative analysis_relpath resolves correctly

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -3137,7 +3137,7 @@ async function runTests() {
       const observerLoopSource = fs.readFileSync(path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'agents', 'observer-loop.sh'), 'utf8');
 
       assert.ok(observerLoopSource.includes('ECC_OBSERVER_MAX_TURNS'), 'observer-loop should allow max-turn overrides');
-      assert.ok(observerLoopSource.includes('max_turns="${ECC_OBSERVER_MAX_TURNS:-20}"'), 'observer-loop should default to 20 turns');
+      assert.ok(observerLoopSource.includes('max_turns="${ECC_OBSERVER_MAX_TURNS:-50}"'), 'observer-loop should default to 50 turns to pair with MAX_ANALYSIS_LINES=500 (#2035)');
       assert.ok(!observerLoopSource.includes('--max-turns 3'), 'observer-loop should not hardcode a 3-turn limit');
       assert.ok(observerLoopSource.includes('ECC_SKIP_OBSERVE=1'), 'observer-loop should suppress observe.sh for automated sessions');
       assert.ok(observerLoopSource.includes('ECC_HOOK_PROFILE=minimal'), 'observer-loop should run automated analysis with the minimal hook profile');


### PR DESCRIPTION
## Summary

Fixes #2035. The observer's `MAX_TURNS` default of `20` was systematically too small for the `MAX_ANALYSIS_LINES` default of `500`. First-cycle analysis on a fresh project consistently failed with `Reached max turns (20)`, forcing users to either raise `ECC_OBSERVER_MAX_TURNS` or lower `ECC_OBSERVER_MAX_ANALYSIS_LINES` before the observer became useful.

This PR pairs the defaults so the out-of-the-box experience succeeds: `MAX_TURNS` is bumped to `50` — the value the reporter empirically settled on for the 500-line default.

## Changes

- `skills/continuous-learning-v2/agents/observer-loop.sh`: change three default-site `20`s to `50` (lines 208, 213, 218) and add a comment explaining why the defaults must stay paired.
- `tests/hooks/hooks.test.js`: update the assertion that pins the default constant so it tracks the new value.

The existing safety floor (turns `< 4` falls back to default) is preserved.

## Test plan

- [x] `node tests/hooks/hooks.test.js` — 237/237 pass (including the updated `observer-loop uses a configurable max-turn budget with safe default` test)
- [x] Confirmed both env-var override (`ECC_OBSERVER_MAX_TURNS=10` still respected) and non-numeric / sub-4 fallback paths still resolve to the new `50` default
- [x] No other call sites of `ECC_OBSERVER_MAX_TURNS` or `max_turns=20` exist in the repo (`rg` confirmed)

## Notes for reviewer

I considered an auto-scale approach (e.g. `max_turns = ceil(max_lines / 10)`) but chose the conservative constant change to minimize blast radius and match the reporter's suggested fix shape. Happy to fold an auto-scale variant in if preferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the observer’s default `MAX_TURNS` from 20 to 50 to match the 500-line analysis default, preventing first-cycle “Reached max turns” failures (addresses #2035). `ECC_OBSERVER_MAX_TURNS` overrides still work, and the <4 safety fallback stays.

- **Bug Fixes**
  - Update `skills/continuous-learning-v2/agents/observer-loop.sh` to default `max_turns` to 50 and adjust fallbacks; add a comment linking the default to `MAX_ANALYSIS_LINES=500`.
  - Update `tests/hooks/hooks.test.js` to assert the new 50-turn default.

<sup>Written for commit 6a2645a0b4c2e1c03aeb99844fd241d5d6994687. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2057?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased default observer loop max turns from 20 to 50.
  * Strengthened validation: non-numeric/empty values now default to 50; values below 4 are clamped to 50.
  * Updated tests to match the new default and validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
