### PR TITLE
fix(instinct-cli): pin file reads and stdout to UTF-8 on Windows

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -20,6 +20,9 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Optional
 
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 # ─────────────────────────────────────────────
 # Configuration
 # ─────────────────────────────────────────────
@@ -95,7 +98,7 @@ def load_all_instincts() -> list[dict]:
         )
         for file in yaml_files:
             try:
-                content = file.read_text()
+                content = file.read_text(encoding="utf-8")
                 parsed = parse_instinct_file(content)
                 for inst in parsed:
                     inst['_source_file'] = str(file)
@@ -196,7 +199,7 @@ def cmd_import(args):
         if not path.exists():
             print(f"File not found: {path}", file=sys.stderr)
             return 1
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
 
     # Parse instincts
     new_instincts = parse_instinct_file(content)


### PR DESCRIPTION
## Summary

`/instinct-status` and `/instinct-import` silently drop instinct files
and crash mid-output on Windows installs where the system code page
isn't UTF-8 (cp950, cp1252, etc.). Three-line fix to pin file I/O and
stdout to UTF-8.

## Root cause

Two bugs, both caused by Python's `Path.read_text()` and `sys.stdout`
defaulting to the OS code page on Windows:

1. **Read-side** — `load_all_instincts()` line 98 and `cmd_import()`
   line 199 call `read_text()` with no `encoding=` argument. UTF-8
   markdown content containing characters like `✅` (U+2705) or `─`
   (U+2500) fails with `UnicodeDecodeError`. The caller catches the
   exception, prints a warning to stderr, and silently drops the
   instinct — the user sees "Personal: 1" when they actually have 5.

2. **Write-side** — `cmd_status()` line 155 prints the confidence
   bar containing `░` (U+2591) and `█` (U+2588). `sys.stdout` is
   tied to the OS code page; on cp950/cp1252 these chars are
   unencodable and `print()` crashes with `UnicodeEncodeError`.

### Reproducer

```powershell
# Windows PowerShell, with system code page cp950 or cp1252
python skills/continuous-learning-v2/scripts/instinct-cli.py status
```

Expected: 5 instincts rendered with confidence bars.
Actual: 4 instincts silently dropped (warnings on stderr), then crash mid-render with:

```
UnicodeEncodeError: 'cp950' codec can't encode character '░' in position 10
```

(Files used in reproduction contain checkmarks and `─` box-drawing chars in
their markdown body — valid UTF-8, confirmed via `file(1)`.)

## Fix

Three lines, no API changes, no behavioral change on UTF-8 systems
(macOS / Linux / Windows with the UTF-8 beta enabled):

```diff
 from collections import defaultdict
 from typing import Optional

+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 # ─────────────────────────────────────────────
 # Configuration
```

```diff
         for file in yaml_files:
             try:
-                content = file.read_text()
+                content = file.read_text(encoding="utf-8")
                 parsed = parse_instinct_file(content)
```

```diff
         if not path.exists():
             print(f"File not found: {path}", file=sys.stderr)
             return 1
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
```

Notes:
- `hasattr(sys.stdout, "reconfigure")` guards against Python < 3.7.
- `errors="replace"` keeps the CLI from crashing on exotic terminals
  that can't render replacement chars — they'll print `?` instead.
- `encoding="utf-8"` is a no-op when the OS default is already UTF-8.

## Test plan

- [x] Reproduced original failure on Windows 11 / Python 3.14.5 / cp950
- [x] Verified after patch: all 5 instincts in `~/.claude/homunculus/instincts/personal/` parse and render correctly without any env-var workaround
- [x] Existing `test_parse_instinct.py` (3 tests for `parse_instinct_file`) unchanged — no regression
- [ ] Maintainer: please verify on macOS or Linux that explicit `encoding="utf-8"` produces no regression vs implicit default (it shouldn't — they're equivalent when locale is `C.UTF-8` / `en_US.UTF-8`)

## Out of scope / follow-up

A regression test for `load_all_instincts()` against a UTF-8 file with
non-ASCII chars would catch this class of bug. The existing test suite
only covers `parse_instinct_file` directly with synthetic strings.
Happy to add this in a follow-up PR if maintainers want it scoped
separately.

## Related

Searched issues + PRs for `cp950 / encoding / utf-8 / UnicodeDecodeError`
and found no duplicates. Apologies if one exists under different terms.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins instinct CLI file reads and stdout to UTF-8 on Windows to prevent dropped instincts and crashes on non-UTF-8 code pages. Fixes decode/encode errors when files contain emoji or box-drawing characters.

- **Bug Fixes**
  - Read instinct files with `encoding="utf-8"` in `load_all_instincts()` and `cmd_import()`.
  - Reconfigure `sys.stdout` to UTF-8 with `errors="replace"` (guarded by `hasattr(sys.stdout, "reconfigure")`) to avoid confidence-bar render crashes.

<sup>Written for commit 90c47fa37918bbb11c8483ecbfe7a6cac6b2e8b1. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2063?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 character encoding support with enhanced error handling
  * Enhanced file reading reliability with explicit UTF-8 encoding across import and parsing operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->