### PR TITLE
fix(hooks): stop false loop warnings and repeated identical context warnings

### DIFF
--- a/scripts/hooks/ecc-context-monitor.js
+++ b/scripts/hooks/ecc-context-monitor.js
@@ -23,7 +23,6 @@ const COST_CRITICAL_USD = 50;
 const FILES_WARNING_COUNT = 20;
 const LOOP_THRESHOLD = 3;
 const STALE_SECONDS = 60;
-const DEBOUNCE_CALLS = 5;
 
 function isEnabledEnv(value, defaultValue = true) {
   if (value === undefined || value === null || String(value).trim() === '') {
@@ -57,7 +56,7 @@ function readWarnState(sessionId) {
   try {
     return JSON.parse(fs.readFileSync(getWarnPath(sessionId), 'utf8'));
   } catch {
-    return { callsSinceWarn: 0, lastSeverity: null };
+    return { callsSinceWarn: 0, lastSeverity: null, lastMessage: null };
   }
 }
 
@@ -220,29 +219,31 @@ function run(rawInput) {
     const warnings = evaluateConditions(evalBridge, { costWarnings: costWarningsEnabled() });
     if (warnings.length === 0) return rawInput;
 
-    // Debounce logic
-    const warnState = readWarnState(sessionId);
-    warnState.callsSinceWarn = (warnState.callsSinceWarn || 0) + 1;
-
-    const topSeverity = severityLabel(warnings[0].severity);
-    const severityEscalated = topSeverity === 'critical' && warnState.lastSeverity !== 'critical';
-
-    const isFirst = !warnState.lastSeverity;
-    if (!isFirst && warnState.callsSinceWarn < DEBOUNCE_CALLS && !severityEscalated) {
-      writeWarnState(sessionId, warnState);
-      return rawInput;
-    }
-
-    // Reset debounce, emit warning
-    warnState.callsSinceWarn = 0;
-    warnState.lastSeverity = topSeverity;
-    writeWarnState(sessionId, warnState);
-
     // Combine top 2 warnings
     const message = warnings
       .slice(0, 2)
       .map(w => w.message)
       .join('\n');
+
+    // Dedupe on message content, not a call counter. The previous logic
+    // re-emitted the *same* warning every DEBOUNCE_CALLS tool calls, so a
+    // single unchanged condition (e.g. a cost figure that only refreshes at
+    // turn boundaries) printed the identical line ~20 times in one turn. Now a
+    // warning is surfaced only when its text changes (cost moved, a new file
+    // count, a new loop) or when we newly escalate to critical — genuinely new
+    // information — and is otherwise suppressed.
+    const warnState = readWarnState(sessionId);
+    const topSeverity = severityLabel(warnings[0].severity);
+    const escalatedToCritical = topSeverity === 'critical' && warnState.lastSeverity !== 'critical';
+    const sameMessage = warnState.lastMessage === message;
+
+    if (sameMessage && !escalatedToCritical) {
+      return rawInput;
+    }
+
+    warnState.lastSeverity = topSeverity;
+    warnState.lastMessage = message;
+    writeWarnState(sessionId, warnState);
 
     const output = {
       hookSpecificOutput: {

--- a/scripts/hooks/ecc-context-monitor.js
+++ b/scripts/hooks/ecc-context-monitor.js
@@ -217,7 +217,18 @@ function run(rawInput) {
     const evalBridge = isStale ? { ...bridge, context_remaining_pct: null } : bridge;
 
     const warnings = evaluateConditions(evalBridge, { costWarnings: costWarningsEnabled() });
-    if (warnings.length === 0) return rawInput;
+    if (warnings.length === 0) {
+      // Clear dedupe state when the condition resolves, so the SAME warning text
+      // recurring later (context dips, recovers, dips again; a loop that stops
+      // then restarts) is surfaced again instead of being suppressed as a
+      // duplicate. Only write when there is state to clear — most tool calls
+      // have no warning, and this keeps the common path free of disk writes.
+      const prior = readWarnState(sessionId);
+      if (prior.lastMessage) {
+        writeWarnState(sessionId, { callsSinceWarn: 0, lastSeverity: null, lastMessage: null });
+      }
+      return rawInput;
+    }
 
     // Combine top 2 warnings
     const message = warnings

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -53,13 +53,22 @@ function hashToolCall(toolName, toolInput) {
     // alone made every distinct edit to the same file collide, so a few normal
     // edits to one file looked like a stuck loop. Include the edit content so
     // different edits to the same file hash differently.
-    key = stableStringify({
-      file_path: toolInput?.file_path,
-      old_string: toolInput?.old_string,
-      new_string: toolInput?.new_string,
-      content: toolInput?.content,
-      edits: toolInput?.edits
-    }).slice(0, HASH_INPUT_LIMIT);
+    // Hash the FULL serialized payload (truncate the digest, not the input):
+    // slicing the serialized string to HASH_INPUT_LIMIT first would collapse
+    // large edits that share their first N chars, reviving the same false-loop
+    // collision for big Write/edit payloads.
+    key = crypto
+      .createHash('sha256')
+      .update(
+        stableStringify({
+          file_path: toolInput?.file_path,
+          old_string: toolInput?.old_string,
+          new_string: toolInput?.new_string,
+          content: toolInput?.content,
+          edits: toolInput?.edits
+        })
+      )
+      .digest('hex');
   } else if (toolInput?.file_path) {
     key = String(toolInput.file_path);
   } else {

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -48,6 +48,18 @@ function hashToolCall(toolName, toolInput) {
   let key = '';
   if (name === 'Bash') {
     key = String(toolInput?.command || '').slice(0, 160);
+  } else if (/^(Edit|MultiEdit|Write|NotebookEdit)$/.test(name)) {
+    // Fingerprint the actual change, not just the path. Hashing on file_path
+    // alone made every distinct edit to the same file collide, so a few normal
+    // edits to one file looked like a stuck loop. Include the edit content so
+    // different edits to the same file hash differently.
+    key = stableStringify({
+      file_path: toolInput?.file_path,
+      old_string: toolInput?.old_string,
+      new_string: toolInput?.new_string,
+      content: toolInput?.content,
+      edits: toolInput?.edits
+    }).slice(0, HASH_INPUT_LIMIT);
   } else if (toolInput?.file_path) {
     key = String(toolInput.file_path);
   } else {

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -79,6 +79,25 @@ function runTests() {
   else failed++;
 
   if (
+    test('different edits to the SAME file produce different hashes (no false loop)', () => {
+      const h1 = hashToolCall('Edit', { file_path: 'a.kt', old_string: 'foo', new_string: 'bar' });
+      const h2 = hashToolCall('Edit', { file_path: 'a.kt', old_string: 'baz', new_string: 'qux' });
+      assert.notStrictEqual(h1, h2);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('identical Edit (same file + same change) still hashes the same', () => {
+      const args = { file_path: 'a.kt', old_string: 'foo', new_string: 'bar' };
+      assert.strictEqual(hashToolCall('Edit', args), hashToolCall('Edit', { ...args }));
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('non-file tools hash by stable input to avoid false loop collisions', () => {
       const h1 = hashToolCall('Glob', { pattern: '**/*.js', path: '/repo/a' });
       const h2 = hashToolCall('Glob', { pattern: '**/*.md', path: '/repo/a' });

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -98,6 +98,20 @@ function runTests() {
   else failed++;
 
   if (
+    test('large edits diverging only after 2048 chars still hash differently', () => {
+      // Shared prefix longer than the old HASH_INPUT_LIMIT (2048) truncation
+      // point; the payloads differ only afterwards. Hashing the full payload
+      // (digest truncated, not input) must keep them distinct.
+      const prefix = 'x'.repeat(4000);
+      const h1 = hashToolCall('Write', { file_path: 'big.txt', content: prefix + 'AAA' });
+      const h2 = hashToolCall('Write', { file_path: 'big.txt', content: prefix + 'BBB' });
+      assert.notStrictEqual(h1, h2);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('non-file tools hash by stable input to avoid false loop collisions', () => {
       const h1 = hashToolCall('Glob', { pattern: '**/*.js', path: '/repo/a' });
       const h2 = hashToolCall('Glob', { pattern: '**/*.md', path: '/repo/a' });


### PR DESCRIPTION
Closes #2120.

## What

Two PostToolUse monitor noise defects (see #2120 for the plain-language writeup):

1. **False "stuck loop" warnings** — `hashToolCall` (`ecc-metrics-bridge.js`) fingerprinted `Edit`/`Write`/`MultiEdit` on `file_path` only, so distinct edits to the same file collided and tripped the loop detector. Now the hash includes the edit content (`old_string`/`new_string`/`content`/`edits`) for `Edit`/`MultiEdit`/`Write`/`NotebookEdit`; identical edits still collide as intended.
2. **Same warning repeated ~20× per turn** — `ecc-context-monitor.js` re-emitted a warning every `DEBOUNCE_CALLS` (5) tool calls even when unchanged. Because the cost figure only refreshes at Stop (turn) boundaries, one stale value printed the identical line ~20 times. Now dedupe on **message content**: surface a warning only when its text changes or on first escalation to critical; otherwise suppress. (`DEBOUNCE_CALLS` removed as now-unused.)

## Tests

- Added regression tests in `tests/hooks/ecc-metrics-bridge.test.js`: distinct edits to the same file hash differently; identical edits still match.
- `node tests/hooks/ecc-metrics-bridge.test.js` → 21 passed; `node tests/hooks/ecc-context-monitor.test.js` → 20 passed.
- Manually verified the dedupe end-to-end: first occurrence emits, identical repeats are suppressed, a changed cost re-emits.

## Risk / rollback

Hook-only change, fail-open preserved (any throw still returns input unchanged). No behavior change to genuine loops or to the first appearance of any warning. Revert the single commit to roll back.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced noisy PostToolUse warnings by preventing false "stuck loop" alerts and deduping repeated, identical context warnings. This cuts warning spam while keeping new or escalated issues visible.

- **Bug Fixes**
  - Loop detector: `hashToolCall` now fingerprints the full serialized edit payload (`old_string`/`new_string`/`content`/`edits`) for `Edit`/`MultiEdit`/`Write`/`NotebookEdit` and truncates the digest, so different edits—even past 2k chars—to the same file don’t collide; identical edits still collide as intended.
  - Context monitor: dedupe on warning message text and only emit on change or first escalation to critical; clear dedupe state when warnings resolve so later recurrences surface; removed `DEBOUNCE_CALLS`.
  - Tests: added regression coverage for distinct vs identical edit hashes and for large edits diverging after 2048 chars.

<sup>Written for commit 45d94aa9a26f228ecf25db66366469dd5f59e21e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate warning notifications by switching to message-based deduplication and clearing dedupe state when no warnings are present
  * Improved edit-loop detection to correctly distinguish different edits on the same file, preventing false loop triggers

* **Tests**
  * Added test coverage to ensure edit-operation hashing is deterministic and sensitive to content differences
<!-- end of auto-generated comment: release notes by coderabbit.ai -->