### PR TITLE
test: skip chmod-based permission tests when running as root

### DIFF
--- a/tests/lib/session-aliases.test.js
+++ b/tests/lib/session-aliases.test.js
@@ -1230,8 +1230,8 @@ function runTests() {
     // session-aliases.js lines 131-137: When saveAliases fails (outer catch),
     // it tries to restore from backup. If the restore ALSO fails, the inner
     // catch at line 135 logs restoreErr. No existing test creates this double-fault.
-    if (process.platform === 'win32') {
-      console.log('    (skipped — chmod not reliable on Windows)');
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      console.log('    (skipped — chmod ineffective on Windows/root)');
       return;
     }
     const isoHome = path.join(os.tmpdir(), `ecc-r90-restore-fail-${Date.now()}`);

--- a/tests/lib/session-manager.test.js
+++ b/tests/lib/session-manager.test.js
@@ -2047,9 +2047,9 @@ file.ts
   // ── Round 112: appendSessionContent with read-only file — returns false ──
   console.log('\nRound 112: appendSessionContent (read-only file):');
   if (test('appendSessionContent returns false when file is read-only (EACCES)', () => {
-    if (process.platform === 'win32') {
-      // chmod doesn't work reliably on Windows — skip
-      assert.ok(true, 'Skipped on Windows');
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      // chmod ineffective on Windows/root — skip
+      assert.ok(true, 'Skipped on Windows/root');
       return;
     }
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'r112-readonly-'));


### PR DESCRIPTION
## What Changed
Two tests provoke EACCES via chmod and already skip on win32, but root ignores file modes, so both fail when the suite runs as root (e.g. in a default Docker container):

- `tests/lib/session-aliases.test.js`: "saveAliases triggers inner restoreErr catch when both save and restore fail"
- `tests/lib/session-manager.test.js`: "appendSessionContent returns false when file is read-only (EACCES)"

Every other chmod-based test in the repo already guards with `process.getuid?.() === 0`; these two were the only ones missing the guard. This applies the same skip condition and message.

## Why This Change
`node tests/run-all.js` should be green in any environment. As root the chmod calls succeed but do not restrict anything, so the code under test never sees EACCES and the assertions fail - an environment artifact, not a product bug.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`) - 2619/2619 verified BOTH as a non-root user (tests execute, pass) and as root (tests skip, suite green) in clean node:22-bookworm containers
- [x] Edge cases considered and tested - `process.getuid?.()` is undefined-safe on Windows where the API does not exist

## Type of Change
- [x] `test:` Tests

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation - n/a
- [x] Added comments for complex logic - skip reason stated in the skip message
- [x] README updated (if needed) - n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip two chmod-based permission tests when running as root (in addition to Windows) to avoid false failures. Aligns with existing `process.getuid?.() === 0` guards and keeps `node tests/run-all.js` green in Docker/root environments.

- **Bug Fixes**
  - `tests/lib/session-aliases.test.js`: Skip on Windows/root; chmod cannot trigger EACCES in the save/restore double-fault case.
  - `tests/lib/session-manager.test.js`: Skip on Windows/root for the read-only file (EACCES) check.

<sup>Written for commit ffc29205acfdf2ce234e811290cbe311aa66e99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test skip conditions across multiple test files to account for root user execution contexts in addition to Windows platform checks. These changes ensure tests reliably bypass execution in environments where system permissions and filesystem behaviors may vary, improving overall test consistency and preventing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->