### PR TITLE
fix: resolve eslint findings in mcp-inventory

### DIFF
--- a/scripts/lib/mcp-inventory/canonical-mcp.js
+++ b/scripts/lib/mcp-inventory/canonical-mcp.js
@@ -219,7 +219,8 @@ function mergeServers(serverRecords) {
 
   return Array.from(byName.values()).map(server => {
     const uniqueSignatures = Array.from(new Set(server.signatures));
-    const { signatures, ...rest } = server;
+    // Rest-destructure to drop signatures from the public record.
+    const { signatures: _signatures, ...rest } = server;
     return {
       ...rest,
       harnessCount: server.sources.length,

--- a/scripts/lib/mcp-inventory/readers/codex.js
+++ b/scripts/lib/mcp-inventory/readers/codex.js
@@ -19,7 +19,6 @@ function loadTomlParser(parseTomlImpl) {
   }
 
   try {
-    // eslint-disable-next-line global-require
     return require('@iarna/toml').parse;
   } catch {
     return null;


### PR DESCRIPTION
## What Changed
- `scripts/lib/mcp-inventory/canonical-mcp.js`: the rest-destructure that drops `signatures` from the public record trips `no-unused-vars`; renamed the discarded binding to `_signatures` to match the allowed unused-var pattern (`/^_/u`).
- `scripts/lib/mcp-inventory/readers/codex.js`: removed an `eslint-disable-next-line global-require` directive that no longer reports anything (flagged as an unused directive).

## Why This Change
`npm run lint` currently fails on `main` (`eslint .` exits 1 on the unused `signatures` binding introduced with the MCP inventory feature). Every open PR rebased onto current main inherits this red lint job, so this 2-line fix unblocks lint CI repo-wide.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`) - full suite 2619/2619 in a clean Linux container (node:22-bookworm, fresh `npm ci`)
- [x] Edge cases considered and tested - `npm run lint` now exits 0; behavior unchanged (the binding was already discarded, the directive was already inert)

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation - n/a, lint-only
- [x] Added comments for complex logic - one comment explaining the intentional rest-destructure omit
- [x] README updated (if needed) - n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ESLint failures in `mcp-inventory` so `npm run lint` passes again and CI unblocks. No runtime behavior changes.

- **Bug Fixes**
  - `scripts/lib/mcp-inventory/canonical-mcp.js`: rename destructured `signatures` to `_signatures` to satisfy `no-unused-vars`.
  - `scripts/lib/mcp-inventory/readers/codex.js`: remove unused `eslint-disable-next-line global-require`; `require('@iarna/toml').parse` remains.

<sup>Written for commit c1d5c079139d7e9716e5be6d0e266bb94b3c9b01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code quality improvements and internal cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->