### PR TITLE
Finalize and enhance SLSA generic generator workflow

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -1,0 +1,66 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow lets you generate SLSA provenance file for your project.
+# The generation satisfies level 3 for the provenance requirements - see https://slsa.dev/spec/v0.1/requirements
+# The project is an initiative of the OpenSSF (openssf.org) and is developed at
+# https://github.com/slsa-framework/slsa-github-generator.
+# The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
+# For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
+
+name: SLSA generic generator
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      digests: ${{ steps.hash.outputs.digests }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ========================================================
+      #
+      # Step 1: Build your artifacts.
+      #
+      # ========================================================
+      - name: Build artifacts
+        run: |
+            # These are some amazing artifacts.
+            echo "artifact1" > artifact1
+            echo "artifact2" > artifact2
+
+      # ========================================================
+      #
+      # Step 2: Add a step to generate the provenance subjects
+      #         as shown below. Update the sha256 sum arguments
+      #         to include all binaries that you generate
+      #         provenance for.
+      #
+      # ========================================================
+      - name: Generate subject for provenance
+        id: hash
+        run: |
+          set -euo pipefail
+
+          # List the artifacts the provenance will refer to.
+          files=$(ls artifact*)
+          # Generate the subjects (base64 encoded).
+          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read   # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.digests }}"
+      upload-assets: true # Optional: Upload to a new release

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -63,7 +63,7 @@ jobs:
       actions: read   # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@68bad40844440577b33778c9f29077a3388838e9 # v1.4.0
     with:
       base64-subjects: "${{ needs.build.outputs.digests }}"
       upload-assets: true # Optional: Upload to a new release

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -9,29 +9,40 @@
 # https://github.com/slsa-framework/slsa-github-generator.
 # The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
-
+#.github/workflows/generator-generic-ossf-slsa3-publish.yml
+#steps.build.outputs.package_file
+#echo "package_file=..." >> $GITHUB_OUTPUT 
 name: SLSA generic generator workflow #1
+
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types:
+      - published
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      actions: write
+
     outputs:
+      package_file: ${{ steps.build.outputs.package_file }}
       digests: ${{ steps.hash.outputs.digests }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
+        uses: actions/checkout@f4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20.x'
+          node-version: "20.x"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -39,16 +50,33 @@ jobs:
       - name: Build artifacts
         id: build
         run: |
+          set -euo pipefail
+
           npm pack --json > npm-pack.json
-          PACKAGE_FILE=$(node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync('npm-pack.json', 'utf8')); console.log(data[0].filename)")
+
+          PACKAGE_FILE=$(node -e "
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('npm-pack.json', 'utf8'));
+            console.log(data[0].filename);
+          ")
+
           echo "package_file=${PACKAGE_FILE}" >> "${GITHUB_OUTPUT}"
 
       - name: Generate subject for provenance
         id: hash
         run: |
           set -euo pipefail
-          # Generate the subjects (base64 encoded).
-          echo "digests=$(sha256sum ${{ steps.build.outputs.package_file }} | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+          FILE="${{ steps.build.outputs.package_file }}"
+
+          if [ ! -f "$FILE" ]; then
+            echo "Package file not found: $FILE"
+            exit 1
+          fi
+
+          DIGESTS=$(sha256sum "$FILE" | base64 -w0)
+
+          echo "digests=${DIGESTS}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -58,12 +86,16 @@ jobs:
           if-no-files-found: error
 
   provenance:
-    needs: [build]
+    needs:
+      - build
+
     permissions:
-      actions: read   # To read the workflow path.
-      id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
+      actions: read
+      id-token: write
+      contents: write
+
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@68bad40844440577b33778c9f29077a3388838e9 # v1.4.0
+
     with:
-      base64-subjects: "${{ needs.build.outputs.digests }}"
-      upload-assets: true # Optional: Upload to a new release
+      base64-subjects: ${{ needs.build.outputs.digests }}
+      upload-assets: true

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -9,10 +9,7 @@
 # https://github.com/slsa-framework/slsa-github-generator.
 # The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
-#.github/workflows/generator-generic-ossf-slsa3-publish.yml
-#steps.build.outputs.package_file
-#echo "package_file=..." >> $GITHUB_OUTPUT 
-name: SLSA generic generator workflow #1
+name: SLSA generic generator
 
 on:
   workflow_dispatch:

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -10,7 +10,7 @@
 # The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
 
-name: SLSA generic generator
+name: SLSA generic generator workflow #1
 on:
   workflow_dispatch:
   release:

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -23,36 +23,39 @@ jobs:
       digests: ${{ steps.hash.outputs.digests }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      # ========================================================
-      #
-      # Step 1: Build your artifacts.
-      #
-      # ========================================================
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
       - name: Build artifacts
+        id: build
         run: |
-            # These are some amazing artifacts.
-            echo "artifact1" > artifact1
-            echo "artifact2" > artifact2
+          npm pack --json > npm-pack.json
+          PACKAGE_FILE=$(node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync('npm-pack.json', 'utf8')); console.log(data[0].filename)")
+          echo "package_file=${PACKAGE_FILE}" >> "${GITHUB_OUTPUT}"
 
-      # ========================================================
-      #
-      # Step 2: Add a step to generate the provenance subjects
-      #         as shown below. Update the sha256 sum arguments
-      #         to include all binaries that you generate
-      #         provenance for.
-      #
-      # ========================================================
       - name: Generate subject for provenance
         id: hash
         run: |
           set -euo pipefail
-
-          # List the artifacts the provenance will refer to.
-          files=$(ls artifact*)
           # Generate the subjects (base64 encoded).
-          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
+          echo "digests=$(sha256sum ${{ steps.build.outputs.package_file }} | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.build.outputs.package_file }}
+          path: ${{ steps.build.outputs.package_file }}
+          if-no-files-found: error
 
   provenance:
     needs: [build]

--- a/tests/scripts/trae-install.test.js
+++ b/tests/scripts/trae-install.test.js
@@ -29,7 +29,7 @@ function runInstall(options = {}) {
     },
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 60000,
+    timeout: 300000,
   });
 }
 
@@ -43,7 +43,7 @@ function runUninstall(options = {}) {
     encoding: 'utf8',
     input: options.input || 'y\n',
     stdio: ['pipe', 'pipe', 'pipe'],
-    timeout: 60000,
+    timeout: 300000,
   });
 }
 


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SLSA Level 3 provenance generation for release artifacts using the OpenSSF generic generator. Also increases `trae-install` test timeouts to prevent Bun-related flakiness.

- **New Features**
  - Adds `.github/workflows/generator-generic-ossf-slsa3-publish.yml` to build an npm tarball with `npm pack`, compute SHA-256 digests, and publish signed provenance via `slsa-framework/slsa-github-generator@v1.4.0` on release or manual runs.
  - Pins actions by commit and sets `persist-credentials: false`; uploads the tarball and provenance as release assets.

- **Bug Fixes**
  - Increases `tests/scripts/trae-install.test.js` timeouts from 60s to 300s for install/uninstall to avoid `ETIMEDOUT` under Bun.

<sup>Written for commit 10f6ed0e0fb69c106b48206299f69ae27f5db9bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
