### PR TITLE
feat: add `taste` skill — music-video creative direction

### DIFF
--- a/skills/taste/SKILL.md
+++ b/skills/taste/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: taste
+description: A creative-direction (taste) layer for music videos and short-form edits in the angelcore / cloud-trance / hyperpop visual family. Distills a named-genre aesthetic vocabulary, a mood + color + light system, and a beat-synced editing grammar, then chains ECC's video skills (video-editing, fal-ai-media, remotion-video-creation, motion-*, content-engine) into one production pipeline. Use when the work is not just making a video function but making it feel intentional, when building a music video, a fancam/edit, a moodboard-driven reel, or when choosing a coherent visual direction for AI-generated b-roll.
+origin: ECC
+---
+
+# Taste
+
+Most AI video advice stops at *how to render frames*. This skill is the layer above
+that: **what the frames should look like, in what order, cut to what rhythm, so the
+result reads as one intentional thing instead of a pile of generations.**
+
+It encodes a specific taste — the **angelcore / cloud-trance / hyperpop** family
+(Bladee "Silver Surfer"-era ethereal trance crossed with heavy angelcore) — distilled
+from a corpus of saved Reels and a tour through a ~70-entry visual-genre library. It
+is opinionated on purpose. Taste is a point of view, not a menu.
+
+> The companion file `references/genre-taxonomy.md` holds the full named-genre catalog.
+> This file is the actionable layer: mood, grammar, pipeline, and a beat-mapped shot plan.
+
+## When to Activate
+
+- Building a **music video**, lyric video, fancam, or visualizer.
+- Making a short-form **edit / reel** where the *feel* matters more than the information.
+- Driving **AI b-roll generation** (fal.ai, Veo, Kling, etc.) and the prompts need a
+  coherent direction instead of one-off vibes.
+- Assembling a **moodboard** or choosing a visual genre before any rendering.
+- The user says "taste", "make it feel like X", "give it a direction", "angelcore",
+  "cloud trance", "hyperpop edit", "Bladee", "dreamcore", or names a saved reference.
+- The current edit works but reads as flat, generic, AI-slop, or stylistically incoherent.
+
+This skill sits **on top of** `video-editing` (the mechanics) and `remotion-video-creation`
+(the renderer). Use those for *how*. Use this for *what and why*.
+
+## Core Thesis
+
+1. **Taste is the last layer, and it must be decided first.** `video-editing` correctly
+   says taste is the final human pass. The trap: if you only decide taste at the end, every
+   generation and cut upstream was a guess. Pick the direction *before* the first prompt,
+   then let it constrain everything.
+2. **Coherence beats novelty.** One look executed across 30 shots beats 30 looks. A named
+   genre (below) is a constraint that buys coherence for free.
+3. **Cut to the song, not to the footage.** In a music video the timeline is the waveform.
+   Every hard cut lands on a beat or a transient. Frame math is in the pipeline section.
+4. **Generate selectively, edit ruthlessly.** AI makes b-roll that does not exist; it does
+   not make taste. You still throw away 80%.
+
+## The Aesthetic Vocabulary (distilled)
+
+The reference corpus tours a large library of *named* visual genres. The full list lives in
+`references/genre-taxonomy.md`. The useful move is not memorizing 70 names — it is seeing
+that **a genre name is a complete prompt-and-grade preset.** When you pick one, you inherit
+its palette, texture, lighting, and subject matter as a unit.
+
+The genres cluster into families. Pick a **primary** family and at most **one accent**:
+
+| Family | Genres in it | Reads as |
+|--------|-------------|----------|
+| **Ethereal / divine** | spiritualism, glacial folk, beacons, zen core, fairy tale | weightless, holy, glowing, soft |
+| **Hyperpop / Y2K-cyber** | cyberdelia, acid house, acid nora, neo aggressano, new liquid | glossy, chrome, neon, kawaii-cyber |
+| **Dark / occult** | dark academia, smoke nostalgia, communist core, abstract tech | high-contrast, ominous, grain |
+| **Retro / print** | retro surfers, art deco, adventure pulp, classic advertising, magazine collage, bumper stickers | flat, graphic, halftone, nostalgic |
+| **Organic / textural** | microbiology core, weaving patterns, fruitage retro, cozy blanket, pacific punk wave | tactile, macro, woven, wet |
+| **Systemic / data** | numbers, mazes, code web, heatmap, pixel, 8-bit | gridded, generative, schematic |
+
+**For the current project**, the primary is **Ethereal / divine** with a **Hyperpop / Y2K-cyber**
+accent — i.e. holy light and crystalline bloom, punctuated by chrome and neon. That pairing
+*is* the angelcore × cloud-trance brief.
+
+## The Mood System — angelcore × cloud-trance
+
+Distilled directly from the strongest reference reels. This is the concrete grade.
+
+### Palette
+- **Base:** near-black void (#05060a) and bone white (#f4f1ea). Most frames are one or the other.
+- **Divine accent:** molten gold / ember orange (#ffb24d → #ff7a18) — the *one warm light* in the dark.
+- **Crystalline accent:** iridescent violet→cyan→magenta bokeh (#8a6bff, #4fc3ff, #ff6ad5) — the
+  hyperpop bloom, used in bright frames.
+- **Danger accent (sparingly):** a single glowing red (#ff2a2a) on monochrome — for one or two
+  shock cuts only.
+- **Hyperpop subject:** candy pink hair / chrome / glossy white against blue sky.
+
+Rule: **one accent per shot.** Gold lives in dark frames; iridescence lives in light frames;
+never both in one shot.
+
+### Light & texture
+- Darkness pierced by a single warm source (ember bloom, divine shaft). High contrast, deep blacks.
+- Crystalline / glitter bokeh, lens flares, bloom, light leaks — *heavenly*, not dirty.
+- Film grain + subtle chromatic aberration on the dark frames; clean gloss on the bright frames.
+- Macro detail on negative space: a hero object centered on black (key, eye, gear, petal, water).
+- Subjects: winged figures, clouds, halos, angels, crystalline structures, candy-cyber portraits.
+
+### Motion
+- Slow, floating, weightless camera (drift, slow push, slow orbit) — *cloud* trance.
+- Bursts of speed only at the drop. Otherwise everything breathes.
+- Particles rising (embers, dust, glitter) — upward motion = ascension.
+
+## The Editing Grammar (distilled)
+
+From the reference edits, the techniques that recur and define the style:
+
+1. **Beat-locked hard cuts.** No dissolves in the verse/drop. Cut on the kick. The eye should
+   feel the BPM.
+2. **Hero-on-black macro inserts.** A single sharp object centered in black negative space,
+   held for 1–2 beats, then cut. Rhythmic montage of these = the cloud-trance signature.
+3. **Bloom / explosion reveal.** A white or ember bloom that blows out the frame on a transient,
+   then resolves into the next shot. The "divine flash" transition.
+4. **Color-pop on monochrome.** Run a passage in B&W, then a single colored element (red eye,
+   gold flame, pink hair) punches through on the downbeat.
+5. **Speed-ramp into the drop.** Ramp footage from slow to fast across the last bar before the
+   drop, hard-cut to tempo on the one.
+6. **Caption keyword highlight (for talking-head / lyric sections only).** All-caps, one or two
+   words highlighted in the accent color, synced to the vocal. Use for lyric video, not for the
+   pure visualizer.
+7. **Reaction PiP (for explainer/edit-commentary only).** Picture-in-picture talking head over
+   b-roll. Out of scope for the music video itself; documented because the corpus uses it heavily.
+
+**Do-nots:** crossfade transitions in tempo sections; more than one accent color per shot; a
+shot held past its musical phrase; readable on-screen UI chrome (crop it out); mixed aspect
+ratios in one timeline.
+
+## The Pipeline — mixing the ECC video skills
+
+This skill is the conductor. Each ECC skill is an instrument. Do not skip layers.
+
+```
+0. TASTE (this skill)        decide genre + mood + grammar BEFORE anything renders
+1. STRUCTURE (video-editing) map the song: timestamps for intro/verse/drop/bridge/outro
+2. GENERATE (fal-ai-media)   make b-roll per genre prompt-presets; throw away 80%
+3. CUT (video-editing/FFmpeg) beat-cut + reframe to 9:16; assemble selects on the grid
+4. COMPOSE (remotion-video-creation) overlays, blooms, lyric text, beat-synced sequencing
+5. MOTION (motion-* skills)  easing curves, light-leak/particle motion, transition timing
+6. AUDIO (fal-ai-media)      transition risers/impacts to sell the cuts (track itself is in Ableton)
+7. POLISH                    grade to the palette above, final pacing pass, export
+8. DISTRIBUTE (content-engine) platform-native versions + caption/cover
+```
+
+| Step | ECC skill to load | What it does here |
+|------|-------------------|-------------------|
+| Structure & cut | `video-editing` | FFmpeg cut/concat/reframe, EDL, scene/silence detection |
+| Generate b-roll | `fal-ai-media` | image/video models per genre preset |
+| Compose & overlay | `remotion-video-creation` | beat-synced `<Sequence>`s, text, blooms, masks |
+| Motion timing | `motion-foundations`, `motion-patterns`, `motion-advanced`, `motion-ui` | easing, springs, light/particle motion |
+| Server-side video | `videodb` | smart reframe, indexing if footage is large |
+| Distribution | `content-engine` | per-platform cuts, covers, captions |
+| Voice/lyric VO | `video-editing` (ElevenLabs section) | only if a spoken layer is needed |
+
+## Beat Math (lock cuts to the song)
+
+The current track is **138 BPM, B minor**. Constants:
+
+- `seconds_per_beat = 60 / 138 = 0.43478s`
+- `frames_per_beat   = fps × 0.43478`  →  **24fps: 10.43**, **30fps: 13.04**, **60fps: 26.09**
+- `1 bar (4 beats)   = 1.7391s`  →  30fps: **52.17 frames**
+- `8-bar phrase      = 13.913s`  →  the loop length from the track
+
+In Remotion, snap every `from={}` to a beat:
+```ts
+const FPS = 30;
+const BPM = 138;
+const beat = (n: number) => Math.round(n * (60 / BPM) * FPS); // beat(n) → frame
+// cut on beats 0,4,8,... :  <Sequence from={beat(0)} durationInFrames={beat(4)}> ...
+```
+
+## Beat-Mapped Shot Plan (this music video)
+
+The song arrangement (from the project's own notes) is
+**Intro → Verse → Drop → Bridge → Drop → Outro (~2:05)**. Map taste to each section:
+
+| Section | Genre/mood lean | Grammar | Shot ideas |
+|---------|-----------------|---------|------------|
+| **Intro** | Ethereal/divine, near-black | slow push, no cuts | ember bloom in the void; a single shaft of gold; dust rising |
+| **Verse** | Dark + macro hero-on-black | hard cuts every 2 beats | key, eye, gear, water drop, petal — rhythmic macro montage |
+| **Drop** | Hyperpop bloom + crystalline | speed-ramp in, cut on the one, fast | candy-pink figure, chrome, iridescent bokeh, winged ascension |
+| **Bridge** | Spiritualism, weightless | one long held shot, color-pop | clouds + halo; single red accent punches once |
+| **Drop 2** | as Drop, intensify | add divine-flash blooms on transients | wings open, glitter burst, light leaks maxed |
+| **Outro** | Glacial folk, cold calm | slow fade to black | crystalline structure dissolving; ember dies out |
+
+## fal.ai Prompt Presets (per mood)
+
+Use with `fal-ai-media`. Each preset is the genre rendered to the project palette. Append
+`9:16, vertical, cinematic, film grain, volumetric light, no text, no watermark` to all.
+
+- **Divine void:** "a single molten-gold ember bloom rising in an infinite near-black void,
+  deep shadow, one warm light source, weightless dust particles, holy, high contrast"
+- **Macro hero:** "extreme macro of an antique brass key / a human eye / interlocking gears,
+  centered on pure black negative space, razor-sharp detail, single rim light"
+- **Crystalline bloom:** "iridescent violet-cyan-magenta crystalline bokeh, glittering light
+  refraction, dreamy lens flares, heavenly glow, soft focus, hyperpop angelcore"
+- **Candy-cyber portrait:** "candy-pink-haired figure, glossy chrome accents, bright blue sky,
+  Y2K hyperpop, clean gloss, saturated, kawaii-cyber"
+- **Winged ascension:** "a winged figure ascending into clouds, halo of light, bone-white and
+  gold, volumetric god-rays, ethereal, religious iconography, soft"
+- **Cold outro:** "pale crystalline ice structure slowly dissolving, glacial folk, cold blue
+  and bone white, minimal, calm, fading to black"
+
+Generate 6–10 per preset, keep 2–3. For motion, animate stills with an image-to-video model
+or generate short clips directly; keep camera moves slow per the Motion rules.
+
+## FFmpeg Recipes (cut + reframe)
+
+```bash
+# Reframe any landscape/raw clip to 9:16 (center crop)
+ffmpeg -i in.mp4 -vf "crop=ih*9/16:ih,scale=1080:1920" v.mp4
+
+# Beat-cut a clip to exactly N beats at 138 BPM (e.g. 2 beats = 0.8696s)
+ffmpeg -i in.mp4 -t 0.8696 -c copy beat2.mp4
+
+# Concatenate beat-selects into the verse montage
+for f in selects/*.mp4; do echo "file '$f'"; done > concat.txt
+ffmpeg -f concat -safe 0 -i concat.txt -c copy verse.mp4
+
+# Strip UI chrome / status bar from a screen-recorded reference (crop top+bottom)
+ffmpeg -i reel.mp4 -vf "crop=iw:ih-300:0:150" clean.mp4
+```
+
+## Remotion Composition Skeleton (beat-synced)
+
+```tsx
+import { AbsoluteFill, Sequence, Video, Img, useCurrentFrame, interpolate } from "remotion";
+
+const FPS = 30, BPM = 138;
+const beat = (n: number) => Math.round(n * (60 / BPM) * FPS);
+
+const Bloom: React.FC = () => {
+  const f = useCurrentFrame();
+  const o = interpolate(f, [0, 3, 12], [0, 1, 0], { extrapolateRight: "clamp" }); // divine flash on a transient
+  return <AbsoluteFill style={{ background: "radial-gradient(#fff,#ffb24d)", opacity: o, mixBlendMode: "screen" }} />;
+};
+
+export const AngelcoreMV: React.FC = () => (
+  <AbsoluteFill style={{ background: "#05060a" }}>
+    {/* Verse: macro hero-on-black, hard cut every 2 beats */}
+    <Sequence from={beat(0)} durationInFrames={beat(2)}><Video src="/selects/key.mp4" /></Sequence>
+    <Sequence from={beat(2)} durationInFrames={beat(2)}><Video src="/selects/eye.mp4" /></Sequence>
+    <Sequence from={beat(4)} durationInFrames={beat(2)}><Video src="/selects/gear.mp4" /></Sequence>
+    {/* Drop: crystalline bloom + flash on the one */}
+    <Sequence from={beat(8)} durationInFrames={beat(16)}><Video src="/selects/crystalline.mp4" /></Sequence>
+    <Sequence from={beat(8)} durationInFrames={beat(1)}><Bloom /></Sequence>
+  </AbsoluteFill>
+);
+```
+Render: `npx remotion render src/index.ts AngelcoreMV out.mp4`. See `remotion-video-creation`
+for project setup, audio track binding, and render flags.
+
+## Key Principles
+
+1. **Decide the genre before the first generation.** Pick one primary family + one accent.
+2. **One accent color per shot.** Gold in the dark, iridescence in the light, red once.
+3. **Every hard cut lands on a beat.** Use the beat math; no transitions in tempo sections.
+4. **Hero-on-black macro is the signature move.** Master it; it carries the verses.
+5. **Generate 10, keep 2.** Coherence comes from rejection, not from prompting harder.
+6. **Crop the chrome.** No status bars, captions, or UI in the final frame.
+7. **Taste is decided first and judged last.** Set the direction, then defend it on every cut.
+
+## Related Skills
+
+- `video-editing` — the mechanical pipeline (FFmpeg, reframe, EDL, polish) this sits on top of
+- `remotion-video-creation` — programmable beat-synced composition and rendering
+- `fal-ai-media` — generate the b-roll, transition SFX, and risers
+- `motion-foundations`, `motion-patterns`, `motion-advanced`, `motion-ui` — easing and motion timing
+- `videodb` — server-side smart reframe and indexing for large footage
+- `content-engine` — platform-native distribution, covers, captions
+- `frontend-design-direction` — the same "decide a direction first" discipline, for UI

--- a/skills/taste/references/genre-taxonomy.md
+++ b/skills/taste/references/genre-taxonomy.md
@@ -1,0 +1,87 @@
+# Visual-Genre Taxonomy
+
+The named-genre catalog distilled from the reference corpus (a tour through a large
+generative visual-style library, plus a set of saved angelcore/hyperpop reels). Each
+name is effectively a **complete prompt-and-grade preset**: picking one inherits its
+palette, texture, lighting, and subject matter as a unit.
+
+Use this as a picker. Choose **one primary** genre and **at most one accent**. The main
+`SKILL.md` groups these into families and maps them to the current music-video project.
+
+## Families and members
+
+### Ethereal / divine — *weightless, holy, glowing, soft*
+- **spiritualism** — religious iconography, halos, god-rays, devotional
+- **glacial folk** — cold blue + bone white, crystalline, minimal, calm
+- **beacons** — single light source in darkness, signal, hope
+- **zen core** — empty space, stillness, balance, muted
+- **fairy tale** — storybook, illustrated, soft enchantment
+- **cozy blanket** — warm, tactile, soft-focus comfort
+
+### Hyperpop / Y2K-cyber — *glossy, chrome, neon, kawaii-cyber*
+- **cyberdelia** — psychedelic cyber, saturated, melting digital
+- **acid house** — rave graphics, smileys, high-saturation acid color
+- **acid nora** — acid-toned painterly, warped
+- **neo aggressano** — aggressive maximal hyperpop, clashing color
+- **new liquid** — wet chrome, liquid metal, glossy reflection
+- **8-bit / pixel** — retro game pixels, dithered, lo-fi digital
+
+### Dark / occult — *high-contrast, ominous, grain*
+- **dark academia** — moody scholarly, sepia, candlelit, gothic
+- **smoke nostalgia** — hazy, smoky, faded memory
+- **communist core** — red star, propaganda poster, bold red/black
+- **abstract tech** — schematic, cold, technical abstraction
+- **microzoathic** — strange organic-dark microscopic forms
+
+### Retro / print — *flat, graphic, halftone, nostalgic*
+- **retro surfers** — 60s–70s surf, sun-faded, beachy
+- **art deco** — geometric gold, 1920s elegance, symmetry
+- **adventure pulp** — pulp comic covers, dramatic, vintage
+- **classic advertising** — mid-century ad illustration
+- **magazine collage** — cut-paper, editorial collage, layered
+- **bumper stickers** — sticker-bomb, kitsch, layered decals
+- **retro print / riso** — limited-palette print, halftone, misregistration
+- **neo lisboa** — tiled, azulejo-inspired, Mediterranean print
+- **factory pomo** — postmodern industrial graphic
+- **2026 austurbano** — near-future urban editorial
+
+### Organic / textural — *tactile, macro, woven, wet*
+- **microbiology core** — cells, micro-organic, petri textures
+- **weaving patterns** — woven fiber, textile, interlace
+- **fruitage retro** — fruit/produce, saturated, glossy still-life
+- **pacific punk wave** — wet, oceanic, washed graphic
+- **shape design** — bold flat shapes, Bauhaus-ish forms
+- **colour fusion** — blended gradients, color-field
+
+### Systemic / data — *gridded, generative, schematic*
+- **numbers** — numeric typography, ledgers, counting
+- **mazes** — labyrinth, path, grid puzzle
+- **code web** — node graphs, network, connections
+- **heatmap** — thermal color mapping, data gradients
+- **the builds** — constructed/blueprint, architectural systems
+- **multilayer** — stacked transparent layers, depth
+- **scrapbooking** — assembled keepsakes, layered ephemera
+
+### Cultural / kitsch — *loud, specific, referential*
+- **catholic kitsch** — devotional kitsch, gilded saints
+- **mexendero / megadero / cubanista** — Latin-American vernacular graphic
+- **asian chic / asian store** — East-Asian retail/pop vernacular
+- **battle of culture** — clashing cultural motifs
+- **premium brands** — luxury packaging, refined commercial
+- **pro collectibles** — trading-card / collectible framing
+- **diaper design / suburbia / ivy league / sharp preppy** — Americana suburban/preppy
+- **carnival difference** — festival, maximal celebration
+- **men x soft club / faces** — portrait-forward, soft club
+- **gomu / proteum aero / ice core / visual hex / vidcoms / anti-ai / photo-first** — misc presets observed
+
+> The exact spelling/membership of some preset names is transcribed from low-resolution
+> screen frames and may vary slightly from the source app's labels. The **families** are the
+> durable, reusable layer; treat individual names as inspiration tags, not canonical IDs.
+
+## How to use a genre as a preset
+
+1. Pick the genre that matches the section's emotional job (see the shot plan in `SKILL.md`).
+2. Translate it into a fal.ai prompt by combining: *its palette + its texture + its subject*,
+   then append the project's global suffix (`9:16, cinematic, film grain, volumetric light, no text`).
+3. Keep one accent color; render 6–10; keep 2–3.
+4. Never mix more than primary + one accent across a single section, or the edit loses coherence.


### PR DESCRIPTION
## What

Adds a new skill, `taste`, under `skills/taste/` (auto-discovered via `./skills/` in `plugin.json`).

`taste` is a **creative-direction layer** for music videos and short-form edits. It encodes a specific, opinionated visual taste — the **angelcore / cloud-trance / hyperpop** family — distilled from a reference corpus of saved reels and a tour through a ~70-entry named-genre visual library.

## Why

ECC's `video-editing` skill nails the *mechanics* (FFmpeg, Remotion, fal.ai, polish) and correctly notes that "taste is the last layer." The gap: if taste is only decided at the end, every upstream generation and cut was a guess. This skill makes taste a **decidable, first-class layer** and chains the existing video skills into one pipeline behind it.

## Contents

- **Aesthetic vocabulary** — the genre catalog grouped into 6 reusable families; full list in `references/genre-taxonomy.md`.
- **Mood system** — concrete palette (hex), light, texture, and motion rules for angelcore × cloud-trance.
- **Editing grammar** — beat-locked cuts, hero-on-black macro inserts, divine-flash blooms, color-pop on monochrome, speed-ramps, with explicit do-nots.
- **Pipeline** — maps each step to an existing ECC skill: `video-editing`, `fal-ai-media`, `remotion-video-creation`, `motion-*`, `videodb`, `content-engine`.
- **Beat math** (138 BPM) + a section-by-section **shot plan** (intro/verse/drop/bridge/outro).
- **fal.ai prompt presets** per mood, **FFmpeg** reframe/beat-cut recipes, and a **Remotion** beat-synced composition skeleton.

## Notes

- Docs-only change; no scripts/hooks touched. Skill is auto-discovered — no manifest edit needed.
- Follows the SKILL.md template from CONTRIBUTING.md (`name`, `description`, `origin: ECC`; When to Use / How It Works / Examples / Related Skills).
- Some genre names are transcribed from low-res reference frames; the *families* are the durable layer (noted inline).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new `taste` skill for music‑video creative direction. It codifies the angelcore × cloud‑trance × hyperpop look and stitches `video-editing` → `fal-ai-media` → `remotion-video-creation` → `motion-*` → `content-engine` into a beat‑locked pipeline.

- **New Features**
  - Adds `skills/taste/SKILL.md` with a mood system, editing grammar, and usage guidance.
  - Adds `skills/taste/references/genre-taxonomy.md` with a named‑genre catalog grouped into families.
  - Includes beat math (138 BPM) and a sectioned shot plan, plus `fal-ai-media` prompt presets, FFmpeg cut/reframe recipes, and a `remotion-video-creation` composition skeleton.
  - Auto‑discovered via `./skills/` in `plugin.json`; no code or manifest changes required.

<sup>Written for commit 194eeb952f777d00974ed9a777e77d1235812373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for the "taste" layer of music video editing, including mood systems, color palettes, lighting principles, and beat-locked editing techniques.
  * Introduced a visual genre taxonomy with preset categories and styling guidance for maintaining visual coherence across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->