### PR TITLE
feat(desktop-notify): route OSC 9 notifications through Ghostty

### DIFF
--- a/scripts/hooks/desktop-notify.js
+++ b/scripts/hooks/desktop-notify.js
@@ -154,20 +154,25 @@ function isUnderMultiplexer() {
 /**
  * Send a macOS notification.
  *
- * On iTerm2 (and not inside tmux/screen), prefers the native escape sequence
- * (ESC ] 9 ; <message> BEL) written to the parent terminal's tty. This makes
- * iTerm2 the notification owner, so clicking the notification focuses the
- * exact iTerm2 tab where Claude Code is running. The default osascript path
- * makes Script Editor the owner instead, which causes clicks to launch
- * Script Editor.
+ * On terminals that support the OSC 9 notification sequence (iTerm2 and
+ * Ghostty), and when not inside tmux/screen, prefers the native escape
+ * sequence (ESC ] 9 ; <message> BEL) written to the parent terminal's tty.
+ * This makes the terminal the notification owner, so clicking the
+ * notification focuses the exact tab/window where Claude Code is running.
+ * The default osascript path makes Script Editor the owner instead, which
+ * causes clicks to launch Script Editor.
  *
- * Falls back to osascript when not running under iTerm2, when tty discovery
- * fails, or when running inside a multiplexer that would swallow OSC 9.
+ * Falls back to osascript when not running under an OSC 9-capable terminal,
+ * when tty discovery fails, or when running inside a multiplexer that would
+ * swallow OSC 9.
  * AppleScript strings do not support backslash escapes, so we replace double
  * quotes with curly quotes and strip backslashes before embedding.
  */
 function notifyMacOS(title, body) {
-  if (process.env.TERM_PROGRAM === 'iTerm.app' && !isUnderMultiplexer()) {
+  const osc9Capable =
+    process.env.TERM_PROGRAM === 'iTerm.app' ||
+    process.env.TERM_PROGRAM === 'ghostty';
+  if (osc9Capable && !isUnderMultiplexer()) {
     try {
       const tty = findTerminalTTY();
       if (tty) {


### PR DESCRIPTION
## Problem

The `desktop-notify` hook prefers the OSC 9 notification escape (`ESC ] 9 ; <message> BEL`) so the terminal owns the notification and clicking it focuses the tab/window running Claude Code. But the capability check is hardcoded to `TERM_PROGRAM === 'iTerm.app'`.

Ghostty users therefore fall through to the `osascript` path, which makes **Script Editor** the notification owner — clicking the notification just launches Script Editor instead of focusing the terminal.

## Fix

Ghostty natively supports the **same OSC 9 sequence** as iTerm2. Adding `'ghostty'` to the OSC 9-capable check routes Ghostty through the escape path, so the notification is owned by Ghostty and clicking it focuses the Ghostty window/tab.

The surrounding logic is already terminal-agnostic:
- `findTerminalTTY()` walks the process tree for any real TTY (not iTerm-specific)
- `isUnderMultiplexer()` still guards tmux/screen, which swallow OSC 9

## Verification

Tested on Ghostty (`TERM_PROGRAM=ghostty`, `TERM=xterm-ghostty`): the notification appears owned by Ghostty and clicking it focuses the terminal. `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route macOS notifications through Ghostty using the OSC 9 escape so clicking a notification focuses the Ghostty tab/window running Claude Code. Adds `ghostty` to the OSC 9-capable `TERM_PROGRAM` check in scripts/hooks/desktop-notify.js; the `osascript` fallback and `tmux`/`screen` guard are unchanged.

<sup>Written for commit 7002119728f92af10d18157ce6c296cb35a2cf70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

