### PR TITLE
fix: guard two script edge cases (tolerant package.json parse, set -u empty array)

### DIFF
--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -499,7 +499,7 @@ function getRepoChecks(rootDir) {
       scopes: ['repo'],
       path: 'package.json',
       description: 'Test script runs validator chain before tests',
-      pass: typeof packageJson.scripts?.test === 'string' && packageJson.scripts.test.includes('validate-commands.js') && packageJson.scripts.test.includes('tests/run-all.js'),
+      pass: typeof packageJson?.scripts?.test === 'string' && packageJson?.scripts?.test.includes('validate-commands.js') && packageJson?.scripts?.test.includes('tests/run-all.js'),
       fix: 'Update package.json test script to run validators plus tests/run-all.js.',
     },
     {

--- a/scripts/harness-audit.js
+++ b/scripts/harness-audit.js
@@ -386,7 +386,7 @@ function findPluginInstall(rootDir) {
 }
 
 function getRepoChecks(rootDir) {
-  const packageJson = JSON.parse(readText(rootDir, 'package.json'));
+  const packageJson = safeParseJson(safeRead(rootDir, 'package.json'));
   const commandPrimary = safeRead(rootDir, 'commands/harness-audit.md').trim();
   const commandParity = safeRead(rootDir, '.opencode/commands/harness-audit.md').trim();
   const hooksJson = safeRead(rootDir, 'hooks/hooks.json');

--- a/skills/frontend-slides/scripts/export-pdf.sh
+++ b/skills/frontend-slides/scripts/export-pdf.sh
@@ -52,7 +52,7 @@ for arg in "$@"; do
             ;;
     esac
 done
-set -- "${POSITIONAL[@]}"
+set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}
 
 # --- Input validation ---
 


### PR DESCRIPTION
## Summary

Two small, independent robustness fixes found while running these scripts on macOS.

### `scripts/harness-audit.js` — tolerate a missing/invalid `package.json`

`getRepoChecks()` parses `package.json` with raw `JSON.parse(readText(...))`, whereas the rest of the file (lines 218 and 822) uses the tolerant `safeParseJson(safeRead(...))`. In `repo` target mode — reachable on a plugin-shaped repo that has no `package.json`, or one with malformed JSON — the raw parse throws an uncaught exception and crashes the whole audit instead of degrading gracefully. This change matches the file's existing convention.

### `skills/frontend-slides/scripts/export-pdf.sh` — guard empty array under `set -u`

`set -- "${POSITIONAL[@]}"` expands an empty array under `set -u` on bash 3.2 (the default `/bin/bash` on macOS), aborting with `POSITIONAL[@]: unbound variable` instead of printing the usage message when the script is run with no positional args. Guarding with `${POSITIONAL[@]+"${POSITIONAL[@]}"}` is a no-op safe under bash 3.2 `set -u`.

## Test plan

- `node -c scripts/harness-audit.js` — passes
- `bash -n skills/frontend-slides/scripts/export-pdf.sh` — passes
- `/bin/bash -c 'set -u; POSITIONAL=(); set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}'` — no longer errors (previously: `unbound variable`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve script robustness on macOS by tolerating missing/invalid package.json in the audit and preventing an unbound variable error in the slide export script. Avoids crashes and shows usage output with no args.

- **Bug Fixes**
  - scripts/harness-audit.js: use `safeParseJson(safeRead(...))` and guard with `packageJson?.scripts?.test` to avoid exceptions when package.json is missing or malformed.
  - skills/frontend-slides/scripts/export-pdf.sh: replace `set -- "${POSITIONAL[@]}"` with `set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}` to avoid "unbound variable" under bash 3.2 `set -u` when no positional args are provided.

<sup>Written for commit 6db26521a9e34cd89eeba80d853b405aeca5abdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2088?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge-case argument handling in PDF export so export works reliably when optional flags yield no positional parameters.

* **Chores**
  * Improved resilience of audit tooling and validation checks by handling missing or invalid configuration gracefully, and making test-script detection tolerant of absent entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->