### PR TITLE
feat(skills): add config-gc skill

### DIFF
--- a/skills/config-gc/SKILL.md
+++ b/skills/config-gc/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: config-gc
+description: Garbage collection for your Claude Code configuration. Periodically scans ~/.claude (skills, memory, hooks, permissions, MCP servers, caches) for redundant, stale, orphaned, or low-value items, then walks the user through a confirm-each-deletion cleanup. Use when the user says "clean up my config", "config GC", "too many skills", "audit my setup", "my .claude is bloated", or asks for a periodic config review.
+origin: ECC
+---
+
+# Config GC — Garbage Collection for Claude Code Setups
+
+Borrowed from runtime garbage collection: periodically scan for objects that are no longer referenced, redundant, expired, or low-value, and reclaim the space. The critical difference: **here, collection requires a human in the loop. Never delete autonomously.**
+
+## When to Activate
+
+- The user asks to clean up, audit, or slim down their Claude Code configuration
+- The user complains about too many skills, noisy hooks, or slow session startup
+- A monthly/periodic config review is due
+- After installing a large skill pack (e.g. this repo), to reconcile overlaps with existing setup
+
+Do NOT activate for: cleaning project source code (that's refactoring), clearing chat history, or uninstalling Claude Code itself.
+
+## Design Philosophy
+
+1. **Append-only configs leak.** Skills, memory files, hooks, and permission entries only ever get added. Without periodic review they rot silently.
+2. **Regular audits beat one-time purges.** Scan every ~30 days, propose a small batch of candidates each time.
+3. **Per-channel strategies.** Each accumulation type (skills, hooks, permissions, ...) has its own staleness signals — don't apply one rule everywhere.
+4. **Soft-delete first.** Rename to `.disabled` > move to `~/.claude/_gc_trash/` > real deletion. Always keep an undo path.
+5. **Forced human-in-the-loop.** Every candidate gets its own `[y/n/skip]` confirmation. No "yes to all" shortcut.
+6. **Keep a log.** Every GC run appends to `~/.claude/gc_log.md`: what was touched, why, and how to undo it.
+
+## Scan Channels
+
+| # | Channel | Path | Staleness / redundancy signals |
+|---|---------|------|--------------------------------|
+| 1 | Skills | `~/.claude/skills/*/` | Heavily overlapping names; never triggered in recent transcripts; domain mismatch with the user's actual work; broken or empty SKILL.md |
+| 2 | Memory | `~/.claude/**/memory/*.md` + its index | Multiple index entries for one topic; contents contradicting newer entries; dates that have passed; orphan files missing from the index; sub-100-word fragments that should merge |
+| 3 | Hooks | `~/.claude/hooks/` + settings | Scripts present on disk but referenced by no hook config; old versions superseded by rewrites |
+| 4 | Permissions | `permissions.allow` in `settings.json` / `settings.local.json` | Duplicate entries; specific entries already covered by a wildcard (e.g. `Bash(git push)` when `Bash(*)` is allowed); one-off grants from past experiments |
+| 5 | MCP servers | `~/.claude.json` or project `.mcp.json` | Servers that fail to connect; functional duplicates; long-unused |
+| 6 | Scheduled reminders / jobs | wherever the user keeps them | Fired one-shots older than 30 days; jobs whose target scripts no longer exist |
+| 7 | Project history | `~/.claude/projects/*/` | Stale handoff snapshots; session records superseded by newer state |
+| 8 | Runtime caches | `cache/`, `file-history/`, `logs/`, `shell-snapshots/` | Sort by size and mtime; propose items >30 days old and large |
+
+## Workflow
+
+1. **Scan** all channels (or the subset the user names). Collect candidates with: path, channel, signal that flagged it, size, last-modified.
+2. **Rank** by confidence (broken/orphaned = high; merely old = low) and present as a numbered table. Cap each run at ~20 candidates — GC is periodic, not exhaustive.
+3. **Confirm one by one.** For each candidate show the evidence, then ask `[y/n/skip]`. The user can stop at any point.
+4. **Soft-delete confirmed items**: prefer `.disabled` rename for skills/hooks, `_gc_trash/<date>/` move for files, comment-out for permission lines. Only hard-delete when the user explicitly asks.
+5. **Log** the run to `~/.claude/gc_log.md`: timestamp, items actioned, undo instructions.
+6. **Report**: reclaimed size, channels still healthy, suggested next review date.
+
+## Example Scan Commands
+
+Orphaned hook scripts (channel 3) — scripts on disk that no hook config references:
+
+```bash
+for f in ~/.claude/hooks/*; do
+  name=$(basename "$f")
+  grep -rq "$name" ~/.claude/settings.json ~/.claude/settings.local.json 2>/dev/null \
+    || echo "ORPHAN: $f"
+done
+```
+
+Redundant permission entries (channel 4) — specific grants shadowed by a wildcard:
+
+```bash
+jq -r '.permissions.allow[]' ~/.claude/settings.local.json | sort | uniq -d
+jq -r '.permissions.allow[]' ~/.claude/settings.local.json \
+  | grep -E '^Bash\(.+\)$' | grep -v '^Bash(\*)$' \
+  | { grep -q 'Bash(\*)' ~/.claude/settings.local.json && cat || true; }
+```
+
+Largest stale caches (channel 8):
+
+```bash
+find ~/.claude/file-history ~/.claude/shell-snapshots -type f -mtime +30 \
+  -printf '%s\t%p\n' 2>/dev/null | sort -rn | head -20
+```
+
+Soft-delete with undo path:
+
+```bash
+mkdir -p ~/.claude/_gc_trash/$(date +%Y-%m-%d)
+mv ~/.claude/skills/dead-skill ~/.claude/_gc_trash/$(date +%Y-%m-%d)/
+echo "$(date -Iseconds) moved skills/dead-skill -> _gc_trash/$(date +%Y-%m-%d)/ (undo: mv back)" >> ~/.claude/gc_log.md
+```
+
+## Anti-Patterns
+
+- **Bulk approval.** Asking "delete all 15? [y/n]" defeats the design. One item, one decision.
+- **Hard-deleting on first pass.** If there's no `_gc_trash/` copy or `.disabled` rename, you did it wrong.
+- **Treating "old" as "dead".** A skill untouched for 60 days may be seasonal (tax season, quarterly reviews). Age is a signal, not a verdict — that's why a human confirms.
+- **Cleaning memory by truncation.** Merging two contradicting memory files requires reading both and keeping the newer truth, not deleting the longer one.
+- **Touching anything outside `~/.claude`** (or the project's `.claude/`). Config GC never wanders into source trees.
+
+## Best Practices
+
+- Run after big additions, not just on a calendar: installing a 50-skill pack is exactly when overlap with existing skills appears.
+- When two skills overlap, prefer disabling the one with the weaker trigger description — it's the one that was probably never firing anyway.
+- Permission cleanup is the highest-value channel per minute spent: redundant allow-entries make security review harder.
+- Keep `gc_log.md` forever. It's tiny, and "when did I disable that hook and why" comes up more often than you'd think.
+
+## Related Skills
+
+- `skill-stocktake` — audits skill *quality*; config-gc audits skill *existence*. Run stocktake on what survives GC.
+- `workspace-surface-audit` — the additive counterpart: recommends what to install. config-gc is the subtractive half of the same lifecycle.
+- `configure-ecc` — after installing skills with it, run config-gc to reconcile overlaps with your pre-existing setup.
+- `continuous-learning` — produces the memory files this skill later audits.
+- `security-review` — pairs well with the permissions channel.

--- a/skills/config-gc/SKILL.md
+++ b/skills/config-gc/SKILL.md
@@ -44,7 +44,7 @@ Do NOT activate for: cleaning project source code (that's refactoring), clearing
 1. **Scan** all channels (or the subset the user names). Collect candidates with: path, channel, signal that flagged it, size, last-modified.
 2. **Rank** by confidence (broken/orphaned = high; merely old = low) and present as a numbered table. Cap each run at ~20 candidates — GC is periodic, not exhaustive.
 3. **Confirm one by one.** For each candidate show the evidence, then ask `[y/n/skip]`. The user can stop at any point.
-4. **Soft-delete confirmed items**: prefer `.disabled` rename for skills/hooks, `_gc_trash/<date>/` move for files, comment-out for permission lines. Only hard-delete when the user explicitly asks.
+4. **Soft-delete confirmed items**: prefer `.disabled` rename for skills/hooks and `_gc_trash/<date>/` move for files. Permission entries live in JSON (no comments possible): back up the settings file, record each removed entry verbatim in `gc_log.md`, then remove it from the `allow` array with `jq`. Only hard-delete when the user explicitly asks.
 5. **Log** the run to `~/.claude/gc_log.md`: timestamp, items actioned, undo instructions.
 6. **Report**: reclaimed size, channels still healthy, suggested next review date.
 
@@ -60,28 +60,39 @@ for f in ~/.claude/hooks/*; do
 done
 ```
 
-Redundant permission entries (channel 4) — specific grants shadowed by a wildcard:
+Redundant permission entries (channel 4) — duplicates, and specific grants shadowed by a wildcard:
 
 ```bash
 jq -r '.permissions.allow[]' ~/.claude/settings.local.json | sort | uniq -d
-jq -r '.permissions.allow[]' ~/.claude/settings.local.json \
-  | grep -E '^Bash\(.+\)$' | grep -v '^Bash(\*)$' \
-  | { grep -q 'Bash(\*)' ~/.claude/settings.local.json && cat || true; }
+if jq -e '.permissions.allow | index("Bash(*)")' ~/.claude/settings.local.json >/dev/null; then
+  jq -r '.permissions.allow[]' ~/.claude/settings.local.json \
+    | grep '^Bash(' | grep -vF 'Bash(*)'
+fi
 ```
 
-Largest stale caches (channel 8):
+Largest stale caches (channel 8) — `du -k` instead of GNU-only `find -printf`, so it works on macOS/BSD too:
 
 ```bash
 find ~/.claude/file-history ~/.claude/shell-snapshots -type f -mtime +30 \
-  -printf '%s\t%p\n' 2>/dev/null | sort -rn | head -20
+  -exec du -k {} + 2>/dev/null | sort -rn | head -20
 ```
 
-Soft-delete with undo path:
+Soft-delete with undo path (capture the date once so the log can't disagree with the directory):
 
 ```bash
-mkdir -p ~/.claude/_gc_trash/$(date +%Y-%m-%d)
-mv ~/.claude/skills/dead-skill ~/.claude/_gc_trash/$(date +%Y-%m-%d)/
-echo "$(date -Iseconds) moved skills/dead-skill -> _gc_trash/$(date +%Y-%m-%d)/ (undo: mv back)" >> ~/.claude/gc_log.md
+gc_date=$(date +%Y-%m-%d)
+mkdir -p ~/.claude/_gc_trash/$gc_date
+mv ~/.claude/skills/dead-skill ~/.claude/_gc_trash/$gc_date/
+echo "$(date -Iseconds) moved skills/dead-skill -> _gc_trash/$gc_date/ (undo: mv back)" >> ~/.claude/gc_log.md
+```
+
+Removing a confirmed-redundant permission entry (JSON has no comments — back up, log, then edit):
+
+```bash
+cp ~/.claude/settings.local.json ~/.claude/settings.local.json.bak
+echo "$(date -Iseconds) removed permission entry: Bash(git push) (undo: restore from .bak or re-add)" >> ~/.claude/gc_log.md
+jq '.permissions.allow -= ["Bash(git push)"]' ~/.claude/settings.local.json.bak \
+  > ~/.claude/settings.local.json
 ```
 
 ## Anti-Patterns


### PR DESCRIPTION
## Summary

Adds `config-gc` — garbage collection for Claude Code configuration sprawl.

Skills, memory files, hooks, permission entries, and MCP servers only ever get *added*; nothing in the default lifecycle removes them. ECC itself ships 230+ skills, so reconciling overlap with a user's pre-existing setup is a real need. This skill is the subtractive half of the lifecycle that `workspace-surface-audit` (recommend/install) and `configure-ecc` (install) cover on the additive side, and it composes with `skill-stocktake` (quality-audits what survives GC).

Design highlights:
- 8 scan channels, each with its own staleness signals (skills / memory / hooks / permissions / MCP / scheduled reminders / project history / runtime caches)
- Hard human-in-the-loop: one candidate, one `[y/n/skip]` — no "yes to all"
- Soft-delete ladder (`.disabled` rename > `_gc_trash/` move > real delete) with an append-only `gc_log.md` undo log
- Copy-pasteable scan commands for orphaned hooks, shadowed permission entries, and stale caches

## Type
- [x] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command

## Testing

Distilled from a config-GC workflow run for months on a real ~/.claude setup (200+ skills, 30+ hooks/scheduled jobs); the channel list and soft-delete ladder come from that practice. Generalized wording re-tested with Claude Code by invoking the skill against a live config and walking the confirm loop.

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `config-gc` skill to clean up Claude Code configs by scanning 8 channels in `~/.claude` for stale or redundant items and guiding users through confirm-each deletions with soft-delete and an undo log; complements `workspace-surface-audit`/`configure-ecc` and pairs with `skill-stocktake`.

Documentation now uses a safe JSON permissions edit flow (backup + `gc_log.md` + `jq` removal), a portable `du -k` cache scan, one captured `gc_date` for consistent trash/log, and simpler `jq index()` checks.

<sup>Written for commit 395498cf60f31eeebee9aca2d14863f74d8b72d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

