### PR TITLE
fix(llm): align Claude provider with current Anthropic API

### DIFF
--- a/src/llm/cli/selector.py
+++ b/src/llm/cli/selector.py
@@ -105,9 +105,9 @@ def interactive_select(
     if models_per_provider is None:
         models_per_provider = {
             "claude": [
-                ("claude-opus-4-5", "Claude Opus 4.5 - Most capable"),
-                ("claude-sonnet-4-7", "Claude Sonnet 4.7 - Balanced"),
-                ("claude-haiku-4-7", "Claude Haiku 4.7 - Fast"),
+                ("claude-opus-4-8", "Claude Opus 4.8 - Most capable"),
+                ("claude-sonnet-4-6", "Claude Sonnet 4.6 - Balanced"),
+                ("claude-haiku-4-5", "Claude Haiku 4.5 - Fast"),
             ],
             "openai": [
                 ("gpt-4o", "GPT-4o - Most capable"),

--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -13,7 +13,14 @@ from llm.core.interface import (
     LLMProvider,
     RateLimitError,
 )
-from llm.core.types import LLMInput, LLMOutput, Message, ModelInfo, ProviderType, ToolCall
+from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, Role, ToolCall
+
+_DEFAULT_MODEL = "claude-sonnet-4-6"
+_OPUS_ADAPTIVE_ONLY_PREFIXES = ("claude-opus-4-7", "claude-opus-4-8")
+
+
+def _uses_adaptive_thinking_only(model: str) -> bool:
+    return any(model.startswith(prefix) for prefix in _OPUS_ADAPTIVE_ONLY_PREFIXES)
 
 
 class ClaudeProvider(LLMProvider):
@@ -23,44 +30,53 @@ class ClaudeProvider(LLMProvider):
         self.client = Anthropic(api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"), base_url=base_url)
         self._models = [
             ModelInfo(
-                name="claude-opus-4-5",
+                name="claude-opus-4-8",
                 provider=ProviderType.CLAUDE,
                 supports_tools=True,
                 supports_vision=True,
-                max_tokens=8192,
-                context_window=200000,
+                max_tokens=64000,
+                context_window=1_000_000,
             ),
             ModelInfo(
-                name="claude-sonnet-4-7",
+                name="claude-sonnet-4-6",
                 provider=ProviderType.CLAUDE,
                 supports_tools=True,
                 supports_vision=True,
-                max_tokens=8192,
-                context_window=200000,
+                max_tokens=64000,
+                context_window=1_000_000,
             ),
             ModelInfo(
-                name="claude-haiku-4-7",
+                name="claude-haiku-4-5",
                 provider=ProviderType.CLAUDE,
                 supports_tools=True,
-                supports_vision=False,
-                max_tokens=4096,
-                context_window=200000,
+                supports_vision=True,
+                max_tokens=16000,
+                context_window=200_000,
             ),
         ]
 
     def generate(self, input: LLMInput) -> LLMOutput:
         try:
+            model = input.model or _DEFAULT_MODEL
+            system_parts = [msg.content for msg in input.messages if msg.role == Role.SYSTEM]
+            api_messages = [
+                msg.to_dict() for msg in input.messages if msg.role not in (Role.SYSTEM,)
+            ]
+
             params: dict[str, Any] = {
-                "model": input.model or "claude-sonnet-4-7",
-                "messages": [msg.to_dict() for msg in input.messages],
-                "temperature": input.temperature,
+                "model": model,
+                "messages": api_messages,
+                "max_tokens": input.max_tokens if input.max_tokens else 16000,
+                "cache_control": {"type": "ephemeral"},
             }
-            if input.max_tokens:
-                params["max_tokens"] = input.max_tokens
-            else:
-                params["max_tokens"] = 8192  # required by Anthropic API
+            if system_parts:
+                params["system"] = "\n\n".join(system_parts)
             if input.tools:
                 params["tools"] = [tool.to_anthropic_tool() for tool in input.tools]
+            if not _uses_adaptive_thinking_only(model):
+                params["temperature"] = input.temperature
+            if _uses_adaptive_thinking_only(model):
+                params["thinking"] = {"type": "adaptive"}
 
             response = self.client.messages.create(**params)
 
@@ -94,6 +110,10 @@ class ClaudeProvider(LLMProvider):
                 usage={
                     "input_tokens": response.usage.input_tokens,
                     "output_tokens": response.usage.output_tokens,
+                    "cache_creation_input_tokens": getattr(
+                        response.usage, "cache_creation_input_tokens", 0
+                    ),
+                    "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0),
                 },
                 stop_reason=response.stop_reason,
             )
@@ -114,4 +134,4 @@ class ClaudeProvider(LLMProvider):
         return bool(self.client.api_key)
 
     def get_default_model(self) -> str:
-        return "claude-sonnet-4-7"
+        return _DEFAULT_MODEL


### PR DESCRIPTION
## Summary

- Replace invalid ECC Claude model IDs (`claude-sonnet-4-7`, `claude-haiku-4-7`, `claude-opus-4-5`) with current Anthropic API IDs (`claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-8`).
- Default provider model is now `claude-sonnet-4-6` (the previous default would fail at the API).
- Route `Role.SYSTEM` messages to the top-level `system` field instead of embedding them in `messages`.
- Enable ephemeral prompt caching (`cache_control`) and expose `cache_read_input_tokens` / `cache_creation_input_tokens` in usage.
- Omit `temperature` for Opus 4.7/4.8 (API returns 400) and set `thinking: {type: "adaptive"}` for those models.
- Update the interactive CLI model picker labels/IDs to match.

## Test plan

- [x] Local smoke test: `PYTHONPATH=src python3` exercises `ClaudeProvider.generate` with a fake client (default model, caching param, Opus adaptive thinking).
- [ ] Existing unit tests: `pytest tests/test_claude_provider.py` (requires pytest in environment).
- [ ] Manual: run ECC LLM CLI with Claude provider and confirm model list + successful API call with `ANTHROPIC_API_KEY` set.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Claude provider with the current Anthropic API to stop model ID errors and improve request handling. Updates the default model, system prompt routing, caching, and the CLI model picker.

- **Bug Fixes**
  - Replaced invalid model IDs with current ones: claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5.
  - Default model is now claude-sonnet-4-6 to avoid API failures.
  - Omit temperature for Opus 4.7/4.8 to prevent 400 errors.

- **New Features**
  - Route `Role.SYSTEM` content to the top-level `system` field.
  - Enable ephemeral prompt caching and expose `cache_read_input_tokens` and `cache_creation_input_tokens` in usage.
  - Set `thinking: { type: "adaptive" }` for Opus 4.7/4.8.
  - Update CLI model picker labels/IDs and model metadata (tokens/context).

<sup>Written for commit ccf5ce197135d7bc30ed35ace00ff3dc32f7fcfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added adaptive-thinking capability for specific Claude models
  * Implemented automatic system message extraction and cache control for Claude requests

* **Updates**
  * Updated Claude model versions: Opus 4.8, Sonnet 4.6, Haiku 4.5
  * Improved token handling with increased default limit to 16,000 tokens
  * Enhanced usage tracking with cache-related token counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->