### PR TITLE
Add NEXUS to mcp-configs/mcp-servers.json (local cost/privacy proxy)

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -3,7 +3,7 @@
     "nexus": {
       "command": "nexus",
       "args": ["mcp"],
-      "description": "NEXUS — local cost/privacy proxy under the harness. Query your own usage and savings (nexus_stats / nexus_savings / nexus_recent / nexus_providers / nexus_cost_breakdown). Routes Claude Code to the cheapest capable model, learns the best provider per task, and masks secrets/PII before they ever leave the machine. Single Go binary, no cloud, no markup. Install: github.com/lynuxis2026-pixel/nexus-proxy"
+      "description": "Local cost/privacy proxy - query your own usage & savings, route to the cheapest capable model, and mask secrets/PII before egress (nexus_stats, nexus_savings, nexus_recent, nexus_providers, nexus_cost_breakdown)"
     },
     "jira": {
       "command": "uvx",

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -1,5 +1,10 @@
 {
   "mcpServers": {
+    "nexus": {
+      "command": "nexus",
+      "args": ["mcp"],
+      "description": "NEXUS — local cost/privacy proxy under the harness. Query your own usage and savings (nexus_stats / nexus_savings / nexus_recent / nexus_providers / nexus_cost_breakdown). Routes Claude Code to the cheapest capable model, learns the best provider per task, and masks secrets/PII before they ever leave the machine. Single Go binary, no cloud, no markup. Install: github.com/lynuxis2026-pixel/nexus-proxy"
+    },
     "jira": {
       "command": "uvx",
       "args": ["mcp-atlassian==0.21.0"],


### PR DESCRIPTION
Follow-up to #2123 — the small, focused change proposed there: one new entry in `mcp-configs/mcp-servers.json` for **NEXUS** (https://github.com/lynuxis2026-pixel/nexus-proxy), a local single-binary cost/privacy proxy that runs under the harness.

Adding it lets an ECC agent introspect its own usage mid-session via these MCP tools:

- `nexus_stats` — requests, cost, tokens, cache savings
- `nexus_savings` — saved $ and % vs all-Claude
- `nexus_recent` — recent requests (provider / model / cost / latency)
- `nexus_providers` — configured providers + tiers
- `nexus_cost_breakdown` — cost grouped by provider

**Opt-in, zero dependency:** it's a single JSON entry; nothing runs unless a user has `nexus` installed and enables it. NEXUS is MIT, one Go binary, no cloud, no token markup. Happy to tweak the wording or add a docs line if you'd prefer.

Stack-them guide: https://github.com/lynuxis2026-pixel/nexus-proxy/blob/main/docs/agent-harnesses.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `nexus` MCP server to `mcp-configs/mcp-servers.json` for a local cost/privacy proxy that surfaces usage/savings, routes to the cheapest capable model, and masks secrets/PII. Opt-in; nothing runs unless `nexus` is installed.

<sup>Written for commit 4b72d497f1cbdef702bf78f652f8e180c29df64b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nexus MCP server configuration entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->