### PR TITLE
fix(dev-server-block): stop blocking dev-<suffix> scripts (dev-setup, dev-docs)

### DIFF
--- a/scripts/hooks/pre-bash-dev-server-block.js
+++ b/scripts/hooks/pre-bash-dev-server-block.js
@@ -161,7 +161,11 @@ process.stdin.on('data', chunk => {
 });
 
 const TMUX_LAUNCHER = /^\s*tmux\s+(new|new-session|new-window|split-window)\b/;
-const DEV_PATTERN = /\b(npm\s+run\s+dev|pnpm(?:\s+run)?\s+dev|yarn(?:\s+run)?\s+dev|bun(?:\s+run)?\s+dev)\b/;
+// Trailing (?![\w-]) rather than \b: \b treats a hyphen as a word boundary, so
+// `dev\b` matches the `dev` prefix of distinct scripts like `dev-setup` /
+// `dev-docs` / `dev-build` and wrongly blocks them. The lookahead still matches
+// the dev server (`dev`, `dev;`, `dev:ssr`, ...) but not a `dev-<suffix>` script.
+const DEV_PATTERN = /\b(npm\s+run\s+dev|pnpm(?:\s+run)?\s+dev|yarn(?:\s+run)?\s+dev|bun(?:\s+run)?\s+dev)(?![\w-])/;
 
 /**
  * Collect every command-line segment we should evaluate. Returns the top-level

--- a/tests/hooks/pre-bash-dev-server-block.test.js
+++ b/tests/hooks/pre-bash-dev-server-block.test.js
@@ -63,6 +63,11 @@ function runTests() {
       const result = runScript('bun run dev');
       assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
     }) ? passed++ : failed++);
+
+    (test('still blocks npm run dev:ssr — colon variant is a dev server (exit 2)', () => {
+      const result = runScript('npm run dev:ssr');
+      assert.strictEqual(result.code, 2, `Expected exit code 2, got ${result.code}`);
+    }) ? passed++ : failed++);
   } else {
     console.log('  (skipping blocking tests on Windows)\n');
   }
@@ -86,6 +91,23 @@ function runTests() {
 
   (test('allows npm run build (exit code 0)', () => {
     const result = runScript('npm run build');
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+  }) ? passed++ : failed++);
+
+  // --- dev-<suffix> scripts are distinct from the dev server, must not be blocked ---
+
+  (test('allows npm run dev-setup — distinct script, not the dev server (exit 0)', () => {
+    const result = runScript('npm run dev-setup');
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+  }) ? passed++ : failed++);
+
+  (test('allows pnpm run dev-docs — distinct script (exit 0)', () => {
+    const result = runScript('pnpm run dev-docs');
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+  }) ? passed++ : failed++);
+
+  (test('allows yarn dev-build — distinct script (exit 0)', () => {
+    const result = runScript('yarn dev-build');
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
   }) ? passed++ : failed++);
 


### PR DESCRIPTION
## Problem

`pre-bash-dev-server-block.js` wrongly **blocks** legitimate npm scripts whose name merely starts with `dev`, e.g. `dev-setup`, `dev-docs`, `dev-build`:

```
$ echo '{"tool_input":{"command":"npm run dev-setup"}}' | node scripts/hooks/pre-bash-dev-server-block.js
[Hook] BLOCKED: Dev server must run in tmux for log access
# exit 2  -- should be exit 0
```

## Root cause

```js
const DEV_PATTERN = /\b(npm\s+run\s+dev|...|bun(?:\s+run)?\s+dev)\b/;
```

The trailing `\b` treats a hyphen as a word boundary, so `dev\b` matches the `dev` prefix of `dev-setup` (boundary between `v` and `-`). These are distinct scripts, not the dev server.

## Fix

Replace the trailing `\b` with a negative lookahead `(?![\w-])`. This is surgical — it only changes the hyphen case:

| command | before | after |
|---|---|---|
| `npm run dev` | blocked | **blocked** (unchanged) |
| `npm run dev:ssr` | blocked | **blocked** (unchanged — still a dev server) |
| `npm run develop` / `devtools` | allowed | allowed (unchanged) |
| `npm run dev-setup` / `dev-docs` / `dev-build` | **blocked** | **allowed** (fixed) |

## Tests

Added regression tests to `tests/hooks/pre-bash-dev-server-block.test.js`: `dev-setup`/`dev-docs`/`dev-build` now pass (exit 0), and `dev:ssr` is asserted to remain blocked so the fix stays scoped to hyphen suffixes. Full file: **33 passed, 0 failed**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the dev server hook from blocking `dev-<suffix>` scripts like `dev-setup` and `dev-docs`. Real dev server commands are still blocked.

- **Bug Fixes**
  - Update `DEV_PATTERN` to use `(?![\w-])` instead of trailing `\b`, allowing `dev-<suffix>` scripts.
  - Behavior unchanged: blocks `npm run dev` and `npm run dev:ssr`; allows `develop` and `devtools`.
  - Add regression tests for allowed `dev-setup`/`dev-docs`/`dev-build` and blocked `dev:ssr`.

<sup>Written for commit 805372ee2932b241503693e2cf2f93e2e3d54817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dev-server blocking logic to better distinguish between the main development server and related utility scripts, allowing scripts like `dev-build` and `dev-docs` to execute properly.

* **Tests**
  * Added test coverage for additional blocking scenarios and utility script allowlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->