### PR TITLE
fix(security): add host/origin allowlist + validate git refs + quote workflow input

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -67,8 +67,9 @@ jobs:
           COREPACK_ENABLE_STRICT: '0'
           npm_config_ignore_scripts: 'true'
           YARN_ENABLE_SCRIPTS: 'false'
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             npm) npm ci --ignore-scripts ;;
             # pnpm v10 can fail CI on ignored native build scripts
             # (for example msgpackr-extract) even though this repo is Yarn-native
@@ -77,7 +78,7 @@ jobs:
             # Yarn Berry (v4+) removed --ignore-engines; engine checking is no longer a core feature
             yarn) yarn install --mode=skip-build ;;
             bun) bun install --ignore-scripts ;;
-            *) echo "Unsupported package manager: ${{ inputs.package-manager }}" && exit 1 ;;
+            *) echo "Unsupported package manager: $PACKAGE_MANAGER" && exit 1 ;;
           esac
 
       - name: Run tests

--- a/.opencode/tools/git-summary.ts
+++ b/.opencode/tools/git-summary.ts
@@ -5,7 +5,24 @@
  */
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
+
+// Conservative subset of git's allowed ref-name characters. Rejects shell
+// metacharacters and option-like leading `-` so a model-supplied baseBranch
+// cannot inject into the shell command line built below.
+const SAFE_GIT_REF = /^[A-Za-z0-9._/-]+$/
+
+function isSafeRef(ref: string): boolean {
+  if (typeof ref !== "string" || ref.length === 0 || ref.length > 200) return false
+  if (!SAFE_GIT_REF.test(ref)) return false
+  if (ref.startsWith("-") || ref.startsWith(".") || ref.startsWith("/")) return false
+  if (ref.includes("..") || ref.includes("//")) return false
+  return true
+}
+
+function isSafeDepth(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 1000
+}
 
 const gitSummaryTool: ToolDefinition = tool({
   description:
@@ -26,19 +43,22 @@ const gitSummaryTool: ToolDefinition = tool({
   },
   async execute(args, context) {
     const cwd = context.worktree || context.directory
-    const depth = args.depth ?? 5
+    const depth = isSafeDepth(args.depth) ? args.depth : 5
     const includeDiff = args.includeDiff ?? true
     const baseBranch = args.baseBranch ?? "main"
 
     const result: Record<string, string> = {
-      branch: run("git branch --show-current", cwd) || "unknown",
-      status: run("git status --short", cwd) || "clean",
-      log: run(`git log --oneline -${depth}`, cwd) || "no commits found",
+      branch: runArgs(["branch", "--show-current"], cwd) || "unknown",
+      status: runArgs(["status", "--short"], cwd) || "clean",
+      log: runArgs(["log", "--oneline", `-${depth}`], cwd) || "no commits found",
     }
 
     if (includeDiff) {
-      result.stagedDiff = run("git diff --cached --stat", cwd) || ""
-      result.branchDiff = run(`git diff ${baseBranch}...HEAD --stat`, cwd) || `unable to diff against ${baseBranch}`
+      result.stagedDiff = runArgs(["diff", "--cached", "--stat"], cwd) || ""
+      result.branchDiff = isSafeRef(baseBranch)
+        ? runArgs(["diff", `${baseBranch}...HEAD`, "--stat"], cwd) ||
+          `unable to diff against ${baseBranch}`
+        : `unable to diff against ${baseBranch} (invalid ref)`
     }
 
     return JSON.stringify(result)
@@ -47,9 +67,9 @@ const gitSummaryTool: ToolDefinition = tool({
 
 export default gitSummaryTool
 
-function run(command: string, cwd: string): string {
+function runArgs(args: string[], cwd: string): string {
   try {
-    return execSync(command, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim()
+    return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim()
   } catch {
     return ""
   }

--- a/scripts/lib/control-pane/server.js
+++ b/scripts/lib/control-pane/server.js
@@ -9,6 +9,43 @@ const { buildControlPaneAction } = require('./actions');
 const { buildControlPaneSnapshot, resolveControlPaneConfig } = require('./state');
 const { renderControlPaneHtml } = require('./ui');
 
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]', '::1']);
+
+// Extract the hostname portion of an HTTP Host header value, stripping any
+// port. Returns null when the header is missing or malformed. Used to gate
+// requests against a local-only allowlist so DNS-rebinding cannot pivot a
+// browser tab into the loopback control-pane API.
+function parseHostHeader(value) {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(\[[^\]]+\]|[^:]+)(?::\d+)?$/);
+  if (!match) return null;
+  return match[1].toLowerCase();
+}
+
+function buildAllowedHostnames(configuredHost) {
+  const set = new Set(LOOPBACK_HOSTNAMES);
+  if (configuredHost) set.add(String(configuredHost).toLowerCase());
+  return set;
+}
+
+function isAllowedHostHeader(hostHeader, allowedHostnames) {
+  const hostname = parseHostHeader(hostHeader);
+  if (!hostname) return false;
+  return allowedHostnames.has(hostname);
+}
+
+function isAllowedOrigin(originHeader, allowedHostnames) {
+  if (!originHeader || typeof originHeader !== 'string') return true;
+  try {
+    const url = new URL(originHeader);
+    return allowedHostnames.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 function usage() {
   return [
     'Usage:',
@@ -159,9 +196,19 @@ function createControlPaneServer(options = {}) {
     env: options.env || process.env,
   });
   const baseQuery = options.query || '';
+  const allowedHostnames = buildAllowedHostnames(host);
 
   const server = http.createServer(async (req, res) => {
     try {
+      if (!isAllowedHostHeader(req.headers.host, allowedHostnames)) {
+        sendJson(res, 421, { ok: false, error: 'Misdirected request' });
+        return;
+      }
+      if (!isAllowedOrigin(req.headers.origin, allowedHostnames)) {
+        sendJson(res, 403, { ok: false, error: 'Forbidden origin' });
+        return;
+      }
+
       const requestUrl = new URL(req.url, `http://${host}:${port || 0}`);
 
       if (req.method === 'GET' && requestUrl.pathname === '/') {
@@ -280,5 +327,8 @@ module.exports = {
   createControlPaneServer,
   parseArgs,
   runAction,
+  isAllowedHostHeader,
+  isAllowedOrigin,
+  buildAllowedHostnames,
   usage,
 };

--- a/tests/scripts/control-pane.test.js
+++ b/tests/scripts/control-pane.test.js
@@ -4,6 +4,7 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const http = require('http');
 const os = require('os');
 const path = require('path');
 const { spawn, spawnSync } = require('child_process');
@@ -14,6 +15,9 @@ const {
   createControlPaneServer,
   parseArgs,
   runAction,
+  isAllowedHostHeader,
+  isAllowedOrigin,
+  buildAllowedHostnames,
 } = require('../../scripts/lib/control-pane/server');
 const {
   main: runControlPaneCli,
@@ -321,6 +325,92 @@ async function runTests() {
       }).then(async response => ({ status: response.status, body: await response.json() }));
       assert.strictEqual(invalidBody.status, 500);
       assert.match(invalidBody.body.error, /JSON/);
+    } finally {
+      await app.close();
+    }
+  })) passed++; else failed++;
+
+  if (await test('classifies Host and Origin headers against the loopback allowlist', async () => {
+    const allowed = buildAllowedHostnames('127.0.0.1');
+    assert.strictEqual(isAllowedHostHeader('127.0.0.1:8765', allowed), true);
+    assert.strictEqual(isAllowedHostHeader('localhost:8765', allowed), true);
+    assert.strictEqual(isAllowedHostHeader('LOCALHOST:8765', allowed), true);
+    assert.strictEqual(isAllowedHostHeader('[::1]:8765', allowed), true);
+    assert.strictEqual(isAllowedHostHeader('attacker.example.com:8765', allowed), false);
+    assert.strictEqual(isAllowedHostHeader('rebind.dnsbin.io', allowed), false);
+    assert.strictEqual(isAllowedHostHeader('', allowed), false);
+    assert.strictEqual(isAllowedHostHeader(undefined, allowed), false);
+
+    // Origin is optional; absence is allowed for non-browser clients.
+    assert.strictEqual(isAllowedOrigin(undefined, allowed), true);
+    assert.strictEqual(isAllowedOrigin('', allowed), true);
+    assert.strictEqual(isAllowedOrigin('http://127.0.0.1:8765', allowed), true);
+    assert.strictEqual(isAllowedOrigin('http://localhost', allowed), true);
+    assert.strictEqual(isAllowedOrigin('http://attacker.example.com', allowed), false);
+    assert.strictEqual(isAllowedOrigin('not-a-url', allowed), false);
+
+    // A non-default configured host should still admit loopback variants.
+    const lan = buildAllowedHostnames('192.168.1.10');
+    assert.strictEqual(isAllowedHostHeader('192.168.1.10:8765', lan), true);
+    assert.strictEqual(isAllowedHostHeader('127.0.0.1:8765', lan), true);
+    assert.strictEqual(isAllowedHostHeader('attacker.example.com:8765', lan), false);
+  })) passed++; else failed++;
+
+  if (await test('rejects requests forged with a non-loopback Host header (DNS rebinding gate)', async () => {
+    const app = await createControlPaneServer({
+      host: '127.0.0.1',
+      port: 0,
+      repoRoot: REPO_ROOT,
+      allowActions: true,
+    });
+
+    await app.listen();
+    try {
+      const address = app.server.address();
+      const actualPort = address && typeof address === 'object' ? address.port : 0;
+
+      const sendWithHeaders = (method, pathname, headers, body) =>
+        new Promise((resolve, reject) => {
+          const req = http.request(
+            { host: '127.0.0.1', port: actualPort, method, path: pathname, headers },
+            response => {
+              let chunks = '';
+              response.on('data', chunk => {
+                chunks += chunk.toString('utf8');
+              });
+              response.on('end', () => {
+                resolve({ status: response.statusCode, body: chunks });
+              });
+            }
+          );
+          req.on('error', reject);
+          if (body) req.write(body);
+          req.end();
+        });
+
+      const forgedHost = await sendWithHeaders('GET', '/api/health', { Host: 'attacker.example.com:1234' });
+      assert.strictEqual(forgedHost.status, 421);
+      assert.match(forgedHost.body, /Misdirected request/);
+
+      const forgedActionHost = await sendWithHeaders(
+        'POST',
+        '/api/actions/sync-knowledge',
+        { Host: 'attacker.example.com:1234', 'content-type': 'application/json' },
+        JSON.stringify({ query: 'rebound' })
+      );
+      assert.strictEqual(forgedActionHost.status, 421);
+
+      const forgedOrigin = await sendWithHeaders('GET', '/api/health', {
+        Host: '127.0.0.1:' + actualPort,
+        Origin: 'http://attacker.example.com',
+      });
+      assert.strictEqual(forgedOrigin.status, 403);
+      assert.match(forgedOrigin.body, /Forbidden origin/);
+
+      const okHost = await sendWithHeaders('GET', '/api/health', { Host: '127.0.0.1:' + actualPort });
+      assert.strictEqual(okHost.status, 200);
+      const okBody = JSON.parse(okHost.body);
+      assert.strictEqual(okBody.ok, true);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Summary

Three defense-in-depth fixes around untrusted input flowing to subprocess execution. None of the affected paths had a direct attacker-reachable proof of exploit, but each one combines a published threat-model boundary (loopback-only, model-supplied tool args, CI input boundary) with the kind of pattern that has bit other agent-tooling projects in the same week. Net effect: an attacker who can pivot through DNS-rebinding, prompt-inject the agent's tool args, or pass attacker-controlled inputs into a downstream caller of the reusable workflow can no longer reach a shell.

## Impact

**1. Control-pane HTTP server — DNS-rebinding gate.** `scripts/lib/control-pane/server.js` binds to `127.0.0.1:8765` by default and exposes `POST /api/actions/:id`, which spawns `cargo run -- graph <subcommand>` with a request-body-supplied `query` and `limit`. The handler did not validate the `Host` or `Origin` header, so a victim visiting `attacker.example` (DNS-rebound to `127.0.0.1`) would trigger same-origin POSTs to the loopback API, ultimately invoking `recall-knowledge` / `sync-knowledge` / `graph-sync` with attacker-shaped strings. `/api/snapshot` is similarly reachable for read-side exfiltration of the graph DB summary.

**2. OpenCode `gitSummary` tool — model-supplied shell input.** `.opencode/tools/git-summary.ts` was building `git diff ${baseBranch}...HEAD --stat` with `execSync`, where `baseBranch` is a `string` tool argument the LLM picks. An attacker who can prompt-inject the agent (untrusted file content, README, PR body, etc.) can drive the model to pass `baseBranch = 'main"; <payload>; echo "x'` and reach RCE on the developer's machine.

**3. Reusable test workflow — script-injection seam.** `.github/workflows/reusable-test.yml` interpolated `${{ inputs.package-manager }}` directly into a bash `case` and into an unsupported-PM `echo`. The repo's own caller (`ci.yml`) constrains `matrix.pm` to a fixed set, but downstream callers of the reusable workflow that forward attacker-controllable input (e.g. an `issue_comment`-triggered workflow) would inject into the runner shell.

## Location

- `scripts/lib/control-pane/server.js:163-205` (handler) + new helpers at the top of the file
- `.opencode/tools/git-summary.ts:30-65`
- `.github/workflows/reusable-test.yml:64-81`

## Fix

- **Control-pane:** Build an `allowedHostnames` set at server start containing the configured `--host` plus loopback variants (`127.0.0.1`, `localhost`, `[::1]`, `::1`). Reject mismatched `Host` headers with `421 Misdirected Request` and non-loopback `Origin` headers (when present) with `403 Forbidden origin` before any route handler runs. `Host` is mandatory; `Origin` is optional so non-browser clients (`fetch` from `node`, `curl`) still work.
- **OpenCode tool:** Swap `execSync` for `execFileSync` with an args-array form so no spawned `git` call passes through a shell. Validate `baseBranch` against `^[A-Za-z0-9._/-]+$` plus the usual git-ref guardrails (no leading `-`/`.`/`/`, no embedded `..` or `//`, max 200 chars). Clamp `depth` to a positive integer ≤ 1000 before interpolating into `-N`.
- **Workflow:** Move `${{ inputs.package-manager }}` into a `PACKAGE_MANAGER` step env var and reference `$PACKAGE_MANAGER` inside the script, per the canonical GitHub script-injection mitigation.

## Detected by

Aeon + Semgrep p/security-audit, surfaced via the **threat-model-claim manual-review axis** (SECURITY.md scopes "Local MCP Ports" verification but not the control-pane HTTP server one floor up; tool-args boundary advertised by OpenCode's tool schema but not enforced at the execSync call site; reusable workflow advertised as composable but unguarded against caller-supplied input).

- Severity: **medium-high** (DNS-rebinding gate), **medium-high** (prompt-injection → RCE via tool args), **low-medium** (dormant CI surface, easy to enable accidentally)
- CWE-918 (server-side request forgery class via DNS rebinding) / CWE-352 (CSRF-equivalent in absence of Host check) / **CWE-78** (OS command injection — opencode tool + workflow)
- No published advisory; this PR is the disclosure.

## Verification

`node tests/run-all.js` — **2686 / 2687 passing.** The one failure (`observe.sh falls back to legacy output fields when tool_response is null`, in `tests/hooks/hooks.test.js`) reproduces on `main` without this branch applied and is unrelated. `npx eslint scripts/**/*.js tests/**/*.js` clean. `node scripts/ci/validate-workflow-security.js` clean.

Two new tests added in `tests/scripts/control-pane.test.js`:
- `classifies Host and Origin headers against the loopback allowlist` — unit test of the classifier against forged and legitimate hostnames including IPv6 / case-insensitive matching and a non-default `--host` LAN binding.
- `rejects requests forged with a non-loopback Host header (DNS rebinding gate)` — end-to-end test against a live server using `http.request` to send forged `Host` and `Origin` headers, asserts `421` / `403` and that the legitimate baseline still returns `200`.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens input handling to block DNS rebinding and command/script injection across the control-pane server, the `git-summary` tool, and the reusable CI workflow. Removes shell entry points and restricts loopback access to prevent untrusted input from reaching a shell.

- **Bug Fixes**
  - Control-pane HTTP server: Allowlist `Host`/`Origin` to loopback and the configured `--host`; reject others with 421/403 before routing. `Origin` remains optional for non-browser clients. (scripts/lib/control-pane/server.js)
  - OpenCode `git-summary` tool: Replace `execSync` with `execFileSync` (args array), validate `baseBranch` as a safe git ref, and clamp `depth` to a small positive int. Protects `log`, staged diff, and branch diff calls. (.opencode/tools/git-summary.ts)
  - Reusable test workflow: Move `${{ inputs.package-manager }}` into `PACKAGE_MANAGER` env and reference `$PACKAGE_MANAGER` in the script to prevent shell injection. (.github/workflows/reusable-test.yml)

<sup>Written for commit 56bd1bd5ad4dc51c101e0dfc0c5d6794ac3309a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted control-pane HTTP API access to exclusively local connections. Requests from external hosts or non-loopback origins are now rejected with appropriate HTTP error responses.

* **Chores**
  * Enhanced input validation in internal git utilities to prevent unsafe git reference injection.
  * Updated GitHub Actions reusable test workflow for improved package manager selection.

* **Tests**
  * Added comprehensive test coverage for control-pane security features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->