### PR TITLE
fix(trae): strip trailing slash so skill manifest entries are single-slash

### DIFF
--- a/.trae/install.sh
+++ b/.trae/install.sh
@@ -151,12 +151,16 @@ do_install() {
     if [ -d "$REPO_ROOT/skills" ]; then
         for d in "$REPO_ROOT/skills"/*/; do
             [ -d "$d" ] || continue
+            # Strip trailing slash so find emits single-slash paths and the
+            # prefix removal below does not leave a leading slash (which would
+            # produce double-slash manifest entries like skills/foo//bar).
+            d="${d%/}"
             skill_name="$(basename "$d")"
             target_skill_dir="$trae_full_path/skills/$skill_name"
             skill_copied=0
 
             while IFS= read -r source_file; do
-                relative_path="${source_file#$d}"
+                relative_path="${source_file#$d/}"
                 target_path="$target_skill_dir/$relative_path"
 
                 mkdir -p "$(dirname "$target_path")"


### PR DESCRIPTION
## Problem
`.trae/install.sh` recorded nested skill files in `.ecc-manifest` with a **doubled slash**, e.g. `skills/skill-comply//pyproject.toml`.

The skills loop iterates `for d in "$REPO_ROOT/skills"/*/`, so `$d` carries a trailing slash. It is used both as the `find` root and as the prefix stripped from each file path. Under bash, BSD `find` with a trailing-slash argument emits `.../skill-comply//file`, so `${source_file#$d}` leaves a leading slash — producing double-slash manifest entries that do not match the single-slash paths `uninstall.sh` expects (so uninstall could miss nested skill files).

This also caused a failing test: `tests/scripts/trae-install.test.js` → “records nested skill files and the full rules tree in the manifest”.

## Fix
Strip the trailing slash from `$d` and remove the `$d/` prefix, so `find` emits clean paths and manifest entries are single-slash.

## Verification
- The previously failing test now passes.
- Full suite: **2589/2589 passing**.
- Confirmed zero `//` entries in a freshly generated manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Trae install script to normalize skill paths and remove double slashes in `.ecc-manifest`. This restores correct uninstall behavior and fixes the failing nested skills test.

- **Bug Fixes**
  - Strip trailing slash from each skill dir and remove the `$d/` prefix so `find` outputs single-slash paths.
  - Manifest entries now match `uninstall.sh` expectations; `tests/scripts/trae-install.test.js` passes.

<sup>Written for commit 9438c5f0907b3afedbf60cb3c89b61188a904443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation script to correctly handle directory path formatting and prevent malformed entries in generated manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->