### PR TITLE
fix(skills): replace ★ star ratings with ASCII N/5 to pass unicode-safety CI

### DIFF
--- a/docs/ja-JP/skills/windows-desktop-e2e/SKILL.md
+++ b/docs/ja-JP/skills/windows-desktop-e2e/SKILL.md
@@ -39,13 +39,13 @@ origin: ECC
 
 | フレームワーク | AutomationId | 信頼性 | 注記 |
 |-----------|-------------|-------------|-------|
-| WPF | ★★★★★ | 優秀 | `x:Name` が直接AutomationIdにマッピング |
-| WinForms | ★★★★☆ | 良好 | `AccessibleName` = AutomationId |
-| UWP / WinUI 3 | ★★★★★ | 優秀 | Microsoftの完全サポート |
-| Qt 6.x | ★★★★★ | 優秀 | アクセシビリティがデフォルトで有効；クラス名が `Qt6*` に変更 |
-| Qt 5.15+ | ★★★★☆ | 良好 | Accessibilityモジュールが改善 |
-| Qt 5.7–5.14 | ★★★☆☆ | 普通 | `QT_ACCESSIBILITY=1` が必要；objectNameは手動設定 |
-| Win32 / MFC | ★★★☆☆ | 普通 | コントロールIDにアクセス可能；テキストマッチングが一般的 |
+| WPF | 5/5 | 優秀 | `x:Name` が直接AutomationIdにマッピング |
+| WinForms | 4/5 | 良好 | `AccessibleName` = AutomationId |
+| UWP / WinUI 3 | 5/5 | 優秀 | Microsoftの完全サポート |
+| Qt 6.x | 5/5 | 優秀 | アクセシビリティがデフォルトで有効；クラス名が `Qt6*` に変更 |
+| Qt 5.15+ | 4/5 | 良好 | Accessibilityモジュールが改善 |
+| Qt 5.7–5.14 | 3/5 | 普通 | `QT_ACCESSIBILITY=1` が必要；objectNameは手動設定 |
+| Win32 / MFC | 3/5 | 普通 | コントロールIDにアクセス可能；テキストマッチングが一般的 |
 
 ## セットアップと前提条件
 

--- a/skills/windows-desktop-e2e/SKILL.md
+++ b/skills/windows-desktop-e2e/SKILL.md
@@ -39,13 +39,13 @@ Your test (Python)
 
 | Framework | AutomationId | Reliability | Notes |
 |-----------|-------------|-------------|-------|
-| WPF | ★★★★★ | Excellent | `x:Name` maps directly to AutomationId |
-| WinForms | ★★★★☆ | Good | `AccessibleName` = AutomationId |
-| UWP / WinUI 3 | ★★★★★ | Excellent | Full Microsoft support |
-| Qt 6.x | ★★★★★ | Excellent | Accessibility enabled by default; class names change to `Qt6*` |
-| Qt 5.15+ | ★★★★☆ | Good | Improved Accessibility module |
-| Qt 5.7–5.14 | ★★★☆☆ | Fair | Needs `QT_ACCESSIBILITY=1`; objectName manual |
-| Win32 / MFC | ★★★☆☆ | Fair | Control IDs accessible; text matching common |
+| WPF | 5/5 | Excellent | `x:Name` maps directly to AutomationId |
+| WinForms | 4/5 | Good | `AccessibleName` = AutomationId |
+| UWP / WinUI 3 | 5/5 | Excellent | Full Microsoft support |
+| Qt 6.x | 5/5 | Excellent | Accessibility enabled by default; class names change to `Qt6*` |
+| Qt 5.15+ | 4/5 | Good | Improved Accessibility module |
+| Qt 5.7–5.14 | 3/5 | Fair | Needs `QT_ACCESSIBILITY=1`; objectName manual |
+| Win32 / MFC | 3/5 | Fair | Control IDs accessible; text matching common |
 
 ## Setup & Prerequisites
 


### PR DESCRIPTION
## Summary

`npm test` currently fails on its very first gate — `check-unicode-safety.js` — with
**58 Unicode-safety violations**. Two skill docs use `★` / `☆` (U+2605 / U+2606) in
their "UIA quality by framework" rating tables, and those characters are caught by the
checker's `\p{Extended_Pictographic}` rule.

This PR replaces the star ratings with an ASCII `N/5` convention that preserves the
exact meaning while making the gate pass.

## Why not the auto-fixer?

The repo's auto-sanitizer (`check-unicode-safety.js --write`) would **silently delete**
the star glyphs, turning `★★★★★` into empty table cells and destroying the rating
information. So this needs a hand-authored replacement rather than the automated one.

## Changes

- `skills/windows-desktop-e2e/SKILL.md`
- `docs/ja-JP/skills/windows-desktop-e2e/SKILL.md`

Mapping used:

| Before  | After |
|---------|-------|
| `★★★★★` | `5/5` |
| `★★★★☆` | `4/5` |
| `★★★☆☆` | `3/5` |

Only the rating cells changed — table structure, prose, and all other content are
untouched. The two locale files are kept in sync.

## Verification

- `node scripts/ci/check-unicode-safety.js` → `Unicode safety check passed` (exit 0)
- No `★` / `☆` characters remain anywhere in the repo
- Diff is minimal: 2 files, 14 lines each, no lockfile or unrelated changes

## Checklist

- [x] Follows the repo's Unicode-safety policy (no emoji / pictographic chars in text)
- [x] `npm test` first gate now passes
- [x] Localized doc (`docs/ja-JP`) updated to match the source
- [x] No unrelated files touched


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Unicode star ratings (★/☆) with ASCII N/5 in the Windows desktop E2E skill docs to satisfy the unicode-safety check and unblock CI. Only rating cells changed in `skills/windows-desktop-e2e/SKILL.md` and `docs/ja-JP/skills/windows-desktop-e2e/SKILL.md` (★★★★★→5/5, ★★★★☆→4/5, ★★★☆☆→3/5).

<sup>Written for commit 75d0e8e7e3e3515fc3fa476f7d8a7578a49ddecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows desktop E2E skill framework quality ratings to use numeric scores (e.g., 5/5, 4/5) instead of star-based indicators for clearer framework compatibility information.
  * Refined quality assessments for supported frameworks including WPF, WinForms, UWP/WinUI 3, Qt, and Win32/MFC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->