### PR TITLE
fix(observer): auto-scale max_turns by analysis batch size

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -205,7 +205,17 @@ PROMPT
   fi
 
   timeout_seconds="${ECC_OBSERVER_TIMEOUT_SECONDS:-120}"
-  max_turns="${ECC_OBSERVER_MAX_TURNS:-20}"
+  # Auto-scale max_turns proportional to analysis batch size when not explicitly set.
+  # The old hardcoded default of 20 is insufficient for the 500-line MAX_ANALYSIS_LINES
+  # default: Claude hits --max-turns before it can write all discovered instinct files.
+  # Formula: 1 turn per 10 analysis lines, floor 20, cap 100. (#2035)
+  if [ -n "${ECC_OBSERVER_MAX_TURNS:-}" ]; then
+    max_turns="${ECC_OBSERVER_MAX_TURNS}"
+  else
+    max_turns=$(( analysis_count / 10 ))
+    if [ "$max_turns" -lt 20 ]; then max_turns=20; fi
+    if [ "$max_turns" -gt 100 ]; then max_turns=100; fi
+  fi
   exit_code=0
 
   case "$max_turns" in

--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -218,6 +218,9 @@ PROMPT
   fi
   exit_code=0
 
+  # Sanitize max_turns. The auto-scaled path above always yields a valid value >=20,
+  # but an explicit ECC_OBSERVER_MAX_TURNS override may be non-numeric, empty, or too
+  # small, so guard here and fall back to the safe default of 20.
   case "$max_turns" in
     ''|*[!0-9]*)
       max_turns=20

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -3137,7 +3137,9 @@ async function runTests() {
       const observerLoopSource = fs.readFileSync(path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'agents', 'observer-loop.sh'), 'utf8');
 
       assert.ok(observerLoopSource.includes('ECC_OBSERVER_MAX_TURNS'), 'observer-loop should allow max-turn overrides');
-      assert.ok(observerLoopSource.includes('max_turns="${ECC_OBSERVER_MAX_TURNS:-20}"'), 'observer-loop should default to 20 turns');
+      assert.ok(observerLoopSource.includes('max_turns=$(( analysis_count / 10 ))'), 'observer-loop should auto-scale max_turns from the analysis batch size when no override is set');
+      assert.ok(observerLoopSource.includes('if [ "$max_turns" -lt 20 ]; then max_turns=20; fi'), 'observer-loop should clamp the auto-scaled budget to a floor of 20 turns');
+      assert.ok(observerLoopSource.includes('if [ "$max_turns" -gt 100 ]; then max_turns=100; fi'), 'observer-loop should clamp the auto-scaled budget to a cap of 100 turns');
       assert.ok(!observerLoopSource.includes('--max-turns 3'), 'observer-loop should not hardcode a 3-turn limit');
       assert.ok(observerLoopSource.includes('ECC_SKIP_OBSERVE=1'), 'observer-loop should suppress observe.sh for automated sessions');
       assert.ok(observerLoopSource.includes('ECC_HOOK_PROFILE=minimal'), 'observer-loop should run automated analysis with the minimal hook profile');


### PR DESCRIPTION
Fixes #2035.

## Problem

`observer-loop.sh` hardcodes `max_turns=20` as the default for the Claude analysis subprocess, while `MAX_ANALYSIS_LINES` defaults to `500`. The two defaults are mismatched: Claude exhausts its turn budget before it can finish reading all observations and writing all qualifying instinct files.

```
Error: Reached max turns (20)
```

## Fix

When `ECC_OBSERVER_MAX_TURNS` is **not** explicitly set, auto-scale `max_turns` proportionally to the actual analysis batch size (`analysis_count`, which is already computed just before this code):

```
max_turns = clamp(analysis_count / 10, floor=20, cap=100)
```

Results:

| `analysis_count` | `max_turns` |
|---|---|
| < 200 lines | 20 (existing floor, unchanged) |
| 500 lines | **50** ← resolves the reported failure |
| 800 lines | 80 |
| ≥ 1000 lines | 100 (cap) |

Setting `ECC_OBSERVER_MAX_TURNS` explicitly still overrides the auto-scaled value, preserving the existing escape hatch.

## Why not just raise the hardcoded default to 50?

Auto-scaling is strictly better: it handles any value of `ECC_OBSERVER_MAX_ANALYSIS_LINES` correctly, whereas a new hardcoded default of 50 would still fail if a user cranks `MAX_ANALYSIS_LINES` beyond 500.

## Files changed

- `skills/continuous-learning-v2/agents/observer-loop.sh` — replace 3-line `max_turns` assignment with an 8-line auto-scaling block

## Testing

Manual verification of the logic (pure shell arithmetic, no external deps):
```bash
for lines in 10 50 199 200 500 800 1000 1500; do
  turns=$(( lines / 10 ))
  [ "$turns" -lt 20 ] && turns=20
  [ "$turns" -gt 100 ] && turns=100
  echo "$lines lines → $turns turns"
done
# 10 lines → 20 turns
# 50 lines → 20 turns
# 199 lines → 20 turns
# 200 lines → 20 turns
# 500 lines → 50 turns  ✓
# 800 lines → 80 turns
# 1000 lines → 100 turns
# 1500 lines → 100 turns (cap)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-scales the observer’s `max_turns` from `analysis_count` so the analysis finishes the default 500-line batch without hitting the turn limit.

- **Bug Fixes**
  - Auto-scale when `ECC_OBSERVER_MAX_TURNS` is unset: `max_turns = clamp(analysis_count / 10, 20, 100)`; explicit override still works and is validated (fallback to 20 if invalid).
  - Updated tests to assert the auto-scaling formula and the 20/100 clamps.

<sup>Written for commit 26dd0435bc67da38b36052aea5325475a99846e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Observer loop now auto-scales its iteration depth based on analysis size (1 turn per ~10 lines, with sensible minimum/maximum bounds) when no manual override is provided, improving responsiveness and resource use.

* **Tests**
  * Validation tests updated to assert the new auto-scaling and clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->