### PR TITLE
fix: surface legacy data warning in instinct-cli status

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -739,7 +739,7 @@ def _warn_legacy_data() -> None:
     print(f"    {HOMUNCULUS_DIR}")
     print()
     print("  Run the migration script to move your data:")
-    print(f"    bash {migrate_script}")
+    print(f'    bash "{migrate_script}"')
     print(f"  Or set CLV2_HOMUNCULUS_DIR={legacy_dir} to use the legacy path.")
     print(f"{'!'*60}\n")
 

--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -728,16 +728,18 @@ def _warn_legacy_data() -> None:
     if not legacy_files:
         return
 
+    migrate_script = Path(__file__).resolve().parent / "migrate-homunculus.sh"
+
     print(f"\n{'!'*60}")
-    print(f"  LEGACY DATA DETECTED")
+    print("  LEGACY DATA DETECTED")
     print(f"{'!'*60}")
     print(f"  Found {len(legacy_files)} file(s) in legacy path:")
     print(f"    {legacy_dir}")
-    print(f"  Active data directory:")
+    print("  Active data directory:")
     print(f"    {HOMUNCULUS_DIR}")
     print()
-    print(f"  Run the migration script to move your data:")
-    print(f"    bash skills/continuous-learning-v2/scripts/migrate-homunculus.sh")
+    print("  Run the migration script to move your data:")
+    print(f"    bash {migrate_script}")
     print(f"  Or set CLV2_HOMUNCULUS_DIR={legacy_dir} to use the legacy path.")
     print(f"{'!'*60}\n")
 

--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -703,8 +703,43 @@ def cmd_status(args) -> int:
                 days_left = max(0, PENDING_TTL_DAYS - item["age_days"])
                 print(f"    - {item['name']} ({days_left}d remaining)")
 
+    # Legacy data warning
+    _warn_legacy_data()
+
     print(f"\n{'='*60}\n")
     return 0
+
+
+def _warn_legacy_data() -> None:
+    """Warn if legacy ~/.claude/homunculus/ contains data while the active
+    path has moved to the XDG directory."""
+    legacy_dir = Path.home() / ".claude" / "homunculus"
+    if legacy_dir == HOMUNCULUS_DIR:
+        return  # CLV2_HOMUNCULUS_DIR explicitly points at the legacy path
+    if not legacy_dir.is_dir():
+        return
+
+    # Count substantive files (skip empty dirs and the directory itself)
+    try:
+        legacy_files = [f for f in legacy_dir.rglob("*") if f.is_file()]
+    except (PermissionError, OSError):
+        print(f"\n  Note: legacy directory exists but cannot be read: {legacy_dir}", file=sys.stderr)
+        return
+    if not legacy_files:
+        return
+
+    print(f"\n{'!'*60}")
+    print(f"  LEGACY DATA DETECTED")
+    print(f"{'!'*60}")
+    print(f"  Found {len(legacy_files)} file(s) in legacy path:")
+    print(f"    {legacy_dir}")
+    print(f"  Active data directory:")
+    print(f"    {HOMUNCULUS_DIR}")
+    print()
+    print(f"  Run the migration script to move your data:")
+    print(f"    bash skills/continuous-learning-v2/scripts/migrate-homunculus.sh")
+    print(f"  Or set CLV2_HOMUNCULUS_DIR={legacy_dir} to use the legacy path.")
+    print(f"{'!'*60}\n")
 
 
 def _print_instincts_by_domain(instincts: list[dict]) -> None:

--- a/tests/scripts/instinct-cli-projects.test.js
+++ b/tests/scripts/instinct-cli-projects.test.js
@@ -219,6 +219,65 @@ test('projects merge deduplicates instincts, appends observations, and removes s
   }
 });
 
+test('status warns when legacy ~/.claude/homunculus contains files', () => {
+  const root = createTempDir();
+  try {
+    const legacyDir = path.join(root, 'home', '.claude', 'homunculus', 'instincts', 'personal');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'old-instinct.yaml'), '---\nid: old\n---\nOld instinct.\n');
+
+    const result = runCli(root, ['status']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.match(result.stdout, /LEGACY DATA DETECTED/);
+    assert.match(result.stdout, /legacy path/i);
+    assert.match(result.stdout, /migration script/i);
+  } finally {
+    cleanupDir(root);
+  }
+});
+
+test('status does not warn when legacy dir is empty', () => {
+  const root = createTempDir();
+  try {
+    const legacyDir = path.join(root, 'home', '.claude', 'homunculus');
+    fs.mkdirSync(legacyDir, { recursive: true });
+
+    const result = runCli(root, ['status']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /LEGACY DATA DETECTED/);
+  } finally {
+    cleanupDir(root);
+  }
+});
+
+test('status does not warn when no legacy dir exists', () => {
+  const root = createTempDir();
+  try {
+    const result = runCli(root, ['status']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /LEGACY DATA DETECTED/);
+  } finally {
+    cleanupDir(root);
+  }
+});
+
+test('status does not warn when CLV2_HOMUNCULUS_DIR points at legacy path', () => {
+  const root = createTempDir();
+  try {
+    const legacyDir = path.join(root, 'home', '.claude', 'homunculus', 'instincts', 'personal');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'active.yaml'), '---\nid: active\n---\nActive.\n');
+
+    const result = runCli(root, ['status'], {
+      env: { CLV2_HOMUNCULUS_DIR: path.join(root, 'home', '.claude', 'homunculus') },
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /LEGACY DATA DETECTED/);
+  } finally {
+    cleanupDir(root);
+  }
+});
+
 test('status migrates legacy no-remote linked worktree project dirs to main worktree id', () => {
   const root = createTempDir();
   const repoParent = createTempDir();


### PR DESCRIPTION
## Summary

- Add `_warn_legacy_data()` to `instinct-cli status` so users with data in the legacy `~/.claude/homunculus/` directory see a clear, actionable warning instead of silently getting "No instincts found"
- Wrap the legacy directory scan in `try/except (PermissionError, OSError)` to avoid crashing when permissions are insufficient
- Add 4 test cases covering: legacy files present, empty legacy dir, no legacy dir, and `CLV2_HOMUNCULUS_DIR` explicitly set to legacy path

Closes #2036

## Test plan

- [x] `node tests/scripts/instinct-cli-projects.test.js` — 9/9 passed (4 new + 5 existing)
- [x] Python syntax check passes
- [ ] Manual verification: create `~/.claude/homunculus/instincts/personal/test.yaml`, run `python3 instinct-cli.py status`, confirm `LEGACY DATA DETECTED` warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a legacy data warning in `instinct-cli status` when instincts are still under `~/.claude/homunculus/`. This explains “No instincts found” and points users to migrate or set `CLV2_HOMUNCULUS_DIR`.

- **Bug Fixes**
  - Added `_warn_legacy_data()` to `cmd_status`; shows legacy file count, paths, and how to migrate or override.
  - Resolve the migrate script path relative to `instinct-cli.py` and quote it to handle spaces; removed unused f-strings (ruff F541).
  - Suppress the warning when `CLV2_HOMUNCULUS_DIR` already points to the legacy path.
  - Handle unreadable legacy dirs (PermissionError/OSError) and add four tests for legacy present/empty/missing and env override. Fixes #2036.

<sup>Written for commit 61fecda0012d5b668877d583d121356ab422b72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The status command now detects legacy homunculus data and displays a “LEGACY DATA DETECTED” warning with counts and steps to migrate or resolve it.

* **Tests**
  * Added tests covering warning emission, suppression, empty-legacy cases, and respect for configured homunculus paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->