### PR TITLE
fix(context-monitor): make cost warnings informational, not commands

### DIFF
--- a/scripts/hooks/ecc-context-monitor.js
+++ b/scripts/hooks/ecc-context-monitor.js
@@ -145,19 +145,19 @@ function evaluateConditions(bridge, options = {}) {
       warnings.push({
         severity: 3,
         type: 'cost',
-        message: `COST CRITICAL: Session cost is $${cost.toFixed(2)}. ` + 'Stop and inform the user about high cost before continuing.'
+        message: `COST CRITICAL: session total ~$${cost.toFixed(2)} (over $${COST_CRITICAL_USD}). Informational only — not an instruction to stop.`
       });
     } else if (cost > COST_WARNING_USD) {
       warnings.push({
         severity: 2,
         type: 'cost',
-        message: `COST WARNING: Session cost is $${cost.toFixed(2)}. ` + 'Review whether the current approach justifies the expense.'
+        message: `COST WARNING: session total ~$${cost.toFixed(2)} (over $${COST_WARNING_USD}). Informational only.`
       });
     } else if (cost > COST_NOTICE_USD) {
       warnings.push({
         severity: 1,
         type: 'cost',
-        message: `COST NOTICE: Session cost is $${cost.toFixed(2)}. ` + 'Consider whether the current approach is efficient.'
+        message: `COST NOTICE: session total ~$${cost.toFixed(2)}. Informational only.`
       });
     }
   }


### PR DESCRIPTION
## Problem
The `ecc-context-monitor` PostToolUse hook emits cost warnings via `additionalContext` with **imperative** text:
- `COST CRITICAL: Session cost is $X. Stop and inform the user about high cost before continuing.`
- `...Review whether the current approach justifies the expense.`
- `...Consider whether the current approach is efficient.`

Subagents read `additionalContext` as an instruction and obey the **"Stop"** — they abandon their task and return a prompt-for-direction instead of their result, derailing multi-agent / fan-out workflows. The main loop is also nudged to halt mid-task. (Hit this repeatedly driving an automated multi-PR session: a read-only investigator subagent bailed mid-audit.)

## Fix
Reword all three severities to pure-informational data: keep the `CRITICAL/WARNING/NOTICE` label, the dollar figure, and the threshold; drop the imperative sentence; state plainly it's informational. **No logic / severity / threshold change.**

```
- COST CRITICAL: Session cost is $X. Stop and inform the user about high cost before continuing.
+ COST CRITICAL: session total ~$X (over $50). Informational only — not an instruction to stop.
```

Existing `tests/hooks/ecc-context-monitor.test.js` passes unchanged (asserts the labels + severities, both preserved).

## Test
`node --test tests/hooks/ecc-context-monitor.test.js` → pass 1, fail 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cost warning messages have been updated to display session total costs in a clear, standardized format (~$...) and are now explicitly marked as informational notifications. Previous operational guidance has been removed to improve overall clarity, reduce user confusion, and enhance transparency in cost monitoring communications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/ECC/pull/2091?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cost warnings from `ecc-context-monitor` informational instead of commands, so subagents don’t stop mid-task. Keeps labels, thresholds, and dollar amounts; only message text changed.

- **Bug Fixes**
  - Reword CRITICAL/WARNING/NOTICE messages to “Informational only” (remove “stop/review/consider”).
  - Prevents subagents and the main loop from halting in multi-agent workflows.
  - No logic, severity, or threshold changes; existing tests pass.

<sup>Written for commit a174e1226d3e8997b201141be48db6a9acd0c3d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2091?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

