### PR TITLE
fix: classify 19 orphaned skills into install modules

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -181,7 +181,15 @@
         "skills/springboot-patterns",
         "skills/springboot-tdd",
         "skills/springboot-verification",
-        "skills/ui-to-vue"
+        "skills/ui-to-vue",
+        "skills/accessibility",
+        "skills/design-system",
+        "skills/motion-foundations",
+        "skills/motion-patterns",
+        "skills/motion-advanced",
+        "skills/nextjs-turbopack",
+        "skills/vite-patterns",
+        "skills/hexagonal-architecture"
       ],
       "targets": [
         "claude",
@@ -215,7 +223,8 @@
         "skills/jpa-patterns",
         "skills/mysql-patterns",
         "skills/postgres-patterns",
-        "skills/prisma-patterns"
+        "skills/prisma-patterns",
+        "skills/redis-patterns"
       ],
       "targets": [
         "claude",
@@ -261,7 +270,15 @@
         "skills/strategic-compact",
         "skills/tdd-workflow",
         "skills/verification-loop",
-        "skills/windows-desktop-e2e"
+        "skills/windows-desktop-e2e",
+        "skills/git-workflow",
+        "skills/codebase-onboarding",
+        "skills/repo-scan",
+        "skills/documentation-lookup",
+        "skills/context-budget",
+        "skills/architecture-decision-records",
+        "skills/opensource-pipeline",
+        "skills/safety-guard"
       ],
       "targets": [
         "claude",
@@ -593,7 +610,8 @@
         "skills/swift-actor-persistence",
         "skills/swift-concurrency-6-2",
         "skills/swift-protocol-di-testing",
-        "skills/swiftui-patterns"
+        "skills/swiftui-patterns",
+        "skills/ios-icon-gen"
       ],
       "targets": [
         "claude",
@@ -638,7 +656,8 @@
         "skills/regex-vs-llm-structured-text",
         "skills/search-first",
         "skills/token-budget-advisor",
-        "skills/team-builder"
+        "skills/team-builder",
+        "skills/agent-payment-x402"
       ],
       "targets": [
         "claude",


### PR DESCRIPTION
## Problem

`skills/` ships 228 skills, but 49 of them appear in **no module's `paths`** in `manifests/install-modules.json`. Because the installer only copies skills that belong to a module — and even the `full` profile installs "all currently *classified* modules" — these 49 are unreachable by **every** profile, including `full`. Notable casualties: `git-workflow`, `accessibility`, `design-system`, `redis-patterns`, and the `motion-*` set.

## Fix

Classifies 19 of those orphans into the most appropriate existing modules (purely additive — no skills moved between modules):

- **framework-language**: accessibility, design-system, motion-foundations, motion-patterns, motion-advanced, nextjs-turbopack, vite-patterns, hexagonal-architecture
- **workflow-quality**: git-workflow, codebase-onboarding, repo-scan, documentation-lookup, context-budget, architecture-decision-records, opensource-pipeline, safety-guard
- **database**: redis-patterns
- **swift-apple**: ios-icon-gen
- **agentic-patterns**: agent-payment-x402

## Verification

- `install-modules.json` still parses as valid JSON.
- Orphan count (skills on disk not classified into any module) drops **49 → 30**.

The remaining 30 orphans (healthcare, homelab, and other niche domains) are left for a follow-up so this PR stays reviewable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies 19 previously orphaned skills into existing install modules so they are installed by all profiles, including full. Orphan skills drop from 49 to 30.

- **Bug Fixes**
  - framework-language: accessibility, design-system, motion-foundations, motion-patterns, motion-advanced, nextjs-turbopack, vite-patterns, hexagonal-architecture
  - workflow-quality: git-workflow, codebase-onboarding, repo-scan, documentation-lookup, context-budget, architecture-decision-records, opensource-pipeline, safety-guard
  - database: redis-patterns
  - swift-apple: ios-icon-gen
  - agentic-patterns: agent-payment-x402

<sup>Written for commit 2ebfecc14a45cc22ecabf3c65cf4c0b791191d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded available skills and modules across multiple categories including framework languages, database patterns, workflow quality, iOS development, and agentic patterns to provide broader capabilities for development and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->