### PR TITLE
fix(docs): sync marketplace add URL across translated READMEs (#2050)

### DIFF
--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -107,7 +107,7 @@
 
 ```bash
 # マーケットプレイスを追加
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # プラグインをインストール
 /plugin install ecc@ecc
@@ -428,7 +428,7 @@ Duplicate hook file detected: ./hooks/hooks.json is already resolved to a loaded
 
 ```bash
 # このリポジトリをマーケットプレイスとして追加
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # プラグインをインストール
 /plugin install ecc@ecc

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -112,7 +112,7 @@
 
 ```bash
 # 마켓플레이스 추가
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # 플러그인 설치
 /plugin install ecc@ecc
@@ -356,7 +356,7 @@ Claude Code v2.1+는 설치된 플러그인의 `hooks/hooks.json`을 **자동으
 
 ```bash
 # 마켓플레이스 추가
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # 플러그인 설치
 /plugin install ecc@ecc

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -121,7 +121,7 @@ Comece em menos de 2 minutos:
 
 ```bash
 # Adicionar marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Instalar plugin
 /plugin install ecc@ecc
@@ -310,7 +310,7 @@ claude --version
 
 ```bash
 # Adicionar este repositório como marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Instalar o plugin
 /plugin install ecc@ecc

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -222,7 +222,7 @@ npx ecc consult "security reviews" --target claude
 
 ```bash
 # Добавьте marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Установите плагин
 /plugin install ecc@ecc
@@ -763,7 +763,7 @@ Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded fil
 
 ```bash
 # Добавить этот репозиторий как marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Установить плагин
 /plugin install ecc@ecc

--- a/docs/th/README.md
+++ b/docs/th/README.md
@@ -50,7 +50,7 @@ ECC ไม่ใช่แค่ชุดไฟล์คอนฟิก แต่
 
 ```bash
 # เพิ่ม marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # ติดตั้ง plugin
 /plugin install ecc@ecc

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -122,7 +122,7 @@ Bu repository yalnızca ham kodu içerir. Rehberler her şeyi açıklıyor.
 
 ```bash
 # Marketplace ekle
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Plugin'i kur
 /plugin install ecc@ecc

--- a/docs/vi-VN/README.md
+++ b/docs/vi-VN/README.md
@@ -48,7 +48,7 @@ Nếu bạn đã cài chồng nhiều lần và thấy skill/hook bị trùng, x
 
 ```bash
 # Thêm marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Cài plugin
 /plugin install ecc@ecc

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -167,7 +167,7 @@
 
 ```bash
 # Add marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Install plugin
 /plugin install ecc@ecc
@@ -603,7 +603,7 @@ Claude Code v2.1+ **会自动加载** 任何已安装插件中的 `hooks/hooks.j
 
 ```bash
 # Add this repo as a marketplace
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # Install the plugin
 /plugin install ecc@ecc

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -67,7 +67,7 @@
 
 ```bash
 # 新增市集
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # 安裝外掛程式
 /plugin install ecc@ecc
@@ -267,7 +267,7 @@ everything-claude-code/
 
 ```bash
 # 將此儲存庫新增為市集
-/plugin marketplace add https://github.com/affaan-m/everything-claude-code
+/plugin marketplace add https://github.com/affaan-m/ECC
 
 # 安裝外掛程式
 /plugin install ecc@ecc


### PR DESCRIPTION
## Summary

PR #2050 fixed the stale `/plugin marketplace add` URL in the root `README.zh-CN.md` after the `everything-claude-code` → `ECC` rename. The same install commands were still present in nine translated copies under `docs/<locale>/README.md`. This PR updates those 15 occurrences so locale-specific onboarding matches the English and German READMEs.

## Problem

When users follow a translated README and run:

```bash
/plugin marketplace add https://github.com/affaan-m/everything-claude-code
/plugin install ecc@ecc
```

Claude Code registers the marketplace under a name derived from `everything-claude-code`, so `/plugin install ecc@ecc` fails with **"Marketplace 'ecc' not found"** — the same failure mode documented in #2050.

Affected files (2 commands each unless noted):

- `docs/zh-CN/README.md`, `docs/zh-TW/README.md`
- `docs/ja-JP/README.md`, `docs/ko-KR/README.md`
- `docs/pt-BR/README.md`, `docs/ru/README.md`
- `docs/tr/README.md`, `docs/th/README.md`, `docs/vi-VN/README.md` (1 each)

## Solution

Replace only the `/plugin marketplace add` GitHub URL with `https://github.com/affaan-m/ECC`, mirroring #2050’s scope. No logic, badge, issue-link, or `settings.json` `"repo"` field changes in this diff.

## Out of scope

- Root `README.zh-CN.md` — already fixed in #2050.
- `docs/de-DE/README.md` — already uses `affaan-m/ECC`.
- Stale `"repo": "affaan-m/everything-claude-code"` in marketplace JSON examples, badge URLs, `git clone` lines, and CONTRIBUTING — left for #2058 / follow-up i18n PRs per maintainer triage notes.
- `EVALUATION.md` / `REPO-ASSESSMENT.md` cleanup — covered by open #2058.

## Test plan

- [x] `grep` confirms zero remaining `/plugin marketplace add .../everything-claude-code` under `docs/*/README.md`
- [x] Diff is 9 files, +15/−15, URL-only
- [x] CI (docs-only; no build required)

## Related

- #2050 — prior fix in root Chinese README (pattern mirrored here)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the `/plugin marketplace add` URL in nine localized READMEs to `https://github.com/affaan-m/ECC`. This fixes the install flow so `/plugin install ecc@ecc` resolves the correct marketplace and avoids the “Marketplace 'ecc' not found” error.

- **Bug Fixes**
  - Replaced the stale `.../everything-claude-code` URL in nine `docs/<locale>/README.md` files.
  - URL-only changes (+15/−15); no other edits.

<sup>Written for commit c85df724a4e843ef6891403d08e449fef17f7ff4. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2068?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin marketplace installation URLs across all supported languages in README documentation files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->