### PR TITLE
feat(skills): add codehealth-mcp skill and CodeScene MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ ECC/
 |   |-- perl-testing/              # Perl TDD with Test2::V0, prove, Devel::Cover (NEW)
 |   |-- autonomous-loops/           # Autonomous loop patterns: sequential pipelines, PR loops, DAG orchestration (NEW)
 |   |-- plankton-code-quality/      # Write-time code quality enforcement with Plankton hooks (NEW)
+|   |-- codehealth-mcp/             # CodeScene Code Health MCP — structural review and regression gates (NEW)
 |
 |-- commands/         # Maintained slash-entry compatibility; prefer skills/
 |   |-- plan.md             # /plan - Implementation planning
@@ -1341,6 +1342,7 @@ Canonical Anthropic skills such as `claude-api`, `frontend-design`, and `skill-c
 | brand-voice | Source-derived writing style profiles from real content |
 | bun-runtime | Bun as runtime, package manager, bundler, and test runner |
 | coding-standards | Universal coding standards |
+| codehealth-mcp | Structural Code Health via CodeScene MCP — review, score deltas, commit/PR gates |
 | content-engine | Platform-native social content and repurposing |
 | crosspost | Multi-platform content distribution across X, LinkedIn, Threads |
 | deep-research | Multi-source research with synthesis and source attribution |

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ ECC/
 |   |-- perl-testing/              # Perl TDD with Test2::V0, prove, Devel::Cover (NEW)
 |   |-- autonomous-loops/           # Autonomous loop patterns: sequential pipelines, PR loops, DAG orchestration (NEW)
 |   |-- plankton-code-quality/      # Write-time code quality enforcement with Plankton hooks (NEW)
-|   |-- codehealth-mcp/             # CodeScene Code Health MCP — structural review and regression gates (NEW)
+|   |-- codehealth-mcp/             # Optional CodeScene Code Health MCP skill (opt-in; not enabled by default) (NEW)
 |
 |-- commands/         # Maintained slash-entry compatibility; prefer skills/
 |   |-- plan.md             # /plan - Implementation planning
@@ -1342,7 +1342,7 @@ Canonical Anthropic skills such as `claude-api`, `frontend-design`, and `skill-c
 | brand-voice | Source-derived writing style profiles from real content |
 | bun-runtime | Bun as runtime, package manager, bundler, and test runner |
 | coding-standards | Universal coding standards |
-| codehealth-mcp | Structural Code Health via CodeScene MCP — review, score deltas, commit/PR gates |
+| codehealth-mcp | Optional — Code Health MCP (opt-in server + token); structural review and commit/PR gates |
 | content-engine | Platform-native social content and repurposing |
 | crosspost | Multi-platform content distribution across X, LinkedIn, Threads |
 | deep-research | Multi-source research with synthesis and source attribution |

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -105,7 +105,7 @@
       "env": {
         "CS_ACCESS_TOKEN": "YOUR_CS_ACCESS_TOKEN_HERE"
       },
-      "description": "CodeScene Code Health — structural review, score deltas, commit/PR safeguards for AI-assisted coding. Free standalone token: https://codescene.com/product/code-health-mcp"
+      "description": "Optional. CodeScene Code Health MCP (community skill: codehealth-mcp). Not enabled by default — copy only if you opt in. Requires your own CS_ACCESS_TOKEN (no bundled credentials). See skills/codehealth-mcp/SKILL.md for data boundaries and failure behavior."
     },
     "magic": {
       "command": "npx",

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -99,6 +99,14 @@
       "args": ["-y", "@upstash/context7-mcp@latest"],
       "description": "Live documentation lookup — use with /docs command and documentation-lookup skill (resolve-library-id, query-docs)."
     },
