### PR TITLE
feat: add Kimi Code CLI support

### DIFF
--- a/.kimi/MIGRATION.md
+++ b/.kimi/MIGRATION.md
@@ -153,10 +153,10 @@ If you have project-level rules in `.claude/rules/`:
 
 ```bash
 # Copy to AGENTS.md
-cat rules/common/*.md > AGENTS.md
+cat .claude/rules/common/*.md > AGENTS.md
 
 # Add language-specific rules
-cat rules/typescript/*.md >> AGENTS.md
+cat .claude/rules/typescript/*.md >> AGENTS.md
 ```
 
 ### 5. Update Your Workflow

--- a/.kimi/MIGRATION.md
+++ b/.kimi/MIGRATION.md
@@ -1,0 +1,265 @@
+# Migration Guide: Claude Code → Kimi Code CLI
+
+This guide helps you migrate from Claude Code with ECC to Kimi Code CLI with ECC.
+
+## Overview
+
+Kimi Code CLI is a Node.js-based AI coding agent that supports plugins, hooks, skills, and subagents. ECC is fully compatible with Kimi Code CLI with some format differences.
+
+## Key Differences
+
+| Feature | Claude Code | Kimi Code CLI | Notes |
+|---------|-------------|---------------|-------|
+| Plugin Config | `.claude-plugin/plugin.json` | `kimi.plugin.json` | Different manifest format |
+| Hooks | `hooks.json` (3 phases) | `config.toml [[hooks]]` | TOML format, same events |
+| Agents | 63 custom markdown files | 3 built-in subagents (`coder`/`explore`/`plan`) | Mapped via skills |
+| Commands | `commands/*.md` | **Not supported** | Converted to Skills |
+| Rules | `~/.claude/rules/` | `AGENTS.md` + `sessionStart.skill` | Consolidated or injected |
+| Skills | `skills/*/SKILL.md` | `skills/*/SKILL.md` | **Full parity** |
+| MCP | Full support | Full support | **Full parity** |
+| Installation | `/plugin install ecc@ecc` | `/plugins` or `kimi plugin install` | Different UX |
+
+## Hook Event Mapping
+
+| Claude Code Hook | Kimi CLI Hook Event | Blockable? |
+|------------------|---------------------|------------|
+| `PreToolUse` | `PreToolUse` | ✅ Yes |
+| `PostToolUse` | `PostToolUse` | — No (observation) |
+| `Stop` | `Stop` | ✅ Yes |
+| `SessionStart` | `SessionStart` | — No (observation) |
+| `SessionEnd` | `SessionEnd` | — No (observation) |
+| `UserPromptSubmit` | `UserPromptSubmit` | ✅ Yes |
+| `SubagentStart` | `SubagentStart` | — No (observation) |
+| `SubagentStop` | `SubagentStop` | — No (observation) |
+| `PreCompact` | `PreCompact` | — No (observation) |
+| `PostCompact` | `PostCompact` | — No (observation) |
+| `Notification` | `Notification` | — No (observation) |
+
+### Hook Response Differences
+
+**Claude Code:**
+```json
+{
+  "PreToolUse": [{
+    "matcher": "Bash",
+    "hooks": [{
+      "type": "command",
+      "command": "node check-danger.js"
+    }]
+  }]
+}
+```
+
+**Kimi Code CLI (`~/.kimi-code/config.toml`):**
+```toml
+[[hooks]]
+event = "PreToolUse"
+matcher = "Bash"
+command = "node check-danger.js"
+timeout = 5
+```
+
+Kimi CLI passes event data via **stdin** as JSON, and uses **exit codes**:
+- `0` = Pass (stdout appended to context)
+- `2` = Block (stderr shown as block reason)
+- Other = Pass (fail-open)
+
+## Agent Mapping
+
+ECC's 63 agents map to Kimi CLI's 3 subagents + skills:
+
+| ECC Agent | Kimi Subagent | Skill Replacement |
+|-----------|--------------|-------------------|
+| `planner` | `plan` | `/skill:ecc-plan` |
+| `architect` | `plan` | `/skill:ecc-plan` + architecture context |
+| `code-reviewer` | `coder` | `/skill:ecc-code-review` |
+| `security-reviewer` | `coder` | `/skill:ecc-security-scan` |
+| `build-error-resolver` | `coder` | `/skill:ecc-build-fix` |
+| `tdd-guide` | `coder` | `/skill:tdd-workflow` |
+| `e2e-runner` | `coder` | `/skill:e2e-testing` |
+| `doc-updater` | `coder` | `/skill:update-docs` |
+| `refactor-cleaner` | `coder` | `/skill:refactor-clean` |
+| `go-reviewer` | `coder` | `/skill:go-review` |
+| `go-build-resolver` | `coder` | `/skill:go-build` |
+| `database-reviewer` | `coder` | `/skill:database-reviewer` |
+| `python-reviewer` | `coder` | `/skill:python-review` |
+| `rust-reviewer` | `coder` | `/skill:rust-review` |
+| `java-reviewer` | `coder` | `/skill:java-review` |
+| `cpp-reviewer` | `coder` | `/skill:cpp-review` |
+| `docs-lookup` | `explore` | `/skill:docs-lookup` |
+| `loop-operator` | `coder` | `/skill:autonomous-loops` |
+| `harness-optimizer` | `coder` | `/skill:harness-optimizer` |
+
+## Command → Skill Mapping
+
+ECC's slash commands are converted to skills in Kimi CLI:
+
+| Claude Command | Kimi Skill | Notes |
+|----------------|------------|-------|
+| `/plan` | `/skill:ecc-plan` | Implementation planning |
+| `/code-review` | `/skill:ecc-code-review` | Code review |
+| `/security` | `/skill:ecc-security-scan` | Security scan |
+| `/build-fix` | `/skill:ecc-build-fix` | Build error resolution |
+| `/tdd` | `/skill:tdd-workflow` | TDD workflow |
+| `/e2e` | `/skill:e2e-testing` | E2E testing |
+| `/refactor-clean` | `/skill:refactor-clean` | Dead code removal |
+| `/verify` | `/skill:verification-loop` | Verification loop |
+| `/eval` | `/skill:eval-harness` | Evaluation harness |
+| `/learn` | `/skill:continuous-learning-v2` | Extract patterns |
+| `/checkpoint` | `/skill:checkpoint` | Save state |
+| `/update-docs` | `/skill:update-docs` | Update docs |
+| `/test-coverage` | `/skill:test-coverage` | Coverage analysis |
+| `/go-review` | `/skill:go-review` | Go review |
+| `/go-test` | `/skill:go-test` | Go TDD |
+| `/go-build` | `/skill:go-build` | Go build fix |
+
+## Migration Steps
+
+### 1. Install Kimi Code CLI
+
+```bash
+# macOS / Linux
+curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
+
+# Windows
+irm https://code.kimi.com/kimi-code/install.ps1 | iex
+```
+
+### 2. Install ECC Plugin
+
+```bash
+# Clone ECC
+git clone https://github.com/affaan-m/ECC.git
+cd ECC
+
+# Install into Kimi CLI
+kimi plugin install .
+
+# Start new session
+kimi /new
+```
+
+### 3. Install ECC Hooks (Optional)
+
+```bash
+node .kimi/install-hooks.mjs
+```
+
+This converts ECC's hook definitions into Kimi CLI's `config.toml` format.
+
+### 4. Migrate Project Rules
+
+If you have project-level rules in `.claude/rules/`:
+
+```bash
+# Copy to AGENTS.md
+cat rules/common/*.md > AGENTS.md
+
+# Add language-specific rules
+cat rules/typescript/*.md >> AGENTS.md
+```
+
+### 5. Update Your Workflow
+
+**Before (Claude Code):**
+```
+/plan "Add user authentication"
+/code-review
+```
+
+**After (Kimi Code CLI):**
+```
+/skill:ecc-plan "Add user authentication"
+/skill:ecc-code-review
+```
+
+**Before (Claude Code with agents):**
+```
+@planner Design the auth system
+@code-reviewer Review my changes
+```
+
+**After (Kimi Code CLI with subagents):**
+```
+Use plan agent to design the auth system
+Use coder agent to review my changes
+```
+
+### 6. Migrate Custom Hooks
+
+If you have custom hooks in your project:
+
+**Claude Code format (`hooks.json`):**
+```json
+{
+  "PreToolUse": [{
+    "matcher": "Edit",
+    "hooks": [{"type": "command", "command": "prettier --write $file_path"}]
+  }]
+}
+```
+
+**Kimi CLI format (`~/.kimi-code/config.toml`):**
+```toml
+[[hooks]]
+event = "PostToolUse"
+matcher = "Edit"
+command = "prettier --write $file_path"
+timeout = 10
+```
+
+Note: Kimi CLI passes event data via stdin as JSON. Scripts need to read stdin:
+
+```javascript
+// kimi-hook.mjs
+let input = '';
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  const payload = JSON.parse(input);
+  // payload.hook_event_name, payload.tool_name, payload.tool_input, etc.
+  
+  if (shouldBlock(payload)) {
+    console.error('Blocking reason');
+    process.exit(2);
+  }
+  process.exit(0);
+});
+```
+
+## Environment Variable Compatibility
+
+| Variable | Claude Code | Kimi CLI | Notes |
+|----------|-------------|----------|-------|
+| `ECC_HOOK_PROFILE` | ✅ | ✅ | minimal/standard/strict |
+| `ECC_DISABLED_HOOKS` | ✅ | ✅ | Comma-separated IDs |
+| `ECC_SESSION_START_MAX_CHARS` | ✅ | ✅ | Context cap |
+| `ECC_SESSION_START_CONTEXT` | ✅ | ✅ | `off` to disable |
+| `ECC_CONTEXT_MONITOR_COST_WARNINGS` | ✅ | ✅ | Toggle cost warnings |
+| `ECC_GOVERNANCE_CAPTURE` | ✅ | ✅ | Enable governance |
+
+## Reverting to Claude Code
+
+If you need to switch back:
+
+1. Claude Code continues using its own config (`~/.claude/`)
+2. The `kimi.plugin.json` and `.kimi/` directory don't interfere
+3. Simply run `claude` instead of `kimi`
+
+## Feature Parity Summary
+
+| Feature | Claude Code | Kimi Code CLI | Status |
+|---------|-------------|---------------|--------|
+| Skills | 251 | 251 | **Full parity** |
+| Agents | 63 custom | 3 built-in + skills | **Functional parity** |
+| Commands | 79 | 0 (converted to skills) | **Functional parity** |
+| Hooks | 3 phases | 13 events | **Full parity + more** |
+| Rules | 8 rule packs | sessionStart + AGENTS.md | **Full parity** |
+| MCP Servers | Full | Full | **Full parity** |
+| Context mgmt | /compact | /compact | **Full parity** |
+| Subagents | Custom | Built-in | **Kimi is simpler** |
+
+## Feedback
+
+For issues specific to:
+- **Kimi Code CLI**: Report to [MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli)
+- **ECC Configuration**: Report to [github.com/affaan-m/ECC](https://github.com/affaan-m/ECC)

--- a/.kimi/README.md
+++ b/.kimi/README.md
@@ -1,0 +1,189 @@
+# ECC for Kimi Code CLI
+
+> Kimi Code CLI plugin support for ECC (Enhanced Cognitive Controller).
+
+## Overview
+
+This directory contains Kimi Code CLI-specific configuration and tools for ECC:
+
+- **`kimi.plugin.json`** (root) — Plugin manifest for Kimi Code CLI
+- **`.kimi/install-hooks.mjs`** — Script to install ECC hooks into `~/.kimi-code/config.toml`
+- **`.kimi/MIGRATION.md`** — Guide for migrating from Claude Code to Kimi Code CLI
+
+## Installation
+
+### Option 1: Install from Repository (Recommended for Development)
+
+```bash
+# Clone ECC
+git clone https://github.com/affaan-m/ECC.git
+cd ECC
+
+# Install plugin into Kimi Code CLI
+kimi plugin install .
+
+# Or install from a ZIP
+kimi plugin install https://github.com/affaan-m/ECC/archive/refs/heads/main.zip
+
+# Start a new session
+kimi /new
+```
+
+### Option 2: Install Hooks (Optional but Recommended)
+
+ECC hooks provide automatic checks, notifications, and governance:
+
+```bash
+node .kimi/install-hooks.mjs
+```
+
+This installs hooks into `~/.kimi-code/config.toml`:
+
+- **Session Start**: Load ECC context initialization
+- **PreToolUse (Bash)**: Dangerous command detection, quality checks
+- **PostToolUse (Edit)**: Auto-format, console.log warnings
+- **Stop**: Session summary for continuous learning
+- **PreCompact**: Save state before context compaction
+
+### Option 3: Install Rules to Project
+
+For project-level rules (applied to current project only):
+
+```bash
+# Copy relevant rules into AGENTS.md
+cat rules/common/coding-style.md rules/common/testing.md rules/common/security.md > AGENTS.md
+
+# Add language-specific rules
+cat rules/typescript/*.md >> AGENTS.md
+```
+
+## Usage
+
+After installation, start Kimi Code CLI:
+
+```bash
+kimi
+```
+
+ECC skills are available via `/skill:` commands:
+
+| Skill | Purpose |
+|-------|---------|
+| `/skill:ecc-plan` | Create implementation plans |
+| `/skill:ecc-code-review` | Review code for quality and security |
+| `/skill:ecc-security-scan` | Run security review |
+| `/skill:ecc-build-fix` | Fix build and type errors |
+| `/skill:tdd-workflow` | Test-driven development |
+| `/skill:security-review` | Security checklist |
+| `/skill:verification-loop` | Continuous verification |
+| `/skill:frontend-patterns` | React/Next.js patterns |
+| `/skill:backend-patterns` | API/database patterns |
+| `/skill:e2e-testing` | Playwright E2E patterns |
+
+### Agent Delegation
+
+Kimi Code CLI has three built-in subagents. ECC maps its agent workflows to them:
+
+| ECC Agent | Kimi Subagent | Use For |
+|-----------|--------------|---------|
+| planner | `plan` | Implementation planning, architecture |
+| code-reviewer | `coder` | Code review (read-only) |
+| security-reviewer | `coder` | Security analysis |
+| build-error-resolver | `coder` | Fix build/type errors |
+| tdd-guide | `coder` | TDD workflow |
+| e2e-runner | `coder` | E2E testing |
+| docs-lookup | `explore` | Codebase exploration |
+
+Example:
+```
+Use plan agent to design the authentication system
+Use explore agent to find all files related to user management
+Use coder agent to review my recent changes
+```
+
+## Hook Runtime Controls
+
+Control hook behavior with environment variables:
+
+```bash
+# Hook strictness profile (default: standard)
+export ECC_HOOK_PROFILE=standard
+
+# Disable specific hooks
+export ECC_DISABLED_HOOKS="pre:bash:tmux-reminder,post:edit:typecheck"
+
+# Cap SessionStart additional context (default: 8000 chars)
+export ECC_SESSION_START_MAX_CHARS=4000
+
+# Disable SessionStart context entirely
+export ECC_SESSION_START_CONTEXT=off
+```
+
+## Configuration Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `kimi.plugin.json` | Plugin root | Manifest (skills, sessionStart, MCP) |
+| `config.toml` | `~/.kimi-code/` | User hooks configuration |
+| `AGENTS.md` | Project root | Project-level rules |
+
+## Updating
+
+```bash
+# Reload plugin (after updates)
+kimi /plugins reload ecc
+
+# Or remove and reinstall
+kimi /plugins remove ecc
+kimi plugin install .
+```
+
+## Troubleshooting
+
+### Plugin Not Loading
+
+1. Verify `kimi.plugin.json` exists in the repository root
+2. Check JSON syntax: `cat kimi.plugin.json | python -m json.tool`
+3. Ensure `skills/` directory exists with valid `SKILL.md` files
+4. Start a new session after installing: `kimi /new`
+
+### Hooks Not Working
+
+1. Check `~/.kimi-code/config.toml` has `[[hooks]]` entries
+2. Verify hook scripts exist and are executable
+3. Check hook exit codes (0 = pass, 2 = block)
+4. Review Kimi CLI logs for hook errors
+
+### Skills Not Found
+
+1. Run `/plugins` to verify ECC is installed
+2. Check that `kimi.plugin.json` has correct `skills` path
+3. Ensure `SKILL.md` files have valid YAML frontmatter
+
+## Differences from Claude Code
+
+| Feature | Claude Code | Kimi Code CLI |
+|---------|-------------|---------------|
+| Plugin install | `/plugin install ecc@ecc` | `/plugins` → Marketplace / Local |
+| Hooks | `hooks.json` in plugin | `config.toml [[hooks]]` |
+| Agents | Custom markdown files | Built-in `coder`/`explore`/`plan` |
+| Commands | `commands/*.md` | Not supported (use Skills) |
+| Rules | `~/.claude/rules/` | `AGENTS.md` or sessionStart skill |
+| Marketplace | Self-hosted | Official + Local |
+
+## Feature Parity
+
+| ECC Feature | Kimi CLI Status |
+|-------------|-----------------|
+| 251 Skills | ✅ Full parity (SKILL.md compatible) |
+| 63 Agents | ⚠️ Mapped to 3 built-in subagents + skills |
+| 79 Commands | ⚠️ Converted to Skills |
+| Hooks | ✅ Full parity (via config.toml) |
+| Rules | ✅ Full parity (via sessionStart + AGENTS.md) |
+| MCP Servers | ✅ Full parity |
+| Session Start Context | ✅ Full parity |
+| Continuous Learning | ✅ Supported |
+
+## License
+
+MIT — Same as ECC core.

--- a/.kimi/README.md
+++ b/.kimi/README.md
@@ -50,8 +50,9 @@ This installs hooks into `~/.kimi-code/config.toml`:
 For project-level rules (applied to current project only):
 
 ```bash
-# Copy relevant rules into AGENTS.md
-cat rules/common/coding-style.md rules/common/testing.md rules/common/security.md > AGENTS.md
+# Append ECC rules to AGENTS.md (preserves existing content)
+echo -e "\n\n# ECC Rules\n" >> AGENTS.md
+cat rules/common/coding-style.md rules/common/testing.md rules/common/security.md >> AGENTS.md
 
 # Add language-specific rules
 cat rules/typescript/*.md >> AGENTS.md

--- a/.kimi/install-hooks.mjs
+++ b/.kimi/install-hooks.mjs
@@ -239,10 +239,10 @@ process.stdin.on('end', () => {
 // Install hook scripts
 console.log('📦 Installing ECC hook scripts...\n');
 for (const hook of HOOK_DEFINITIONS) {
-  const scriptPath = path.join(HOOKS_DIR, `${hook.id}.mjs`);
+  const scriptPath = path.join(HOOKS_DIR, `${hook.id}.cjs`);
   fs.writeFileSync(scriptPath, hook.script);
   fs.chmodSync(scriptPath, 0o755);
-  console.log(`  ✓ ${hook.id}.mjs`);
+  console.log(`  ✓ ${hook.id}.cjs`);
 }
 
 // Read existing config
@@ -273,7 +273,8 @@ for (const hook of HOOK_DEFINITIONS) {
   if (hook.matcher) {
     tomlHooks += `matcher = "${hook.matcher}"\n`;
   }
-  tomlHooks += `command = "node ${path.join(HOOKS_DIR, `${hook.id}.mjs`)}"\n`;
+  const scriptPath = path.join(HOOKS_DIR, `${hook.id}.cjs`);
+  tomlHooks += `command = 'node "${scriptPath}"'\n`;
   tomlHooks += `timeout = ${hook.timeout}\n\n`;
 }
 tomlHooks += `${eccEndMarker}\n`;

--- a/.kimi/install-hooks.mjs
+++ b/.kimi/install-hooks.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * ECC Hooks Installer for Kimi Code CLI
+ *
+ * Installs ECC hooks into ~/.kimi-code/config.toml
+ * Hooks provide: dangerous command detection, quality checks,
+ * session management, and continuous learning.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const KIMI_HOME = path.join(os.homedir(), '.kimi-code');
+const CONFIG_PATH = path.join(KIMI_HOME, 'config.toml');
+const HOOKS_DIR = path.join(KIMI_HOME, 'hooks');
+const ECC_ROOT = path.resolve(__dirname, '..');
+
+// Ensure directories exist
+fs.mkdirSync(KIMI_HOME, { recursive: true });
+fs.mkdirSync(HOOKS_DIR, { recursive: true });
+
+// Core hook definitions for Kimi CLI
+// Each hook receives event data via stdin as JSON
+const HOOK_DEFINITIONS = [
+  {
+    id: 'ecc-session-start',
+    event: 'SessionStart',
+    matcher: 'startup',
+    description: 'Initialize ECC context on session start',
+    timeout: 10,
+    script: `#!/usr/bin/env node
+// ECC Session Start Hook
+// Loads baseline context and initializes session state
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const MAX_STDIN = 1024 * 1024;
+let data = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', chunk => {
+  if (data.length < MAX_STDIN) data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const payload = JSON.parse(data || '{}');
+    const cwd = payload.cwd || process.cwd();
+    
+    // Check for project-level AGENTS.md
+    const agentsMdPath = path.join(cwd, 'AGENTS.md');
+    if (fs.existsSync(agentsMdPath)) {
+      const content = fs.readFileSync(agentsMdPath, 'utf8');
+      const truncated = content.slice(0, 8000);
+      console.log('[ECC] Loaded project rules from AGENTS.md');
+      console.log('--- AGENTS.md (truncated) ---');
+      console.log(truncated);
+    }
+    
+    // Show ECC status
+    console.log('[ECC] Session initialized. Skills available via /skill:<name>');
+    console.log('[ECC] Key skills: ecc-plan, ecc-code-review, ecc-security-scan, tdd-workflow');
+  } catch (err) {
+    // fail-open
+  }
+  process.exit(0);
+});
+`,
+  },
+  {
+    id: 'ecc-danger-check',
+    event: 'PreToolUse',
+    matcher: 'Bash',
+    description: 'Block dangerous bash commands',
+    timeout: 5,
+    script: `#!/usr/bin/env node
+// ECC Dangerous Command Check
+// Blocks rm -rf /, mkfs, dd to /dev/sda, etc.
+
+const MAX_STDIN = 1024 * 1024;
+let data = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', chunk => {
+  if (data.length < MAX_STDIN) data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const payload = JSON.parse(data || '{}');
+    const command = payload.tool_input?.command ?? '';
+    
+    const DANGEROUS = [
+      'rm -rf /',
+      'rm -rf /*',
+      'rm -rf ~/',
+      'mkfs.',
+      'dd if=/dev/zero',
+      '> /dev/sda',
+      ':(){ :|:& };:',
+    ];
+    
+    for (const pattern of DANGEROUS) {
+      if (command.includes(pattern)) {
+        console.error('[ECC] BLOCKED: Dangerous command detected: ' + pattern);
+        console.error('[ECC] Command: ' + command);
+        process.exit(2);
+      }
+    }
+  } catch (err) {
+    // fail-open
+  }
+  process.exit(0);
+});
+`,
+  },
+  {
+    id: 'ecc-console-log-check',
+    event: 'PostToolUse',
+    matcher: 'Edit',
+    description: 'Warn about console.log in edited files',
+    timeout: 5,
+    script: `#!/usr/bin/env node
+// ECC Console.log Check
+// Warns when console.log is left in JS/TS files
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_STDIN = 1024 * 1024;
+let data = '';
+process.stdin.setEncoding('utf8');
+
+const EXCLUDED = [
+  /\\.test\\.[jt]sx?$/,
+  /\\.spec\\.[jt]sx?$/,
+  /\\.config\\.[jt]s$/,
+  /scripts\//,
+  /__tests__\//,
+];
+
+process.stdin.on('data', chunk => {
+  if (data.length < MAX_STDIN) data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const payload = JSON.parse(data || '{}');
+    const filePath = payload.tool_input?.file_path ?? '';
+    
+    if (!filePath.match(/\\.(ts|tsx|js|jsx)$/)) {
+      process.exit(0);
+    }
+    
+    if (EXCLUDED.some(p => p.test(filePath))) {
+      process.exit(0);
+    }
+    
+    if (fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath, 'utf8');
+      if (content.includes('console.log')) {
+        console.error('[ECC] WARNING: console.log found in ' + filePath);
+        console.error('[ECC] Remove debug statements before committing');
+      }
+    }
+  } catch (err) {
+    // fail-open
+  }
+  process.exit(0);
+});
+`,
+  },
+  {
+    id: 'ecc-stop-summary',
+    event: 'Stop',
+    description: 'Session stop summary for continuous learning',
+    timeout: 10,
+    script: `#!/usr/bin/env node
+// ECC Stop Hook
+// Generates session summary for continuous learning
+
+const MAX_STDIN = 1024 * 1024;
+let data = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', chunk => {
+  if (data.length < MAX_STDIN) data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const payload = JSON.parse(data || '{}');
+    console.log('[ECC] Session complete. Use /skill:continuous-learning-v2 to extract patterns.');
+  } catch (err) {
+    // fail-open
+  }
+  process.exit(0);
+});
+`,
+  },
+  {
+    id: 'ecc-pre-compact',
+    event: 'PreCompact',
+    matcher: 'auto',
+    description: 'Save state before automatic context compaction',
+    timeout: 5,
+    script: `#!/usr/bin/env node
+// ECC Pre-Compact Hook
+// Saves key session state before context is compacted
+
+const MAX_STDIN = 1024 * 1024;
+let data = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', chunk => {
+  if (data.length < MAX_STDIN) data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const payload = JSON.parse(data || '{}');
+    console.log('[ECC] Context compaction starting. Key decisions and plans preserved.');
+  } catch (err) {
+    // fail-open
+  }
+  process.exit(0);
+});
+`,
+  },
+];
+
+// Install hook scripts
+console.log('📦 Installing ECC hook scripts...\n');
+for (const hook of HOOK_DEFINITIONS) {
+  const scriptPath = path.join(HOOKS_DIR, `${hook.id}.mjs`);
+  fs.writeFileSync(scriptPath, hook.script);
+  fs.chmodSync(scriptPath, 0o755);
+  console.log(`  ✓ ${hook.id}.mjs`);
+}
+
+// Read existing config
+let config = '';
+if (fs.existsSync(CONFIG_PATH)) {
+  config = fs.readFileSync(CONFIG_PATH, 'utf-8');
+}
+
+// Remove existing ECC hooks to avoid duplicates
+const eccStartMarker = '# === ECC Hooks Start ===';
+const eccEndMarker = '# === ECC Hooks End ===';
+
+if (config.includes(eccStartMarker)) {
+  const startIdx = config.indexOf(eccStartMarker);
+  const endIdx = config.indexOf(eccEndMarker);
+  if (startIdx !== -1 && endIdx !== -1) {
+    config = config.slice(0, startIdx) + config.slice(endIdx + eccEndMarker.length);
+    console.log('\n🔄 Updated existing ECC hooks');
+  }
+}
+
+// Generate TOML config
+let tomlHooks = `\n${eccStartMarker}\n# ECC Hooks — Auto-installed. Edit with care.\n`;
+for (const hook of HOOK_DEFINITIONS) {
+  tomlHooks += `# ${hook.description}\n`;
+  tomlHooks += `[[hooks]]\n`;
+  tomlHooks += `event = "${hook.event}"\n`;
+  if (hook.matcher) {
+    tomlHooks += `matcher = "${hook.matcher}"\n`;
+  }
+  tomlHooks += `command = "node ${path.join(HOOKS_DIR, `${hook.id}.mjs`)}"\n`;
+  tomlHooks += `timeout = ${hook.timeout}\n\n`;
+}
+tomlHooks += `${eccEndMarker}\n`;
+
+config += tomlHooks;
+fs.writeFileSync(CONFIG_PATH, config);
+
+console.log(`\n✅ ECC hooks installed to ${CONFIG_PATH}`);
+console.log(`📁 Hook scripts: ${HOOKS_DIR}`);
+console.log(`\nInstalled hooks:`);
+for (const hook of HOOK_DEFINITIONS) {
+  console.log(`  • ${hook.event}${hook.matcher ? ` (${hook.matcher})` : ''} — ${hook.description}`);
+}
+
+console.log(`\n⚙️  Hook runtime controls:`);
+console.log(`  export ECC_HOOK_PROFILE=minimal|standard|strict`);
+console.log(`  export ECC_DISABLED_HOOKS="id1,id2"`);
+console.log(`\n🚀 Start a new Kimi session to activate: kimi /new`);

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 Not just configs. A complete system: skills, instincts, memory optimization, continuous learning, security scanning, and research-first development. Production-ready agents, skills, hooks, rules, MCP configurations, and legacy command shims evolved over 10+ months of intensive daily use building real products.
 
