### PR TITLE
fix(commands): resolve active plugin root in /instinct-status (#2037)

### DIFF
--- a/.opencode/commands/instinct-status.md
+++ b/.opencode/commands/instinct-status.md
@@ -9,16 +9,15 @@ Show instinct status from continuous-learning-v2: $ARGUMENTS
 
 ## Your Task
 
-Run:
+Resolve the active ECC plugin root with the same walker `hooks/hooks.json`
+uses (env var → standard install → known plugin roots → plugin cache →
+fallback), then run the instinct CLI. This avoids reading a stale legacy
+`~/.claude/skills/continuous-learning-v2/` install when the plugin is
+active under `~/.claude/plugins/cache/...` (#2037).
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/scripts/instinct-cli.py" status
-```
-
-If `CLAUDE_PLUGIN_ROOT` is unavailable, use:
-
-```bash
-python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py status
+ECC_ROOT="${CLAUDE_PLUGIN_ROOT:-$(node -e "var r=(()=>{var e=process.env.CLAUDE_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.claude'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['ecc'],['ecc@ecc'],['marketplaces','ecc'],['everything-claude-code'],['everything-claude-code@everything-claude-code'],['marketplaces','everything-claude-code']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['ecc','everything-claude-code']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();console.log(r)")}"
+python3 "$ECC_ROOT/skills/continuous-learning-v2/scripts/instinct-cli.py" status
 ```
 
 ## Behavior Notes

--- a/commands/instinct-status.md
+++ b/commands/instinct-status.md
@@ -10,16 +10,16 @@ Shows learned instincts for the current project plus global instincts, grouped b
 
 ## Implementation
 
-Run the instinct CLI using the plugin root path:
+Run the instinct CLI, resolving the active ECC plugin root the same way
+`hooks/hooks.json` and the other slash commands (`/sessions`, `/skill-health`)
+do — env var → standard install → known plugin roots → plugin cache → fallback.
+This avoids the divergence that happens when `CLAUDE_PLUGIN_ROOT` is unset
+while a legacy `~/.claude/skills/continuous-learning-v2/` directory still
+exists (#2037).
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/scripts/instinct-cli.py" status
-```
-
-Or if `CLAUDE_PLUGIN_ROOT` is not set (manual installation), use:
-
-```bash
-python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py status
+ECC_ROOT="${CLAUDE_PLUGIN_ROOT:-$(node -e "var r=(()=>{var e=process.env.CLAUDE_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.claude'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['ecc'],['ecc@ecc'],['marketplaces','ecc'],['everything-claude-code'],['everything-claude-code@everything-claude-code'],['marketplaces','everything-claude-code']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['ecc','everything-claude-code']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();console.log(r)")}"
+python3 "$ECC_ROOT/skills/continuous-learning-v2/scripts/instinct-cli.py" status
 ```
 
 ## Usage

--- a/docs/ja-JP/commands/instinct-status.md
+++ b/docs/ja-JP/commands/instinct-status.md
@@ -10,16 +10,16 @@ command: true
 
 ## 実装
 
-プラグインルートパスを使用してインスティンクトCLIを実行します:
+`hooks/hooks.json` および他のスラッシュコマンド（`/sessions`、`/skill-health`）
+と同じリゾルバ（環境変数 → 標準インストール → 既知のプラグインルート →
+プラグインキャッシュ → フォールバック）でインスティンクトCLIを実行します。
+これにより、`CLAUDE_PLUGIN_ROOT` が未設定で
+レガシーの `~/.claude/skills/continuous-learning-v2/` ディレクトリが
+残っているときに発生するパスの分岐を回避します (#2037)。
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/scripts/instinct-cli.py" status
-```
-
-または、`CLAUDE_PLUGIN_ROOT` が設定されていない場合（手動インストール）の場合は:
-
-```bash
-python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py status
+ECC_ROOT="${CLAUDE_PLUGIN_ROOT:-$(node -e "var r=(()=>{var e=process.env.CLAUDE_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.claude'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['ecc'],['ecc@ecc'],['marketplaces','ecc'],['everything-claude-code'],['everything-claude-code@everything-claude-code'],['marketplaces','everything-claude-code']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['ecc','everything-claude-code']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();console.log(r)")}"
+python3 "$ECC_ROOT/skills/continuous-learning-v2/scripts/instinct-cli.py" status
 ```
 
 ## 使用方法

--- a/docs/tr/commands/instinct-status.md
+++ b/docs/tr/commands/instinct-status.md
@@ -10,16 +10,16 @@ Mevcut proje için öğrenilen içgüdüleri ve global içgüdüleri, domain'e g
 
 ## Uygulama
 
-Plugin root path kullanarak instinct CLI'ı çalıştır:
+`hooks/hooks.json` ve diğer slash komutlarının (`/sessions`, `/skill-health`)
+kullandığı çözümleyiciyle (env var → standart kurulum → bilinen plugin
+kökleri → plugin önbelleği → fallback) instinct CLI'ı çalıştır.
+Bu, `CLAUDE_PLUGIN_ROOT` ayarlanmamışken eski bir
+`~/.claude/skills/continuous-learning-v2/` dizini hâlâ varsa oluşan
+yol sapmasını önler (#2037).
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/scripts/instinct-cli.py" status
-```
-
-Veya `CLAUDE_PLUGIN_ROOT` ayarlanmamışsa (manuel kurulum):
-
-```bash
-python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py status
+ECC_ROOT="${CLAUDE_PLUGIN_ROOT:-$(node -e "var r=(()=>{var e=process.env.CLAUDE_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.claude'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['ecc'],['ecc@ecc'],['marketplaces','ecc'],['everything-claude-code'],['everything-claude-code@everything-claude-code'],['marketplaces','everything-claude-code']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['ecc','everything-claude-code']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();console.log(r)")}"
+python3 "$ECC_ROOT/skills/continuous-learning-v2/scripts/instinct-cli.py" status
 ```
 
 ## Kullanım

--- a/docs/zh-CN/commands/instinct-status.md
+++ b/docs/zh-CN/commands/instinct-status.md
@@ -10,16 +10,14 @@ command: true
 
 ## 实现
 
-使用插件根路径运行本能 CLI：
+以与 `hooks/hooks.json` 和其他斜杠命令（`/sessions`、`/skill-health`）
+相同的解析器运行本能 CLI——环境变量 → 标准安装 → 已知插件根 → 插件缓存 → 回退。
+这样可以避免当 `CLAUDE_PLUGIN_ROOT` 未设置而旧的
+`~/.claude/skills/continuous-learning-v2/` 目录仍然存在时发生的路径分歧 (#2037)。
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/skills/continuous-learning-v2/scripts/instinct-cli.py" status
-```
-
-或者，如果未设置 `CLAUDE_PLUGIN_ROOT`（手动安装），则使用：
-
-```bash
-python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py status
+ECC_ROOT="${CLAUDE_PLUGIN_ROOT:-$(node -e "var r=(()=>{var e=process.env.CLAUDE_PLUGIN_ROOT;if(e&&e.trim())return e.trim();var p=require('path'),f=require('fs'),h=require('os').homedir(),d=p.join(h,'.claude'),q=p.join('scripts','lib','utils.js');if(f.existsSync(p.join(d,q)))return d;for(var s of [['ecc'],['ecc@ecc'],['marketplaces','ecc'],['everything-claude-code'],['everything-claude-code@everything-claude-code'],['marketplaces','everything-claude-code']]){var l=p.join(d,'plugins',...s);if(f.existsSync(p.join(l,q)))return l}try{for(var g of ['ecc','everything-claude-code']){var b=p.join(d,'plugins','cache',g);for(var o of f.readdirSync(b,{withFileTypes:true})){if(!o.isDirectory())continue;for(var v of f.readdirSync(p.join(b,o.name),{withFileTypes:true})){if(!v.isDirectory())continue;var c=p.join(b,o.name,v.name);if(f.existsSync(p.join(c,q)))return c}}}}catch(x){}return d})();console.log(r)")}"
+python3 "$ECC_ROOT/skills/continuous-learning-v2/scripts/instinct-cli.py" status
 ```
 
 ## 用法

--- a/tests/lib/command-plugin-root.test.js
+++ b/tests/lib/command-plugin-root.test.js
@@ -22,6 +22,7 @@ function test(name, fn) {
 
 const sessionsDoc = fs.readFileSync(path.join(__dirname, '..', '..', 'commands', 'sessions.md'), 'utf8');
 const skillHealthDoc = fs.readFileSync(path.join(__dirname, '..', '..', 'commands', 'skill-health.md'), 'utf8');
+const instinctStatusDoc = fs.readFileSync(path.join(__dirname, '..', '..', 'commands', 'instinct-status.md'), 'utf8');
 
 test('sessions command uses shared inline resolver in all node scripts', () => {
   assert.strictEqual((sessionsDoc.match(/const _r = /g) || []).length, 6);
@@ -35,6 +36,19 @@ test('skill-health command uses shared inline resolver in all shell snippets', (
   assert.strictEqual((skillHealthDoc.match(/\['marketplaces','ecc'\]/g) || []).length, 3);
   assert.strictEqual((skillHealthDoc.match(/\['marketplaces','everything-claude-code'\]/g) || []).length, 3);
   assert.strictEqual((skillHealthDoc.match(/\['ecc','everything-claude-code'\]/g) || []).length, 3);
+});
+
+test('instinct-status command uses shared inline resolver (no stale legacy fallback) (#2037)', () => {
+  assert.strictEqual((instinctStatusDoc.match(/var r=/g) || []).length, 1);
+  assert.strictEqual((instinctStatusDoc.match(/\['marketplaces','ecc'\]/g) || []).length, 1);
+  assert.strictEqual((instinctStatusDoc.match(/\['marketplaces','everything-claude-code'\]/g) || []).length, 1);
+  assert.strictEqual((instinctStatusDoc.match(/\['ecc','everything-claude-code'\]/g) || []).length, 1);
+  // The pre-fix template hard-coded the legacy path as a fallback when
+  // CLAUDE_PLUGIN_ROOT was unset. Asserting its absence prevents regression.
+  assert.ok(
+    !instinctStatusDoc.includes('python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py'),
+    'instinct-status should not hard-code the legacy ~/.claude install path as a fallback'
+  );
 });
 
 test('inline resolver covers current and legacy marketplace plugin roots', () => {


### PR DESCRIPTION
## Summary

Fixes #2037.

The `/instinct-status` slash command template expanded `${CLAUDE_PLUGIN_ROOT}` directly and documented a `python3 ~/.claude/skills/continuous-learning-v2/scripts/instinct-cli.py` fallback for manual installs. When users had both an active plugin install (under `~/.claude/plugins/cache/<slug>/<org>/<version>/`) AND a legacy `~/.claude/skills/continuous-learning-v2/` directory left over from a previous manual install, an empty `CLAUDE_PLUGIN_ROOT` (which Claude Code does not always populate in slash-command shell contexts, per the issue repro) silently made the command read the stale legacy install while the active plugin hooks and observer wrote to the new XDG path.

End result, as the reporter described: a fully functional, actively learning system that appeared completely broken to the user — "No instincts found" while observations were accumulating elsewhere.

## Fix

Replace the brittle two-block template with the same inline-resolver pattern that `hooks/hooks.json` and the other slash commands (`/sessions`, `/skill-health`) already use:

```bash
ECC_ROOT="${CLAUDE_PLUGIN_ROOT:-$(node -e "var r=(()=>{...resolver...})();console.log(r)")}"
python3 "$ECC_ROOT/skills/continuous-learning-v2/scripts/instinct-cli.py" status
```

The resolver chain is: env var → standard install → known plugin roots → plugin cache walk → fallback. It's the canonical `INLINE_RESOLVE` constant exported from `scripts/lib/resolve-ecc-root.js` — **no new code is introduced**, just consistent adoption of the existing pattern across all slash commands.

## Files changed

- `commands/instinct-status.md` — canonical
- `.opencode/commands/instinct-status.md`
- `docs/zh-CN/commands/instinct-status.md`
- `docs/ja-JP/commands/instinct-status.md`
- `docs/tr/commands/instinct-status.md`
- `tests/lib/command-plugin-root.test.js` — extends the existing pattern (which already covers `sessions.md` and `skill-health.md`) with an `instinct-status.md` assertion, plus a regression guard that the legacy `~/.claude/skills/...` fallback string is no longer present.

## Test plan

- [x] `node tests/lib/command-plugin-root.test.js` — 4/4 pass (3 prior + 1 new)
- [x] `node tests/lib/resolve-ecc-root.test.js` — 23/23 pass (resolver itself is unchanged; existing tests already cover the env-unset → plugin-cache-walk path that fixes this bug)
- [x] `node tests/hooks/hooks.test.js` — 237/237 pass (sanity)
- [x] Smoke-tested the new bash block locally with `unset CLAUDE_PLUGIN_ROOT`; the resolver returns the correct active install path (falls through to `~/.claude` cleanly when no install is present, which matches the documented final-fallback behavior).

## Notes for reviewer

- All five copies are kept in sync in this PR (canonical + opencode + 3 translations). Surrounding prose in each translation is preserved; only the Implementation section's two code blocks → one code block change.
- The inline resolver blob is the verbatim string from `INLINE_RESOLVE` in `scripts/lib/resolve-ecc-root.js`, so any future tightening of the resolver only needs to update that one constant + the inlined copies in `hooks.json`, `sessions.md`, `skill-health.md`, and now `instinct-status.md` (the existing `tests/lib/command-plugin-root.test.js` already pins this consistency).
- Did not consolidate the inline blob into a shared script file because the current architecture deliberately keeps the resolver inlinable into bash (Node has to find the wrapper before it can `require()` anything from the plugin tree — chicken-and-egg). The pre-minified `INLINE_RESOLVE` export is the maintainer's solution to that constraint and is reused here as-is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale path resolution in `/instinct-status` that could read a legacy install when `CLAUDE_PLUGIN_ROOT` was unset, causing “No instincts found.” The command now uses the shared inline resolver to always target the active plugin install (#2037).

- **Bug Fixes**
  - Replaced the two-block template with the canonical inline resolver (env var → standard install → known plugin roots → plugin cache → fallback) from `scripts/lib/resolve-ecc-root.js`.
  - Updated all copies of the command (canonical, `.opencode`, JA/TR/ZH) to use the resolver; polished zh-CN phrasing.
  - Extended tests to assert the resolver is present and the legacy `~/.claude/skills/...` fallback is not used.

<sup>Written for commit 6c99b786ee66733b24ecd372ad841e9503916b9a. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2059?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated instinct-status command docs (EN/JA/TR/ZH) to show a prioritized plugin-root resolution and run the status example using the resolved root for more reliable command examples.

* **Tests**
  * Added tests to validate the resolver is invoked correctly and to prevent regressions that reintroduce legacy hardcoded fallback paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->