### PR TITLE
fix(ecc2): port webhook sender to ureq 3 Agent API

### DIFF
--- a/ecc2/src/notifications.rs
+++ b/ecc2/src/notifications.rs
@@ -403,16 +403,17 @@ fn run_notification_command(_program: &str, _args: &[String]) -> Result<()> {
 
 #[cfg(not(test))]
 fn send_webhook_request(target: &WebhookTarget, payload: serde_json::Value) -> Result<()> {
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(std::time::Duration::from_secs(5))
-        .timeout_read(std::time::Duration::from_secs(5))
-        .build();
+    let agent = ureq::Agent::config_builder()
+        .timeout_connect(Some(std::time::Duration::from_secs(5)))
+        .timeout_recv_response(Some(std::time::Duration::from_secs(5)))
+        .build()
+        .new_agent();
     let response = agent
         .post(&target.url)
         .send_json(payload)
         .with_context(|| format!("POST {}", target.url))?;
 
-    if response.status() >= 200 && response.status() < 300 {
+    if response.status().is_success() {
         Ok(())
     } else {
         anyhow::bail!("{} returned {}", target.url, response.status());


### PR DESCRIPTION
## Summary
#2209 bumped ureq 2 → 3 in `ecc2/Cargo.toml`, but the companion code port to `src/notifications.rs` did not land with it (the branch update raced the squash merge), leaving `cargo build` red on main (`ureq::AgentBuilder` no longer exists).

This ports `send_webhook_request` to the ureq 3 API:
- `AgentBuilder::new()` → `Agent::config_builder()...build().new_agent()`
- `timeout_connect/timeout_read(Duration)` → `timeout_connect/timeout_recv_response(Some(Duration))`
- numeric status comparison → `StatusCode::is_success()`

## Test plan
- [x] `cargo build` in ecc2/ — clean
- [x] `cargo test` in ecc2/ — 462/462 pass
- [x] Full `npm test` was green on this exact tree state (pr-2209 + main merge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the webhook sender in ecc2 to the `ureq` 3 Agent API to fix build breakage on main after the dependency bump. Replaces `AgentBuilder` with `Agent::config_builder().build().new_agent()`, updates timeouts to `timeout_connect(Some)` and `timeout_recv_response(Some)`, and switches to `StatusCode::is_success()` for response checks.

<sup>Written for commit e33632690b6aed49e3a46c946ea4a408c0c2c3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/affaan-m/ECC/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

