### PR TITLE
docs(claude): install manual skills at top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,13 +898,15 @@ cp -r rules/arkts ~/.claude/rules/ecc/
 
 # Copy skills first (primary workflow surface)
 # Recommended (new users): core/general skills only
-mkdir -p ~/.claude/skills/ecc
-cp -r .agents/skills/* ~/.claude/skills/ecc/
-cp -r skills/search-first ~/.claude/skills/ecc/
+mkdir -p ~/.claude/skills
+cp -r .agents/skills/* ~/.claude/skills/
+cp -r skills/search-first ~/.claude/skills/
+# Claude Code loads skills only from direct children of ~/.claude/skills.
+# Do not nest manual installs under ~/.claude/skills/ecc/.
 
 # Optional: add niche/framework-specific skills only when needed
 # for s in django-patterns django-tdd laravel-patterns springboot-patterns quarkus-patterns; do
-# cp -r skills/$s ~/.claude/skills/ecc/
+# cp -r skills/$s ~/.claude/skills/
 # done
 
 # Optional: keep maintained slash-command compatibility during migration

--- a/docs/de-DE/README.md
+++ b/docs/de-DE/README.md
@@ -896,13 +896,15 @@ cp -r rules/arkts ~/.claude/rules/ecc/
 
 # Zuerst Skills kopieren (primäre Workflow-Oberfläche)
 # Empfohlen (neue Nutzer): nur Kern-/allgemeine Skills
-mkdir -p ~/.claude/skills/ecc
-cp -r .agents/skills/* ~/.claude/skills/ecc/
-cp -r skills/search-first ~/.claude/skills/ecc/
+mkdir -p ~/.claude/skills
+cp -r .agents/skills/* ~/.claude/skills/
+cp -r skills/search-first ~/.claude/skills/
+# Claude Code lädt Skills nur aus direkten Unterverzeichnissen von ~/.claude/skills.
+# Manuelle Installationen nicht unter ~/.claude/skills/ecc/ verschachteln.
 
 # Optional: nischen-/framework-spezifische Skills nur bei Bedarf hinzufügen
 # for s in django-patterns django-tdd laravel-patterns springboot-patterns quarkus-patterns; do
-# cp -r skills/$s ~/.claude/skills/ecc/
+# cp -r skills/$s ~/.claude/skills/
 # done
 
 # Optional: gepflegte Slash-Command-Kompatibilität während der Migration behalten

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -832,13 +832,15 @@ cp -r everything-claude-code/rules/php ~/.claude/rules/ecc/
 
 # Сначала скопировать навыки (основной рабочий интерфейс)
 # Рекомендуется для новых пользователей: только core/general skills
-mkdir -p ~/.claude/skills/ecc
-cp -r everything-claude-code/.agents/skills/* ~/.claude/skills/ecc/
-cp -r everything-claude-code/skills/search-first ~/.claude/skills/ecc/
+mkdir -p ~/.claude/skills
+cp -r everything-claude-code/.agents/skills/* ~/.claude/skills/
+cp -r everything-claude-code/skills/search-first ~/.claude/skills/
+# Claude Code загружает навыки только из прямых подкаталогов ~/.claude/skills.
+# Не вкладывайте ручную установку в ~/.claude/skills/ecc/.
 
 # Опционально: добавляйте нишевые/framework-specific skills только при необходимости
 # for s in django-patterns django-tdd laravel-patterns springboot-patterns; do
-# cp -r everything-claude-code/skills/$s ~/.claude/skills/ecc/
+# cp -r everything-claude-code/skills/$s ~/.claude/skills/
 # done
 
 # Опционально: сохранить поддерживаемую slash-command совместимость во время миграции

--- a/tests/docs/install-identifiers.test.js
+++ b/tests/docs/install-identifiers.test.js
@@ -61,6 +61,12 @@ const publicCommandNamespaceDocs = [
   'docs/zh-TW/README.md',
 ];
 
+const manualClaudeSkillInstallDocs = [
+  'README.md',
+  'docs/de-DE/README.md',
+  'docs/ru/README.md',
+];
+
 for (const relativePath of pluginAndManualInstallDocs) {
   const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 
@@ -92,6 +98,21 @@ for (const relativePath of publicCommandNamespaceDocs) {
     assert.ok(
       content.includes('/ecc:plan'),
       'Expected docs to show the short plugin command namespace'
+    );
+  });
+}
+
+for (const relativePath of manualClaudeSkillInstallDocs) {
+  const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+  test(`${relativePath} keeps manual Claude skill installs top-level`, () => {
+    assert.ok(
+      !/^\s*#?\s*(mkdir\s+-p|cp\s+.*)\s+.*~\/\.claude\/skills\/ecc(\/|\b)/m.test(content),
+      'Claude Code does not discover skills installed by commands targeting ~/.claude/skills/ecc'
+    );
+    assert.ok(
+      content.includes('~/.claude/skills/'),
+      'Expected manual install docs to copy skills into direct ~/.claude/skills children'
     );
   });
 }

--- a/tests/docs/install-identifiers.test.js
+++ b/tests/docs/install-identifiers.test.js
@@ -107,7 +107,7 @@ for (const relativePath of manualClaudeSkillInstallDocs) {
 
   test(`${relativePath} keeps manual Claude skill installs top-level`, () => {
     assert.ok(
-      !/^\s*#?\s*(mkdir\s+-p|cp\s+.*)\s+.*~\/\.claude\/skills\/ecc(\/|\b)/m.test(content),
+      !/^\s*#?\s*(mkdir\s+-p|md\s+.*|cp\s+.*|copy\s+.*|cpi\s+.*|New-Item\s+.*|Copy-Item\s+.*)\s+.*(~|\$HOME)[\\/]\.claude[\\/]skills[\\/]ecc([\\/]|\b)/mi.test(content),
       'Claude Code does not discover skills installed by commands targeting ~/.claude/skills/ecc'
     );
     assert.ok(


### PR DESCRIPTION
Fixes #2108

## Summary
- update manual Claude Code install snippets to copy skills directly under `~/.claude/skills/` instead of the unsupported nested `~/.claude/skills/ecc/` path
- keep rules under the existing `~/.claude/rules/ecc/` namespace
- update the German and Russian README copies that had the same stale manual skill path
- add a docs regression test so future manual install snippets do not reintroduce nested Claude skill install commands

## Triage notes
- I checked #2107 first, but current `main` already has shell-word parsing and passing regressions for `--no-verify` inside commit messages.
- I checked #2151 next, but current `main` already prunes expired session tmp files and has coverage for `ECC_SESSION_RETENTION_DAYS`.

## Tests
- `node tests/docs/install-identifiers.test.js`
- `node tests/scripts/install-readme-clarity.test.js`
- `rg -n "^#?\s*(mkdir\s+-p|cp\s+.*)\s+.*~/.claude/skills/ecc" README.md docs/de-DE/README.md docs/ru/README.md` (no matches; rg exits 1 when no matches are found)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual Claude Code install docs so skills are copied directly into `~/.claude/skills/` (not `~/.claude/skills/ecc/`), ensuring Claude discovers them. Rules remain under `~/.claude/rules/ecc/`. Fixes #2108.

- **Bug Fixes**
  - Updated install snippets in `README.md`, `docs/de-DE/README.md`, and `docs/ru/README.md` to use top-level `~/.claude/skills/` with a short note about discovery.
  - Kept rules path under `~/.claude/rules/ecc/` unchanged.
  - Hardened docs regression test to block nested skill installs across Unix and PowerShell forms (supports `~`/`$HOME`, `/`/`\`, and `mkdir`/`cp`/`md`/`copy`/`cpi`/`New-Item`/`Copy-Item`).

<sup>Written for commit 709a43da4283cfcd201389ed72acd65d9e2ea698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated manual installation instructions to place skills directly under ~/.claude/skills/ (not nested).
  * Clarified Claude Code only loads skills from direct children of ~/.claude/skills/ and added an explicit warning against nesting.
  * Applied changes in English, German, and Russian docs; optional framework/niche install example adjusted.

* **Tests**
  * Added tests validating the updated manual skill installation documentation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->