### PR TITLE
test: guard broken-symlink tests so the suite passes on Windows

### DIFF
--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -2579,14 +2579,18 @@ function runTests() {
     const brokenLink = path.join(skillsDir, 'broken-skill');
     try {
       fs.symlinkSync('/nonexistent/target/path', brokenLink);
-    } catch {
-      // Skip on systems that don't support symlinks (e.g. Windows without
-      // Developer Mode / admin rights, where symlinkSync throws EPERM).
-      console.log('    (skipped — symlinks not supported)');
-      cleanupTestDir(testDir);
-      cleanupTestDir(agentsDir);
-      fs.rmSync(skillsDir, { recursive: true, force: true });
-      return;
+    } catch (err) {
+      // Skip only where symlink creation is blocked (e.g. Windows without
+      // Developer Mode / admin rights → EPERM/EACCES); rethrow anything else
+      // so real failures aren't masked.
+      if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+        console.log('    (skipped — symlinks not supported)');
+        cleanupTestDir(testDir);
+        cleanupTestDir(agentsDir);
+        fs.rmSync(skillsDir, { recursive: true, force: true });
+        return;
+      }
+      throw err;
     }
 
     // Command that references the valid skill (should resolve)

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -2577,7 +2577,17 @@ function runTests() {
     fs.mkdirSync(validSkill, { recursive: true });
     // Broken symlink: target does not exist — statSync will throw ENOENT
     const brokenLink = path.join(skillsDir, 'broken-skill');
-    fs.symlinkSync('/nonexistent/target/path', brokenLink);
+    try {
+      fs.symlinkSync('/nonexistent/target/path', brokenLink);
+    } catch {
+      // Skip on systems that don't support symlinks (e.g. Windows without
+      // Developer Mode / admin rights, where symlinkSync throws EPERM).
+      console.log('    (skipped — symlinks not supported)');
+      cleanupTestDir(testDir);
+      cleanupTestDir(agentsDir);
+      fs.rmSync(skillsDir, { recursive: true, force: true });
+      return;
+    }
 
     // Command that references the valid skill (should resolve)
     fs.writeFileSync(path.join(testDir, 'cmd.md'),

--- a/tests/lib/session-manager.test.js
+++ b/tests/lib/session-manager.test.js
@@ -1384,7 +1384,15 @@ src/main.ts
 
     // Create a broken symlink that matches the session filename pattern
     const brokenSymlink = '2026-02-10-deadbeef-session.tmp';
-    fs.symlinkSync('/nonexistent/path/that/does/not/exist', path.join(sessionsDir, brokenSymlink));
+    try {
+      fs.symlinkSync('/nonexistent/path/that/does/not/exist', path.join(sessionsDir, brokenSymlink));
+    } catch {
+      // Skip on systems that don't support symlinks (e.g. Windows without
+      // Developer Mode / admin rights, where symlinkSync throws EPERM).
+      console.log('    (skipped — symlinks not supported)');
+      fs.rmSync(isoHome, { recursive: true, force: true });
+      return;
+    }
 
     const origHome = process.env.HOME;
     const origUserProfile = process.env.USERPROFILE;
@@ -1421,7 +1429,15 @@ src/main.ts
 
     // Create a broken symlink that matches a session ID pattern
     const brokenFile = '2026-02-11-deadbeef-session.tmp';
-    fs.symlinkSync('/nonexistent/target/that/does/not/exist', path.join(sessionsDir, brokenFile));
+    try {
+      fs.symlinkSync('/nonexistent/target/that/does/not/exist', path.join(sessionsDir, brokenFile));
+    } catch {
+      // Skip on systems that don't support symlinks (e.g. Windows without
+      // Developer Mode / admin rights, where symlinkSync throws EPERM).
+      console.log('    (skipped — symlinks not supported)');
+      fs.rmSync(isoHome, { recursive: true, force: true });
+      return;
+    }
 
     const origHome = process.env.HOME;
     const origUserProfile = process.env.USERPROFILE;

--- a/tests/lib/session-manager.test.js
+++ b/tests/lib/session-manager.test.js
@@ -1386,12 +1386,16 @@ src/main.ts
     const brokenSymlink = '2026-02-10-deadbeef-session.tmp';
     try {
       fs.symlinkSync('/nonexistent/path/that/does/not/exist', path.join(sessionsDir, brokenSymlink));
-    } catch {
-      // Skip on systems that don't support symlinks (e.g. Windows without
-      // Developer Mode / admin rights, where symlinkSync throws EPERM).
-      console.log('    (skipped — symlinks not supported)');
-      fs.rmSync(isoHome, { recursive: true, force: true });
-      return;
+    } catch (err) {
+      // Skip only where symlink creation is blocked (e.g. Windows without
+      // Developer Mode / admin rights → EPERM/EACCES); rethrow anything else
+      // so real failures aren't masked.
+      if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+        console.log('    (skipped — symlinks not supported)');
+        fs.rmSync(isoHome, { recursive: true, force: true });
+        return;
+      }
+      throw err;
     }
 
     const origHome = process.env.HOME;
@@ -1431,12 +1435,16 @@ src/main.ts
     const brokenFile = '2026-02-11-deadbeef-session.tmp';
     try {
       fs.symlinkSync('/nonexistent/target/that/does/not/exist', path.join(sessionsDir, brokenFile));
-    } catch {
-      // Skip on systems that don't support symlinks (e.g. Windows without
-      // Developer Mode / admin rights, where symlinkSync throws EPERM).
-      console.log('    (skipped — symlinks not supported)');
-      fs.rmSync(isoHome, { recursive: true, force: true });
-      return;
+    } catch (err) {
+      // Skip only where symlink creation is blocked (e.g. Windows without
+      // Developer Mode / admin rights → EPERM/EACCES); rethrow anything else
+      // so real failures aren't masked.
+      if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+        console.log('    (skipped — symlinks not supported)');
+        fs.rmSync(isoHome, { recursive: true, force: true });
+        return;
+      }
+      throw err;
     }
 
     const origHome = process.env.HOME;

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -1417,12 +1417,16 @@ function runTests() {
     const brokenLink = path.join(tmpDir, 'broken.txt');
     try {
       fs.symlinkSync('/nonexistent/path/does/not/exist', brokenLink);
-    } catch {
-      // Skip on systems that don't support symlinks (e.g. Windows without
-      // Developer Mode / admin rights, where symlinkSync throws EPERM).
-      console.log('    (skipped — symlinks not supported)');
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-      return;
+    } catch (err) {
+      // Skip only where symlink creation is blocked (e.g. Windows without
+      // Developer Mode / admin rights → EPERM/EACCES); rethrow anything else
+      // so real failures aren't masked.
+      if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+        console.log('    (skipped — symlinks not supported)');
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        return;
+      }
+      throw err;
     }
 
     try {

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -1415,7 +1415,15 @@ function runTests() {
     const realFile = path.join(tmpDir, 'real.txt');
     fs.writeFileSync(realFile, 'content');
     const brokenLink = path.join(tmpDir, 'broken.txt');
-    fs.symlinkSync('/nonexistent/path/does/not/exist', brokenLink);
+    try {
+      fs.symlinkSync('/nonexistent/path/does/not/exist', brokenLink);
+    } catch {
+      // Skip on systems that don't support symlinks (e.g. Windows without
+      // Developer Mode / admin rights, where symlinkSync throws EPERM).
+      console.log('    (skipped — symlinks not supported)');
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    }
 
     try {
       const results = utils.findFiles(tmpDir, '*.txt');


### PR DESCRIPTION
## Problem

Four test cases create a **dangling symlink** with `fs.symlinkSync()` (to exercise `statSync` catch branches) without guarding for platforms where symlink creation isn't permitted. On **Windows without Developer Mode / admin rights**, `fs.symlinkSync` throws `EPERM`, so these tests **fail** and `npm test` is red on Windows:

| File | Round | Test |
|------|-------|------|
| `tests/ci/validators.test.js` | 73 | skips unreadable skill directory entries (broken symlink) |
| `tests/lib/session-manager.test.js` | 83 | getAllSessions skips broken symlink .tmp files gracefully |
| `tests/lib/session-manager.test.js` | 84 | getSessionById returns null when matching session is a broken symlink |
| `tests/lib/utils.test.js` | 84 | findFiles skips broken symlinks that match the pattern |

### Reproduction (Windows 11, Node 24, non-admin)
```
$ node tests/ci/validators.test.js
  ✗ skips unreadable skill directory entries without error (broken symlink)
    Error: EPERM: operation not permitted, symlink 'C:\nonexistent\target\path' -> '...\broken-skill'
  Results: Passed: 164, Failed: 1
```
Same `EPERM` failure in the session-manager (×2) and utils rounds.

## Fix

Wrap each `symlinkSync` in `try/catch` and skip cleanly on failure, **mirroring the convention already used in this repo** — see `tests/ci/validators.test.js` Round 57 and `tests/hooks/config-protection.test.js`:

```js
try {
  fs.symlinkSync('/nonexistent/...', linkPath);
} catch {
  // Skip on systems that don't support symlinks (e.g. Windows without
  // Developer Mode / admin rights, where symlinkSync throws EPERM).
  console.log('    (skipped — symlinks not supported)');
  /* clean up temp dirs */ return;
}
```

On Linux/macOS and admin Windows the symlink still succeeds and the tests run **exactly as before**; only the unsupported-symlink path now skips instead of failing. Test-only change — no runtime/source behavior is affected.

## Verification

After the change, on the same Windows machine:

```
tests/ci/validators.test.js        Results: Passed: 165, Failed: 0   (was 164/1)
tests/lib/session-manager.test.js  Results: Passed: 169, Failed: 0   (was 167/2)
tests/lib/utils.test.js            Failed: 0                         (was 1)
```
The guarded tests print `(skipped — symlinks not supported)`. `npx eslint` on the three files and `scripts/ci/check-unicode-safety.js` both pass.

## Notes / out of scope
- `tests/scripts/trae-install.test.js` also uses `symlinkSync`, but that file is already skipped wholesale on Windows ("Trae shell scripts are Unix-only"), so it does not fail — intentionally left untouched.
- Separately observed on Windows (not addressed here, possible follow-ups): a timeout-enforcement test in `tests/integration/hooks.test.js` and a slow `tests/lib/agent-compress.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded dangling-symlink tests so the suite passes on Windows where symlink creation needs admin/Developer Mode. When `fs.symlinkSync` throws `EPERM`/`EACCES`, tests skip and clean up; other errors rethrow to avoid masking real failures.

- **Bug Fixes**
  - Wrapped `fs.symlinkSync` in try/catch in `tests/ci/validators.test.js`, `tests/lib/session-manager.test.js` (×2), and `tests/lib/utils.test.js`; on `EPERM`/`EACCES` log skip, clean up, and return; otherwise rethrow.
  - No source/runtime changes; behavior unchanged on systems where symlinks work.

<sup>Written for commit 0dc969220bed1edca2b4aa1952c60556c887904f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test resilience on systems where creating symlinks is restricted. Tests that attempt to create broken symlinks now catch unsupported errors, log a skip, clean up temporary test artifacts, and return early instead of failing. When symlink creation succeeds, original assertions still run—improving cross-platform reliability of the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->