### PR TITLE
docs: restore on-brand ECC header, consolidate sponsors, visual guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 **Language:** English | [Português (Brasil)](docs/pt-BR/README.md) | [简体中文](README.zh-CN.md) | [繁體中文](docs/zh-TW/README.md) | [日本語](docs/ja-JP/README.md) | [한국어](docs/ko-KR/README.md) | [Türkçe](docs/tr/README.md) | [Русский](docs/ru/README.md) | [Tiếng Việt](docs/vi-VN/README.md) | [ไทย](docs/th/README.md) | [Deutsch](docs/de-DE/README.md) | [Español](docs/es/README.md)
 
-# ECC
+<div align="center">
 
-![ECC - the harness-native operator system for agentic work](assets/hero.png)
+<a href="https://ecc.tools"><img src="assets/ecc-icon.svg" width="120" alt="ECC logo" /></a>
+
+<h1>ECC</h1>
+
+<p><strong>The harness-native operator system for agentic work.</strong></p>
+
+</div>
 
 [![Stars](https://img.shields.io/github/stars/affaan-m/ECC?style=flat)](https://github.com/affaan-m/ECC/stargazers)
 [![Forks](https://img.shields.io/github/forks/affaan-m/ECC?style=flat)](https://github.com/affaan-m/ECC/network/members)
@@ -77,10 +83,30 @@ ECC v2.0.0 adds the public Hermes operator story on top of that reusable layer: 
 <sub>**OSS stays free.** This repo is MIT-licensed forever. ECC Pro is the hosted GitHub App for private repos. <a href="https://github.com/sponsors/affaan-m">Sponsors</a> and <a href="https://ecc.tools/pricing">Pro subscribers</a> fund the work — that's why a single maintainer ships weekly across 7 harnesses.</sub>
 
 <div align="center">
-  <sub><strong>Business sponsors</strong></sub><br />
-  <a href="https://www.coderabbit.ai"><img src="assets/images/sponsors/coderabbit.png" width="72" alt="CodeRabbit logo" /></a>
-  &nbsp;&nbsp;
-  <a href="https://www.greptile.com/go/ecc"><img src="assets/images/sponsors/greptile.png" width="72" alt="Greptile logo" /></a>
+
+<sub><strong>Business sponsors</strong></sub>
+
+<table>
+<tr>
+<td align="center" width="220">
+  <a href="https://www.coderabbit.ai">
+    <img src="assets/images/sponsors/coderabbit.png" width="96" alt="CodeRabbit logo" /><br />
+    <strong>CodeRabbit</strong>
+  </a>
+</td>
+<td align="center" width="220">
+  <a href="https://www.greptile.com/go/ecc">
+    <img src="assets/images/sponsors/greptile.png" width="96" alt="Greptile logo" /><br />
+    <strong>Greptile</strong>
+  </a>
+</td>
+</tr>
+</table>
+
+<sub><strong>Community sponsors:</strong> <a href="https://github.com/mikejmorgan-ai">Mike Morgan</a> · <a href="https://github.com/jasonwu513">@jasonwu513</a> · <a href="https://github.com/1anter">@1anter</a> · <a href="https://github.com/massimotodaro">@massimotodaro</a> · <a href="https://github.com/meadmccabe">@meadmccabe</a></sub>
+
+<sub><a href="https://github.com/sponsors/affaan-m"><strong>Become a Sponsor</strong></a> · <a href="SPONSORS.md">Sponsor Tiers</a> · <a href="SPONSORING.md">Sponsorship Program</a></sub>
+
 </div>
 
 ---
@@ -91,28 +117,30 @@ This repo is the raw code only. The guides explain everything.
 
 <table>
 <tr>
-<td width="33%">
-<a href="https://x.com/affaan/status/2012378465664745795">
-<img src="./assets/images/guides/shorthand-guide.png" alt="The Shorthand Guide to ECC" />
+<td width="50%" align="center">
+<a href="./the-shortform-guide.md">
+<img src="./assets/images/shortform/00-header.png" width="420" alt="The Shorthand Guide to ECC" /><br />
+<b>The Shorthand Guide</b>
 </a>
+<br /><sub>Setup, foundations, philosophy. <b>Read this first.</b> (<a href="https://x.com/affaan/status/2012378465664745795">thread</a>)</sub>
 </td>
-<td width="33%">
-<a href="https://x.com/affaan/status/2014040193557471352">
-<img src="./assets/images/guides/longform-guide.png" alt="The Longform Guide to ECC" />
+<td width="50%" align="center">
+<a href="./the-longform-guide.md">
+<img src="./assets/images/longform/01-header.png" width="420" alt="The Longform Guide to ECC" /><br />
+<b>The Longform Guide</b>
 </a>
+<br /><sub>Token optimization, memory persistence, evals, parallelization. (<a href="https://x.com/affaan/status/2014040193557471352">thread</a>)</sub>
 </td>
-<td width="33%">
-<a href="https://x.com/affaan/status/2033263813387223421">
-<img src="./assets/images/security/security-guide-header.png" alt="The Shorthand Guide to Everything Agentic Security" />
-</a>
-</td>
-</tr>
-<tr>
-<td align="center"><b>Shorthand Guide</b><br/>Setup, foundations, philosophy. <b>Read this first.</b></td>
-<td align="center"><b>Longform Guide</b><br/>Token optimization, memory persistence, evals, parallelization.</td>
-<td align="center"><b>Security Guide</b><br/>Attack vectors, sandboxing, sanitization, CVEs, AgentShield.</td>
 </tr>
 </table>
+
+<div align="center">
+<a href="./the-security-guide.md">
+<img src="./assets/images/security/security-guide-header.png" width="420" alt="The Shorthand Guide to Everything Agentic Security" /><br />
+<b>The Security Guide</b>
+</a>
+<br /><sub>Attack vectors, sandboxing, sanitization, CVEs, AgentShield. (<a href="https://x.com/affaan/status/2033263813387223421">thread</a>)</sub>
+</div>
 
 | Topic | What You'll Learn |
 |-------|-------------------|
@@ -1771,17 +1799,7 @@ These configs work for my workflow. You should:
 
 ## Sponsors
 
-ECC stays free because paid sponsors fund the work. Featured README placement is reserved for active sponsors.
-
-<div align="center">
-  <a href="https://www.coderabbit.ai"><img src="assets/images/sponsors/coderabbit.png" width="80" alt="CodeRabbit logo" /></a>
-  &nbsp;&nbsp;&nbsp;
-  <a href="https://www.greptile.com/go/ecc"><img src="assets/images/sponsors/greptile.png" width="80" alt="Greptile logo" /></a>
-  <br />
-  <sub><strong>CodeRabbit</strong> · <strong>Greptile</strong></sub>
-</div>
-
-[**Become a Sponsor**](https://github.com/sponsors/affaan-m) | [Sponsor Tiers](SPONSORS.md) | [Sponsorship Program](SPONSORING.md)
+Featured sponsors are at the top of this README — full list and tiers in [SPONSORS.md](SPONSORS.md). [Become a sponsor](https://github.com/sponsors/affaan-m).
 
 ---
 

--- a/the-shortform-guide.md
+++ b/the-shortform-guide.md
@@ -211,7 +211,7 @@ git worktree add ../feature-branch feature-branch
 
 Stream and watch logs/bash processes Claude runs:
 
-<https://github.com/user-attachments/assets/shortform/07-tmux-video.mp4>
+[Watch: tmux session streaming a long-running command (video)](./assets/images/shortform/07-tmux-video.mp4)
 
 ```bash
 tmux new -s dev


### PR DESCRIPTION
## Summary

- **Hero**: `assets/hero.png` rendered the wrong product name and a baked-in version stamp. Replaced with a centered HTML header (`assets/ecc-icon.svg` logo + `<h1>ECC</h1>` + tagline). No version numbers baked anywhere. Badge rows kept. The PNG itself stays on disk because 7 localized READMEs and the npm publish surface still reference it.
- **Sponsors**: removed the duplication. Top placement is now a polished centered table — CodeRabbit and Greptile logos at consistent size linked to coderabbit.ai and greptile.com/go/ecc, a one-line community sponsors row from SPONSORS.md, then the Become a Sponsor links. Bottom `## Sponsors` section reduced to a one-liner pointing to SPONSORS.md.
- **Guide links**: the guide cards now link to the local guide files (`the-shortform-guide.md`, `the-longform-guide.md`, `the-security-guide.md`) using each guide's own header image at width 420, with the X threads kept as secondary links.
- **Shortform guide**: fixed a broken `github.com/user-attachments` video URL to point at the in-repo `assets/images/shortform/07-tmux-video.mp4`.

## Verification

- `npx markdownlint README.md the-shortform-guide.md the-longform-guide.md` — clean
- `npm test` — 2688/2688 passing, exit 0
- All images referenced by both guides verified present on disk (restored previously via revert 0e9f613f)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the on-brand README header and consolidates sponsor placement, plus switches guide links to local visual cards and fixes a broken video link. Improves branding, reduces duplication, and makes guides easier to find.

- **Refactors**
  - Replaced off-brand `assets/hero.png` with a centered HTML header using `assets/ecc-icon.svg`, `<h1>ECC</h1>`, and tagline; kept the PNG on disk for localized READMEs and npm surfaces.
  - Consolidated sponsors into a single centered table at the top (CodeRabbit, Greptile, community row) with “Become a Sponsor” links; bottom section now points to `SPONSORS.md`.
  - Converted guide links to visual cards that point to local files (`the-shortform-guide.md`, `the-longform-guide.md`, `the-security-guide.md`) using each guide’s header image (width 420); X threads remain as secondary links.

- **Bug Fixes**
  - Fixed broken video link in `the-shortform-guide.md` to use the in-repo asset: `./assets/images/shortform/07-tmux-video.mp4`.

<sup>Written for commit aee61249e8cbcc70fbfe86643f018db1c7aec49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