-Works across **Codex**, **Claude Code**, **Cursor**, **OpenCode**, **Gemini**, **Zed**, **GitHub Copilot**, and other AI agent harnesses.
+Works across **Codex**, **Claude Code**, **Cursor**, **OpenCode**, **Gemini**, **Zed**, **Kimi Code CLI**, **GitHub Copilot**, and other AI agent harnesses.
 
 ECC v2.0.0-rc.1 adds the public Hermes operator story on top of that reusable layer: start with the [Hermes setup guide](docs/HERMES-SETUP.md), then review the [rc.1 release notes](docs/releases/2.0.0-rc.1/release-notes.md) and [cross-harness architecture](docs/architecture/cross-harness.md).
 
@@ -1150,6 +1150,7 @@ Yes. ECC is cross-platform:
 - **Gemini CLI**: Experimental project-local support via `.gemini/GEMINI.md` and shared installer plumbing.
 - **OpenCode**: Full plugin support in `.opencode/`. See [OpenCode Support](#opencode-support).
 - **Codex**: First-class support for both macOS app and CLI, with adapter drift guards and SessionStart fallback. See PR [#257](https://github.com/affaan-m/ECC/pull/257).
+- **Kimi Code CLI**: Full plugin support via `kimi.plugin.json`, with 251 skills, hooks via `config.toml`, and built-in subagent delegation. See [Kimi Code CLI Support](#kimi-code-cli-support).
 - **GitHub Copilot (VS Code)**: Instruction and prompt layer via `.github/copilot-instructions.md`, `.vscode/settings.json`, and `.github/prompts/`. See [GitHub Copilot Support](#github-copilot-support).
 - **Antigravity**: Tightly integrated setup for workflows, skills, and flattened rules in `.agent/`. See [Antigravity Guide](docs/ANTIGRAVITY-GUIDE.md).
 - **JoyCode / CodeBuddy**: Project-local selective install adapters for commands, agents, skills, and flattened rules. See [JoyCode Adapter Guide](docs/JOYCODE-GUIDE.md).
@@ -1402,6 +1403,78 @@ ECC provides Zed project support through a conservative `.zed` adapter for proje
 ```
 
 The adapter writes ECC-managed files under `.zed/` and keeps BYOK/OpenRouter credentials out of the repo. Configure Zed account or API keys through Zed's own settings UI or your local user settings.
+
+---
+
+## Kimi Code CLI Support
+
+ECC provides **full Kimi Code CLI support** via the `kimi.plugin.json` manifest, with 251 skills, hooks via `~/.kimi-code/config.toml`, and built-in subagent delegation.
+
+### Quick Start
+
+```bash
+# Install Kimi Code CLI (if not already installed)
+curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
+
+# Install ECC plugin into Kimi Code CLI
+cd /path/to/ECC
+kimi plugin install .
+
+# Or install from ZIP
+kimi plugin install https://github.com/affaan-m/ECC/archive/refs/heads/main.zip
+
+# Start a new session
+kimi /new
+```
+
+### Install Hooks (Optional but Recommended)
+
+```bash
+node .kimi/install-hooks.mjs
+```
+
+This installs ECC hooks into `~/.kimi-code/config.toml` for dangerous command detection, quality checks, and session management.
+
+### Install Rules to Project
+
+```bash
+# Copy relevant rules into AGENTS.md
+cat rules/common/coding-style.md rules/common/testing.md rules/common/security.md > AGENTS.md
+```
+
+### Using ECC with Kimi Code CLI
+
+After installation, use ECC skills via `/skill:` commands:
+
+```
+/skill:ecc-plan "Add user authentication"
+/skill:ecc-code-review
+/skill:ecc-security-scan
+/skill:tdd-workflow
+/skill:verification-loop
+```
+
+Delegate to subagents using Kimi CLI's built-in agents:
+
+```
+Use plan agent to design the database schema
+Use explore agent to find all API endpoints
+Use coder agent to review my recent changes
+```
+
+### Feature Parity
+
+| Feature | Status |
+|---------|--------|
+| 251 Skills | ✅ Full parity (SKILL.md format compatible) |
+| Agents | ⚠️ Mapped to 3 built-in subagents (`coder`/`explore`/`plan`) |
+| Commands | ⚠️ Converted to Skills (`/skill:ecc-plan`, etc.) |
+| Hooks | ✅ Full parity via `config.toml [[hooks]]` |
+| Rules | ✅ Via `sessionStart.skill` + `AGENTS.md` |
+| MCP Servers | ✅ Full parity |
+| Continuous Learning | ✅ Supported |
+
+See [`.kimi/MIGRATION.md`](.kimi/MIGRATION.md) for detailed migration guide from Claude Code.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1438,8 +1438,9 @@ This installs ECC hooks into `~/.kimi-code/config.toml` for dangerous command de
 ### Install Rules to Project
 
 ```bash
-# Copy relevant rules into AGENTS.md
-cat rules/common/coding-style.md rules/common/testing.md rules/common/security.md > AGENTS.md
+# Append ECC rules to AGENTS.md (preserves existing content)
+echo -e "\n\n# ECC Rules\n" >> AGENTS.md
+cat rules/common/coding-style.md rules/common/testing.md rules/common/security.md >> AGENTS.md
 ```
 
 ### Using ECC with Kimi Code CLI

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://code.kimi.com/schema/kimi.plugin.json",
+  "name": "ecc",
+  "version": "2.0.0-rc.1",
+  "description": "Enhanced Cognitive Controller (ECC) — harness performance optimization system for Kimi Code CLI. 63 agent workflows, 251 skills, reusable hooks, rules, and operator workflows.",
+  "author": {
+    "name": "Affaan Mustafa",
+    "url": "https://x.com/affaanmustafa"
+  },
+  "homepage": "https://ecc.tools",
+  "repository": "https://github.com/affaan-m/ECC",
+  "license": "MIT",
+  "keywords": [
+    "kimi-code",
+    "agents",
+    "skills",
+    "hooks",
+    "rules",
+    "tdd",
+    "code-review",
+    "security",
+    "workflow",
+    "automation",
+    "best-practices"
+  ],
+  "skills": "./skills/",
+  "sessionStart": {
+    "skill": "ecc-session-start"
+  },
+  "skillInstructions": "You are operating with ECC (Enhanced Cognitive Controller) capabilities. When planning complex work, prefer the /skill:ecc-plan workflow. When reviewing code, use the code-review skill. For security-sensitive changes, run the security-scan skill. Always follow verification loops for critical tasks and prefer skills over ad-hoc responses.",
+  "interface": {
+    "displayName": "ECC",
+    "shortDescription": "Harness performance optimization for Kimi Code CLI",
+    "longDescription": "ECC provides 63 agent workflows, 251 skills, reusable hooks, rules, and operator workflows for Kimi Code CLI. Install hooks separately via the ECC hooks installer for full functionality.",
+    "developerName": "Affaan Mustafa",
+    "websiteURL": "https://ecc.tools"
+  },
+  "mcpServers": {}
+}

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -16,7 +16,8 @@
         "codebuddy",
         "joycode",
         "qwen",
-        "zed"
+        "zed",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -41,7 +42,8 @@
         "codebuddy",
         "joycode",
         "qwen",
-        "zed"
+        "zed",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -119,7 +121,8 @@
         "codebuddy",
         "joycode",
         "qwen",
-        "zed"
+        "zed",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -467,7 +470,7 @@
     {
       "id": "prediction-market-skills",
       "kind": "skills",
-      "description": "Public, non-advisory prediction-market and Itô basket research workflows with gated Itô API access.",
+      "description": "Public, non-advisory prediction-market and It\u00f4 basket research workflows with gated It\u00f4 API access.",
       "paths": [
         "skills/ito-basket-compare",
         "skills/ito-data-atlas-agent",

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -42,6 +42,7 @@ Targets:
   joycode      - Install commands, agents, skills, and flattened rules into ./.joycode/
   qwen         - Install commands, agents, skills, rules, and Qwen config into ~/.qwen/
   zed          - Install project settings, commands, agents, skills, and flattened rules into ./.zed/
+  kimi         - Install rules, skills, and Kimi CLI configs into ./.kimi/
 
 Options:
   --profile <name>    Resolve and install a manifest profile

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed'];
+const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed', 'kimi'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',
@@ -70,6 +70,12 @@ const LEGACY_COMPAT_BASE_MODULE_IDS_BY_TARGET = Object.freeze({
     'rules-core',
     'agents-core',
     'commands-core',
+    'platform-configs',
+    'workflow-quality',
+  ],
+  kimi: [
+    'rules-core',
+    'agents-core',
     'platform-configs',
     'workflow-quality',
   ],

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -12,6 +12,7 @@ const PLATFORM_SOURCE_PATH_OWNERS = Object.freeze({
   '.codebuddy': 'codebuddy',
   '.qwen': 'qwen',
   '.zed': 'zed',
+  '.kimi': 'kimi',
 });
 
 function normalizeRelativePath(relativePath) {

--- a/scripts/lib/install-targets/kimi-project.js
+++ b/scripts/lib/install-targets/kimi-project.js
@@ -1,0 +1,10 @@
+const { createInstallTargetAdapter } = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'kimi-project',
+  target: 'kimi',
+  kind: 'project',
+  rootSegments: ['.kimi'],
+  installStatePathSegments: ['ecc-install-state.json'],
+  nativeRootRelativePath: '.kimi',
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -6,6 +6,7 @@ const codexHome = require('./codex-home');
 const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
 const joycodeProject = require('./joycode-project');
+const kimiProject = require('./kimi-project');
 const opencodeHome = require('./opencode-home');
 const qwenHome = require('./qwen-home');
 const zedProject = require('./zed-project');
@@ -22,6 +23,7 @@ const ADAPTERS = Object.freeze([
   joycodeProject,
   qwenHome,
   zedProject,
+  kimiProject,
 ]);
 
 function listInstallTargetAdapters() {

--- a/skills/ecc-build-fix/SKILL.md
+++ b/skills/ecc-build-fix/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # /build-fix — Build Error Resolution
 
-## When to Use
+## When to Activate
 
 - Build fails (TypeScript, Webpack, Vite, etc.)
 - Type errors appear

--- a/skills/ecc-build-fix/SKILL.md
+++ b/skills/ecc-build-fix/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: ecc-build-fix
+description: Fix build and compilation errors with minimal changes. Use when builds fail or type errors occur.
+origin: ECC
+---
+
+# /build-fix — Build Error Resolution
+
+## When to Use
+
+- Build fails (TypeScript, Webpack, Vite, etc.)
+- Type errors appear
+- Compilation errors
+- Lint errors that block CI
+
+## Delegation
+
+For complex build issues, delegate to the `coder` subagent:
+
+```
+Use coder agent to fix build errors
+```
+
+## Resolution Process
+
+### 1. Identify the Error
+- Read the full error message
+- Identify the file and line number
+- Understand the error type (type mismatch, missing import, syntax, etc.)
+
+### 2. Gather Context
+- Read the affected file and surrounding code
+- Check recent changes that might have caused it
+- Look at related files (imports, dependencies)
+
+### 3. Apply Minimal Fix
+- Fix only what's needed to resolve the error
+- Don't refactor unrelated code
+- Prefer type fixes over `any` annotations
+- If adding `any` is unavoidable, add a TODO comment
+
+### 4. Verify
+- Run the build again
+- Run relevant tests
+- Check that the fix doesn't introduce new issues
+
+## Common Fixes
+
+### TypeScript
+- Missing import → Add import statement
+- Type mismatch → Fix the type or the value
+- `any` creeping in → Add proper types
+- Generic inference failure → Explicit generic parameters
+
+### Build Tools
+- Missing dependency → `npm install` the package
+- Config error → Fix config file (webpack, vite, tsconfig)
+- Path alias not resolved → Check tsconfig paths / alias config
+
+### Lint
+- Unused variable → Remove or prefix with `_`
+- Formatting → Run formatter (`prettier --write`)
+- Rule violation → Fix code or justify with eslint-disable comment
+
+## Principles
+
+- **Minimal changes**: Fix only the error, don't refactor
+- **Root cause**: Fix the cause, not just the symptom
+- **Type safety**: Avoid `any`; prefer proper types
+- **Verify**: Always run build/tests after fixing
+
+## Output Format
+
+```markdown
+## Build Fix Summary
+
+### Errors Found
+1. `[Error message]` in `file.ts:line`
+   - **Cause**: [Root cause]
+   - **Fix**: [What was changed]
+
+### Changes Made
+- `file1.ts`: [Description of change]
+- `file2.ts`: [Description of change]
+
+### Verification
+- [ ] Build passes
+- [ ] Tests pass
+- [ ] No new errors introduced
+```

--- a/skills/ecc-code-review/SKILL.md
+++ b/skills/ecc-code-review/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # /code-review — Code Review Workflow
 
-## When to Use
+## When to Activate
 
 - After writing or modifying code
 - Before committing changes

--- a/skills/ecc-code-review/SKILL.md
+++ b/skills/ecc-code-review/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ecc-code-review
+description: Review code for quality, security, and maintainability. Use after writing or modifying code. Delegates to coder subagent for large reviews.
+origin: ECC
+---
+
+# /code-review — Code Review Workflow
+
+## When to Use
+
+- After writing or modifying code
+- Before committing changes
+- When asked to review a PR or diff
+- After completing a feature
+
+## Delegation
+
+For large reviews or multi-file changes, delegate to the `coder` subagent:
+
+```
+Use coder agent to review: [description of changes]
+```
+
+## Review Process
+
+### 1. Gather Context
+- Run `git diff --staged` and `git diff` to see all changes
+- If no diff, check recent commits with `git log --oneline -5`
+- Identify the scope and purpose of changes
+
+### 2. Read Surrounding Code
+- Don't review changes in isolation
+- Read full files to understand imports, dependencies, call sites
+- Check tests for the modified code
+
+### 3. Apply Review Checklist
+
+#### Quality
+- [ ] Code is readable and well-organized
+- [ ] Functions are small and focused (single responsibility)
+- [ ] Naming is clear and consistent
+- [ ] No dead code or unused imports
+- [ ] Error handling is comprehensive
+- [ ] Edge cases are handled
+
+#### Security
+- [ ] No hardcoded secrets or credentials
+- [ ] User input is validated and sanitized
+- [ ] SQL queries are parameterized
+- [ ] Auth/authorization checks are present for sensitive paths
+- [ ] XSS prevention for web output
+- [ ] Error messages don't leak sensitive internals
+
+#### Performance
+- [ ] No unnecessary computations
+- [ ] Efficient data structures chosen
+- [ ] Database queries are optimized
+- [ ] No N+1 query problems
+
+#### Testing
+- [ ] Tests cover critical paths
+- [ ] Edge cases are tested
+- [ ] Error scenarios have tests
+- [ ] 80%+ coverage maintained
+
+#### Maintainability
+- [ ] Follows project conventions
+- [ ] Consistent with existing patterns
+- [ ] Documentation/comments where needed
+- [ ] No unnecessary complexity
+
+### 4. Confidence-Based Filtering
+
+**IMPORTANT**: Do not flood the review with noise.
+
+- **Report** if you are >80% confident it is a real issue
+- **Skip** stylistic preferences unless they violate project conventions
+- **Skip** issues in unchanged code unless CRITICAL security issues
+- **Consolidate** similar issues
+- **Prioritize** issues that could cause bugs, security vulnerabilities, or data loss
+
+## Output Format
+
+```markdown
+## Code Review: [Feature/Change]
+
+### Summary
+[1-2 sentence overall assessment: PASS with notes, or NEEDS CHANGES]
+
+### Issues Found
+| Severity | File:Line | Issue | Suggestion |
+|----------|-----------|-------|------------|
+| 🔴 Critical | `auth.ts:42` | SQL injection risk | Use parameterized query |
+| 🟡 Medium | `utils.ts:88` | Missing null check | Add `if (!data)` guard |
+| 🟢 Low | `types.ts:12` | Typo in comment | Fix spelling |
+
+### Positive Notes
+- [What's done well]
+
+### Action Items
+- [ ] [Task 1]
+- [ ] [Task 2]
+```
+
+## Severity Definitions
+
+- **🔴 Critical**: Security vulnerability, data loss risk, crash, or major bug
+- **🟡 Medium**: Bug risk, performance issue, or maintainability concern
+- **🟢 Low**: Style, documentation, or minor improvement

--- a/skills/ecc-plan/SKILL.md
+++ b/skills/ecc-plan/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # /plan — Implementation Planning
 
-## When to Use
+## When to Activate
 
 - Starting a new feature
 - Complex refactoring

--- a/skills/ecc-plan/SKILL.md
+++ b/skills/ecc-plan/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: ecc-plan
+description: Create comprehensive implementation plans for features, refactoring, and architectural changes. Use the plan subagent for complex work.
+origin: ECC
+---
+
+# /plan — Implementation Planning
+
+## When to Use
+
+- Starting a new feature
+- Complex refactoring
+- Architectural changes
+- Any multi-step implementation task
+
+## Delegation
+
+For complex plans, delegate to the `plan` subagent:
+
+```
+Use plan agent to create an implementation plan for: [task description]
+```
+
+The `plan` agent runs in isolated context, focuses purely on planning without executing code.
+
+## Planning Process
+
+### 1. Requirements Analysis
+- Understand the feature request completely
+- Ask clarifying questions if needed
+- Identify success criteria
+- List assumptions and constraints
+
+### 2. Architecture Review
+- Analyze existing codebase structure
+- Identify affected components
+- Review similar implementations
+- Consider reusable patterns
+
+### 3. Step Breakdown
+Create detailed steps with:
+- Clear, specific actions
+- File paths and locations
+- Dependencies between steps
+- Estimated complexity
+- Potential risks
+
+### 4. Implementation Order
+- Prioritize by dependencies
+- Group related changes
+- Minimize context switching
+- Enable incremental testing
+
+## Output Format
+
+```markdown
+# Implementation Plan: [Feature Name]
+
+## Overview
+1-2 sentence summary of what this plan accomplishes.
+
+## Requirements
+- [Requirement 1]
+- [Requirement 2]
+
+## Files to Modify
+| File | Change | Reason |
+|------|--------|--------|
+| `src/feature.ts` | Add new module | Core implementation |
+| `tests/feature.test.ts` | Add tests | TDD coverage |
+
+## Implementation Steps
+1. [Step 1 with specific file and action]
+2. [Step 2 with specific file and action]
+3. [Step 3 ...]
+
+## Testing Strategy
+- Unit tests for [component]
+- Integration tests for [flow]
+- E2E tests for [critical path]
+
+## Risks & Mitigation
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| [Risk 1] | High | [How to handle] |
+
+## Verification Checklist
+- [ ] All tests pass
+- [ ] 80%+ coverage
+- [ ] Security review completed
+- [ ] Documentation updated
+```
+
+## Post-Planning
+
+After creating the plan:
+1. Present it to the user for approval
+2. Break into incremental commits
+3. Execute step by step
+4. Verify each step before proceeding

--- a/skills/ecc-security-scan/SKILL.md
+++ b/skills/ecc-security-scan/SKILL.md
@@ -6,7 +6,7 @@ origin: ECC
 
 # /security-scan — Security Review
 
-## When to Use
+## When to Activate
 
 - After writing code that handles user input
 - After modifying authentication/authorization code

--- a/skills/ecc-security-scan/SKILL.md
+++ b/skills/ecc-security-scan/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: ecc-security-scan
+description: Run comprehensive security review on code changes. Use when code handles auth, user input, APIs, or sensitive data.
+origin: ECC
+---
+
+# /security-scan — Security Review
+
+## When to Use
+
+- After writing code that handles user input
+- After modifying authentication/authorization code
+- After adding API endpoints
+- After changes to data handling or storage
+- Before shipping sensitive features
+- As part of pre-commit verification
+
+## Delegation
+
+For comprehensive security reviews, delegate to the `coder` subagent:
+
+```
+Use coder agent to run security scan on: [files/changes]
+```
+
+## Security Checklist
+
+### Authentication & Authorization
+- [ ] Passwords are hashed (bcrypt/Argon2, not MD5/SHA1)
+- [ ] JWT tokens have expiration and secure signing
+- [ ] Session management is secure (httpOnly, secure, SameSite)
+- [ ] RBAC/permissions are enforced at every access point
+- [ ] No privilege escalation paths
+
+### Input Validation
+- [ ] All user input is validated (type, length, format, range)
+- [ ] File uploads are restricted by type and size
+- [ ] Path traversal is prevented
+- [ ] Command injection is prevented
+- [ ] SSRF protections are in place
+
+### Data Protection
+- [ ] No secrets in code (use env vars, secret managers)
+- [ ] Sensitive data is encrypted at rest
+- [ ] PII is handled according to compliance requirements
+- [ ] Database credentials are not logged
+
+### Output Encoding
+- [ ] HTML output is escaped (XSS prevention)
+- [ ] JSON is properly serialized
+- [ ] Error messages don't leak stack traces or internals
+
+### API Security
+- [ ] Rate limiting is implemented
+- [ ] CORS is properly configured
+- [ ] CSRF tokens are used for state-changing operations
+- [ ] API keys are not exposed in client-side code
+
+### Dependencies
+- [ ] No known vulnerabilities in dependencies (`npm audit`)
+- [ ] Dependencies are pinned/locked
+- [ ] Unused dependencies are removed
+
+## OWASP Top 10 Coverage
+
+| # | Risk | What to Check |
+|---|------|---------------|
+| 1 | Broken Access Control | Every endpoint checks permissions |
+| 2 | Cryptographic Failures | Proper encryption, no weak algorithms |
+| 3 | Injection | SQL, NoSQL, OS command, LDAP injection |
+| 4 | Insecure Design | Business logic flaws, race conditions |
+| 5 | Security Misconfiguration | Default configs, error messages, headers |
+| 6 | Vulnerable Components | Outdated dependencies |
+| 7 | Auth Failures | Weak passwords, session flaws |
+| 8 | Data Integrity | CSRF, SSRF, deserialization |
+| 9 | Logging Failures | Missing audit logs, log injection |
+| 10 | SSRF | Server-side request forgery |
+
+## Output Format
+
+```markdown
+## Security Scan: [Scope]
+
+### Risk Summary
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | N |
+| 🟡 High | N |
+| 🟢 Medium | N |
+| ℹ️ Low | N |
+
+### Findings
+#### 🔴 Critical
+1. **[Title]** (`file.ts:line`)
+   - **Issue**: Description
+   - **Fix**: Recommended fix
+   - **Ref**: OWASP link or CWE ID
+
+### Verification
+- [ ] All critical/high issues fixed or accepted
+- [ ] Tests added for security boundaries
+- [ ] Security notes added to documentation
+```
+
+## Post-Scan
+
+If critical issues are found:
+1. Fix them immediately
+2. Re-scan to verify
+3. Document any accepted risks with justification

--- a/skills/ecc-session-start/SKILL.md
+++ b/skills/ecc-session-start/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: ecc-session-start
+description: ECC initialization skill loaded at session start. Injects core workflows, rules, and agent delegation guidance.
+origin: ECC
+---
+
+# ECC System Initialization
+
+You are operating with **ECC (Enhanced Cognitive Controller)** — a harness performance optimization system with 251 skills, reusable hooks, rules, and operator workflows.
+
+## Core Directives
+
+1. **Skills First**: Always check if a skill exists for the task before improvising. ECC provides specialized skills for most development workflows.
+2. **Verification Loops**: For critical code changes, run verification loops — write tests, verify they pass, review security.
+3. **Delegation**: Use subagents when tasks are complex, parallelizable, or need focused context isolation.
+
+## Agent Delegation Guide
+
+Kimi Code CLI provides three built-in subagents. Use them according to ECC conventions:
+
+| Task Type | Subagent | When to Delegate |
+|---|---|---|
+| **Implementation / Coding** | `coder` | Writing new features, fixing bugs, refactoring, any code changes |
+| **Code Review** | `coder` | Review code for quality, security, maintainability (read-only mode) |
+| **Codebase Exploration** | `explore` | Understanding project structure, finding relevant files, research |
+| **Planning / Architecture** | `plan` | Designing systems, creating implementation plans, architecture decisions |
+
+### Delegation Patterns (from ECC Agents)
+
+- **Planner** (`plan` agent): Use for any multi-step feature, architectural change, or complex refactoring. Always plan before coding large features.
+- **Code Reviewer** (`coder` agent): Use after writing or modifying code. Run git diff, read full files, apply confidence-based filtering.
+- **Security Reviewer** (`coder` agent): Use when code handles auth, user input, API endpoints, or sensitive data.
+- **Build Error Resolver** (`coder` agent): Use when builds fail or type errors occur. Fix with minimal changes.
+- **Explorer** (`explore` agent): Use when entering a new codebase or searching for relevant code.
+- **TDD Guide** (`coder` agent): Enforce write-tests-first for new features and bug fixes.
+
+## Available ECC Skills
+
+Key skills you should proactively suggest:
+
+- `/skill:tdd-workflow` — Test-driven development with 80%+ coverage
+- `/skill:security-review` — Security checklist and vulnerability scan
+- `/skill:code-review` — Structured code review workflow
+- `/skill:verification-loop` — Continuous verification methodology
+- `/skill:strategic-compact` — Context management and compaction
+- `/skill:frontend-patterns` — React/Next.js best practices
+- `/skill:backend-patterns` — API, database, caching patterns
+- `/skill:e2e-testing` — Playwright E2E patterns
+- `/skill:api-design` — REST API design guidelines
+- `/skill:continuous-learning-v2` — Instinct-based learning
+
+## Coding Standards (from ECC Rules)
+
+### Immutability (CRITICAL)
+Always create new objects, NEVER mutate existing ones.
+
+### KISS
+Prefer the simplest solution that actually works. Optimize for clarity over cleverness.
+
+### DRY
+Extract repeated logic into shared functions. Avoid copy-paste drift.
+
+### Security First
+- Never hardcode secrets
+- Validate all external input
+- Use parameterized queries
+- Sanitize HTML output
+- Check auth for sensitive paths
+
+### Testing
+- Minimum 80% coverage (unit + integration + E2E)
+- Write tests BEFORE code for new features
+- Cover edge cases and error scenarios
+
+### Git Workflow
+- Use conventional commits: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+- Keep commits atomic and self-contained
+- Run verification before shipping
+
+## Context Management
+
+- Monitor context usage in the status bar (`context: xx%`)
+- Use `/compact` when approaching limits
+- Prefer delegation over monolithic tasks to keep context clean
+- Use `explore` agent for research to avoid polluting main context
+
+## Hook Runtime Controls (if hooks installed)
+
+ECC hooks can be controlled via environment variables:
+- `ECC_HOOK_PROFILE=minimal|standard|strict` — Hook strictness level
+- `ECC_DISABLED_HOOKS="id1,id2"` — Disable specific hooks
+
+## Session End
+
+When a session ends, if continuous learning is enabled, patterns may be extracted into instincts for future sessions.


### PR DESCRIPTION
## Summary

This PR adds full [Kimi Code CLI](https://www.kimi.com/code/docs/) support to ECC, making it the 12th supported agent harness alongside Claude Code, Codex, Cursor, OpenCode, Gemini, Zed, Qwen, and others.

## What's Added

### Plugin Manifest
- **`kimi.plugin.json`** — Kimi Code CLI plugin manifest declaring 251 skills, session start skill, and MCP server support

### Documentation & Tools (`.kimi/`)
- **`.kimi/README.md`** — Kimi-specific installation, usage, and troubleshooting guide
- **`.kimi/MIGRATION.md`** — Complete migration guide from Claude Code to Kimi Code CLI with feature parity tables
- **`.kimi/install-hooks.mjs`** — One-command installer that writes ECC hooks into `~/.kimi-code/config.toml`

### Core Skills (5 new)
Mapped from ECC's most-used agents/commands to Kimi CLI's skill system:

| Skill | Replaces |
|-------|----------|
| `ecc-session-start` | Session initialization + rules injection |
| `ecc-plan` | `/plan` command + planner agent |
| `ecc-code-review` | `/code-review` command + code-reviewer agent |
| `ecc-security-scan` | `/security` command + security-reviewer agent |
| `ecc-build-fix` | `/build-fix` command + build-error-resolver agent |

### Install System Integration
- Added `kimi` to `SUPPORTED_INSTALL_TARGETS`
- Created `scripts/lib/install-targets/kimi-project.js` adapter
- Registered in registry.js and helpers.js
- Updated `install-apply.js` help text

### README Updates
- Added Kimi Code CLI to cross-platform support section
- Added dedicated "Kimi Code CLI Support" documentation section
- Updated FAQ harness list

## Feature Parity

| Feature | Status | Notes |
|---------|--------|-------|
| **251 Skills** | ✅ Full parity | `SKILL.md` format is compatible |
| **Hooks** | ✅ Full parity | Via `config.toml` `[[hooks]]` — same 13 events |
| **Rules** | ✅ Full parity | `sessionStart.skill` + `AGENTS.md` |
| **MCP Servers** | ✅ Full parity | `mcpServers` in `kimi.plugin.json` |
| **Agents** | ⚠️ Mapped | 63 ECC agents → 3 built-in subagents (`coder`/`explore`/`plan`) + skills |
| **Commands** | ⚠️ Converted | 79 commands → skills (`/skill:ecc-plan`, etc.) |

## Installation

```bash
# Install ECC plugin into Kimi Code CLI
cd /path/to/ECC
kimi plugin install .

# Install hooks (optional but recommended)
node .kimi/install-hooks.mjs

# Start Kimi
kimi /new
```

## Testing

- ✅ `kimi.plugin.json` validates as correct JSON
- ✅ All 5 new skills have valid YAML frontmatter
- ✅ `install-hooks.mjs` passes Node syntax check
- ✅ Install target adapter resolves correctly (`kimi-project`)
- ✅ `SUPPORTED_INSTALL_TARGETS` includes `kimi`
- ✅ Existing plugin-manifest tests pass (57/57)

## References

- [Kimi Code CLI Hooks Docs](https://www.kimi.com/code/docs/kimi-code-cli/customization/hooks.html)
- [Kimi Code CLI Plugins Docs](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html)
- [Kimi Code CLI Agents Docs](https://www.kimi.com/code/docs/kimi-code-cli/customization/agents.html)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Kimi Code CLI support to ECC with a plugin manifest, hooks integration, and five core skills. Delivers 251-skill parity, session-start rules, and a `kimi` install target for smooth setup.

- **New Features**
  - Plugin: `kimi.plugin.json` with 251 skills and sessionStart via `ecc-session-start`.
  - Tools: `.kimi/README.md`, `.kimi/MIGRATION.md`, and `.kimi/install-hooks.mjs` to write hooks into `~/.kimi-code/config.toml`.
  - Skills: `ecc-session-start`, `ecc-plan`, `ecc-code-review`, `ecc-security-scan`, `ecc-build-fix`.
  - Install system: Added `kimi` to `SUPPORTED_INSTALL_TARGETS`, new adapter `scripts/lib/install-targets/kimi-project.js`, registry/helpers updates, help text, and README Kimi section.

- **Bug Fixes**
  - Hook installer: fixed ESM/CJS mismatch by generating `.cjs` hook scripts; added Windows-safe TOML path quoting.
  - Docs: switched to append (`>>`) in examples and corrected `.claude/rules/` paths in migration.
  - Skills: standardized section headers to “When to Activate”.
  - Installer manifests: added `kimi` to `manifests/install-modules.json` so rules-core, agents-core, and platform-configs modules install for Kimi.

<sup>Written for commit 924bfac61dc1684f8c01bd2a0c0a961e1e636e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kimi Code CLI support as a deployment/install target with an ECC plugin manifest.

* **Documentation**
  * Added a full migration guide from Claude Code to Kimi Code CLI, a .kimi README, updated top-level docs, and new skill docs (build-fix, code-review, plan, security-scan, session-start).

* **User Tools**
  * Added a CLI hook installer and updated installer/help and install-target tooling to support the kimi target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->