### PR TITLE
browser-qa: read-only safety default, baseline-or-die, honest a11y scope

### DIFF
--- a/skills/browser-qa/SKILL.md
+++ b/skills/browser-qa/SKILL.md
@@ -18,6 +18,14 @@ origin: ECC
 
 Uses the browser automation MCP (claude-in-chrome, Playwright, or Puppeteer) to interact with live pages like a real user.
 
+### Safety first — blast radius (run read-only by default)
+
+Browser QA drives real auth and real user journeys, so treat the blast radius explicitly.
+Default to **read-only**: never run a **mutating** journey (checkout, payment, delete,
+mass-update) against a production URL — require an explicit opt-in **and** a staging/preview
+URL. Use seeded **test credentials**, never real production logins, and **redact**
+credentials/tokens/PII before saving any screenshot.
+
 ### Phase 1: Smoke Test
 ```
 1. Navigate to target URL
@@ -25,6 +33,7 @@ Uses the browser automation MCP (claude-in-chrome, Playwright, or Puppeteer) to 
 3. Verify no 4xx/5xx in network requests
 4. Screenshot above-the-fold on desktop + mobile viewport
 5. Check Core Web Vitals: LCP < 2.5s, CLS < 0.1, INP < 200ms
+   (INP replaced FID in March 2024; thresholds per web.dev)
 ```
 
 ### Phase 2: Interaction Test
@@ -32,14 +41,17 @@ Uses the browser automation MCP (claude-in-chrome, Playwright, or Puppeteer) to 
 1. Click every nav link — verify no dead links
 2. Submit forms with valid data — verify success state
 3. Submit forms with invalid data — verify error state
-4. Test auth flow: login → protected page → logout
+4. Test auth flow: login → protected page → logout (test creds only, never prod)
 5. Test critical user journeys (checkout, onboarding, search)
+   — read-only by default; only exercise mutating journeys against staging
+     with explicit opt-in (see "Safety first" above)
 ```
 
 ### Phase 3: Visual Regression
 ```
 1. Screenshot key pages at 3 breakpoints (375px, 768px, 1440px)
-2. Compare against baseline screenshots (if stored)
+2. Compare against committed baseline screenshots
+   — no baseline ⇒ report INCONCLUSIVE, never a silent PASS
 3. Flag layout shifts > 5px, missing elements, overflow
 4. Check dark mode if applicable
 ```
@@ -47,10 +59,14 @@ Uses the browser automation MCP (claude-in-chrome, Playwright, or Puppeteer) to 
 ### Phase 4: Accessibility
 ```
 1. Run axe-core or equivalent on each page
-2. Flag WCAG AA violations (contrast, labels, focus order)
+2. Flag WCAG 2.2 AA violations (contrast, labels, focus order)
 3. Verify keyboard navigation works end-to-end
 4. Check screen reader landmarks
 ```
+
+> Note: axe-core automatically covers roughly 30–40% of WCAG. A clean run is **necessary,
+> not sufficient** — keyboard nav, focus order, and a screen-reader pass still need a manual
+> check. Don't report "accessible" from an automated pass alone.
 
 ## Output Format
 
@@ -75,6 +91,7 @@ Uses the browser automation MCP (claude-in-chrome, Playwright, or Puppeteer) to 
 - 2 AA violations: missing alt text on hero image, low contrast on footer links
 
 ### Verdict: SHIP WITH FIXES (2 issues, 0 blockers)
+# verdict ∈ SHIP / SHIP WITH FIXES / DO NOT SHIP; use INCONCLUSIVE if no visual baseline
 ```
 
 ## Integration


### PR DESCRIPTION
Hi — love this skill. I used `browser-qa` as the base for an internal hardened variant and would like to contribute the small, generally-useful safety/honesty bits back. **Additive only** — no behavior removed, matches the existing lean style. One file changed (`skills/browser-qa/SKILL.md`).

**What this adds**

1. **Safety / blast radius (read-only default).** Phase 2 drives real auth + checkout, but nothing today stops that running against production. Adds a read-only default: mutating journeys (checkout/payment/delete) require an explicit opt-in **and** a staging URL; use test creds, never prod; redact credentials/PII before saving screenshots.
2. **baseline-or-die.** Phase 3 "compare against baseline (if stored)" could silently PASS with no baseline. Now: no baseline ⇒ **INCONCLUSIVE**, never a silent PASS.
3. **Honest a11y scope.** axe-core auto-covers ~30–40% of WCAG; added a "necessary, not sufficient" note so a clean axe run isn't reported as "accessible".
4. **Accuracy.** WCAG pinned to **2.2** AA; noted **INP replaced FID** (March 2024), thresholds per web.dev.

Happy to adjust wording or split further if you'd prefer smaller commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `browser-qa` safer by default and stricter about pass criteria. Adds read-only guidance, enforces baselines for visual diffs, and clarifies a11y/CWV accuracy.

- **New Features**
  - Read-only default for mutating flows (checkout/payment/delete): require explicit opt-in and a staging URL; use test creds only; redact credentials/PII in screenshots.
  - Visual regression requires a committed baseline; if missing, report INCONCLUSIVE (never a silent PASS). Documents allowed verdicts.
  - Accessibility and metrics accuracy: scope automated a11y (axe covers ~30–40%, necessary not sufficient), pin WCAG to 2.2 AA, and note INP replaces FID with web.dev thresholds.

<sup>Written for commit 59887976890f82d34c5b7093cde6662b4c3eaba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced browser automation guidelines emphasizing safe, read-only behavior by default with explicit opt-in for mutating operations
  * Clarified accessibility testing requirements, emphasizing manual validation (keyboard, focus, screen-reader) beyond automation tools
  * Updated verdict output rules for consistency
  * Improved clarity on test credential usage and sensitive data redaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->