### PR TITLE
Neutralize public ECC metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![Perl](https://img.shields.io/badge/-Perl-39457E?logo=perl&logoColor=white)
 ![Markdown](https://img.shields.io/badge/-Markdown-000000?logo=markdown&logoColor=white)
 
-> **182K+ stars** | **28K+ forks** | **170+ contributors** | **12+ language ecosystems** | **Anthropic Hackathon Winner**
+> **182K+ stars** | **28K+ forks** | **170+ contributors** | **12+ language ecosystems** | **Cross-harness agent workflows**
 
 ---
 
@@ -34,11 +34,11 @@
 
 ---
 
-**The harness-native operator system for agentic work. From an Anthropic hackathon winner.**
+**The harness-native operator system for agentic work. Built from real-world multi-harness engineering workflows.**
 
 Not just configs. A complete system: skills, instincts, memory optimization, continuous learning, security scanning, and research-first development. Production-ready agents, skills, hooks, rules, MCP configurations, and legacy command shims evolved over 10+ months of intensive daily use building real products.
 
-Works across **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Gemini**, **Zed**, **GitHub Copilot**, and other AI agent harnesses.
+Works across **Codex**, **Claude Code**, **Cursor**, **OpenCode**, **Gemini**, **Zed**, **GitHub Copilot**, and other AI agent harnesses.
 
 ECC v2.0.0-rc.1 adds the public Hermes operator story on top of that reusable layer: start with the [Hermes setup guide](docs/HERMES-SETUP.md), then review the [rc.1 release notes](docs/releases/2.0.0-rc.1/release-notes.md) and [cross-harness architecture](docs/architecture/cross-harness.md).
 
@@ -86,12 +86,12 @@ This repo is the raw code only. The guides explain everything.
 <tr>
 <td width="33%">
 <a href="https://x.com/affaanmustafa/status/2012378465664745795">
-<img src="./assets/images/guides/shorthand-guide.png" alt="The Shorthand Guide to Everything Claude Code" />
+<img src="./assets/images/guides/shorthand-guide.png" alt="The Shorthand Guide to ECC" />
 </a>
 </td>
 <td width="33%">
 <a href="https://x.com/affaanmustafa/status/2014040193557471352">
-<img src="./assets/images/guides/longform-guide.png" alt="The Longform Guide to Everything Claude Code" />
+<img src="./assets/images/guides/longform-guide.png" alt="The Longform Guide to ECC" />
 </a>
 </td>
 <td width="33%">

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
   "name": "ecc-universal",
   "version": "2.0.0-rc.1",
-  "description": "Harness-native agent operating system for Claude Code, Codex, OpenCode, Cursor, Gemini, and terminal workflows - skills, hooks, rules, MCP conventions, and operator control-plane patterns",
+  "description": "Harness-native agent operating system for Codex, OpenCode, Cursor, Gemini, Claude Code, and terminal workflows - skills, hooks, rules, MCP conventions, and operator control-plane patterns",
   "publishConfig": {
     "access": "public"
   },
   "keywords": [
-    "claude-code",
     "ai",
     "agents",
     "skills",
     "hooks",
     "mcp",
     "rules",
-    "claude",
-    "anthropic",
+    "harness",
+    "agent-harness",
     "tdd",
     "code-review",
     "security",


### PR DESCRIPTION
## Summary
- Move the README first viewport from Anthropic-specific proof text to neutral cross-harness ECC positioning.
- Reorder supported harnesses so Codex/open harnesses are first without removing factual Claude Code compatibility.
- Update npm package metadata by replacing Claude/Anthropic-specific keywords with harness-native discovery terms.

## Verification
- `npm run catalog:check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Neutralized ECC public messaging to be cross-harness, not Anthropic-specific. Updated README and `ecc-universal` `package.json`: prioritized Codex/OpenCode in the harness list and replaced Anthropic/Claude keywords with harness-native terms.

<sup>Written for commit 4267b5eee9478c283f0dc1834ab2b9c0bf868684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2083?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package metadata and project description to reflect expanded workflow coverage across multiple development IDEs, code editors, and terminal environments, emphasizing harness-native operator system capabilities.
  * Refreshed project marketing materials with updated tagline, hero section badges, and guide naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->