### PR TITLE
fix(gateguard): gate force/path git checkout as destructive

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -269,7 +269,14 @@ function isDestructiveGit(tokens) {
   }
 
   if (command === 'checkout') {
-    return rest.includes('--');
+    // `git checkout -- <path>`, `git checkout .`, and the force forms
+    // (`--force` / `-f`) all discard uncommitted working-tree changes,
+    // mirroring the `switch` handler below.
+    return rest.some(t => {
+      if (t === '--' || t === '.' || t === '--force') return true;
+      if (!t.startsWith('-') || t.startsWith('--')) return false;
+      return t.slice(1).includes('f');
+    });
   }
 
   if (command === 'clean') {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -301,6 +301,22 @@ function runTests() {
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('rollback'));
   })) passed++; else failed++;
 
+  // --- Test 7b: gates force/path git checkout as destructive Bash ---
+  clearState();
+  if (test('denies git checkout -f as destructive Bash', () => {
+    const input = {
+      tool_name: 'Bash',
+      tool_input: { command: 'git checkout -f main' }
+    };
+    const result = runBashHook(input);
+    assert.strictEqual(result.code, 0, 'exit code should be 0');
+    const output = parseOutput(result.stdout);
+    assert.ok(output, 'should produce JSON output');
+    assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny');
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+    assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('rollback'));
+  })) passed++; else failed++;
+
   // --- Test 8: denies first routine Bash, allows second ---
   clearState();
   if (test('denies first routine Bash, allows second', () => {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -301,7 +301,10 @@ function runTests() {
     assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('rollback'));
   })) passed++; else failed++;
 
-  // --- Test 7b: gates force/path git checkout as destructive Bash ---
+  /**
+   * Test 7b: `git checkout -f <branch>` (force checkout) discards uncommitted
+   * working-tree changes, so it must be gated as destructive Bash.
+   */
   clearState();
   if (test('denies git checkout -f as destructive Bash', () => {
     const input = {


### PR DESCRIPTION
## Summary

GateGuard challenges destructive commands before they run, but its `git checkout` handler in `scripts/hooks/gateguard-fact-force.js` only flagged `git checkout -- <path>`:

```js
if (command === 'checkout') {
  return rest.includes('--');
}
```

It missed:
- `git checkout --force` / `git checkout -f <branch>` — force checkout, **discards local uncommitted changes**
- `git checkout .` — **discards all working-tree changes**

So those forms bypassed the gate. Worse, once the once-per-session **routine-Bash** gate is satisfied by any prior command, `git checkout -f main` runs with **no challenge at all** — exactly the destructive scenario GateGuard exists to catch. The semantically-identical `git switch -f main` *is* gated, so this is an inconsistent gap, not policy.

## Fix

Mirror the existing `switch` handler (which already covers `--force` / `-f`): treat `--`, `.`, `--force`, and short `-f`-style flags on `checkout` as destructive.

```js
if (command === 'checkout') {
  return rest.some(t => {
    if (t === '--' || t === '.' || t === '--force') return true;
    if (!t.startsWith('-') || t.startsWith('--')) return false;
    return t.slice(1).includes('f');
  });
}
```

This preserves the existing `--` behavior and leaves branch-switching (`git checkout main`, `git checkout -b new`) un-gated.

## Verification

Added a test to `tests/hooks/gateguard-fact-force.test.js` asserting `git checkout -f main` is denied with a `Destructive` fact-forcing message (alongside the existing `git push --force` / `git commit --amend` cases). Verified it fails before the fix (only the routine gate fires) and passes after. The gateguard suite is green (92/92); full `node tests/run-all.js` is 2618 passed with 1 pre-existing unrelated failure (`scripts/trae-install.test.js`, identical on `main`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a gap in GateGuard so destructive `git checkout` forms (`--`, `.`, `--force`, `-f`) are challenged, preventing unprompted discards of uncommitted changes. Non-destructive branch switching remains unaffected.

- **Bug Fixes**
  - Flag `git checkout` with `--`, `.`, `--force`, or `-f` as destructive in `scripts/hooks/gateguard-fact-force.js`.
  - Add test (Test 7b) asserting `git checkout -f main` is denied as destructive.

<sup>Written for commit 82aada84403a63529cacee054680ec87305bca62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened detection of destructive git checkout actions to also recognize additional force/discard invocation forms that can overwrite working-tree changes, improving protection against unintended destructive operations.

* **Tests**
  * Added new test coverage to confirm these destructive checkout patterns are detected and denied, including checks for denial reasons and gate state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->