### PR TITLE
fix(ecc2): resolve duplicate kill_process definition that breaks the Windows build

### DIFF
--- a/ecc2/src/session/manager.rs
+++ b/ecc2/src/session/manager.rs
@@ -3634,24 +3634,6 @@ fn send_signal(pid: u32, signal: i32) -> Result<()> {
     Err(error).with_context(|| format!("Failed to kill process {pid}"))
 }
 
-#[cfg(not(unix))]
-async fn kill_process(pid: u32) -> Result<()> {
-    let status = Command::new("taskkill")
-        .args(["/F", "/PID", &pid.to_string()])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .with_context(|| format!("Failed to invoke taskkill for process {pid}"))?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        anyhow::bail!("taskkill failed for process {pid}");
-    }
-}
-
 pub struct SessionStatus {
     harness: SessionHarnessInfo,
     profile: Option<SessionAgentProfile>,


### PR DESCRIPTION
## Problem

`cargo build` fails on Windows with a duplicate-definition error:

```
error[E0428]: the name `kill_process` is defined multiple times
    --> src\session\manager.rs:3638:1
     |
3609 | fn kill_process(pid: u32) -> Result<()> {
     | --------------------------------------- previous definition of the value `kill_process` here
...
3638 | async fn kill_process(pid: u32) -> Result<()> {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `kill_process` redefined here
     |
     = note: `kill_process` must be defined only once in the value namespace of this module
For more information about this error, try `rustc --explain E0428`.
error: could not compile `ecc-tui` (bin "ecc-tui") due to 1 previous error
```

`ecc2/src/session/manager.rs` defines three cfg-gated `kill_process` variants:

- `#[cfg(unix)]` — sync, libc signals
- `#[cfg(windows)]` — sync, `taskkill`
- `#[cfg(not(unix))]` — **async**, `taskkill`

On Windows, **both `cfg(windows)` and `cfg(not(unix))` evaluate true**, so the sync and async versions both compile in and collide. This affects **every Windows target** — the overlap is independent of toolchain, so `x86_64-pc-windows-msvc` hits the identical collision as `x86_64-pc-windows-gnu`. Unix builds are unaffected because only `cfg(unix)` matches there — which is why Linux/macOS CI never caught it.

## Fix

Delete the stray `#[cfg(not(unix))]` async definition. It was unusable regardless of the collision — both call sites are synchronous and never `.await` it:

- `enforce_session_heartbeats_with<F>` is bound `where F: Fn(u32) -> Result<()>` (a sync fn) and receives `kill_process` as a plain fn-pointer, invoked as `terminate_pid(pid)` with no await;
- `stop_session_recorded` calls `kill_process(pid)?` synchronously.

The surviving `#[cfg(windows)]` sync version is also **strictly better** than the deleted async one: it passes `/T` to `taskkill` (terminates the whole child process tree, so spawned agent subprocesses aren't orphaned) and surfaces the actual exit status on failure. The async version had neither.

One file, 18-line deletion. Verified on Windows (`x86_64-pc-windows-gnu`): builds clean, `cargo check` passes, and no other `cfg(windows)` / `cfg(not(unix))` overlaps exist in the crate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows build by removing a duplicate `kill_process` definition. The async `#[cfg(not(unix))]` version is deleted so only the Windows sync `taskkill` implementation remains.

- **Bug Fixes**
  - Removed the `#[cfg(not(unix))]` async `kill_process` that collided with `#[cfg(windows)]` (E0428).
  - Windows builds now succeed; callers remain sync and use the `taskkill /T /F` implementation.

<sup>Written for commit 545fcf43adeb99d2100a8091d8a13b47b55de01c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal process management logic by removing deprecated code paths and consolidating platform-specific implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->