### PR TITLE
fix(.cursor/hooks): route block-no-verify through local hook to fix message-body false positives (#2107)

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -17,7 +17,7 @@
     ],
     "beforeShellExecution": [
       {
-        "command": "npx block-no-verify@1.1.2",
+        "command": "node .cursor/hooks/before-shell-execution-block-no-verify.js",
         "event": "beforeShellExecution",
         "description": "Block git hook-bypass flag to protect pre-commit, commit-msg, and pre-push hooks from being skipped"
       },

--- a/.cursor/hooks/before-shell-execution-block-no-verify.js
+++ b/.cursor/hooks/before-shell-execution-block-no-verify.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Cursor wrapper for block-no-verify.
+ *
+ * Cursor hooks previously called `npx block-no-verify@1.1.2`, an external
+ * package whose matcher over-matches: it blocks legitimate `git commit`
+ * whenever the literal string `--no-verify` (or `no-verify`) appears
+ * anywhere in the command string, including inside the commit message
+ * body. See issue #2107.
+ *
+ * The Claude Code surface already routes through the local, in-repo hook
+ * `scripts/hooks/block-no-verify.js`, which performs flag-position-aware
+ * tokenisation (skipping the value of `-m`, `-F`, `-am "..."`, etc.) and
+ * passes 25 regression tests covering every false-positive case.
+ *
+ * This wrapper gives Cursor the same matcher: read Cursor stdin, transform
+ * to the Claude Code `tool_input.command` shape the local hook understands,
+ * delegate to its exported `run()`, then forward the exit code and stderr.
+ */
+
+'use strict';
+
+const { readStdin, hookEnabled } = require('./adapter');
+const { run } = require('../../scripts/hooks/block-no-verify');
+
+readStdin()
+  .then(raw => {
+    if (!hookEnabled('pre:bash:block-no-verify', ['minimal', 'standard', 'strict'])) {
+      process.stdout.write(raw);
+      return;
+    }
+
+    let command = '';
+    try {
+      const parsed = JSON.parse(raw || '{}');
+      command = String(parsed.command || parsed.args?.command || '');
+    } catch {
+      command = String(raw || '');
+    }
+
+    // Local hook accepts either the raw command string or a Claude-Code
+    // shaped `{ tool_input: { command } }` JSON. Pass the Claude shape so
+    // the JSON branch in extractCommand() is exercised the same way the
+    // Claude Code surface exercises it — keeps the two surfaces on the
+    // same code path.
+    const claudeInput = JSON.stringify({ tool_input: { command } });
+    const result = run(claudeInput);
+
+    if (result && result.exitCode === 2) {
+      if (result.stderr) {
+        process.stderr.write(String(result.stderr) + '\n');
+      }
+      process.exit(2);
+    }
+
+    process.stdout.write(raw);
+  })
+  .catch(() => {
+    // Per repo rule: hooks must exit 0 on non-critical errors and never
+    // unexpectedly block tool execution. A parse / transport error here
+    // is non-critical — fall through.
+    process.exit(0);
+  });

--- a/tests/hooks/cursor-block-no-verify.test.js
+++ b/tests/hooks/cursor-block-no-verify.test.js
@@ -1,0 +1,147 @@
+/**
+ * Tests for .cursor/hooks/before-shell-execution-block-no-verify.js
+ *
+ * Issue #2107: previously .cursor/hooks.json wired `npx block-no-verify@1.1.2`,
+ * which over-matches and blocks legitimate commits whose message body
+ * mentions `--no-verify` or `-n`. The wrapper added in this PR delegates
+ * to the local scripts/hooks/block-no-verify.js so Cursor users get the
+ * same flag-position-aware matcher Claude Code already uses.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const wrapper = path.join(
+  __dirname, '..', '..',
+  '.cursor', 'hooks', 'before-shell-execution-block-no-verify.js'
+);
+
+function runWrapper(input, env = {}) {
+  const rawInput = typeof input === 'string' ? input : JSON.stringify(input);
+  const result = spawnSync('node', [wrapper], {
+    input: rawInput,
+    encoding: 'utf8',
+    env: { ...process.env, ECC_HOOK_PROFILE: 'standard', ...env },
+    timeout: 15000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  return {
+    code: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+console.log('\ncursor block-no-verify wrapper tests');
+console.log('─'.repeat(50));
+
+// --- Cursor input shapes ---
+
+if (test('reads Cursor top-level command field', () => {
+  const r = runWrapper({ command: 'git commit -m "hello"' });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('reads Cursor args.command field', () => {
+  const r = runWrapper({ args: { command: 'git commit -m "hello"' } });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Issue #2107 false positives now allowed ---
+
+if (test('#2107: allows --no-verify mentioned in double-quoted message body', () => {
+  const r = runWrapper({ command: 'git commit -m "docs: explain why we never pass --no-verify"' });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('#2107: allows --no-verify mentioned in single-quoted message body', () => {
+  const r = runWrapper({ command: "git commit -m 'docs: discuss --no-verify risk'" });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('#2107: allows -n mentioned in quoted message body', () => {
+  const r = runWrapper({ command: 'git commit -m "fix: handle -n flag in parser"' });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('#2107: allows commit message containing the literal string "block-no-verify"', () => {
+  const r = runWrapper({ command: 'git commit -m "feat: add block-no-verify hook"' });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Real bypass attempts still blocked ---
+
+if (test('still blocks real --no-verify flag', () => {
+  const r = runWrapper({ command: 'git commit --no-verify -m "msg"' });
+  assert.strictEqual(r.code, 2, `expected 2, got ${r.code}`);
+  assert.ok(r.stderr.includes('BLOCKED'), `stderr should contain BLOCKED: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still blocks -n shorthand on git commit', () => {
+  const r = runWrapper({ command: 'git commit -n -m "msg"' });
+  assert.strictEqual(r.code, 2, `expected 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still blocks core.hooksPath override', () => {
+  const r = runWrapper({ command: 'git -c core.hooksPath=/dev/null commit -m "msg"' });
+  assert.strictEqual(r.code, 2, `expected 2, got ${r.code}`);
+  assert.ok(r.stderr.includes('core.hooksPath'), `stderr should mention core.hooksPath: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still blocks --no-verify on git push', () => {
+  const r = runWrapper({ command: 'git push --no-verify' });
+  assert.strictEqual(r.code, 2, `expected 2, got ${r.code}`);
+})) passed++; else failed++;
+
+// --- Pass-through cases ---
+
+if (test('allows non-git commands', () => {
+  const r = runWrapper({ command: 'npm test' });
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('handles empty stdin gracefully', () => {
+  const r = runWrapper('');
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('handles malformed JSON gracefully (treats raw as command string)', () => {
+  const r = runWrapper('git commit -m "hello"');
+  assert.strictEqual(r.code, 0, `expected 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Disable via ECC_DISABLED_HOOKS ---
+
+if (test('respects ECC_DISABLED_HOOKS=pre:bash:block-no-verify', () => {
+  const r = runWrapper(
+    { command: 'git commit --no-verify -m "msg"' },
+    { ECC_DISABLED_HOOKS: 'pre:bash:block-no-verify' }
+  );
+  // When the hook is disabled, the wrapper should pass through (exit 0)
+  // even on a real bypass attempt.
+  assert.strictEqual(r.code, 0, `expected 0 when disabled, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+console.log('─'.repeat(50));
+console.log(`Passed: ${passed}  Failed: ${failed}`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Cursor hooks were still wired to `npx block-no-verify@1.1.2`, the
  external package whose matcher over-matches: it blocks legitimate
  `git commit` whenever the literal string `--no-verify` (or `no-verify`)
  appears anywhere in the command — including inside the commit message
  body. See [#2107](https://github.com/affaan-m/ECC/issues/2107) for the
  reproduction.
- The Claude Code surface (`hooks/hooks.json`) already routes through
  the local `scripts/hooks/block-no-verify.js`, which uses
  flag-position-aware tokenisation (`-m`/`-F`/`-am "..."` / `-tn` etc.)
  and already passes 25 regression tests covering every false-positive
  case described in #2107. Cursor users were missing out.
- Add a thin Cursor wrapper, `.cursor/hooks/before-shell-execution-block-no-verify.js`,
  that reads Cursor stdin, transforms to the Claude Code
  `tool_input.command` shape, delegates to the local hook's exported
  `run()`, and forwards exit code and stderr. Update `.cursor/hooks.json`
  to call the wrapper instead of the npx package.
- The wrapper honours the standard `ECC_HOOK_PROFILE` and
  `ECC_DISABLED_HOOKS=pre:bash:block-no-verify` runtime gating via
  `adapter.hookEnabled`, matching the rest of the Cursor hook surface.

## Verification

- `node tests/hooks/cursor-block-no-verify.test.js` — 14/14 pass (new
  file; pins each false-positive case from #2107 plus the still-blocked
  real bypass attempts and the disable-via-env path).
- `node tests/hooks/block-no-verify.test.js` — 25/25 pass (existing
  local-hook tests stay green).
- `node tests/run-all.js` — 2633/2633 pass.
- `node scripts/ci/validate-no-personal-paths.js` — clean.
- `node scripts/ci/check-unicode-safety.js` — clean.
- `node scripts/ci/validate-hooks.js` — 28 hook matchers validated.
- `npx eslint tests/hooks/cursor-block-no-verify.test.js` — clean
  (`.cursor/**` is intentionally ignored by `eslint.config.js`).

Fixes #2107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Cursor’s `block-no-verify` hook through the local, flag-aware implementation to stop false blocks when `--no-verify` appears in commit messages, while still blocking real bypass attempts. Fixes #2107.

- **Bug Fixes**
  - Replaced `npx block-no-verify@1.1.2` with `node .cursor/hooks/before-shell-execution-block-no-verify.js`, which delegates to `scripts/hooks/block-no-verify.js` for position-aware parsing and consistent behavior with Claude Code.
  - Added `tests/hooks/cursor-block-no-verify.test.js` (14 cases) to pin false-positive regressions and blocking paths; wrapper respects `ECC_HOOK_PROFILE` and `ECC_DISABLED_HOOKS`.

<sup>Written for commit 484b6d57f95a156f22a86bf63cbd36178aeec428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for hook wrapper behavior, validating bypass prevention across multiple commit/push scenarios, malformed input handling, and configuration-based disabling.

* **Chores**
  * Migrated pre-execution hook implementation from external npm package to local wrapper script, improving system reliability and operational consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->