### PR TITLE
fix(session-end): preserve $-sequences in user messages (summary corruption)

### DIFF
--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -255,16 +255,20 @@ async function main() {
     if (summary && updatedContent) {
       const summaryBlock = buildSummaryBlock(summary);
 
+      // Use function replacers: summaryBlock embeds raw user-message text, and a
+      // string replacement argument interprets $-sequences ($&, $$, $`, $', $n).
+      // A $& in a user message would otherwise re-inject the entire matched block
+      // and corrupt the persisted summary. A function replacer is treated literally.
       if (updatedContent.includes(SUMMARY_START_MARKER) && updatedContent.includes(SUMMARY_END_MARKER)) {
         updatedContent = updatedContent.replace(
           new RegExp(`${escapeRegExp(SUMMARY_START_MARKER)}[\\s\\S]*?${escapeRegExp(SUMMARY_END_MARKER)}`),
-          summaryBlock
+          () => summaryBlock
         );
       } else {
         // Migration path for files created before summary markers existed.
         updatedContent = updatedContent.replace(
           /## (?:Session Summary|Current State)[\s\S]*?$/,
-          `${summaryBlock}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\`\n`
+          () => `${summaryBlock}\n\n### Notes for Next Session\n-\n\n### Context to Load\n\`\`\`\n[relevant files]\n\`\`\`\n`
         );
       }
     }

--- a/tests/hooks/session-end.test.js
+++ b/tests/hooks/session-end.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for session-end.js hook
+ *
+ * Run with: node tests/hooks/session-end.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { getDateString, sanitizeSessionId } = require('../../scripts/lib/utils');
+
+const script = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'session-end.js');
+const START = '<!-- ECC:SUMMARY:START -->';
+const END = '<!-- ECC:SUMMARY:END -->';
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+function countOccurrences(haystack, needle) {
+  let n = 0;
+  let i = 0;
+  while ((i = haystack.indexOf(needle, i)) !== -1) {
+    n += 1;
+    i += needle.length;
+  }
+  return n;
+}
+
+function runTests() {
+  console.log('\n=== Testing session-end.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  // Regression: a user message containing $-sequences ($&, $$, $`, $') must be
+  // written verbatim into the rewritten summary block. The block is fed to
+  // String.prototype.replace as the replacement argument, where those sequences
+  // are special — without escaping/a function replacer they corrupt the summary
+  // (e.g. $& injects the entire matched old block, duplicating the markers).
+  (test('preserves $-sequences in user messages when rewriting the summary block', () => {
+    // Isolate HOME so getSessionsDir() resolves under a temp dir.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-session-end-'));
+    try {
+      const sessionsDir = path.join(home, '.claude', 'session-data');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      // shortId is derived from the transcript filename UUID (last 8 chars).
+      const uuid = 'abcdef12-3456-7890-abcd-ef0123456789';
+      const shortId = sanitizeSessionId(uuid.slice(-8).toLowerCase());
+      const today = getDateString();
+      const sessionFile = path.join(sessionsDir, `${today}-${shortId}-session.tmp`);
+
+      // Pre-seed a session file that already has summary markers, so the
+      // idempotent rewrite path runs .replace() with the new summary block.
+      fs.writeFileSync(
+        sessionFile,
+        `# Session: ${today}\n**Date:** ${today}\n---\n${START}\n## Session Summary\n\n### Tasks\n- old task\n${END}\n`
+      );
+
+      // Transcript whose user message contains replacement-special $-sequences.
+      const userText = 'release $& fallback $$ done';
+      const transcript = path.join(home, `${uuid}.jsonl`);
+      fs.writeFileSync(
+        transcript,
+        JSON.stringify({ type: 'user', message: { role: 'user', content: userText } }) + '\n'
+      );
+
+      const res = spawnSync('node', [script], {
+        encoding: 'utf8',
+        input: JSON.stringify({ transcript_path: transcript }),
+        env: { ...process.env, HOME: home, USERPROFILE: home, CLAUDE_SESSION_ID: '' },
+        timeout: 10000,
+      });
+      assert.strictEqual(res.status || 0, 0, `hook exited ${res.status}: ${res.stderr}`);
+
+      const out = fs.readFileSync(sessionFile, 'utf8');
+      // User text must survive verbatim (no $&/$$ interpretation).
+      assert.ok(out.includes(`- ${userText}`), `expected verbatim user text in:\n${out}`);
+      // Exactly one marker pair — a $& bug re-injects the matched block, duplicating markers.
+      assert.strictEqual(countOccurrences(out, START), 1, `START marker should appear once:\n${out}`);
+      assert.strictEqual(countOccurrences(out, END), 1, `END marker should appear once:\n${out}`);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Problem

`session-end.js` (Stop hook) silently **corrupts the persisted session summary** when a user message contains a `$`-sequence (`$&`, `$$`, `$\``, `$'`) — which is common in dev work (regexes, `PASS=$1`, prices like `$5`, shell snippets).

## Root cause

The regenerated summary block embeds raw user-message text, and is passed as the **replacement argument** to `String.prototype.replace` (lines 259 & 265):

```js
updatedContent = updatedContent.replace(markerRegex, summaryBlock); // summaryBlock has user text
```

In a replacement string, `$&` = the whole match, `$$` = `$`, etc. `buildSummarySection` escapes newlines and backticks but **not `$`**. So on any repeat Stop (when the file already has the summary markers), a user message like `release $& fallback` makes `$&` re-inject the entire matched old block, **duplicating the summary markers** and dropping the user's text.

Verified corruption on a `release $& fallback $$ done` message (markers duplicated, `$$` → `$`):
```
### Tasks
- release <!-- ECC:SUMMARY:START -->
## Session Summary
### Tasks
- old task
<!-- ECC:SUMMARY:END --> fallback $ done
```

## Fix

Use **function replacers** (`() => summaryBlock`) at both rewrite sites — a function replacement is treated literally, so no `$`-interpretation occurs. (Equivalent to escaping `$`→`$$`; the function form is cleaner and covers all sequences.)

## Tests

Adds `tests/hooks/session-end.test.js` — an end-to-end regression test (seeds a marker'd session file + a transcript whose user message contains `$&`/`$$`, runs the hook, asserts the text survives verbatim and the markers appear exactly once). Confirmed it fails on the current code and passes with the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes summary corruption in the session-end hook when user messages include $-sequences (e.g., $&, $$). Replacements now treat the summary block literally so user text is preserved and markers appear once.

- **Bug Fixes**
  - Use function replacers for both summary rewrite paths to avoid `$` interpretation by `String.prototype.replace`.
  - Add an end-to-end regression test that verifies `$&`, `$$`, `$'`, and `$`` are preserved and that the summary marker pair appears exactly once.

<sup>Written for commit d5c3e811fc9ef7631c929d642fafd53a33314eff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain special characters in user messages could interfere with session summary generation and storage.

* **Tests**
  * Added regression tests to verify session summary reliability with various message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->