### PR TITLE
fix(project-detect): match packageKeys on boundaries, not substrings (preact→react)

### DIFF
--- a/scripts/lib/project-detect.js
+++ b/scripts/lib/project-detect.js
@@ -390,7 +390,20 @@ function detectProjectType(projectDir) {
           depList = elixirDeps;
           break;
       }
-      hasDep = rule.packageKeys.some(key => depList.some(dep => dep.toLowerCase().includes(key.toLowerCase())));
+      // Boundary-aware match: a dependency matches a packageKey only when it
+      // equals the key, or the key is a prefix immediately followed by a
+      // delimiter (/ . _ -). Plain substring matching wrongly classified
+      // `preact` / `reactive` as `react`. This still matches the real cases:
+      // react-dom, @remix-run/node, spring-boot-starter, org.springframework.boot,
+      // github.com/labstack/echo/v4, phoenix_live_view.
+      hasDep = rule.packageKeys.some(key => {
+        const k = key.toLowerCase();
+        return depList.some(dep => {
+          const d = dep.toLowerCase();
+          if (!d.startsWith(k)) return false;
+          return d.length === k.length || /[/._-]/.test(d[k.length]);
+        });
+      });
     }
 
     if (hasMarker || hasDep) {

--- a/tests/lib/project-detect.test.js
+++ b/tests/lib/project-detect.test.js
@@ -207,6 +207,39 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('does not misclassify preact as react (substring guard)', () => {
+    const dir = createTempDir();
+    try {
+      writeTestFile(dir, 'package.json', '{"dependencies":{"preact":"10.0.0"}}');
+      const result = detectProjectType(dir);
+      assert.ok(!result.frameworks.includes('react'), `preact wrongly detected as react: ${JSON.stringify(result.frameworks)}`);
+    } finally {
+      cleanupDir(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not misclassify reactive as react (substring guard)', () => {
+    const dir = createTempDir();
+    try {
+      writeTestFile(dir, 'package.json', '{"dependencies":{"reactive":"1.0.0"}}');
+      const result = detectProjectType(dir);
+      assert.ok(!result.frameworks.includes('react'), `reactive wrongly detected as react: ${JSON.stringify(result.frameworks)}`);
+    } finally {
+      cleanupDir(dir);
+    }
+  })) passed++; else failed++;
+
+  if (test('still detects react from react-dom alone (prefix-delimiter match preserved)', () => {
+    const dir = createTempDir();
+    try {
+      writeTestFile(dir, 'package.json', '{"dependencies":{"react-dom":"18.0.0"}}');
+      const result = detectProjectType(dir);
+      assert.ok(result.frameworks.includes('react'), `react-dom should still map to react: ${JSON.stringify(result.frameworks)}`);
+    } finally {
+      cleanupDir(dir);
+    }
+  })) passed++; else failed++;
+
   if (test('detects angular from angular.json', () => {
     const dir = createTempDir();
     try {


### PR DESCRIPTION
## Problem

Framework detection misclassifies dependencies whose name merely *contains* a framework key. `project-detect.js` reports **`preact` — and even `reactive` — as `react`**:

```js
// package.json: { "dependencies": { "preact": "10.0.0" } }
detectProjectType(dir).frameworks // => ["react"]   (wrong)
```

Other collisions: `svelte-check`-only → `svelte`, `nextra` → `nextjs`.

## Root cause

```js
hasDep = rule.packageKeys.some(key => depList.some(dep => dep.toLowerCase().includes(key.toLowerCase())));
```

`String.includes` is unbounded substring matching with no name boundary.

## Fix

Match only when the dependency **equals** the key, or the key is a **prefix immediately followed by a delimiter** (`/` `.` `_` `-`):

```js
if (!d.startsWith(k)) return false;
return d.length === k.length || /[/._-]/.test(d[k.length]);
```

This still matches every real case — `react-dom`, `@remix-run/node`, `spring-boot-starter`, `org.springframework.boot`, `github.com/labstack/echo/v4`, `phoenix_live_view` — while excluding `preact`/`reactive` (and incidentally fixing `nextra`).

I kept all four delimiters (`/ . _ -`) so the dotted/scoped/underscored ecosystem keys (Spring, Go module paths, Elixir) keep working — happy to tune the delimiter set if you'd prefer something narrower.

## Tests

Adds regression tests to `tests/lib/project-detect.test.js`: `preact`/`reactive` no longer map to `react`, and `react-dom` alone still does. Full file: **33 passed, 0 failed** (the 2 new negative cases fail on current `main`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix framework detection by matching `packageKeys` on name boundaries instead of substrings. This stops false positives like `preact`/`reactive` → `react` while keeping `react-dom` and `@remix-run/node` working.

- **Bug Fixes**
  - Replace substring match with boundary check: equal to key or key followed by a delimiter (`/ . _ -`).
  - Add regression tests for negative and positive cases.

<sup>Written for commit b517a8aed08bdb8f9ad7bbe3a117f54513741179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved framework dependency detection with refined package matching logic, reducing false positives from similarly-named dependencies.

**Tests**
- Added test cases to verify correct framework detection with similar-named packages and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->