### PR TITLE
fix(session-start): support ECC_SESSION_RETENTION_DAYS opt-out + document env var (#2151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,8 @@ export ECC_SESSION_START_MAX_CHARS=4000
 # Disable SessionStart additional context entirely for low-context/local-model setups
 export ECC_SESSION_START_CONTEXT=off
 
-# Session-tmp retention window in days (default: 30). Set to 0/off/disabled to keep all sessions.
+# Session-tmp retention window in days (default: 30).
+# Set to 0, off, false, disabled, never, or none to keep all sessions (disable pruning).
 export ECC_SESSION_RETENTION_DAYS=14
 
 # Keep context/scope/loop warnings but suppress API-rate cost estimates
@@ -490,6 +491,7 @@ Windows PowerShell:
 
 ```powershell
 [Environment]::SetEnvironmentVariable('ECC_CONTEXT_MONITOR_COST_WARNINGS', 'off', 'User')
+[Environment]::SetEnvironmentVariable('ECC_SESSION_RETENTION_DAYS', '14', 'User')
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -479,6 +479,9 @@ export ECC_SESSION_START_MAX_CHARS=4000
 # Disable SessionStart additional context entirely for low-context/local-model setups
 export ECC_SESSION_START_CONTEXT=off
 
+# Session-tmp retention window in days (default: 30). Set to 0/off/disabled to keep all sessions.
+export ECC_SESSION_RETENTION_DAYS=14
+
 # Keep context/scope/loop warnings but suppress API-rate cost estimates
 export ECC_CONTEXT_MONITOR_COST_WARNINGS=off
 ```

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -83,9 +83,22 @@ function dedupeRecentSessions(searchDirs) {
     .sort((left, right) => right.mtime - left.mtime || left.dirIndex - right.dirIndex);
 }
 
+/**
+ * Resolve session retention days from the ECC_SESSION_RETENTION_DAYS env var.
+ *
+ * @returns {number|null} The retention window in days, or `null` when the
+ *   user has explicitly opted out of pruning. Falsy/garbage values fall back
+ *   to {@link DEFAULT_SESSION_RETENTION_DAYS}.
+ */
 function getSessionRetentionDays() {
   const raw = process.env.ECC_SESSION_RETENTION_DAYS;
   if (!raw) return DEFAULT_SESSION_RETENTION_DAYS;
+
+  const normalized = String(raw).trim().toLowerCase();
+  if (['0', 'off', 'false', 'disabled', 'never', 'none'].includes(normalized)) {
+    return null;
+  }
+
   const parsed = Number.parseInt(raw, 10);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_RETENTION_DAYS;
 }
@@ -526,9 +539,13 @@ async function main() {
   ensureDir(learnedDir);
 
   const retentionDays = getSessionRetentionDays();
-  const prunedSessions = pruneExpiredSessions(sessionSearchDirs, retentionDays);
-  if (prunedSessions > 0) {
-    log(`[SessionStart] Pruned ${prunedSessions} expired session(s) older than ${retentionDays} day(s)`);
+  if (retentionDays === null) {
+    log('[SessionStart] Pruning disabled via ECC_SESSION_RETENTION_DAYS');
+  } else {
+    const prunedSessions = pruneExpiredSessions(sessionSearchDirs, retentionDays);
+    if (prunedSessions > 0) {
+      log(`[SessionStart] Pruned ${prunedSessions} expired session(s) older than ${retentionDays} day(s)`);
+    }
   }
 
   const observerSessionId = resolveSessionId();

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -5006,6 +5006,103 @@ async function runTests() {
     passed++;
   else failed++;
 
+  if (
+    await asyncTest('disables pruning when ECC_SESSION_RETENTION_DAYS=0', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-start-prune-off-${Date.now()}`);
+      const sessionsDir = getCanonicalSessionsDir(isoHome);
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
+
+      const expiredFile = path.join(sessionsDir, '2026-01-01-keepme-session.tmp');
+      fs.writeFileSync(expiredFile, '# Old Session\n\nSHOULD STILL EXIST');
+      const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(expiredFile, ninetyDaysAgo, ninetyDaysAgo);
+
+      try {
+        const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome,
+          ECC_SESSION_RETENTION_DAYS: '0',
+        });
+
+        assert.strictEqual(result.code, 0);
+        assert.ok(fs.existsSync(expiredFile), 'Should keep all sessions when retention is opt-out=0');
+        assert.ok(result.stderr.includes('Pruning disabled via ECC_SESSION_RETENTION_DAYS'),
+          `Should log pruning disabled, stderr: ${result.stderr}`);
+        assert.ok(!result.stderr.includes('Pruned'), `Should not log any pruning, stderr: ${result.stderr}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('disables pruning when ECC_SESSION_RETENTION_DAYS=off', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-start-prune-offstr-${Date.now()}`);
+      const sessionsDir = getCanonicalSessionsDir(isoHome);
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
+
+      const expiredFile = path.join(sessionsDir, '2025-12-15-keepme-session.tmp');
+      fs.writeFileSync(expiredFile, '# Forensic Session\n\nKEEP ME');
+      const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(expiredFile, sixtyDaysAgo, sixtyDaysAgo);
+
+      try {
+        const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome,
+          ECC_SESSION_RETENTION_DAYS: 'off',
+        });
+
+        assert.strictEqual(result.code, 0);
+        assert.ok(fs.existsSync(expiredFile), 'Should keep all sessions when retention is opt-out=off');
+        assert.ok(result.stderr.includes('Pruning disabled via ECC_SESSION_RETENTION_DAYS'),
+          `Should log pruning disabled, stderr: ${result.stderr}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('falls back to default retention when ECC_SESSION_RETENTION_DAYS is garbage', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-start-prune-garbage-${Date.now()}`);
+      const sessionsDir = getCanonicalSessionsDir(isoHome);
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(path.join(isoHome, '.claude', 'skills', 'learned'), { recursive: true });
+
+      const expiredFile = path.join(sessionsDir, '2026-01-01-pruneme-session.tmp');
+      fs.writeFileSync(expiredFile, '# Old Session\n\nDELETE ME');
+      const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(expiredFile, fortyDaysAgo, fortyDaysAgo);
+
+      try {
+        const result = await runScript(path.join(scriptsDir, 'session-start.js'), '', {
+          HOME: isoHome,
+          USERPROFILE: isoHome,
+          ECC_SESSION_RETENTION_DAYS: 'bogus-value',
+        });
+
+        assert.strictEqual(result.code, 0);
+        assert.ok(!fs.existsSync(expiredFile),
+          'Should fall back to default 30-day retention and prune the 40-day-old file');
+        assert.ok(result.stderr.includes('Pruned 1 expired session'),
+          `Should log pruning at default retention, stderr: ${result.stderr}`);
+        assert.ok(!result.stderr.includes('Pruning disabled'),
+          'Should NOT treat garbage as opt-out');
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
   console.log('\nRound 55: session-start.js (newest session selection):');
 
   if (


### PR DESCRIPTION
## Summary
- Extend `getSessionRetentionDays()` so `ECC_SESSION_RETENTION_DAYS=0|off|false|disabled|never|none` disables session-tmp pruning entirely. Issue #2151 follow-up — the underlying retention pass landed previously; this closes the configurability + discoverability gaps the original report asked for. Default behavior is unchanged.
- Document `ECC_SESSION_RETENTION_DAYS` in the README "Hook Runtime Controls" section alongside the other `ECC_SESSION_*` knobs (was previously undocumented, so users could not discover the setting).
- Add three regression tests covering opt-out via `0`, opt-out via `off`, and garbage-value fallback to default 30.

Fixes #2151

## Verification
- `node tests/hooks/hooks.test.js` — 240/240 green (incl. 3 new retention tests).
- `node tests/run-all.js` — 2622/2622 green.
- `npx eslint scripts/hooks/session-start.js tests/hooks/hooks.test.js` — clean.
- `node scripts/ci/validate-no-personal-paths.js` — clean.
- `node scripts/ci/check-unicode-safety.js` — clean.
- `node scripts/ci/validate-hooks.js` — 28 matchers validated.
- `node scripts/ci/validate-rules.js` — 115 files validated.
- Manual: `ECC_SESSION_RETENTION_DAYS=0 …` skips the prune pass; `ECC_SESSION_RETENTION_DAYS=14 …` prunes at 14 days; `ECC_SESSION_RETENTION_DAYS=garbage …` falls back to 30-day default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-out support for session-tmp pruning via `ECC_SESSION_RETENTION_DAYS` and documents the env var. Default 30-day behavior stays the same with clear logging when pruning is disabled. Fixes #2151.

- **Bug Fixes**
  - Treat `0/off/false/disabled/never/none` as opt-out; skip pruning and log "Pruning disabled via ECC_SESSION_RETENTION_DAYS". Garbage values fall back to 30 days.
  - Document `ECC_SESSION_RETENTION_DAYS` in README with default, all six opt-out values, and a Windows PowerShell example.
  - Add regression tests for opt-out (`0`, `off`) and default fallback.

<sup>Written for commit a75130de54ed2c2c6baa8b2c7c702e102a83c1d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment variable to configure temporary session file retention (default: 30 days) with explicit options to disable pruning via common values (e.g., 0/off/false/disabled/never/none).

* **Documentation**
  * README updated with configuration details, examples, and a Windows PowerShell snippet showing a 14-day example.

* **Tests**
  * Added tests covering disabled retention and fallback behavior for invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->