### PR TITLE
fix: warn when populated legacy ~/.claude/homunculus exists (#2036)

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -137,6 +137,35 @@ def _ensure_global_dirs():
         d.mkdir(parents=True, exist_ok=True)
 
 
+def _detect_legacy_homunculus_dir() -> "Path | None":
+    """Detect a populated legacy ~/.claude/homunculus tree that the current
+    XDG-based CLI does NOT read from.
+
+    Issue #2036: when ECC migrated to XDG_DATA_HOME (default
+    ~/.local/share/ecc-homunculus/), users with an older manual install at
+    ~/.claude/homunculus/ silently had observations written to the new path
+    while `instinct-cli.py status` continued to look at the old one. We warn
+    explicitly when both paths exist so the divergence is visible instead of
+    appearing as "system is broken".
+    """
+    legacy = Path.home() / ".claude" / "homunculus"
+    if legacy == HOMUNCULUS_DIR:
+        return None
+    try:
+        if not legacy.is_dir():
+            return None
+        # Treat the directory as populated only if it contains real ECC
+        # state -- projects/, instincts/, evolved/, or observations.jsonl.
+        # An empty placeholder dir is not worth warning about.
+        for marker in ("projects", "instincts", "evolved", "observations.jsonl"):
+            target = legacy / marker
+            if target.exists():
+                return legacy
+    except OSError:
+        return None
+    return None
+
+
 # ─────────────────────────────────────────────
 # Path Validation
 # ─────────────────────────────────────────────
@@ -702,6 +731,24 @@ def cmd_status(args) -> int:
             for item in expiring_soon:
                 days_left = max(0, PENDING_TTL_DAYS - item["age_days"])
                 print(f"    - {item['name']} ({days_left}d remaining)")
+
+    # Issue #2036: legacy ~/.claude/homunculus is invisible to the current
+    # XDG-based CLI. Surface the divergence so users debugging "no instincts
+    # found" don't spend hours tracing path mismatches.
+    legacy_dir = _detect_legacy_homunculus_dir()
+    if legacy_dir is not None:
+        migrate_script = (
+            Path(__file__).resolve().parent / "migrate-homunculus.sh"
+        )
+        print(f"\n{'-'*60}")
+        print(f"  ⚠ Legacy data found at {legacy_dir}")
+        print(f"    The current CLI reads from {HOMUNCULUS_DIR}")
+        print( "    and does NOT see anything under the legacy path.")
+        if migrate_script.exists():
+            print(f"    Run: {migrate_script}")
+        else:
+            print(f"    Migrate by moving {legacy_dir} into {HOMUNCULUS_DIR}")
+        print( "    (or remove the legacy directory once you've confirmed it's empty).")
 
     print(f"\n{'='*60}\n")
     return 0

--- a/tests/scripts/instinct-cli-projects.test.js
+++ b/tests/scripts/instinct-cli-projects.test.js
@@ -254,6 +254,62 @@ test('status migrates legacy no-remote linked worktree project dirs to main work
   }
 });
 
+test('status warns when populated legacy ~/.claude/homunculus exists alongside XDG path (#2036)', () => {
+  const root = createTempDir();
+  try {
+    const home = path.join(root, 'home');
+    const legacyHomunculus = path.join(home, '.claude', 'homunculus', 'projects');
+    fs.mkdirSync(legacyHomunculus, { recursive: true });
+    // Drop a sentinel project dir so the helper sees a populated tree.
+    fs.mkdirSync(path.join(legacyHomunculus, 'deadbeef'), { recursive: true });
+
+    const result = runCli(root, ['status']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.match(
+      result.stdout,
+      /Legacy data found at .*\.claude\/homunculus/,
+      'status should warn about the populated legacy directory'
+    );
+  } finally {
+    cleanupDir(root);
+  }
+});
+
+test('status stays quiet when no legacy ~/.claude/homunculus exists (#2036)', () => {
+  const root = createTempDir();
+  try {
+    const home = path.join(root, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    const result = runCli(root, ['status']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.doesNotMatch(
+      result.stdout,
+      /Legacy data found/,
+      'status should not warn when no legacy directory exists'
+    );
+  } finally {
+    cleanupDir(root);
+  }
+});
+
+test('status stays quiet when legacy ~/.claude/homunculus exists but is empty (#2036)', () => {
+  const root = createTempDir();
+  try {
+    const home = path.join(root, 'home');
+    const legacy = path.join(home, '.claude', 'homunculus');
+    fs.mkdirSync(legacy, { recursive: true });
+    const result = runCli(root, ['status']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.doesNotMatch(
+      result.stdout,
+      /Legacy data found/,
+      'empty placeholder legacy directory should not trigger the warning'
+    );
+  } finally {
+    cleanupDir(root);
+  }
+});
+
 console.log(`\nPassed: ${passed}`);
 console.log(`Failed: ${failed}`);
 


### PR DESCRIPTION
## What Changed

`cmd_status` now detects when `~/.claude/homunculus/` contains real ECC state (projects/, instincts/, evolved/, observations.jsonl) and the active `HOMUNCULUS_DIR` resolves elsewhere — typically because the user installed via the plugin path on XDG defaults but still has data from an older manual install at `~/.claude/homunculus/`. When that divergence is detected, status prints a one-line warning that names both paths and points at the existing `migrate-homunculus.sh` script.

The detection lives in a small helper, `_detect_legacy_homunculus_dir()`, alongside `_resolve_homunculus_dir()` so the path policy stays in one section of the file.

## Why This Change

#2036 documented a real reproduction: observations were accumulating at `~/.local/share/ecc-homunculus/projects/<new-hash>/`, while `instinct-cli.py status` still reported "No instincts found" because the user's stale local CLI looked at `~/.claude/homunculus/<old-hash>/`. The two CLIs used different hash algorithms, different roots, and nothing in the live tooling told the user where the divergence was. Hours of debugging later, the reporter found the issue manually.

The current CLI can't fix the old CLI's behavior, but it can surface the divergence: when `~/.claude/homunculus/` is populated AND we read from a different directory, we say so directly. The empty-placeholder path was the obvious follow-up: users who have already migrated and left an empty `~/.claude/homunculus/` shell behind get nothing, so the warning only fires when there's real lingering state.

## Testing Done

- [x] Manual testing completed (`python3 instinct-cli.py status` against a tmpdir HOME with the legacy tree present)
- [x] Automated tests pass locally (`node tests/scripts/instinct-cli-projects.test.js` — 8 / 8 pass, +3 new)
- [x] Edge cases considered and tested (populated legacy dir / no legacy dir / empty placeholder dir)

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

Closes #2036

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear warning in `instinct-cli.py status` when a populated legacy `~/.claude/homunculus/` exists but the CLI reads from the XDG path, so users can spot and fix path divergence.

- **Bug Fixes**
  - Added `_detect_legacy_homunculus_dir()` to flag a populated legacy dir (projects/, instincts/, evolved/, or observations.jsonl) when `HOMUNCULUS_DIR` points elsewhere.
  - `cmd_status` prints a short warning with both paths and suggests running `migrate-homunculus.sh`. Empty legacy dirs are ignored.
  - Tests cover: populated legacy dir warns; no legacy dir stays silent; empty legacy dir stays silent.

<sup>Written for commit 97bd809e790011b80c343d79b16969d8abb40c79. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/ECC/pull/2072?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for legacy data directories with prominent warnings in the status command when found.
  * Displays migration instructions and current data path to help users manage legacy data.

* **Tests**
  * Added three new status command tests covering legacy data detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->