### PR TITLE
fix: send claude prompt via stdin so Windows shell mode doesn't mangle it

### DIFF
--- a/scripts/claw.js
+++ b/scripts/claw.js
@@ -89,13 +89,17 @@ function askClaude(systemPrompt, history, userMessage, model) {
   if (model) {
     args.push('--model', model);
   }
-  args.push('-p', fullPrompt);
+  args.push('-p');
 
-  // On Windows, the `claude` binary installed via npm is `claude.cmd`.
-  // Node's spawn() cannot resolve `.cmd` wrappers via PATH without shell: true,
-  // so this call fails with `spawn claude ENOENT` on Windows otherwise.
+  // On Windows the `claude` binary installed via npm is `claude.cmd`/`claude.ps1`,
+  // and Node's spawn() cannot resolve those wrappers via PATH without shell: true.
+  // But shell mode concatenates args *unescaped*, so a multi-line prompt passed as
+  // an arg gets mangled (newlines and the `===` section markers truncate it, and
+  // claude receives an empty prompt). Fix: send the prompt over stdin via `input`
+  // and keep only the short, safe flags (`--model`, `-p`) as args.
   // 'claude' is a hardcoded literal here (not user input), so shell mode is safe.
   const result = spawnSync('claude', args, {
+    input: fullPrompt,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
     env: { ...process.env, CLAUDECODE: '' },


### PR DESCRIPTION
## Problem

On Windows, `scripts/claw.js` → `askClaude()` sends an **empty prompt** to Claude. A normal turn comes back with something like *"that came through empty"*, and Node also prints a `DEP0190` warning about passing unescaped args under `shell: true`.

### Root cause

`askClaude()` passes the full multi-line prompt as a `claude -p <prompt>` **argument** while spawning with `shell: true`. `shell: true` is needed on Windows to resolve the npm `claude.cmd` / `claude.ps1` wrappers via `PATH` — but it also means Node concatenates the args into a command string that `cmd.exe` re-parses **unescaped**. The prompt built by `buildPrompt()` is multi-line and contains `=== SYSTEM CONTEXT ===` / `=== USER MESSAGE ===` markers, so its newlines truncate the command line and `claude -p` receives nothing usable.

## Fix

Keep only the short, safe flags (`--model`, `-p`) as args, and send the prompt over **stdin** via `spawnSync`'s `input` option:

```js
args.push('-p');               // was: args.push('-p', fullPrompt)
const result = spawnSync('claude', args, {
  input: fullPrompt,           // prompt via stdin — never hits the shell command line
  ...
});
```

The prompt never touches the shell, so multi-line / special-character prompts arrive intact. `claude -p` reads the prompt from stdin, which behaves identically on macOS/Linux, so this is cross-platform (no `os.platform()` branching needed).

## Testing

- **Windows 11, Node 24, `claude` CLI via npm:**
  - Before: a real turn returned *"…came through empty."*
  - After: real turns return correct responses, and the expected assistant turn is written to the session markdown.
- `node tests/scripts/claw.test.js` → **19/19 pass**, including `askClaude() handles subprocess error gracefully` (which exercises the new stdin path).

No behavior change on macOS/Linux; no test changes required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the full prompt to `claude` via stdin instead of a command-line arg to prevent Windows shell mangling. Fixes empty prompts on Windows while keeping behavior unchanged on macOS/Linux.

- **Bug Fixes**
  - In `scripts/claw.js` → `askClaude()`, keep only `--model` and `-p` as args and pass the prompt via `spawnSync` `input`.
  - Continue using `shell: true` so Windows can resolve `claude.cmd`/`claude.ps1`; prompt no longer hits the shell.
  - Verified on Windows 11; no behavior change on macOS/Linux.

<sup>Written for commit 1706bc571292b1dc42f92de8cf19fa9e9fc74fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved command-line input handling for enhanced reliability and stability across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->