### PR TITLE
chore: pin rust toolchain to 1.96 for edition2024 deps

### DIFF
--- a/ecc2/rust-toolchain.toml
+++ b/ecc2/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# Minimum 1.85 required: several dependencies use edition2024.
+channel = "1.96"
+components = ["rustfmt", "clippy"]

--- a/ecc2/src/session/manager.rs
+++ b/ecc2/src/session/manager.rs
@@ -5043,6 +5043,9 @@ mod tests {
         run_git(path, ["init", "-q"])?;
         run_git(path, ["config", "user.name", "ECC Tests"])?;
         run_git(path, ["config", "user.email", "ecc-tests@example.com"])?;
+        // Keep fixtures hermetic: a global core.hooksPath (e.g. identity-checking
+        // pre-push hooks) must not run inside test repos.
+        run_git(path, ["config", "core.hooksPath", "hooks-disabled"])?;
         fs::write(path.join("README.md"), "hello\n")?;
         run_git(path, ["add", "README.md"])?;
         run_git(path, ["commit", "-qm", "init"])?;

--- a/ecc2/src/tui/dashboard.rs
+++ b/ecc2/src/tui/dashboard.rs
@@ -15047,6 +15047,9 @@ diff --git a/src/lib.rs b/src/lib.rs
         run_git(path, &["init", "-q"])?;
         run_git(path, &["config", "user.name", "ECC Tests"])?;
         run_git(path, &["config", "user.email", "ecc-tests@example.com"])?;
+        // Keep fixtures hermetic: a global core.hooksPath (e.g. identity-checking
+        // pre-push hooks) must not run inside test repos.
+        run_git(path, &["config", "core.hooksPath", "hooks-disabled"])?;
         fs::write(path.join("README.md"), "hello\n")?;
         run_git(path, &["add", "README.md"])?;
         run_git(path, &["commit", "-qm", "init"])?;


### PR DESCRIPTION
## Summary
- Add `ecc2/rust-toolchain.toml` pinning stable **1.96** with rustfmt + clippy components. Several transitive dependencies now require edition2024, which needs rustc 1.85+; environments on older stable (e.g. 1.84) could no longer build `ecc2/`. This also unblocks the open dependabot cargo-major PRs (#2208–#2211).
- Make ecc2 git test fixtures hermetic: temp repos now set `core.hooksPath` to a nonexistent dir so a developer's global identity-checking pre-push hooks can't fail `submit_pr_prompt_passes_custom_metadata_to_gh` (or any future fixture pushes).

## Test plan
- [x] `cargo build` in `ecc2/` on rustc 1.96.0 — clean (warnings only, pre-existing)
- [x] `cargo test` in `ecc2/` — 462/462 pass
- [x] Full repo suite `npm test` — 2688/2688 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Rust toolchain to 1.96 for `ecc2` to support edition2024 dependencies and prevent build failures on older rustc. Also make git test fixtures hermetic by disabling hooks so global pre-push hooks can't affect tests.

- **Dependencies**
  - Add `ecc2/rust-toolchain.toml` with channel `1.96` and components `rustfmt`, `clippy`.
  - Unblocks cargo-major updates (#2208–#2211).

- **Bug Fixes**
  - Set `core.hooksPath` to a dummy path in test git repos to avoid running global hooks.

<sup>Written for commit f14fea6403ee42357289111c4e0446e371ec6e1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

