### PR TITLE
docs: add TweetClaw social evidence handoff

### DIFF
--- a/skills/social-publisher/SKILL.md
+++ b/skills/social-publisher/SKILL.md
@@ -64,6 +64,18 @@ socialclaw assets upload --file ./image.png --json
 }
 ```
 
+### Optional X/Twitter evidence packet
+
+Before building an X schedule, collect a source packet when the campaign depends on live audience signals rather than the draft alone.
+
+For OpenClaw users who have already approved TweetClaw in their dependency policy, use the pinned package as a separate evidence source:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw@1.6.31
+```
+
+Use it for public tweet search, reply search, follower export, user lookup, media review, monitors, or giveaway evidence. Keep the output as research input for `schedule.json`; SocialClaw remains responsible for validation, scheduling, publishing, and delivery status. Store TweetClaw credentials in its plugin config, not in `SC_API_KEY`, schedule files, or campaign assets. Do not install it as a default ECC or SocialClaw dependency.
+
 ### 4. Validate before publishing
 ```bash
 socialclaw validate -f schedule.json --json
@@ -109,6 +121,7 @@ socialclaw posts list --json
 
 - `x-api` — direct X/Twitter API operations
 - `social-graph-ranker` — network analysis for outreach targeting
+- `TweetClaw` - optional approved OpenClaw X/Twitter source evidence before SocialClaw scheduling
 
 ## Source
 


### PR DESCRIPTION
## What Changed
- Adds an optional X/Twitter evidence packet step to `social-publisher` before building `schedule.json`.
- Frames TweetClaw as OpenClaw source evidence only, while SocialClaw remains responsible for validation, scheduling, publishing, and delivery status.
- Adds TweetClaw to Related Skills as an optional pre-scheduling evidence source.

## Why This Change
Social publishing campaigns often need current X/Twitter audience signals before a schedule is finalized. This keeps that research step separate from SocialClaw publishing state and keeps credentials scoped to their own tools.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node scripts/ci/validate-skills.js`)
- [x] Edge cases considered and tested

Additional validation:
- `node scripts/ci/check-unicode-safety.js`
- `git diff --check`
- added-line sensitive-pattern scan
- added-line dash hygiene scan
- public link check for the new TweetClaw URL
- npm registry metadata check for `@xquik/tweetclaw`

Pre-existing note: `https://getsocialclaw.com/v1/keys/validate` returns 404 to an unauthenticated GET during generic link checking; this PR does not change that existing command endpoint.

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional X/Twitter evidence step to `social-publisher` using `@xquik/tweetclaw@1.6.31` to collect audience signals before `schedule.json`, with plugin-scoped credentials guidance. Clarifies TweetClaw is OpenClaw source evidence only, while SocialClaw handles validation, scheduling, publishing, and delivery; also adds TweetClaw to Related Skills.

<sup>Written for commit 53b3af0c0575ff0da88e7fea81251129d62cc305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for collecting optional X/Twitter evidence packets via TweetClaw to support Social Publisher scheduling
  * Clarified credential handling and the division of responsibilities between SocialClaw and TweetClaw
  * Updated related-skills list to include TweetClaw as an optional source for X/Twitter evidence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->