### PR TITLE
Improve console.log detection in pre-commit hook

### DIFF
--- a/scripts/hooks/check-console-log.js
+++ b/scripts/hooks/check-console-log.js
@@ -52,6 +52,52 @@ process.stdin.on('end', () => {
 
     for (const file of files) {
       const content = readFile(file);
+      if (content) {
+        const lines = content.split('\n');
+        const matchedLines = [];
+
+        lines.forEach((line, index) => {
+          if (line.includes('console.log')) {
+            matchedLines.push(index + 1);
+          }
+        });
+
+        if (matchedLines.length > 0) {
+          log(`[Hook] WARNING: console.log found in ${file} on line(s): ${matchedLines.join(', ')}`);
+          hasConsole = true;
+        }
+      }
+    }
+
+    if (hasConsole) {
+      log('[Hook] Remove console.log statements before committing');
+    }
+  } catch (err) {
+    log(`[Hook] check-console-log error: ${err.message}`);
+  }
+
+  // Always output the original data
+  process.stdout.write(data);
+  process.exit(0);
+});
+  }
+});
+
+process.stdin.on('end', () => {
+  try {
+    if (!isGitRepo()) {
+      process.stdout.write(data);
+      process.exit(0);
+    }
+
+    const files = getGitModifiedFiles(['\\.tsx?$', '\\.jsx?$'])
+      .filter(f => fs.existsSync(f))
+      .filter(f => !EXCLUDED_PATTERNS.some(pattern => pattern.test(f)));
+
+    let hasConsole = false;
+
+    for (const file of files) {
+      const content = readFile(file);
       if (content && content.includes('console.log')) {
         log(`[Hook] WARNING: console.log found in ${file}`);
         hasConsole = true;


### PR DESCRIPTION
Enhance console log check to report line numbers.

## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal code quality checks to provide more detailed diagnostics during development workflow.

*No end-user visible changes in this release.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-commit hook now reports exact line numbers for any console.log in staged JS/TS files, making cleanups faster. It warns with file and line numbers but does not block commits.

- **New Features**
  - Lists line numbers for `console.log` in `.js`, `.jsx`, `.ts`, and `.tsx` files.
  - Keeps current behavior: warn only (no commit blocking).

<sup>Written for commit f2fbe65c962fb66667203ecab84a3c34cfe44fb7. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2064?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

