### PR TITLE
feat(mcp): add parallel-search server catalog entry

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -97,10 +97,7 @@
     "parallel-search": {
       "type": "http",
       "url": "https://search.parallel.ai/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_PARALLEL_API_KEY_HERE"
-      },
-      "description": "Parallel Web Search — LLM-optimized web_search and web_fetch tools that take an objective + queries and return citation-backed excerpts in a single call (replaces multiple keyword searches). Works key-free for anonymous use (remove the headers block); set Authorization: Bearer with a key from platform.parallel.ai for higher rate limits."
+      "description": "Parallel Web Search — LLM-optimized web_search and web_fetch tools that take an objective + queries and return citation-backed excerpts in a single call (replaces multiple keyword searches). Works key-free for anonymous use. For higher rate limits, add a headers block: { \"Authorization\": \"Bearer YOUR_PARALLEL_API_KEY_HERE\" } using a key from platform.parallel.ai."
     },
     "context7": {
       "command": "npx",

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -94,6 +94,14 @@
       },
       "description": "Web search, research, and data ingestion via Exa API — prefer task-scoped use for broader research after GitHub search and primary docs"
     },
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_PARALLEL_API_KEY_HERE"
+      },
+      "description": "Parallel Web Search — LLM-optimized web_search and web_fetch tools that take an objective + queries and return citation-backed excerpts in a single call (replaces multiple keyword searches). Works key-free for anonymous use (remove the headers block); set Authorization: Bearer with a key from platform.parallel.ai for higher rate limits."
+    },
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"],


### PR DESCRIPTION
## Summary
Adds the hosted **Parallel Web Search** MCP server (`https://search.parallel.ai/mcp`) to `mcp-configs/mcp-servers.json`, alongside the existing `exa-web-search` entry.

Parallel's Search MCP exposes two tools (`web_search`, `web_fetch`) that take an *objective + queries* and return citation-backed excerpts in a single call — designed to replace multi-step keyword searches and reduce token use during research / docs lookup workflows.

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] MCP server catalog entry

## Details
- **Transport:** Streamable HTTP
- **Auth:** anonymous use works out of the box; `Authorization: Bearer YOUR_PARALLEL_API_KEY` (from [platform.parallel.ai](https://platform.parallel.ai)) unlocks higher rate limits. Users can remove the `headers` block for key-free use.
- **Placement:** inserted directly after `exa-web-search` to keep web-search options grouped.
- **Docs:** https://docs.parallel.ai/integrations/mcp/search-mcp

## Testing
- `python3 -m json.tool mcp-configs/mcp-servers.json` validates JSON.
- Connected to the server via `claude mcp add --transport http parallel-search https://search.parallel.ai/mcp` and confirmed `web_search` / `web_fetch` tools register.

## Checklist
- [x] Follows existing entry format (mirrors `exa-web-search`, `vercel`, `browser-use` shape)
- [x] Tested locally with Claude Code
- [x] No sensitive info (placeholder key only)
- [x] Clear description

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the hosted Parallel Web Search MCP server (`https://search.parallel.ai/mcp`) to `mcp-configs/mcp-servers.json`, alongside `exa-web-search`, exposing `web_search` and `web_fetch` for citation-backed results in a single call. The entry is key-free by default (no headers block); to raise rate limits, add an `Authorization: Bearer YOUR_PARALLEL_API_KEY_HERE` header.

<sup>Written for commit a2e2a7f6172b3accace3d1292c83b753724a2f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2085?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Parallel Web Search server configuration enabling HTTP-based integration with an external search endpoint.
  * Configuration includes descriptive guidance for using the service, including optional Authorization header usage for authenticated requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->