### PR TITLE
docs: quote pip extras install example

### DIFF
--- a/skills/django-celery/SKILL.md
+++ b/skills/django-celery/SKILL.md
@@ -22,7 +22,7 @@ Production-grade patterns for background task processing in Django using Celery 
 ### Installation
 
 ```bash
-pip install celery[redis] django-celery-results django-celery-beat
+pip install 'celery[redis]' django-celery-results django-celery-beat
 ```
 
 ### `celery.py` — App Entrypoint


### PR DESCRIPTION
## Summary
- Quote the `celery[redis]` extra in the Django Celery installation example.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `skills/django-celery/SKILL.md`
- This does not change any generated skill behavior or dependencies.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search checked for quote/pip/extras terms.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote `celery[redis]` in the Django Celery `pip` install example to prevent shell bracket expansion (e.g., zsh) and ensure correct installation. Docs-only change; no behavior or dependencies affected.

<sup>Written for commit 413ac1d587031b22ad2836bd0954be4df516463c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Django-Celery skill installation instructions with corrected package specifier formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->