+    "codescene": {
+      "command": "npx",
+      "args": ["-y", "@codescene/codehealth-mcp"],
+      "env": {
+        "CS_ACCESS_TOKEN": "YOUR_CS_ACCESS_TOKEN_HERE"
+      },
+      "description": "CodeScene Code Health — structural review, score deltas, commit/PR safeguards for AI-assisted coding. Free standalone token: https://codescene.com/product/code-health-mcp"
+    },
     "magic": {
       "command": "npx",
       "args": ["-y", "@magicuidesign/mcp@latest"],

--- a/skills/codehealth-mcp/SKILL.md
+++ b/skills/codehealth-mcp/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: codehealth-mcp
+description: Real-time structural Code Health via CodeScene MCP — review before edits, verify score deltas after changes, gate commits and PRs. Use when reviewing code quality, refactoring, checking if AI changes degraded a file, or before commit/PR.
+origin: community
+---
+
+# Code Health MCP (CodeScene)
+
+Structural maintainability feedback for AI-assisted coding. Complements style/lint skills (`coding-standards`, `plankton-code-quality`) with **design-level** health scores and regression gates.
+
+**Product:** [CodeScene Code Health MCP](https://codescene.com/product/code-health-mcp)  
+**Package:** `@codescene/codehealth-mcp` (stdio via npx)
+
+## When to Activate
+
+- User asks to **review code quality**, **refactor** a file, or check if **AI changes degraded** maintainability
+- Before editing a **hotspot**, legacy module, or unfamiliar file
+- Before **commit** or **pull request** when you need a maintainability safeguard
+- After a large agent-written diff — verify Code Health did not regress
+- Pair with `verification-loop`, `tdd-workflow`, or `/quality-gate` as a structural check (not a replacement for tests/lint)
+
+## MCP setup
+
+### 1. Enable the server
+
+Copy the `codescene` entry from `mcp-configs/mcp-servers.json` into your harness MCP config.
+
+**Claude Code** (`~/.claude.json` → `mcpServers`):
+
+```json
+"codescene": {
+  "command": "npx",
+  "args": ["-y", "@codescene/codehealth-mcp"],
+  "env": {
+    "CS_ACCESS_TOKEN": "YOUR_CS_ACCESS_TOKEN_HERE"
+  }
+}
+```
+
+**Project-scoped:** merge the same block into `.mcp.json` at the repo root.
+
+### 2. Standalone token (free)
+
+Get a token from [codescene.com/product/code-health-mcp](https://codescene.com/product/code-health-mcp).  
+No paid CodeScene platform account required for the tools below.
+
+Restart the session and confirm the `codescene` MCP server is connected before calling tools.
+
+## Standalone tools only (no paid account)
+
+| Tool | When to use |
+|------|-------------|
+| `code_health_review` | Full structural analysis **before** modifying a file |
+| `code_health_score` | Quick numeric score after each change (delta check) |
+| `pre_commit_code_health_safeguard` | Block commits that introduce Code Health regressions |
+| `analyze_change_set` | Branch-level check **before** opening a PR |
+
+Do **not** call platform-only tools (e.g. repository-wide technical debt hotspot lists). Do **not** reference `delta_analysis` — not available on standalone.
+
+## Code Health scores (1–10)
+
+| Range | Meaning | Agent behavior |
+|-------|---------|----------------|
+| **9.0–10.0** | Green — healthy | Safer to extend; still prefer vertical slices |
+| **4.0–8.9** | Yellow — debt | Tread carefully; no drive-by refactors |
+| **1.0–3.9** | Red — severe debt | Narrow scope only |
+
+## Workflow
+
+### Before touching a file
+
+1. Run `code_health_review` on the target path.
+2. Record baseline score and listed code smells.
+3. Plan the smallest change that addresses the task.
+
+**Scope by score:**
+
+- **Below 5** — Problematic: minimal diff only; no broad refactors.
+- **5–7** — Warning: fix what you came for; do not expand scope.
+- **Above 7** — Safer to refactor; still verify after each edit.
+
+### After each change
+
+1. Run `code_health_score` on the same file.
+2. Compare to the baseline from `code_health_review`.
+3. If the score **regressed**, fix before continuing. Never mark the task done while the score is lower than when you started.
+
+### Before every commit
+
+Run `pre_commit_code_health_safeguard` on the repository path. If gates fail, fix degradations before committing.
+
+### Before a PR
+
+Run `analyze_change_set` against the base branch (e.g. `main`). Resolve file-level degradations before opening the PR.
+
+## AGENTS.md / CLAUDE.md block
+
+Paste into the project agent instructions:
+
+```md
+## Code Health (CodeScene MCP)
+
+Before modifying any file: run `code_health_review`, note score and issues.
+
+- Score below 5: problematic range — scope changes narrowly.
+- Score 5–7: warning range — no broad refactors.
+
+After each change: run `code_health_score` to verify delta.
+
+- If score regressed: fix before continuing; never declare done if score dropped.
+
+Before every commit: run `pre_commit_code_health_safeguard`.
+
+Before PR: run `analyze_change_set`.
+```
+
+## Pairing with ECC
+
+| ECC skill / flow | Code Health MCP role |
+|------------------|----------------------|
+| `coding-standards` | Style/naming; Code Health = structure/complexity |
+| `plankton-code-quality` | Write-time lint/format; Code Health = pre/post edit structural gate |
+| `verification-loop` / `/quality-gate` | Add structural regression check before "done" |
+| `security-review` | Security vs maintainability — use both when relevant |
+| `tdd-workflow` | Tests pass ≠ healthy design — check score after refactors |
+
+**Context tip:** ECC recommends keeping MCP count low. Enable `codescene` when doing substantive edits; disable when not needed.
+
+## Anti-patterns
+
+```markdown
+# BAD: Edit first, check later
+[large refactor without code_health_review]
+
+# BAD: Ignore score drop
+"Tests pass" → mark task done while Code Health decreased
+
+# BAD: Broad refactor on red-score file (below 5)
+Drive-by cleanup across the module
+
+# GOOD: review → small change → score → commit safeguard → analyze_change_set
+```
+
+## Example outcome
+
+On `pallets/flask`, review → targeted refactor → score verification improved Code Health from **4.82 → 9.1** using only standalone MCP tools (free token).
+
+## Related Skills
+
+- `coding-standards` — baseline conventions
+- `plankton-code-quality` — write-time lint/format hooks
+- `verification-loop` — build/test/lint gate
+- `tdd-workflow` — test-first development
+- `security-review` — security checklist
+- `documentation-lookup` — library docs via Context7 (orthogonal)

--- a/skills/codehealth-mcp/SKILL.md
+++ b/skills/codehealth-mcp/SKILL.md
@@ -8,8 +8,18 @@ origin: community
 
 Structural maintainability feedback for AI-assisted coding. Complements style/lint skills (`coding-standards`, `plankton-code-quality`) with **design-level** health scores and regression gates.
 
-**Product:** [CodeScene Code Health MCP](https://codescene.com/product/code-health-mcp)  
+**Upstream:** [codescene-oss/codescene-mcp-server](https://github.com/codescene-oss/codescene-mcp-server)  
 **Package:** `@codescene/codehealth-mcp` (stdio via npx)
+
+## Security and boundaries
+
+**Opt-in (ECC):** The `codescene` block in `mcp-configs/mcp-servers.json` is a template only. ECC plugin installs do not auto-enable bundled MCP servers. Copy the entry into your config only if you want it. You can exclude it during ECC install/sync with `ECC_DISABLED_MCPS=codescene,...`.
+
+**Credentials:** No bundled token. Set `CS_ACCESS_TOKEN` yourself (see [getting-a-personal-access-token.md](https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/getting-a-personal-access-token.md) in the upstream repo). Never commit tokens to the repo.
+
+**What the tools read:** When invoked, tools analyze files and git state **in the local repository** you point them at (paths you pass, plus branch context for `analyze_change_set`). They do not run by themselves. For standalone mode, follow upstream privacy docs: [codescene-mcp-server README](https://github.com/codescene-oss/codescene-mcp-server#frequently-asked-questions) and [CodeScene policies](https://codescene.com/policies). Do not use this skill for secrets, credentials, or paths you do not want analyzed.
+
+**If the MCP is unavailable (offline, bad token, server crash):** Do not invent Code Health scores. Tell the user the check was skipped. Continue only with explicit user approval. Prefer lint/tests/verification-loop for gating when MCP is down. Re-enable checks once the server connects.
 
 ## When to Use
 
@@ -43,7 +53,7 @@ Copy the `codescene` entry from `mcp-configs/mcp-servers.json` into your harness
 
 **Project-scoped:** merge the same block into `.mcp.json` at the repo root.
 
-Get a free standalone token from [codescene.com/product/code-health-mcp](https://codescene.com/product/code-health-mcp) — no paid CodeScene platform account required. Restart the session and confirm the `codescene` server is connected.
+Token setup is documented in the upstream repo (link above). Standalone mode does not require a paid CodeScene platform account for the four tools listed below. Restart the session and confirm the `codescene` server is connected before relying on scores.
 
 ### 2. Call standalone tools only
 

--- a/skills/codehealth-mcp/SKILL.md
+++ b/skills/codehealth-mcp/SKILL.md
@@ -11,7 +11,7 @@ Structural maintainability feedback for AI-assisted coding. Complements style/li
 **Product:** [CodeScene Code Health MCP](https://codescene.com/product/code-health-mcp)  
 **Package:** `@codescene/codehealth-mcp` (stdio via npx)
 
-## When to Activate
+## When to Use
 
 - User asks to **review code quality**, **refactor** a file, or check if **AI changes degraded** maintainability
 - Before editing a **hotspot**, legacy module, or unfamiliar file
@@ -19,9 +19,13 @@ Structural maintainability feedback for AI-assisted coding. Complements style/li
 - After a large agent-written diff — verify Code Health did not regress
 - Pair with `verification-loop`, `tdd-workflow`, or `/quality-gate` as a structural check (not a replacement for tests/lint)
 
-## MCP setup
+## When to Activate
 
-### 1. Enable the server
+Same triggers as **When to Use** above — this heading is what ECC uses for skill auto-activation.
+
+## How It Works
+
+### 1. Connect the MCP server
 
 Copy the `codescene` entry from `mcp-configs/mcp-servers.json` into your harness MCP config.
 
@@ -39,14 +43,9 @@ Copy the `codescene` entry from `mcp-configs/mcp-servers.json` into your harness
 
 **Project-scoped:** merge the same block into `.mcp.json` at the repo root.
 
-### 2. Standalone token (free)
+Get a free standalone token from [codescene.com/product/code-health-mcp](https://codescene.com/product/code-health-mcp) — no paid CodeScene platform account required. Restart the session and confirm the `codescene` server is connected.
 
-Get a token from [codescene.com/product/code-health-mcp](https://codescene.com/product/code-health-mcp).  
-No paid CodeScene platform account required for the tools below.
-
-Restart the session and confirm the `codescene` MCP server is connected before calling tools.
-
-## Standalone tools only (no paid account)
+### 2. Call standalone tools only
 
 | Tool | When to use |
 |------|-------------|
@@ -57,7 +56,7 @@ Restart the session and confirm the `codescene` MCP server is connected before c
 
 Do **not** call platform-only tools (e.g. repository-wide technical debt hotspot lists). Do **not** reference `delta_analysis` — not available on standalone.
 
-## Code Health scores (1–10)
+### 3. Interpret scores (1–10)
 
 | Range | Meaning | Agent behavior |
 |-------|---------|----------------|
@@ -65,37 +64,43 @@ Do **not** call platform-only tools (e.g. repository-wide technical debt hotspot
 | **4.0–8.9** | Yellow — debt | Tread carefully; no drive-by refactors |
 | **1.0–3.9** | Red — severe debt | Narrow scope only |
 
-## Workflow
+### 4. Run the feedback loop
 
-### Before touching a file
+**Before touching a file**
 
 1. Run `code_health_review` on the target path.
 2. Record baseline score and listed code smells.
 3. Plan the smallest change that addresses the task.
 
-**Scope by score:**
+Scope by score: **below 5** — minimal diff only; **5–7** — no broad refactors; **above 7** — safer to refactor, still verify after each edit.
 
-- **Below 5** — Problematic: minimal diff only; no broad refactors.
-- **5–7** — Warning: fix what you came for; do not expand scope.
-- **Above 7** — Safer to refactor; still verify after each edit.
-
-### After each change
+**After each change**
 
 1. Run `code_health_score` on the same file.
 2. Compare to the baseline from `code_health_review`.
 3. If the score **regressed**, fix before continuing. Never mark the task done while the score is lower than when you started.
 
-### Before every commit
+**Before every commit** — run `pre_commit_code_health_safeguard` on the repository path.
 
-Run `pre_commit_code_health_safeguard` on the repository path. If gates fail, fix degradations before committing.
+**Before a PR** — run `analyze_change_set` against the base branch (e.g. `main`).
 
-### Before a PR
+## Examples
 
-Run `analyze_change_set` against the base branch (e.g. `main`). Resolve file-level degradations before opening the PR.
+### Example: Flask maintainability improvement
 
-## AGENTS.md / CLAUDE.md block
+On `pallets/flask`, an agent loop using only standalone tools:
 
-Paste into the project agent instructions:
+1. `code_health_review` on a target module (baseline **4.82**)
+2. Targeted refactor addressing listed smells
+3. `code_health_score` after each edit
+4. `pre_commit_code_health_safeguard` before commit
+5. `analyze_change_set` before PR
+
+Result: Code Health **4.82 → 9.1** (free standalone token only).
+
+### Example: AGENTS.md enforcement block
+
+Paste into the project `AGENTS.md` or `CLAUDE.md`:
 
 ```md
 ## Code Health (CodeScene MCP)
@@ -114,19 +119,7 @@ Before every commit: run `pre_commit_code_health_safeguard`.
 Before PR: run `analyze_change_set`.
 ```
 
-## Pairing with ECC
-
-| ECC skill / flow | Code Health MCP role |
-|------------------|----------------------|
-| `coding-standards` | Style/naming; Code Health = structure/complexity |
-| `plankton-code-quality` | Write-time lint/format; Code Health = pre/post edit structural gate |
-| `verification-loop` / `/quality-gate` | Add structural regression check before "done" |
-| `security-review` | Security vs maintainability — use both when relevant |
-| `tdd-workflow` | Tests pass ≠ healthy design — check score after refactors |
-
-**Context tip:** ECC recommends keeping MCP count low. Enable `codescene` when doing substantive edits; disable when not needed.
-
-## Anti-patterns
+### Example: anti-patterns vs correct loop
 
 ```markdown
 # BAD: Edit first, check later
@@ -141,9 +134,17 @@ Drive-by cleanup across the module
 # GOOD: review → small change → score → commit safeguard → analyze_change_set
 ```
 
-## Example outcome
+## Pairing with ECC
 
-On `pallets/flask`, review → targeted refactor → score verification improved Code Health from **4.82 → 9.1** using only standalone MCP tools (free token).
+| ECC skill / flow | Code Health MCP role |
+|------------------|----------------------|
+| `coding-standards` | Style/naming; Code Health = structure/complexity |
+| `plankton-code-quality` | Write-time lint/format; Code Health = pre/post edit structural gate |
+| `verification-loop` / `/quality-gate` | Add structural regression check before "done" |
+| `security-review` | Security vs maintainability — use both when relevant |
+| `tdd-workflow` | Tests pass ≠ healthy design — check score after refactors |
+
+**Context tip:** ECC recommends keeping MCP count low. Enable `codescene` when doing substantive edits; disable when not needed.
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

Adds **codehealth-mcp** - a community skill for the [CodeScene Code Health MCP](https://codescene.com/product/code-health-mcp)  plus a bundled `codescene` entry in `mcp-configs/mcp-servers.json`.

Fills a gap called out in ECC's domain coverage: **structural maintainability** for AI-assisted edits (complements `coding-standards`, `plankton-code-quality`, and `verification-loop`).

## Type

- [x] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] MCP config

## Standalone scope (free token)

Documents only four tools (no paid CodeScene account):

- `code_health_review`
- `code_health_score`
- `pre_commit_code_health_safeguard`
- `analyze_change_set`

Does not reference `delta_analysis` or platform-only hotspot tools.

## Workflow

review → edit → score delta → commit safeguard → branch analysis before PR

## Example

On `pallets/flask`, that loop improved Code Health **4.82 → 9.1** (standalone token only).

## Testing

- [ ] Copied skill to `~/.claude/skills/codehealth-mcp/`
- [ ] Added `codescene` MCP with `CS_ACCESS_TOKEN`
- [ ] `code_health_review` + `code_health_score` on a sample file
- [ ] Skill auto-activates on "review code quality" / refactor prompts

## Checklist

- [x] Follows ECC SKILL.md format (`When to Activate`, `Related Skills`, `origin: community`)
- [x] Under 500 lines
- [x] No secrets in repo (placeholder env var only)
- [x] README tree + Codex table updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `codehealth-mcp` skill and an optional `codescene` MCP config powered by `@codescene/codehealth-mcp` for structural Code Health reviews, score checks, and commit/PR gates. Clarifies opt-in usage, local analysis boundaries, and behavior when the MCP is offline.

- **New Features**
  - `skills/codehealth-mcp/SKILL.md` with When to Use, setup, 1–10 score bands, loop examples, and an enforcement block; adds a Security and boundaries section (opt-in, no bundled credentials, local-read scope, offline behavior).
  - `codescene` in `mcp-configs/mcp-servers.json` using `CS_ACCESS_TOKEN`; optional and not enabled by default.
  - Standalone tools documented: `code_health_review`, `code_health_score`, `pre_commit_code_health_safeguard`, `analyze_change_set` (excludes platform-only tools).
  - README updated to list the skill and note opt-in.

- **Migration**
  - Set `CS_ACCESS_TOKEN` and copy the `codescene` server block into your MCP config (user or project).
  - Restart the session; enable only if you opt in.

<sup>Written for commit 43a44a4b54cbed06674f69e407ab2d81b14e7ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Code Health MCP skill for structural maintainability scoring and regression gates (CodeScene-powered).
  * Registered a new, opt-in MCP server configuration to enable the skill.

* **Documentation**
  * Added comprehensive setup and usage docs covering token setup, score ranges (green/yellow/red), recommended workflows, agent instructions, anti-patterns, and integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->