### PR TITLE
Fix claude-project target for legacy language installs

### DIFF
--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -262,18 +262,16 @@ function isDirectoryNonEmpty(dirPath) {
   return fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory() && fs.readdirSync(dirPath).length > 0;
 }
 
-function planClaudeLegacyInstall(context) {
-  const adapter = getInstallTargetAdapter('claude');
-  const targetRoot = adapter.resolveRoot({ homeDir: context.homeDir });
-  const rulesDir = context.claudeRulesDir || path.join(targetRoot, 'rules', CLAUDE_ECC_NAMESPACE);
-  const installStatePath = adapter.getInstallStatePath({ homeDir: context.homeDir });
+function planClaudeStyleLegacyInstall(context, { adapterId, adapterRootInput, rulesDir: rulesDirOverride }) {
+  const adapter = getInstallTargetAdapter(adapterId);
+  const targetRoot = adapter.resolveRoot(adapterRootInput);
+  const rulesDir = rulesDirOverride || path.join(targetRoot, 'rules', CLAUDE_ECC_NAMESPACE);
+  const installStatePath = adapter.getInstallStatePath(adapterRootInput);
   const operations = [];
   const warnings = [];
 
   if (isDirectoryNonEmpty(rulesDir)) {
-    warnings.push(
-      `Destination ${rulesDir}/ already exists and files may be overwritten`
-    );
+    warnings.push(`Destination ${rulesDir}/ already exists and files may be overwritten`);
   }
 
   addRecursiveCopyOperations(operations, {
@@ -285,9 +283,7 @@ function planClaudeLegacyInstall(context) {
 
   for (const language of context.languages) {
     if (!LANGUAGE_NAME_PATTERN.test(language)) {
-      warnings.push(
-        `Invalid language name '${language}'. Only alphanumeric, dash, and underscore are allowed`
-      );
+      warnings.push(`Invalid language name '${language}'. Only alphanumeric, dash, and underscore are allowed`);
       continue;
     }
 
@@ -308,7 +304,7 @@ function planClaudeLegacyInstall(context) {
   return {
     mode: 'legacy',
     adapter,
-    target: 'claude',
+    target: adapterId,
     targetRoot,
     installRoot: rulesDir,
     installStatePath,
@@ -316,6 +312,22 @@ function planClaudeLegacyInstall(context) {
     warnings,
     selectedModules: ['legacy-claude-rules'],
   };
+}
+
+function planClaudeLegacyInstall(context) {
+  return planClaudeStyleLegacyInstall(context, {
+    adapterId: 'claude',
+    adapterRootInput: { homeDir: context.homeDir },
+    rulesDir: context.claudeRulesDir || null,
+  });
+}
+
+function planClaudeProjectLegacyInstall(context) {
+  return planClaudeStyleLegacyInstall(context, {
+    adapterId: 'claude-project',
+    adapterRootInput: { repoRoot: context.projectRoot },
+    rulesDir: null,
+  });
 }
 
 function planCursorLegacyInstall(context) {
@@ -503,6 +515,8 @@ function createLegacyInstallPlan(options = {}) {
   let plan;
   if (target === 'claude') {
     plan = planClaudeLegacyInstall(context);
+  } else if (target === 'claude-project') {
+    plan = planClaudeProjectLegacyInstall(context);
   } else if (target === 'cursor') {
     plan = planCursorLegacyInstall(context);
   } else {

--- a/scripts/lib/install/request.js
+++ b/scripts/lib/install/request.js
@@ -2,7 +2,7 @@
 
 const { validateInstallModuleIds, LOCALE_ALIAS_TO_COMPONENT_ID, listSupportedLocales } = require('../install-manifests');
 
-const LEGACY_INSTALL_TARGETS = ['claude', 'cursor', 'antigravity'];
+const LEGACY_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity'];
 
 function dedupeStrings(values) {
   return [...new Set((Array.isArray(values) ? values : []).map(value => String(value).trim()).filter(Boolean))];


### PR DESCRIPTION
## Summary

Fixes legacy language installation flow to accept the `claude-project` target.

Previously, running:

```bash
./install.sh --target claude-project python typescript
```

failed during target validation because `claude-project` was not included in the legacy install target allowlist.

## Changes

* Added `claude-project` to the legacy install target validation list.
* Updated request validation logic to recognize the target correctly.
* Verified with dry-run installation.

## Reproduction

Before:

```bash
./install.sh --target claude-project python typescript
```

Result:

```text
Error: Unknown install target: claude-project
```

After:

```bash
./install.sh --target claude-project python typescript --dry-run
```

Result:

```text
Mode: legacy-compat
Target: claude-project
Adapter: claude-project
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes legacy language installs for the `claude-project` target. Added the target to the legacy allowlist, wired it into `createLegacyInstallPlan`, and extracted a shared `planClaudeStyleLegacyInstall` used by both `claude` and `claude-project` to generate the correct rules plan.

<sup>Written for commit 3dd2f957fa7cf0c4f3ed778c5f152cbb01385d0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for "claude-project" as an installation target.
  * Installer now consolidates legacy install behavior for consistent handling across targets.

* **Bug Fixes / Improvements**
  * Improved handling of language rule files: validates language names, skips missing language rule directories with warnings, and surfaces overwrite/validation warnings during install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->