### PR TITLE
fix: shrink default OpenCode install surface and gate hooks-runtime

### DIFF
--- a/manifests/install-profiles.json
+++ b/manifests/install-profiles.json
@@ -11,6 +11,14 @@
         "workflow-quality"
       ]
     },
+    "opencode": {
+      "description": "Default OpenCode setup with commands, platform configs, and quality workflow support. It intentionally excludes hooks-runtime; opt in with --modules hooks-runtime.",
+      "modules": [
+        "commands-core",
+        "platform-configs",
+        "workflow-quality"
+      ]
+    },
     "core": {
       "description": "Minimal harness baseline with commands, hooks, platform configs, and quality workflow support.",
       "modules": [

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -111,6 +111,18 @@ const LEGACY_LANGUAGE_EXTRA_MODULE_IDS = Object.freeze({
   swift: [],
   typescript: ['framework-language'],
 });
+const TARGET_DEFAULT_PROFILE_IDS = Object.freeze({
+  opencode: 'opencode',
+});
+const TARGET_DEFAULT_EXCLUSIONS = Object.freeze({
+  opencode: [
+    {
+      moduleId: 'hooks-runtime',
+      reason: 'OpenCode defaults intentionally exclude hooks-runtime until users opt in.',
+      optInCommand: './install.sh --target opencode --modules hooks-runtime',
+    },
+  ],
+});
 
 function readJson(filePath, label) {
   try {
@@ -416,6 +428,22 @@ function expandComponentIdsToModuleIds(componentIds, manifests) {
   return dedupeStrings(expandedModuleIds);
 }
 
+function getTargetDefaultProfileId(target, manifests) {
+  const profileId = target ? TARGET_DEFAULT_PROFILE_IDS[target] : null;
+  return profileId && manifests.profiles[profileId] ? profileId : null;
+}
+
+function getTargetDefaultExclusions(target, manifests) {
+  const exclusions = target ? TARGET_DEFAULT_EXCLUSIONS[target] : null;
+  if (!Array.isArray(exclusions)) {
+    return [];
+  }
+
+  return exclusions
+    .filter(exclusion => manifests.modulesById.has(exclusion.moduleId))
+    .map(exclusion => ({ ...exclusion }));
+}
+
 function resolveLegacyCompatibilitySelection(options = {}) {
   const manifests = loadInstallManifests(options);
   const target = options.target || null;
@@ -471,11 +499,29 @@ function resolveLegacyCompatibilitySelection(options = {}) {
 
 function resolveInstallPlan(options = {}) {
   const manifests = loadInstallManifests(options);
-  const profileId = options.profileId || null;
+  const requestedProfileId = options.profileId || null;
   const explicitModuleIds = dedupeStrings(options.moduleIds);
   const includedComponentIds = dedupeStrings(options.includeComponentIds);
   const excludedComponentIds = dedupeStrings(options.excludeComponentIds);
   const requestedModuleIds = [];
+  const target = options.target || null;
+
+  if (target && !SUPPORTED_INSTALL_TARGETS.includes(target)) {
+    throw new Error(
+      `Unknown install target: ${target}. Expected one of ${SUPPORTED_INSTALL_TARGETS.join(', ')}`
+    );
+  }
+
+  const shouldUseTargetDefaultProfile = !requestedProfileId
+    && explicitModuleIds.length === 0
+    && includedComponentIds.length === 0;
+  const targetDefaultProfileId = shouldUseTargetDefaultProfile
+    ? getTargetDefaultProfileId(target, manifests)
+    : null;
+  const profileId = requestedProfileId || targetDefaultProfileId;
+  const targetDefaultExclusions = targetDefaultProfileId
+    ? getTargetDefaultExclusions(target, manifests)
+    : [];
 
   if (profileId) {
     const profile = manifests.profiles[profileId];
@@ -501,13 +547,12 @@ function resolveInstallPlan(options = {}) {
       excludedModuleOwners.set(moduleId, owners);
     }
   }
-
-  const target = options.target || null;
-  if (target && !SUPPORTED_INSTALL_TARGETS.includes(target)) {
-    throw new Error(
-      `Unknown install target: ${target}. Expected one of ${SUPPORTED_INSTALL_TARGETS.join(', ')}`
-    );
+  for (const exclusion of targetDefaultExclusions) {
+    const owners = excludedModuleOwners.get(exclusion.moduleId) || [];
+    owners.push(`${target} default`);
+    excludedModuleOwners.set(exclusion.moduleId, owners);
   }
+
   const validatedProjectRoot = readOptionalStringOption(options, 'projectRoot');
   const validatedHomeDir = readOptionalStringOption(options, 'homeDir');
   const targetPlanningInput = target
@@ -533,7 +578,10 @@ function resolveInstallPlan(options = {}) {
 
   const selectedIds = new Set();
   const skippedTargetIds = new Set();
-  const excludedIds = new Set(excludedModuleIds);
+  const excludedIds = new Set([
+    ...excludedModuleIds,
+    ...targetDefaultExclusions.map(exclusion => exclusion.moduleId),
+  ]);
   const visitingIds = new Set();
   const resolvedIds = new Set();
 
@@ -622,6 +670,12 @@ function resolveInstallPlan(options = {}) {
     explicitModuleIds,
     includedComponentIds,
     excludedComponentIds,
+    targetDefaultProfileId,
+    targetDefaultExclusions,
+    warnings: targetDefaultExclusions.map(exclusion => (
+      `${exclusion.moduleId} is intentionally excluded from the OpenCode default. `
+        + `Opt in with: ${exclusion.optInCommand}`
+    )),
     selectedModuleIds: selectedModules.map(module => module.id),
     skippedModuleIds: skippedModules.map(module => module.id),
     excludedModuleIds: excludedModules.map(module => module.id),


### PR DESCRIPTION
## What Changed

A new `opencode` profile in `manifests/install-profiles.json` ships only `commands-core`, `platform-configs`, and `workflow-quality`, intentionally excluding `hooks-runtime`. `scripts/lib/install-manifests.js` selects this profile as the default when an OpenCode install requests no explicit profile, modules, or components, and registers `hooks-runtime` as a target-default exclusion so it is dropped from the resolved plan with a warning naming the opt-in command `./install.sh --target opencode --modules hooks-runtime`. An explicit `--modules hooks-runtime` still installs it.

## Why This Change

Issue #2079 reports that installing ECC into OpenCode Desktop with the full module set (including `hooks-runtime`) makes the provider go silent after restart; deleting `.opencode` restores it. The owner labeled it P1 and asked ECC to make the default OpenCode install smaller and gate `hooks-runtime` behind an explicit opt-in, which is repo-side install ergonomics rather than an OpenCode change. Claude Code defaults are untouched.

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Verified the default OpenCode plan selects only the three safe modules and excludes `hooks-runtime`, that explicit `--modules hooks-runtime` still installs it, that the Claude default profile is unchanged, and that the plan output names the excluded module and opt-in command.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (N/A: the warning text emitted at install time already names the opt-in command; no separate docs page covers install profiles)
- [x] Added comments for complex logic
- [ ] README updated (if needed)

Fixes #2079


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the OpenCode default install smaller and disable `hooks-runtime` by default to prevent the post-restart silence reported in #2079. Adds a new `opencode` profile and a target-level exclusion with a clear opt-in path.

- **Bug Fixes**
  - Added `opencode` profile with `commands-core`, `platform-configs`, `workflow-quality`.
  - Default to this profile when `--target opencode` and no profile/modules/components are provided.
  - Exclude `hooks-runtime` by default; plan prints warning with opt-in: ./install.sh --target opencode --modules hooks-runtime
  - Explicit `--modules hooks-runtime` still installs it.
  - Other targets remain unchanged (Claude defaults unaffected).

<sup>Written for commit 31f35562552a6024371cf09d69d161a8cb5b26a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `opencode` installation profile with default setup including core commands, platform configurations, and quality workflow.

* **Chores**
  * Updated installation configuration to apply target-specific defaults. The `hooks-runtime` module is now opt-in only via `--modules hooks-runtime` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->