### PR TITLE
fix(suggest-compact): sweep stale counter temp files (#2156)

### DIFF
--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -99,12 +99,25 @@ async function main() {
   const tempDir = getTempDir();
   const counterFile = path.join(tempDir, `${COUNTER_PREFIX}${sessionId}`);
 
-  // Keep the temp dir bounded: sweep counter files older than the retention
-  // window before doing any counting. Best-effort and never blocks (#2156).
+  // Keep the temp dir bounded by sweeping stale counter files (#2156), but only
+  // pay for the directory scan once per session. The sweep only needs to run on
+  // a session's first tool call — i.e. when this session's counter file does not
+  // exist yet. On every subsequent PreToolUse the file is already present, so we
+  // skip the readdir/stat entirely and keep the blocking hot path fast. Stale
+  // files still get cleaned up promptly because every new session triggers a
+  // sweep. Best-effort throughout and never blocks.
+  let isFirstToolCall;
   try {
-    sweepStaleCounters(tempDir, resolveTtlDays(), counterFile);
+    isFirstToolCall = !fs.existsSync(counterFile);
   } catch {
-    /* cleanup is best-effort — never let it affect the count or exit code */
+    isFirstToolCall = true; // can't tell — fall back to attempting the sweep
+  }
+  if (isFirstToolCall) {
+    try {
+      sweepStaleCounters(tempDir, resolveTtlDays(), counterFile);
+    } catch {
+      /* cleanup is best-effort — never let it affect the count or exit code */
+    }
   }
 
   const rawThreshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -23,6 +23,59 @@ const {
   output
 } = require('../lib/utils');
 
+// Shared prefix for the per-session counter temp files. Used both to build the
+// current session's counter path and to sweep stale ones.
+const COUNTER_PREFIX = 'claude-tool-count-';
+
+/**
+ * Resolve the retention window (in days) for stale counter temp files.
+ * Env-tunable via COMPACT_STATE_TTL_DAYS. 0 disables the sweep. Invalid or
+ * out-of-range values fall back to the conservative 14-day default.
+ */
+function resolveTtlDays() {
+  const raw = parseInt(process.env.COMPACT_STATE_TTL_DAYS || '14', 10);
+  if (!Number.isFinite(raw) || raw < 0 || raw > 3650) return 14;
+  return raw;
+}
+
+/**
+ * Best-effort cleanup of orphaned counter temp files.
+ *
+ * Each session writes one `claude-tool-count-<sessionId>` file and nothing ever
+ * removed them, so the temp dir grew unbounded (one file per session, forever —
+ * issue #2156). Sweep deletes counter files whose mtime is older than the
+ * retention window. It never throws: counting must not depend on cleanup
+ * succeeding, and a hook must never block Claude.
+ *
+ * @param {string} tempDir   Directory holding the counter files.
+ * @param {number} ttlDays   Retention window in days (0 = sweep disabled).
+ * @param {string} keepFile  Absolute path of the current session's counter
+ *                           file, which is never deleted even if stale.
+ */
+function sweepStaleCounters(tempDir, ttlDays, keepFile) {
+  if (!ttlDays || ttlDays <= 0) return;
+  const cutoff = Date.now() - ttlDays * 24 * 60 * 60 * 1000;
+  let entries;
+  try {
+    entries = fs.readdirSync(tempDir);
+  } catch {
+    return; // temp dir unreadable — nothing to do
+  }
+  for (const name of entries) {
+    if (!name.startsWith(COUNTER_PREFIX)) continue;
+    const full = path.join(tempDir, name);
+    if (full === keepFile) continue;
+    try {
+      const stats = fs.statSync(full);
+      if (stats.isFile() && stats.mtimeMs < cutoff) {
+        fs.unlinkSync(full);
+      }
+    } catch {
+      // File vanished mid-sweep, or is unreadable — ignore and continue.
+    }
+  }
+}
+
 async function resolveSessionId() {
   // Claude Code passes hook input via stdin JSON; session_id is the
   // canonical field. Fall back to the legacy env var, then 'default'.
@@ -43,7 +96,17 @@ async function main() {
   // legacy env var, or 'default' as fallback.
   const rawSessionId = await resolveSessionId();
   const sessionId = rawSessionId.replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
-  const counterFile = path.join(getTempDir(), `claude-tool-count-${sessionId}`);
+  const tempDir = getTempDir();
+  const counterFile = path.join(tempDir, `${COUNTER_PREFIX}${sessionId}`);
+
+  // Keep the temp dir bounded: sweep counter files older than the retention
+  // window before doing any counting. Best-effort and never blocks (#2156).
+  try {
+    sweepStaleCounters(tempDir, resolveTtlDays(), counterFile);
+  } catch {
+    /* cleanup is best-effort — never let it affect the count or exit code */
+  }
+
   const rawThreshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
   const threshold = Number.isFinite(rawThreshold) && rawThreshold > 0 && rawThreshold <= 10000
     ? rawThreshold

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -61,6 +61,9 @@ Add to your `~/.claude/settings.json`:
 
 Environment variables:
 - `COMPACT_THRESHOLD` — Tool calls before first suggestion (default: 50)
+- `COMPACT_STATE_TTL_DAYS` — Retention window for the per-session counter temp
+  files; the hook sweeps `claude-tool-count-*` files older than this on each run
+  (default: 14; set to `0` to disable cleanup)
 
 ## Compaction Decision Guide
 

--- a/tests/hooks/suggest-compact.test.js
+++ b/tests/hooks/suggest-compact.test.js
@@ -451,6 +451,113 @@ function runTests() {
   })) passed++;
   else failed++;
 
+  // ── Stale counter temp-file cleanup (#2156) ──
+  console.log('\nStale counter cleanup (#2156):');
+
+  // Backdate a file's mtime by N days so the sweep treats it as stale.
+  function backdateFile(filePath, days) {
+    const when = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    fs.utimesSync(filePath, when, when);
+  }
+
+  if (test('deletes stale counter files older than retention window', () => {
+    const stale = getCounterFilePath(`stale-${Date.now()}`);
+    fs.writeFileSync(stale, '5');
+    backdateFile(stale, 30); // older than the 14-day default
+    const { sessionId, cleanup } = createCounterContext();
+    cleanup();
+    try {
+      const result = runCompact({ CLAUDE_SESSION_ID: sessionId });
+      assert.strictEqual(result.code, 0, 'Should exit 0');
+      assert.ok(!fs.existsSync(stale), 'Stale counter file should be swept');
+    } finally {
+      try { fs.unlinkSync(stale); } catch (_err) { /* ignore */ }
+      cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('keeps fresh counter files within the retention window', () => {
+    const fresh = getCounterFilePath(`fresh-${Date.now()}`);
+    fs.writeFileSync(fresh, '5');
+    backdateFile(fresh, 3); // well within the 14-day default
+    const { sessionId, cleanup } = createCounterContext();
+    cleanup();
+    try {
+      runCompact({ CLAUDE_SESSION_ID: sessionId });
+      assert.ok(fs.existsSync(fresh), 'Fresh counter file should be kept');
+    } finally {
+      try { fs.unlinkSync(fresh); } catch (_err) { /* ignore */ }
+      cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('never deletes the current session counter file', () => {
+    const { sessionId, counterFile, cleanup } = createCounterContext();
+    cleanup();
+    // Pre-create the current session's counter and backdate it far past the TTL.
+    fs.writeFileSync(counterFile, '5');
+    backdateFile(counterFile, 100);
+    try {
+      runCompact({ CLAUDE_SESSION_ID: sessionId });
+      assert.ok(fs.existsSync(counterFile), 'Current session counter must survive sweep');
+      const count = parseInt(fs.readFileSync(counterFile, 'utf8').trim(), 10);
+      assert.strictEqual(count, 6, 'Current counter should increment, not be reset');
+    } finally {
+      cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('COMPACT_STATE_TTL_DAYS=0 disables the sweep', () => {
+    const stale = getCounterFilePath(`stale-disabled-${Date.now()}`);
+    fs.writeFileSync(stale, '5');
+    backdateFile(stale, 100);
+    const { sessionId, cleanup } = createCounterContext();
+    cleanup();
+    try {
+      runCompact({ CLAUDE_SESSION_ID: sessionId, COMPACT_STATE_TTL_DAYS: '0' });
+      assert.ok(fs.existsSync(stale), 'Sweep disabled → stale file must remain');
+    } finally {
+      try { fs.unlinkSync(stale); } catch (_err) { /* ignore */ }
+      cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('custom COMPACT_STATE_TTL_DAYS shortens the window', () => {
+    const stale = getCounterFilePath(`stale-custom-${Date.now()}`);
+    fs.writeFileSync(stale, '5');
+    backdateFile(stale, 5); // would survive default 14, but not TTL=2
+    const { sessionId, cleanup } = createCounterContext();
+    cleanup();
+    try {
+      runCompact({ CLAUDE_SESSION_ID: sessionId, COMPACT_STATE_TTL_DAYS: '2' });
+      assert.ok(!fs.existsSync(stale), '5-day-old file should be swept with TTL=2');
+    } finally {
+      try { fs.unlinkSync(stale); } catch (_err) { /* ignore */ }
+      cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('does not touch unrelated temp files', () => {
+    const unrelated = path.join(os.tmpdir(), `unrelated-${Date.now()}.tmp`);
+    fs.writeFileSync(unrelated, 'keep me');
+    backdateFile(unrelated, 100);
+    const { sessionId, cleanup } = createCounterContext();
+    cleanup();
+    try {
+      runCompact({ CLAUDE_SESSION_ID: sessionId });
+      assert.ok(fs.existsSync(unrelated), 'Non-counter temp files must be untouched');
+    } finally {
+      try { fs.unlinkSync(unrelated); } catch (_err) { /* ignore */ }
+      cleanup();
+    }
+  })) passed++;
+  else failed++;
+
   // Summary
   console.log(`
 Results: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Addresses **part 1** of #2156.

`scripts/hooks/suggest-compact.js` writes one `claude-tool-count-<sessionId>`
file per session into the temp dir, and nothing ever removed them. Over time the
temp dir fills with thousands of orphaned counter files (at least one per
session, indefinitely).

## Changes

- **`scripts/hooks/suggest-compact.js`** — add a best-effort `sweepStaleCounters()`
  pass at the start of `main()`:
  - Deletes `claude-tool-count-*` files whose mtime is older than the retention
    window.
  - Tunable via `COMPACT_STATE_TTL_DAYS` (default **14 days**; `0` disables).
  - Skips the current session's counter file.
  - Never throws and never changes the exit code — counting and the tool call
    must not depend on cleanup succeeding (hooks must always `exit 0`).
- **`tests/hooks/suggest-compact.test.js`** — 6 new tests (stale deleted, fresh
  kept, current-session file preserved + still increments, `TTL=0` disables,
  custom TTL shortens window, unrelated temp files untouched).
- **`skills/strategic-compact/SKILL.md`** — document `COMPACT_STATE_TTL_DAYS`.

## Testing

```
node tests/hooks/suggest-compact.test.js   # 30 passed (24 existing + 6 new)
node scripts/ci/validate-hooks.js          # Validated 28 hook matchers
```

No regression in the existing suite; the file stays under the 200-line hook limit.

## Note on part 2

The issue also proposes keying the counter on `projHash + YYYYMMDD` so the count
survives `/compact` session-id rotation. That's a behavior change to the
session-isolation semantics that the current test suite pins (e.g. "uses separate
counter files per session ID"), so I've left it out of this PR to keep the
cleanup fix focused and low-risk. Happy to follow up with that as a separate PR
if you'd like it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sweep stale `claude-tool-count-*` temp files in `scripts/hooks/suggest-compact.js` and run the sweep only on a session’s first call to avoid per-invocation I/O. Addresses #2156 and #2162 and keeps counting behavior unchanged (hook still exits 0).

- **Bug Fixes**
  - Added `sweepStaleCounters()` to delete counter files older than a retention window.
  - Runs sweep only on the session’s first tool call (skips readdir/stat on subsequent calls).
  - Skips the current session’s counter file.
  - Configurable via `COMPACT_STATE_TTL_DAYS` (default 14 days; `0` disables).
  - Added 6 tests for cleanup behavior and updated `skills/strategic-compact/SKILL.md`.

<sup>Written for commit 46da602a258dc09f12618fc45a88244028c05278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added COMPACT_STATE_TTL_DAYS env var to configure retention for temporary counter files (defaults to 14 days; 0 disables cleanup).
  * Introduced best-effort stale-counter cleanup that runs once per session and never removes the current session’s counter or impacts normal operation on failure.

* **Documentation**
  * Updated configuration docs with COMPACT_STATE_TTL_DAYS details.

* **Tests**
  * Added tests covering stale-counter cleanup behavior and TTL cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->