### PR TITLE
fix(skills): move top-level `origin` frontmatter key under `metadata` (spec compliance)

### DIFF
--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -2,7 +2,8 @@
 name: accessibility
 description: Design, implement, and audit inclusive digital products using WCAG 2.2 Level AA
   standards. Use this skill to generate semantic ARIA for Web and accessibility traits for Web and Native platforms (iOS/Android).
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Accessibility (WCAG 2.2)

--- a/skills/agent-architecture-audit/SKILL.md
+++ b/skills/agent-architecture-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-architecture-audit
 description: Full-stack diagnostic for agent and LLM applications. Audits the 12-layer agent stack for wrapper regression, memory pollution, tool discipline failures, hidden repair loops, and rendering corruption. Produces severity-ranked findings with code-first fixes. Essential for developers building agent applications, autonomous loops, or any LLM-powered feature.
-origin: oh-my-agent-check
+metadata:
+  origin: oh-my-agent-check
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/agent-eval/SKILL.md
+++ b/skills/agent-eval/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-eval
 description: Head-to-head comparison of coding agents (Claude Code, Aider, Codex, etc.) on custom tasks with pass rate, cost, time, and consistency metrics
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/agent-harness-construction/SKILL.md
+++ b/skills/agent-harness-construction/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-harness-construction
 description: Design and optimize AI agent action spaces, tool definitions, and observation formatting for higher completion rates.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Agent Harness Construction

--- a/skills/agent-introspection-debugging/SKILL.md
+++ b/skills/agent-introspection-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-introspection-debugging
 description: Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Agent Introspection Debugging

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-payment-x402
 description: Add x402 payment execution to AI agents with per-task budgets, spending controls, and non-custodial wallets. Supports Base through agentwallet-sdk and X Layer through OKX Payments / OKX Agent Payments Protocol.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Agent Payment Execution (x402)

--- a/skills/agent-sort/SKILL.md
+++ b/skills/agent-sort/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-sort
 description: Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Agent Sort

--- a/skills/agentic-engineering/SKILL.md
+++ b/skills/agentic-engineering/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agentic-engineering
 description: Operate as an agentic engineer using eval-first execution, decomposition, and cost-aware model routing.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Agentic Engineering

--- a/skills/agentic-os/SKILL.md
+++ b/skills/agentic-os/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agentic-os
 description: Build persistent multi-agent operating systems on Claude Code. Covers kernel architecture, specialist agents, slash commands, file-based memory, scheduled automation, and state management without external databases.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Agentic OS

--- a/skills/ai-first-engineering/SKILL.md
+++ b/skills/ai-first-engineering/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ai-first-engineering
 description: Engineering operating model for teams where AI agents generate a large share of implementation output.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # AI-First Engineering

--- a/skills/ai-regression-testing/SKILL.md
+++ b/skills/ai-regression-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ai-regression-testing
 description: Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # AI Regression Testing

--- a/skills/android-clean-architecture/SKILL.md
+++ b/skills/android-clean-architecture/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: android-clean-architecture
 description: Clean Architecture patterns for Android and Kotlin Multiplatform projects — module structure, dependency rules, UseCases, Repositories, and data layer patterns.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Android Clean Architecture

--- a/skills/angular-developer/SKILL.md
+++ b/skills/angular-developer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: angular-developer
 description: Generates Angular code and provides architectural guidance. Trigger when creating projects, components, or services, or for best practices on reactivity (signals, linkedSignal, resource), forms, dependency injection, routing, SSR, accessibility (ARIA), animations, styling (component styles, Tailwind CSS), testing, or CLI tooling.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Angular Developer Guidelines

--- a/skills/api-connector-builder/SKILL.md
+++ b/skills/api-connector-builder/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: api-connector-builder
 description: Build a new API connector or provider by matching the target repo's existing integration pattern exactly. Use when adding one more integration without inventing a second architecture.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: api-design
 description: REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # API Design Patterns

--- a/skills/architecture-decision-records/SKILL.md
+++ b/skills/architecture-decision-records/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: architecture-decision-records
 description: Capture architectural decisions made during Claude Code sessions as structured ADRs. Auto-detects decision moments, records context, alternatives considered, and rationale. Maintains an ADR log so future developers understand why the codebase is shaped the way it is.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Architecture Decision Records

--- a/skills/article-writing/SKILL.md
+++ b/skills/article-writing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: article-writing
 description: Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Article Writing

--- a/skills/automation-audit-ops/SKILL.md
+++ b/skills/automation-audit-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: automation-audit-ops
 description: Evidence-first automation inventory and overlap audit workflow for ECC. Use when the user wants to know which jobs, hooks, connectors, MCP servers, or wrappers are live, broken, redundant, or missing before fixing anything.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Automation Audit Ops

--- a/skills/autonomous-agent-harness/SKILL.md
+++ b/skills/autonomous-agent-harness/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: autonomous-agent-harness
 description: Transform Claude Code into a fully autonomous agent system with persistent memory, scheduled operations, computer use, and task queuing. Replaces standalone agent frameworks (Hermes, AutoGPT) by leveraging Claude Code's native crons, dispatch, MCP tools, and memory. Use when the user wants continuous autonomous operation, scheduled tasks, or a self-directing agent loop.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Autonomous Agent Harness

--- a/skills/autonomous-loops/SKILL.md
+++ b/skills/autonomous-loops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: autonomous-loops
 description: "Patterns and architectures for autonomous Claude Code loops — from simple sequential pipelines to RFC-driven multi-agent DAG systems."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Autonomous Loops Skill

--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: backend-patterns
 description: Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Backend Development Patterns

--- a/skills/benchmark-optimization-loop/SKILL.md
+++ b/skills/benchmark-optimization-loop/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: benchmark-optimization-loop
 description: Use when the user asks to make something faster, try many variants, run recursive optimization, benchmark latency/throughput/cost, or choose the best implementation by repeated measured tests.
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/benchmark/SKILL.md
+++ b/skills/benchmark/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: benchmark
 description: Use this skill to measure performance baselines, detect regressions before/after PRs, and compare stack alternatives.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Benchmark — Performance Baseline & Regression Detection

--- a/skills/blender-motion-state-inspection/SKILL.md
+++ b/skills/blender-motion-state-inspection/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: blender-motion-state-inspection
 description: Use this skill when inspecting Blender characters, rigs, poses, animation retargeting, ground contact, facing direction, or model-vs-motion alignment where screenshots alone are not enough.
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   complex multi-PR task, or describes work that needs multiple sessions.
   DO NOT TRIGGER when: task is completable in a single PR or fewer
   than 3 tool calls, or user says "just do it".
-origin: community
+metadata:
+  origin: community
 ---
 
 # Blueprint — Construction Plan Generator

--- a/skills/brand-voice/SKILL.md
+++ b/skills/brand-voice/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: brand-voice
 description: Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Brand Voice

--- a/skills/browser-qa/SKILL.md
+++ b/skills/browser-qa/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: browser-qa
 description: Use this skill to automate visual testing and UI interaction verification using browser automation after deploying features.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Browser QA — Automated Visual Testing & Interaction

--- a/skills/bun-runtime/SKILL.md
+++ b/skills/bun-runtime/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: bun-runtime
 description: Bun as runtime, package manager, bundler, and test runner. When to choose Bun vs Node, migration notes, and Vercel support.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Bun Runtime

--- a/skills/canary-watch/SKILL.md
+++ b/skills/canary-watch/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: canary-watch
 description: Use this skill to monitor and verify a deployed URL after releases — checks HTTP endpoints, SSE streams, static assets, console errors, and performance regressions after deploys, merges, or dependency upgrades. Smoke / canary / post-deploy verification.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Canary Watch — Post-Deploy Monitoring

--- a/skills/carrier-relationship-management/SKILL.md
+++ b/skills/carrier-relationship-management/SKILL.md
@@ -10,8 +10,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/cisco-ios-patterns/SKILL.md
+++ b/skills/cisco-ios-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cisco-ios-patterns
 description: Cisco IOS and IOS-XE review patterns for show commands, config hierarchy, wildcard masks, ACL placement, interface hygiene, and safe change-window verification.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Cisco IOS Patterns

--- a/skills/ck/SKILL.md
+++ b/skills/ck/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ck
 description: Persistent per-project memory for Claude Code. Auto-loads project context on session start, tracks sessions with git activity, and writes to native memory. Commands run deterministic Node.js scripts — behavior is consistent across model versions.
-origin: community
+metadata:
+  origin: community
 version: 2.0.0
 author: sreedhargs89
 repo: https://github.com/sreedhargs89/context-keeper

--- a/skills/claude-devfleet/SKILL.md
+++ b/skills/claude-devfleet/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: claude-devfleet
 description: Orchestrate multi-agent coding tasks via Claude DevFleet — plan projects, dispatch parallel agents in isolated worktrees, monitor progress, and read structured reports.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Claude DevFleet Multi-Agent Orchestration

--- a/skills/click-path-audit/SKILL.md
+++ b/skills/click-path-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: click-path-audit
 description: "Trace every user-facing button/touchpoint through its full state change sequence to find bugs where functions individually work but cancel each other out, produce wrong final state, or leave the UI in an inconsistent state. Use when: systematic debugging found no bugs but users report broken buttons, or after any major refactor touching shared state stores."
-origin: community
+metadata:
+  origin: community
 ---
 
 # /click-path-audit — Behavioural Flow Audit

--- a/skills/clickhouse-io/SKILL.md
+++ b/skills/clickhouse-io/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: clickhouse-io
 description: ClickHouse database patterns, query optimization, analytics, and data engineering best practices for high-performance analytical workloads.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # ClickHouse Analytics Patterns

--- a/skills/code-tour/SKILL.md
+++ b/skills/code-tour/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: code-tour
 description: Create CodeTour `.tour` files — persona-targeted, step-by-step walkthroughs with real file and line anchors. Use for onboarding tours, architecture walkthroughs, PR tours, RCA tours, and structured "explain how this works" requests.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Code Tour

--- a/skills/codebase-onboarding/SKILL.md
+++ b/skills/codebase-onboarding/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: codebase-onboarding
 description: Analyze an unfamiliar codebase and generate a structured onboarding guide with architecture map, key entry points, conventions, and a starter CLAUDE.md. Use when joining a new project or setting up Claude Code for the first time in a repo.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Codebase Onboarding

--- a/skills/codehealth-mcp/SKILL.md
+++ b/skills/codehealth-mcp/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: codehealth-mcp
 description: Real-time structural Code Health via CodeScene MCP — review before edits, verify score deltas after changes, gate commits and PRs. Use when reviewing code quality, refactoring, checking if AI changes degraded a file, or before commit/PR.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Code Health MCP (CodeScene)

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: coding-standards
 description: Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Coding Standards & Best Practices

--- a/skills/compose-multiplatform-patterns/SKILL.md
+++ b/skills/compose-multiplatform-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: compose-multiplatform-patterns
 description: Compose Multiplatform and Jetpack Compose patterns for KMP projects — state management, navigation, theming, performance, and platform-specific UI.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Compose Multiplatform Patterns

--- a/skills/config-gc/SKILL.md
+++ b/skills/config-gc/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: config-gc
 description: Garbage collection for your Claude Code configuration. Periodically scans ~/.claude (skills, memory, hooks, permissions, MCP servers, caches) for redundant, stale, orphaned, or low-value items, then walks the user through a confirm-each-deletion cleanup. Use when the user says "clean up my config", "config GC", "too many skills", "audit my setup", "my .claude is bloated", or asks for a periodic config review.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Config GC — Garbage Collection for Claude Code Setups

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: configure-ecc
 description: Interactive installer for Everything Claude Code — guides users through selecting and installing skills and rules to user-level or project-level directories, verifies paths, and optionally optimizes installed files.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Configure Everything Claude Code (ECC)

--- a/skills/connections-optimizer/SKILL.md
+++ b/skills/connections-optimizer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: connections-optimizer
 description: Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Connections Optimizer

--- a/skills/content-engine/SKILL.md
+++ b/skills/content-engine/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: content-engine
 description: Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Content Engine

--- a/skills/content-hash-cache-pattern/SKILL.md
+++ b/skills/content-hash-cache-pattern/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: content-hash-cache-pattern
 description: Cache expensive file processing results using SHA-256 content hashes — path-independent, auto-invalidating, with service layer separation.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Content-Hash File Cache Pattern

--- a/skills/context-budget/SKILL.md
+++ b/skills/context-budget/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: context-budget
 description: Audits Claude Code context window consumption across agents, skills, MCP servers, and rules. Identifies bloat, redundant components, and produces prioritized token-savings recommendations.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Context Budget

--- a/skills/continuous-agent-loop/SKILL.md
+++ b/skills/continuous-agent-loop/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: continuous-agent-loop
 description: Patterns for continuous autonomous agent loops with quality gates, evals, and recovery controls.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Continuous Agent Loop

--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: continuous-learning-v2
 description: Instinct-based learning system that observes sessions via hooks, creates atomic instincts with confidence scoring, and evolves them into skills/commands/agents. v2.1 adds project-scoped instincts to prevent cross-project contamination.
-origin: ECC
+metadata:
+  origin: ECC
 version: 2.1.0
 ---
 

--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: continuous-learning
 description: "[DEPRECATED - use continuous-learning-v2] Legacy v1 stop-hook skill extractor. v2 is a strict superset with instinct-based, project-scoped, hook-reliable learning. Do not invoke v1; route continuous learning, session learning, and pattern extraction requests to continuous-learning-v2."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Continuous Learning Skill - DEPRECATED

--- a/skills/cost-aware-llm-pipeline/SKILL.md
+++ b/skills/cost-aware-llm-pipeline/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cost-aware-llm-pipeline
 description: Cost optimization patterns for LLM API usage — model routing by task complexity, budget tracking, retry logic, and prompt caching.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Cost-Aware LLM Pipeline

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cost-tracking
 description: Track and report Claude Code token usage, spending, and budgets from a local cost-tracking database. Use when the user asks about costs, spending, usage, tokens, budgets, or cost breakdowns by project, tool, session, or date.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Cost Tracking

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: council
 description: Convene a four-voice council for ambiguous decisions, tradeoffs, and go/no-go calls. Use when multiple valid paths exist and you need structured disagreement before choosing.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Council

--- a/skills/cpp-coding-standards/SKILL.md
+++ b/skills/cpp-coding-standards/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cpp-coding-standards
 description: C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # C++ Coding Standards (C++ Core Guidelines)

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cpp-testing
 description: Use only when writing/updating/fixing C++ tests, configuring GoogleTest/CTest, diagnosing failing or flaky tests, or adding coverage/sanitizers.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # C++ Testing (Agent Skill)

--- a/skills/crosspost/SKILL.md
+++ b/skills/crosspost/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: crosspost
 description: Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Crosspost

--- a/skills/csharp-testing/SKILL.md
+++ b/skills/csharp-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: csharp-testing
 description: C# and .NET testing patterns with xUnit, FluentAssertions, mocking, integration tests, and test organization best practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # C# Testing Patterns

--- a/skills/customer-billing-ops/SKILL.md
+++ b/skills/customer-billing-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: customer-billing-ops
 description: Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Customer Billing Ops

--- a/skills/customs-trade-compliance/SKILL.md
+++ b/skills/customs-trade-compliance/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/dart-flutter-patterns/SKILL.md
+++ b/skills/dart-flutter-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dart-flutter-patterns
 description: Production-ready Dart and Flutter patterns covering null safety, immutable state, async composition, widget architecture, popular state management frameworks (BLoC, Riverpod, Provider), GoRouter navigation, Dio networking, Freezed code generation, and clean architecture.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Dart/Flutter Patterns

--- a/skills/dashboard-builder/SKILL.md
+++ b/skills/dashboard-builder/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dashboard-builder
 description: Build monitoring dashboards that answer real operator questions for Grafana, SigNoz, and similar platforms. Use when turning metrics into a working dashboard instead of a vanity board.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/data-scraper-agent/SKILL.md
+++ b/skills/data-scraper-agent/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: data-scraper-agent
 description: Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Scrapes on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Data Scraper Agent

--- a/skills/data-throughput-accelerator/SKILL.md
+++ b/skills/data-throughput-accelerator/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: data-throughput-accelerator
 description: Use when large data ingestion, backfill, export, ETL, warehouse loading, manifest catch-up, or table synchronization needs to become much faster while preserving data correctness.
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/database-migrations/SKILL.md
+++ b/skills/database-migrations/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: database-migrations
 description: Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate).
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Database Migration Patterns

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: deep-research
 description: Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Deep Research

--- a/skills/defi-amm-security/SKILL.md
+++ b/skills/defi-amm-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: defi-amm-security
 description: Security checklist for Solidity AMM contracts, liquidity pools, and swap flows. Covers reentrancy, CEI ordering, donation or inflation attacks, oracle manipulation, slippage, admin controls, and integer math.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/deployment-patterns/SKILL.md
+++ b/skills/deployment-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: deployment-patterns
 description: Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Deployment Patterns

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: design-system
 description: Use this skill to generate or audit design systems, check visual consistency, and review PRs that touch styling.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Design System — Generate & Audit Visual Systems

--- a/skills/django-celery/SKILL.md
+++ b/skills/django-celery/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: django-celery
 description: Django + Celery async task patterns — configuration, task design, beat scheduling, retries, canvas workflows, monitoring, and testing. Use when adding background jobs, scheduled tasks, or async processing to a Django app.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Django + Celery Async Task Patterns

--- a/skills/django-patterns/SKILL.md
+++ b/skills/django-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: django-patterns
 description: Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Django Development Patterns

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: django-security
 description: Django security best practices, authentication, authorization, CSRF protection, SQL injection prevention, XSS prevention, and secure deployment configurations.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Django Security Best Practices

--- a/skills/django-tdd/SKILL.md
+++ b/skills/django-tdd/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: django-tdd
 description: Django testing strategies with pytest-django, TDD methodology, factory_boy, mocking, coverage, and testing Django REST Framework APIs.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Django Testing with TDD

--- a/skills/django-verification/SKILL.md
+++ b/skills/django-verification/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: django-verification
 description: "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Django Verification Loop

--- a/skills/dmux-workflows/SKILL.md
+++ b/skills/dmux-workflows/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dmux-workflows
 description: Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # dmux Workflows

--- a/skills/docker-patterns/SKILL.md
+++ b/skills/docker-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: docker-patterns
 description: Docker and Docker Compose patterns for local development, container security, networking, volume strategies, and multi-service orchestration.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Docker Patterns

--- a/skills/documentation-lookup/SKILL.md
+++ b/skills/documentation-lookup/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: documentation-lookup
 description: Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Documentation Lookup (Context7)

--- a/skills/dotnet-patterns/SKILL.md
+++ b/skills/dotnet-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dotnet-patterns
 description: Idiomatic C# and .NET patterns, conventions, dependency injection, async/await, and best practices for building robust, maintainable .NET applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # .NET Development Patterns

--- a/skills/dynamic-workflow-mode/SKILL.md
+++ b/skills/dynamic-workflow-mode/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dynamic-workflow-mode
 description: "Design task-local harnesses, eval gates, and reusable skill extraction for Claude dynamic workflow mode and other adaptive agent harnesses."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Dynamic Workflow Mode

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: e2e-testing
 description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # E2E Testing Patterns

--- a/skills/ecc-guide/SKILL.md
+++ b/skills/ecc-guide/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ecc-guide
 description: Guide users through ECC's current agents, skills, commands, hooks, rules, install profiles, and project onboarding by reading the live repository surface before answering.
-origin: community
+metadata:
+  origin: community
 ---
 
 # ECC Guide

--- a/skills/ecc-tools-cost-audit/SKILL.md
+++ b/skills/ecc-tools-cost-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ecc-tools-cost-audit
 description: Evidence-first ECC Tools burn and billing audit workflow. Use when investigating runaway PR creation, quota bypass, premium-model leakage, duplicate jobs, or GitHub App cost spikes in the ECC Tools repo.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # ECC Tools Cost Audit

--- a/skills/email-ops/SKILL.md
+++ b/skills/email-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: email-ops
 description: Evidence-first mailbox triage, drafting, send verification, and sent-mail-safe follow-up workflow for ECC. Use when the user wants to organize email, draft or send through the real mail surface, or prove what landed in Sent.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Email Ops

--- a/skills/energy-procurement/SKILL.md
+++ b/skills/energy-procurement/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/enterprise-agent-ops/SKILL.md
+++ b/skills/enterprise-agent-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: enterprise-agent-ops
 description: Operate long-lived agent workloads with observability, security boundaries, and lifecycle management.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Enterprise Agent Ops

--- a/skills/error-handling/SKILL.md
+++ b/skills/error-handling/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: error-handling
 description: Patterns for robust error handling across TypeScript, Python, and Go. Covers typed errors, error boundaries, retries, circuit breakers, and user-facing error messages.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Error Handling Patterns

--- a/skills/eval-harness/SKILL.md
+++ b/skills/eval-harness/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: eval-harness
 description: Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/evm-token-decimals/SKILL.md
+++ b/skills/evm-token-decimals/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: evm-token-decimals
 description: Prevent silent decimal mismatch bugs across EVM chains. Covers runtime decimal lookup, chain-aware caching, bridged-token precision drift, and safe normalization for bots, dashboards, and DeFi tools.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: exa-search
 description: Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Exa Search

--- a/skills/fal-ai-media/SKILL.md
+++ b/skills/fal-ai-media/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: fal-ai-media
 description: Unified media generation via fal.ai MCP — image, video, and audio. Covers text-to-image (Nano Banana), text/image-to-video (Seedance, Kling, Veo 3), text-to-speech (CSM-1B), and video-to-audio (ThinkSound). Use when the user wants to generate images, videos, or audio with AI.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # fal.ai Media Generation

--- a/skills/fastapi-patterns/SKILL.md
+++ b/skills/fastapi-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: fastapi-patterns
 description: FastAPI best practices covering project structure, Pydantic v2 schemas, dependency injection, async handlers, authentication, authorization, transactional service layers, and testing with httpx and pytest.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # FastAPI Patterns

--- a/skills/finance-billing-ops/SKILL.md
+++ b/skills/finance-billing-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: finance-billing-ops
 description: Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Finance Billing Ops

--- a/skills/flox-environments/SKILL.md
+++ b/skills/flox-environments/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: flox-environments
 description: "Create reproducible, cross-platform development environments with Flox — a declarative environment manager built on Nix. ALWAYS use this skill when the user needs to: set up a project with system-level dependencies (compilers, databases, native libraries like openssl, libvips, BLAS, LAPACK); configure reproducible toolchains for Python, Node.js, Rust, Go, C/C++, Java, Ruby, Elixir, PHP, or any language; manage environments that must work identically across macOS and Linux; pin exact package versions for a team; run local services (PostgreSQL, Redis, Kafka) alongside development tools; onboard new developers with a single command; or solve 'works on my machine' problems. Especially valuable for AI-assisted and vibe coding — Flox lets agents install tools into a project-scoped environment without sudo, system pollution, or sandbox restrictions, and the resulting environment is committed to the repo so anyone can reproduce it instantly. Use this skill even if the user doesn't mention Flox — if they describe needing reproducible, declarative, cross-platform dev environments with system packages, this is the right tool. Also use when the user mentions .flox/, manifest.toml, flox activate, or FloxHub."
-origin: Flox
+metadata:
+  origin: Flox
 ---
 
 # Flox Environments

--- a/skills/flutter-dart-code-review/SKILL.md
+++ b/skills/flutter-dart-code-review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: flutter-dart-code-review
 description: Library-agnostic Flutter/Dart code review checklist covering widget best practices, state management patterns (BLoC, Riverpod, Provider, GetX, MobX, Signals), Dart idioms, performance, accessibility, security, and clean architecture.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Flutter/Dart Code Review Best Practices

--- a/skills/frontend-a11y/SKILL.md
+++ b/skills/frontend-a11y/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Accessibility patterns for React and Next.js — semantic HTML, ARIA attributes,
   form labeling, keyboard navigation, focus management, and screen reader support.
   Use when building any interactive UI component or form.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Frontend Accessibility Patterns

--- a/skills/frontend-design-direction/SKILL.md
+++ b/skills/frontend-design-direction/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: frontend-design-direction
 description: Set an ECC-specific frontend design direction for production UI work. Use when building or improving websites, dashboards, applications, components, landing pages, visual tools, or any web UI that needs stronger product-specific design judgment.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Frontend Design Direction

--- a/skills/frontend-patterns/SKILL.md
+++ b/skills/frontend-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: frontend-patterns
 description: Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Frontend Development Patterns

--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Frontend Slides

--- a/skills/fsharp-testing/SKILL.md
+++ b/skills/fsharp-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: fsharp-testing
 description: F# testing patterns with xUnit, FsUnit, Unquote, FsCheck property-based testing, integration tests, and test organization best practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # F# Testing Patterns

--- a/skills/gan-style-harness/SKILL.md
+++ b/skills/gan-style-harness/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gan-style-harness
 description: "GAN-inspired Generator-Evaluator agent harness for building high-quality applications autonomously. Based on Anthropic's March 2026 harness design paper."
-origin: ECC-community
+metadata:
+  origin: ECC-community
 tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gateguard
 description: Fact-forcing gate that blocks Edit/Write/Bash (including MultiEdit) and demands concrete investigation (importers, data schemas, user instruction) before allowing the action. Measurably improves output quality by +2.25 points vs ungated agents.
-origin: community
+metadata:
+  origin: community
 ---
 
 # GateGuard — Fact-Forcing Pre-Action Gate

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: git-workflow
 description: Git workflow patterns including branching strategies, commit conventions, merge vs rebase, conflict resolution, and collaborative development best practices for teams of all sizes.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Git Workflow Patterns

--- a/skills/github-ops/SKILL.md
+++ b/skills/github-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: github-ops
 description: GitHub repository operations, automation, and management. Issue triage, PR management, CI/CD operations, release management, and security monitoring using the gh CLI. Use when the user wants to manage GitHub issues, PRs, CI status, releases, contributors, stale items, or any GitHub operational task beyond simple git commands.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # GitHub Operations

--- a/skills/golang-patterns/SKILL.md
+++ b/skills/golang-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: golang-patterns
 description: Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Go Development Patterns

--- a/skills/golang-testing/SKILL.md
+++ b/skills/golang-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: golang-testing
 description: Go testing patterns including table-driven tests, subtests, benchmarks, fuzzing, and test coverage. Follows TDD methodology with idiomatic Go practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Go Testing Patterns

--- a/skills/google-workspace-ops/SKILL.md
+++ b/skills/google-workspace-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: google-workspace-ops
 description: Operate across Google Drive, Docs, Sheets, and Slides as one workflow surface for plans, trackers, decks, and shared documents. Use when the user needs to find, summarize, edit, migrate, or clean up Google Workspace assets without dropping to raw tool calls.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Google Workspace Ops

--- a/skills/healthcare-cdss-patterns/SKILL.md
+++ b/skills/healthcare-cdss-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: healthcare-cdss-patterns
 description: Clinical Decision Support System (CDSS) development patterns. Drug interaction checking, dose validation, clinical scoring (NEWS2, qSOFA), alert severity classification, and integration into EMR workflows.
-origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+metadata:
+  origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
 version: "1.0.0"
 ---
 

--- a/skills/healthcare-emr-patterns/SKILL.md
+++ b/skills/healthcare-emr-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: healthcare-emr-patterns
 description: EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry.
-origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+metadata:
+  origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
 version: "1.0.0"
 ---
 

--- a/skills/healthcare-eval-harness/SKILL.md
+++ b/skills/healthcare-eval-harness/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: healthcare-eval-harness
 description: Patient safety evaluation harness for healthcare application deployments. Automated test suites for CDSS accuracy, PHI exposure, clinical workflow integrity, and integration compliance. Blocks deployments on safety failures.
-origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+metadata:
+  origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
 version: "1.0.0"
 ---
 

--- a/skills/healthcare-phi-compliance/SKILL.md
+++ b/skills/healthcare-phi-compliance/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: healthcare-phi-compliance
 description: Protected Health Information (PHI) and Personally Identifiable Information (PII) compliance patterns for healthcare applications. Covers data classification, access control, audit trails, encryption, and common leak vectors.
-origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+metadata:
+  origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
 version: "1.0.0"
 ---
 

--- a/skills/hermes-imports/SKILL.md
+++ b/skills/hermes-imports/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: hermes-imports
 description: Convert local Hermes operator workflows into sanitized ECC skills and release-pack artifacts. Use when preparing a Hermes workflow for public ECC reuse without leaking private workspace state, credentials, or local-only paths.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Hermes Imports

--- a/skills/hexagonal-architecture/SKILL.md
+++ b/skills/hexagonal-architecture/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: hexagonal-architecture
 description: Design, implement, and refactor Ports & Adapters systems with clear domain boundaries, dependency inversion, and testable use-case orchestration across TypeScript, Java, Kotlin, and Go services.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Hexagonal Architecture

--- a/skills/hipaa-compliance/SKILL.md
+++ b/skills/hipaa-compliance/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: hipaa-compliance
 description: HIPAA-specific entrypoint for healthcare privacy and security work. Use when a task is explicitly framed around HIPAA, PHI handling, covered entities, BAAs, breach posture, or US healthcare compliance requirements.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/homelab-network-readiness/SKILL.md
+++ b/skills/homelab-network-readiness/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: homelab-network-readiness
 description: Readiness checklist for homelab VLAN segmentation, local DNS filtering, and WireGuard-style remote access before changing router, firewall, DHCP, or VPN configuration.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Homelab Network Readiness

--- a/skills/homelab-network-setup/SKILL.md
+++ b/skills/homelab-network-setup/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: homelab-network-setup
 description: Practical home and homelab network planning for gateways, switches, access points, IP ranges, DHCP reservations, DNS, cabling, and common beginner mistakes.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Homelab Network Setup

--- a/skills/homelab-pihole-dns/SKILL.md
+++ b/skills/homelab-pihole-dns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: homelab-pihole-dns
 description: Pi-hole installation, blocklist management, DNS-over-HTTPS setup, DHCP integration, local DNS records, and troubleshooting broken DNS resolution on a home network.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Homelab Pi-hole DNS

--- a/skills/homelab-vlan-segmentation/SKILL.md
+++ b/skills/homelab-vlan-segmentation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: homelab-vlan-segmentation
 description: Segmenting home networks into VLANs for IoT, guest, trusted, and server traffic using UniFi, pfSense/OPNsense, and MikroTik — including switch trunk config, firewall rules, and wireless SSID mapping.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Homelab VLAN Segmentation

--- a/skills/homelab-wireguard-vpn/SKILL.md
+++ b/skills/homelab-wireguard-vpn/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: homelab-wireguard-vpn
 description: WireGuard VPN server setup, peer configuration, key generation, split tunneling vs full tunnel routing, and remote access to a home network from mobile and laptop clients.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Homelab WireGuard VPN

--- a/skills/inherit-legacy-style/SKILL.md
+++ b/skills/inherit-legacy-style/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: inherit-legacy-style
 description: Legacy-project style inheritance skill. Use when the user types /inherit-legacy-style, or when onboarding an AI coding agent onto a hand-written legacy project and you need to prevent "style drift" (the model imposing its pretrained mainstream idioms onto the project). Language- and framework-agnostic — it aligns meta-architecture only, not syntax. Once run, it becomes a behavioral constraint on all subsequent coding tasks. Do NOT use for pure research or one-off questions unrelated to code-style alignment.
-origin: community
+metadata:
+  origin: community
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write, AskUserQuestion
 ---
 

--- a/skills/inventory-demand-planning/SKILL.md
+++ b/skills/inventory-demand-planning/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/investor-materials/SKILL.md
+++ b/skills/investor-materials/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: investor-materials
 description: Create and update pitch decks, one-pagers, investor memos, accelerator applications, financial models, and fundraising materials. Use when the user needs investor-facing documents, projections, use-of-funds tables, milestone plans, or materials that must stay internally consistent across multiple fundraising assets.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Investor Materials

--- a/skills/investor-outreach/SKILL.md
+++ b/skills/investor-outreach/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: investor-outreach
 description: Draft cold emails, warm intro blurbs, follow-ups, update emails, and investor communications for fundraising. Use when the user wants outreach to angels, VCs, strategic investors, or accelerators and needs concise, personalized, investor-facing messaging.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Investor Outreach

--- a/skills/ios-icon-gen/SKILL.md
+++ b/skills/ios-icon-gen/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ios-icon-gen
 description: Generate iOS app icons as PNG imagesets for Xcode asset catalogs from SF Symbols (5000+ Apple-native) or Iconify API (275k+ open source icons from 200+ collections). Use when generating icons, creating icon assets, adding icons to asset catalog, or searching for icons for iOS projects.
-origin: community
+metadata:
+  origin: community
 ---
 
 # iOS Icon Generator

--- a/skills/iterative-retrieval/SKILL.md
+++ b/skills/iterative-retrieval/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: iterative-retrieval
 description: Pattern for progressively refining context retrieval to solve the subagent context problem
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Iterative Retrieval Pattern

--- a/skills/ito-basket-compare/SKILL.md
+++ b/skills/ito-basket-compare/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ito-basket-compare
 description: Compare Itô prediction-market baskets against a user's knowledge base, portfolio notes, financial context, watchlist, or research thesis. Use for read-only basket comparison and gap analysis without investment advice or live trading.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Itô Basket Compare

--- a/skills/ito-data-atlas-agent/SKILL.md
+++ b/skills/ito-data-atlas-agent/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ito-data-atlas-agent
 description: Design background Data Atlas style agents for Itô basket research, market discovery, parameter drafting, and human-in-the-loop editing. Use for architecture and workflow planning, not live order execution.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Itô Data Atlas Agent

--- a/skills/ito-market-intelligence/SKILL.md
+++ b/skills/ito-market-intelligence/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ito-market-intelligence
 description: Research prediction-market events, venues, underliers, liquidity, and news context for Itô basket workflows. Use for read-only market intelligence, API-gated Itô exploration, and source-grounded prediction-market briefings without investment advice or live trading.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Itô Market Intelligence

--- a/skills/ito-trade-planner/SKILL.md
+++ b/skills/ito-trade-planner/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ito-trade-planner
 description: Build a non-advisory prediction-market trade planning worksheet for Itô or venue workflows. Use to inspect venues, underliers, constraints, order prerequisites, and manual execution steps without placing trades or recommending positions.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Itô Trade Planner

--- a/skills/java-coding-standards/SKILL.md
+++ b/skills/java-coding-standards/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: java-coding-standards
 description: "Java coding standards for Spring Boot and Quarkus services: naming, immutability, Optional usage, streams, exceptions, generics, CDI, reactive patterns, and project layout. Automatically applies framework-specific conventions."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Java Coding Standards

--- a/skills/jira-integration/SKILL.md
+++ b/skills/jira-integration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: jira-integration
 description: Use this skill when retrieving Jira tickets, analyzing requirements, updating ticket status, adding comments, or transitioning issues. Provides Jira API patterns via MCP or direct REST calls.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Jira Integration Skill

--- a/skills/jpa-patterns/SKILL.md
+++ b/skills/jpa-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: jpa-patterns
 description: JPA/Hibernate patterns for entity design, relationships, query optimization, transactions, auditing, indexing, pagination, and pooling in Spring Boot.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # JPA/Hibernate Patterns

--- a/skills/knowledge-ops/SKILL.md
+++ b/skills/knowledge-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: knowledge-ops
 description: Knowledge base management, ingestion, sync, and retrieval across multiple storage layers (local files, MCP memory, vector stores, Git repos). Use when the user wants to save, organize, sync, deduplicate, or search across their knowledge systems.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Knowledge Operations

--- a/skills/kotlin-coroutines-flows/SKILL.md
+++ b/skills/kotlin-coroutines-flows/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kotlin-coroutines-flows
 description: Kotlin Coroutines and Flow patterns for Android and KMP — structured concurrency, Flow operators, StateFlow, error handling, and testing.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Kotlin Coroutines & Flows

--- a/skills/kotlin-exposed-patterns/SKILL.md
+++ b/skills/kotlin-exposed-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kotlin-exposed-patterns
 description: JetBrains Exposed ORM patterns including DSL queries, DAO pattern, transactions, HikariCP connection pooling, Flyway migrations, and repository pattern.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Kotlin Exposed Patterns

--- a/skills/kotlin-ktor-patterns/SKILL.md
+++ b/skills/kotlin-ktor-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kotlin-ktor-patterns
 description: Ktor server patterns including routing DSL, plugins, authentication, Koin DI, kotlinx.serialization, WebSockets, and testApplication testing.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Ktor Server Patterns

--- a/skills/kotlin-patterns/SKILL.md
+++ b/skills/kotlin-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kotlin-patterns
 description: Idiomatic Kotlin patterns, best practices, and conventions for building robust, efficient, and maintainable Kotlin applications with coroutines, null safety, and DSL builders.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Kotlin Development Patterns

--- a/skills/kotlin-testing/SKILL.md
+++ b/skills/kotlin-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kotlin-testing
 description: Kotlin testing patterns with Kotest, MockK, coroutine testing, property-based testing, and Kover coverage. Follows TDD methodology with idiomatic Kotlin practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Kotlin Testing Patterns

--- a/skills/kubernetes-patterns/SKILL.md
+++ b/skills/kubernetes-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kubernetes-patterns
 description: Kubernetes workload patterns, resource management, RBAC, probes, autoscaling, ConfigMap/Secret handling, and kubectl debugging for production-grade deployments.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Kubernetes Patterns

--- a/skills/laravel-patterns/SKILL.md
+++ b/skills/laravel-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: laravel-patterns
 description: Laravel architecture patterns, routing/controllers, Eloquent ORM, service layers, queues, events, caching, and API resources for production apps.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Laravel Development Patterns

--- a/skills/laravel-plugin-discovery/SKILL.md
+++ b/skills/laravel-plugin-discovery/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: laravel-plugin-discovery
 description: Discover and evaluate Laravel packages via LaraPlugins.io MCP. Use when the user wants to find plugins, check package health, or assess Laravel/PHP compatibility.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Laravel Plugin Discovery

--- a/skills/laravel-security/SKILL.md
+++ b/skills/laravel-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: laravel-security
 description: Laravel security best practices — authentication, authorization, Eloquent safety, CSRF, XSS prevention, API security, and secure deployment configurations.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Laravel Security Best Practices

--- a/skills/laravel-tdd/SKILL.md
+++ b/skills/laravel-tdd/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: laravel-tdd
 description: Laravel testing strategies with PHPUnit, Pest, model factories, HTTP tests, Sanctum authentication testing, mocking, and coverage.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Laravel Testing with TDD

--- a/skills/laravel-verification/SKILL.md
+++ b/skills/laravel-verification/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: laravel-verification
 description: "Verification loop for Laravel projects: env checks, linting, static analysis, tests with coverage, security scans, and deployment readiness."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Laravel Verification Loop

--- a/skills/latency-critical-systems/SKILL.md
+++ b/skills/latency-critical-systems/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: latency-critical-systems
 description: Use for latency-sensitive systems such as realtime dashboards, market data, streaming agents, execution gateways, queues, caches, or HFT-like infrastructure where freshness and p95 latency matter.
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/lead-intelligence/SKILL.md
+++ b/skills/lead-intelligence/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: lead-intelligence
 description: AI-native lead intelligence and outreach pipeline. Replaces Apollo, Clay, and ZoomInfo with agent-powered signal scoring, mutual ranking, warm path discovery, source-derived voice modeling, and channel-specific outreach across email, LinkedIn, and X. Use when the user wants to find, qualify, and reach high-value contacts.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Lead Intelligence

--- a/skills/llm-trading-agent-security/SKILL.md
+++ b/skills/llm-trading-agent-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: llm-trading-agent-security
 description: Security patterns for autonomous trading agents with wallet or transaction authority. Covers prompt injection, spend limits, pre-send simulation, circuit breakers, MEV protection, and key handling.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/logistics-exception-management/SKILL.md
+++ b/skills/logistics-exception-management/SKILL.md
@@ -10,8 +10,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/make-interfaces-feel-better/SKILL.md
+++ b/skills/make-interfaces-feel-better/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: make-interfaces-feel-better
 description: Apply concrete design-engineering details that make interfaces feel polished. Use when reviewing or improving UI spacing, typography, borders, shadows, motion, hit areas, icons, text wrapping, and interaction states.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Make Interfaces Feel Better

--- a/skills/manim-video/SKILL.md
+++ b/skills/manim-video/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manim-video
 description: Build reusable Manim explainers for technical concepts, graphs, system diagrams, and product walkthroughs, then hand off to the wider ECC video stack if needed. Use when the user wants a clean animated explainer rather than a generic talking-head script.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Manim Video

--- a/skills/market-research/SKILL.md
+++ b/skills/market-research/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: market-research
 description: Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Market Research

--- a/skills/marketing-campaign/SKILL.md
+++ b/skills/marketing-campaign/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: marketing-campaign
 description: End-to-end marketing campaign planning and execution. Covers audience research, positioning, campaign angle definition, landing page copy, email sequences, social posts, ad copy, short-form video scripts, and content calendars. Use as the orchestration layer for multi-channel product launches.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Marketing Campaign

--- a/skills/mcp-server-patterns/SKILL.md
+++ b/skills/mcp-server-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: mcp-server-patterns
 description: Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # MCP Server Patterns

--- a/skills/messages-ops/SKILL.md
+++ b/skills/messages-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: messages-ops
 description: Evidence-first live messaging workflow for ECC. Use when the user wants to read texts or DMs, recover a recent one-time code, inspect a thread before replying, or prove which message source was actually checked.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Messages Ops

--- a/skills/mle-workflow/SKILL.md
+++ b/skills/mle-workflow/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: mle-workflow
 description: Production machine-learning engineering workflow for data contracts, reproducible training, model evaluation, deployment, monitoring, and rollback. Use when building, reviewing, or hardening ML systems beyond one-off notebooks.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Machine Learning Engineering Workflow

--- a/skills/motion-ui/SKILL.md
+++ b/skills/motion-ui/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: motion-ui
 description: "Production-ready UI motion system for React/Next.js. Use when implementing animations, transitions, or motion patterns."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Motion System v4.2

--- a/skills/mysql-patterns/SKILL.md
+++ b/skills/mysql-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: mysql-patterns
 description: MySQL and MariaDB schema, query, indexing, transaction, replication, and connection-pool patterns for production backends.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # MySQL Patterns

--- a/skills/nanoclaw-repl/SKILL.md
+++ b/skills/nanoclaw-repl/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nanoclaw-repl
 description: Operate and extend NanoClaw v2, ECC's zero-dependency session-aware REPL built on claude -p.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # NanoClaw REPL

--- a/skills/nestjs-patterns/SKILL.md
+++ b/skills/nestjs-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nestjs-patterns
 description: NestJS architecture patterns for modules, controllers, providers, DTO validation, guards, interceptors, config, and production-grade TypeScript backends.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # NestJS Development Patterns

--- a/skills/netmiko-ssh-automation/SKILL.md
+++ b/skills/netmiko-ssh-automation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: netmiko-ssh-automation
 description: Safe Python Netmiko patterns for read-only collection, bounded batch SSH, TextFSM parsing, guarded config changes, timeouts, and network automation error handling.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Netmiko SSH Automation

--- a/skills/network-bgp-diagnostics/SKILL.md
+++ b/skills/network-bgp-diagnostics/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: network-bgp-diagnostics
 description: Diagnostics-only BGP troubleshooting patterns for neighbor state, route exchange, prefix policy, AS path inspection, and safe evidence collection.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Network BGP Diagnostics

--- a/skills/network-config-validation/SKILL.md
+++ b/skills/network-config-validation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: network-config-validation
 description: Pre-deployment checks for router and switch configuration, including dangerous commands, duplicate addresses, subnet overlaps, stale references, management-plane risk, and IOS-style security hygiene.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Network Config Validation

--- a/skills/network-interface-health/SKILL.md
+++ b/skills/network-interface-health/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: network-interface-health
 description: Diagnose interface errors, drops, CRCs, duplex mismatches, flapping, speed negotiation issues, and counter trends on routers, switches, and Linux hosts.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Network Interface Health

--- a/skills/nextjs-turbopack/SKILL.md
+++ b/skills/nextjs-turbopack/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nextjs-turbopack
 description: Next.js 16+ and Turbopack — incremental bundling, FS caching, dev speed, and when to use Turbopack vs webpack.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Next.js and Turbopack

--- a/skills/nodejs-keccak256/SKILL.md
+++ b/skills/nodejs-keccak256/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nodejs-keccak256
 description: Prevent Ethereum hashing bugs in JavaScript and TypeScript. Node's sha3-256 is NIST SHA3, not Ethereum Keccak-256, and silently breaks selectors, signatures, storage slots, and address derivation.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/nutrient-document-processing/SKILL.md
+++ b/skills/nutrient-document-processing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nutrient-document-processing
 description: Process, convert, OCR, extract, redact, sign, and fill documents using the Nutrient DWS API. Works with PDFs, DOCX, XLSX, PPTX, HTML, and images.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Nutrient Document Processing

--- a/skills/nuxt4-patterns/SKILL.md
+++ b/skills/nuxt4-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nuxt4-patterns
 description: Nuxt 4 app patterns for hydration safety, performance, route rules, lazy loading, and SSR-safe data fetching with useFetch and useAsyncData.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Nuxt 4 Patterns

--- a/skills/openclaw-persona-forge/SKILL.md
+++ b/skills/openclaw-persona-forge/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: openclaw-persona-forge
 description: "为 OpenClaw AI Agent 锻造完整的龙虾灵魂方案。根据用户偏好或随机抽卡， 输出身份定位、灵魂描述(SOUL.md)、角色化底线规则、名字和头像生图提示词。 如当前环境提供已审核的生图 skill，可自动生成统一风格头像图片。 当用户需要创建、设计或定制 OpenClaw 龙虾灵魂时使用。 不适用于：微调已有 SOUL.md、非 OpenClaw 平台的角色设计、纯工具型无性格 Agent。 触发词：龙虾灵魂、虾魂、OpenClaw 灵魂、养虾灵魂、龙虾角色、龙虾定位、 龙虾剧本杀角色、龙虾游戏角色、龙虾 NPC、龙虾性格、龙虾背景故事、 lobster soul、lobster character、抽卡、随机龙虾、龙虾 SOUL、gacha。"
-origin: community
+metadata:
+  origin: community
 ---
 
 # 龙虾灵魂锻造炉

--- a/skills/opensource-pipeline/SKILL.md
+++ b/skills/opensource-pipeline/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: opensource-pipeline
 description: "Open-source pipeline: fork, sanitize, and package private projects for safe public release. Chains 3 agents (forker, sanitizer, packager). Triggers: '/opensource', 'open source this', 'make this public', 'prepare for open source'."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Open-Source Pipeline Skill

--- a/skills/orch-add-feature/SKILL.md
+++ b/skills/orch-add-feature/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orch-add-feature
 description: Orchestrate building a brand-new feature end to end — research, plan, TDD implementation, review, and gated commit — by delegating each phase to the matching ECC agent. Use when adding a capability that does not exist yet.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # orch-add-feature

--- a/skills/orch-build-mvp/SKILL.md
+++ b/skills/orch-build-mvp/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orch-build-mvp
 description: Orchestrate bootstrapping a working MVP from a design or spec document — ingest the doc, plan thin vertical slices, scaffold the first end-to-end slice, then TDD-implement, review, and gated commit. Use to turn an SDD/PRD into a running starting point.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # orch-build-mvp

--- a/skills/orch-change-feature/SKILL.md
+++ b/skills/orch-change-feature/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orch-change-feature
 description: Orchestrate altering an existing, working feature to new desired behavior — update its tests to the new spec, change the implementation to match, review, and gated commit. Use when behavior is not broken but should be different.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # orch-change-feature

--- a/skills/orch-fix-defect/SKILL.md
+++ b/skills/orch-fix-defect/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orch-fix-defect
 description: Orchestrate fixing a bug — reproduce it as a failing regression test, fix to green, review, and gated commit — by delegating each phase to the matching ECC agent. Use when existing behavior is broken or wrong.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # orch-fix-defect

--- a/skills/orch-pipeline/SKILL.md
+++ b/skills/orch-pipeline/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orch-pipeline
 description: Shared orchestration engine for the orch-* skill family. Defines the gated Research-Plan-TDD-Review-Commit pipeline, the size classifier, the agent map, and the two human gates that the orch-* operation skills delegate to. Not usually invoked directly.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Orchestrator Pipeline (shared engine)

--- a/skills/orch-refine-code/SKILL.md
+++ b/skills/orch-refine-code/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orch-refine-code
 description: Orchestrate a behavior-preserving refactor — confirm tests are green, restructure without changing behavior, keep tests green, review, and gated commit. Use when the structure should improve but behavior must not change.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # orch-refine-code

--- a/skills/parallel-execution-optimizer/SKILL.md
+++ b/skills/parallel-execution-optimizer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: parallel-execution-optimizer
 description: Use when the user wants a task done much faster through parallel work, concurrent agents, batched tool calls, isolated worktrees, or many independent verification lanes without losing correctness.
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/perl-patterns/SKILL.md
+++ b/skills/perl-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: perl-patterns
 description: Modern Perl 5.36+ idioms, best practices, and conventions for building robust, maintainable Perl applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Modern Perl Development Patterns

--- a/skills/perl-security/SKILL.md
+++ b/skills/perl-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: perl-security
 description: Comprehensive Perl security covering taint mode, input validation, safe process execution, DBI parameterized queries, web security (XSS/SQLi/CSRF), and perlcritic security policies.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Perl Security Patterns

--- a/skills/perl-testing/SKILL.md
+++ b/skills/perl-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: perl-testing
 description: Perl testing patterns using Test2::V0, Test::More, prove runner, mocking, coverage with Devel::Cover, and TDD methodology.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Perl Testing Patterns

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: plan-orchestrate
 description: Read a plan document, decompose it into steps, design a per-step agent chain from the ECC catalogue, and emit ready-to-paste /orchestrate custom prompts. Generative only — never invokes /orchestrate itself. Use when the user has a multi-step plan and wants to drive it through orchestrate without composing chains by hand.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Plan Orchestrate

--- a/skills/plankton-code-quality/SKILL.md
+++ b/skills/plankton-code-quality/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: plankton-code-quality
 description: "Write-time code quality enforcement using Plankton — auto-formatting, linting, and Claude-powered fixes on every file edit via hooks."
-origin: community
+metadata:
+  origin: community
 ---
 
 # Plankton Code Quality Skill

--- a/skills/postgres-patterns/SKILL.md
+++ b/skills/postgres-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: postgres-patterns
 description: PostgreSQL database patterns for query optimization, schema design, indexing, and security. Based on Supabase best practices.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # PostgreSQL Patterns

--- a/skills/prediction-market-oracle-research/SKILL.md
+++ b/skills/prediction-market-oracle-research/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: prediction-market-oracle-research
 description: Research prediction markets as data sources or oracle signals for products, agents, dashboards, and corporate decision intelligence. Use for source-grounded analysis of market-implied probabilities, caveats, and integration patterns without investment advice.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Prediction Market Oracle Research

--- a/skills/prediction-market-risk-review/SKILL.md
+++ b/skills/prediction-market-risk-review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: prediction-market-risk-review
 description: Review prediction-market, basket, oracle, and trading-agent workflows for compliance, safety, data-quality, privacy, and execution risk. Use before any workflow handles venue auth, user portfolio data, API keys, or trade planning.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Prediction Market Risk Review

--- a/skills/prisma-patterns/SKILL.md
+++ b/skills/prisma-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: prisma-patterns
 description: Prisma ORM patterns for TypeScript backends — schema design, query optimization, transactions, pagination, and critical traps like updateMany returning count not records, $transaction timeouts, migrate dev resetting the DB, @updatedAt skipped on bulk writes, and serverless connection exhaustion.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Prisma Patterns

--- a/skills/product-capability/SKILL.md
+++ b/skills/product-capability/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: product-capability
 description: Translate PRD intent, roadmap asks, or product discussions into an implementation-ready capability plan that exposes constraints, invariants, interfaces, and unresolved decisions before multi-service work starts. Use when the user needs an ECC-native PRD-to-SRS lane instead of vague planning prose.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Product Capability

--- a/skills/product-lens/SKILL.md
+++ b/skills/product-lens/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: product-lens
 description: Use this skill to validate the "why" before building, run product diagnostics, and pressure-test product direction before the request becomes an implementation contract.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Product Lens — Think Before You Build

--- a/skills/production-audit/SKILL.md
+++ b/skills/production-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: production-audit
 description: Local-evidence production readiness audit for shipped apps, pre-launch reviews, post-merge checks, and "what breaks in prod?" questions without sending repo data to an external audit service.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Production Audit

--- a/skills/production-scheduling/SKILL.md
+++ b/skills/production-scheduling/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/project-flow-ops/SKILL.md
+++ b/skills/project-flow-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: project-flow-ops
 description: Operate execution flow across GitHub and Linear by triaging issues and pull requests, linking active work, and keeping GitHub public-facing while Linear remains the internal execution layer. Use when the user wants backlog control, PR triage, or GitHub-to-Linear coordination.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Project Flow Ops

--- a/skills/prompt-optimizer/SKILL.md
+++ b/skills/prompt-optimizer/SKILL.md
@@ -12,8 +12,8 @@ description: >-
   "just do it" / "直接做". DO NOT TRIGGER when user says "优化代码",
   "优化性能", "optimize performance", "optimize this code" — those are
   refactoring/performance tasks, not prompt optimization.
-origin: community
 metadata:
+  origin: community
   author: YannJY02
   version: "1.0.0"
 ---

--- a/skills/python-patterns/SKILL.md
+++ b/skills/python-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: python-patterns
 description: Pythonic idioms, PEP 8 standards, type hints, and best practices for building robust, efficient, and maintainable Python applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Python Development Patterns

--- a/skills/python-testing/SKILL.md
+++ b/skills/python-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: python-testing
 description: Python testing strategies using pytest, TDD methodology, fixtures, mocking, parametrization, and coverage requirements.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Python Testing Patterns

--- a/skills/pytorch-patterns/SKILL.md
+++ b/skills/pytorch-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: pytorch-patterns
 description: PyTorch deep learning patterns and best practices for building robust, efficient, and reproducible training pipelines, model architectures, and data loading.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # PyTorch Development Patterns

--- a/skills/quality-nonconformance/SKILL.md
+++ b/skills/quality-nonconformance/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/quarkus-patterns/SKILL.md
+++ b/skills/quarkus-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: quarkus-patterns
 description: Quarkus 3.x LTS architecture patterns with Camel for messaging, RESTful API design, CDI services, data access with Panache, and async processing. Use for Java Quarkus backend work with event-driven architectures.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Quarkus Development Patterns

--- a/skills/quarkus-security/SKILL.md
+++ b/skills/quarkus-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: quarkus-security
 description: Quarkus Security best practices for authentication, authorization, JWT/OIDC, RBAC, input validation, CSRF, secrets management, and dependency security.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Quarkus Security Review

--- a/skills/quarkus-tdd/SKILL.md
+++ b/skills/quarkus-tdd/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: quarkus-tdd
 description: Test-driven development for Quarkus 3.x LTS using JUnit 5, Mockito, REST Assured, Camel testing, and JaCoCo. Use when adding features, fixing bugs, or refactoring event-driven services.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Quarkus TDD Workflow

--- a/skills/quarkus-verification/SKILL.md
+++ b/skills/quarkus-verification/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: quarkus-verification
 description: "Verification loop for Quarkus projects: build, static analysis, tests with coverage, security scans, native compilation, and diff review before release or PR."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Quarkus Verification Loop

--- a/skills/ralphinho-rfc-pipeline/SKILL.md
+++ b/skills/ralphinho-rfc-pipeline/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ralphinho-rfc-pipeline
 description: RFC-driven multi-agent DAG execution pattern with quality gates, merge queues, and work unit orchestration.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Ralphinho RFC Pipeline

--- a/skills/react-patterns/SKILL.md
+++ b/skills/react-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: react-patterns
 description: React 18/19 patterns including hooks discipline, server/client component boundaries, Suspense + error boundaries, form actions, data fetching, state management decision trees, and accessibility-first composition. Use when writing or reviewing React components.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # React Patterns

--- a/skills/react-performance/SKILL.md
+++ b/skills/react-performance/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: react-performance
 description: React and Next.js performance optimization patterns adapted from Vercel Engineering's React Best Practices (https://github.com/vercel-labs/agent-skills). Organizes 70+ rules across 8 priority categories — waterfalls, bundle size, server-side, client fetching, re-render, rendering, JS micro-perf, advanced. Use when writing, reviewing, or refactoring React/Next.js code for performance.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # React Performance

--- a/skills/react-testing/SKILL.md
+++ b/skills/react-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: react-testing
 description: React component testing with React Testing Library, Vitest/Jest, MSW for network mocking, accessibility assertions with axe, and the decision boundary between component tests and Playwright/Cypress end-to-end runs. Use when writing or fixing tests for React components, hooks, or pages.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # React Testing

--- a/skills/recsys-pipeline-architect/SKILL.md
+++ b/skills/recsys-pipeline-architect/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: recsys-pipeline-architect
 description: Design composable recommendation, ranking, and feed pipelines using the six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework popularized by xAI's open-sourced For You algorithm. Use this skill whenever the user is building any system that picks "the top K items for a (user, context)" — social feeds, content CMSs, RAG rerankers, task prioritizers, notification triage, search reranking, ad ranking.
-origin: community
+metadata:
+  origin: community
 ---
 
 # recsys-pipeline-architect

--- a/skills/recursive-decision-ledger/SKILL.md
+++ b/skills/recursive-decision-ledger/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: recursive-decision-ledger
 description: Use when the user asks for repeated rollouts, marked decision processes, high-dimensional search, stochastic optimization, local-optima exploration, ensemble comparison, or recursive reasoning with a visible evidence trail.
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 

--- a/skills/redis-patterns/SKILL.md
+++ b/skills/redis-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: redis-patterns
 description: Redis data structure patterns, caching strategies, distributed locks, rate limiting, pub/sub, and connection management for production applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Redis Patterns

--- a/skills/regex-vs-llm-structured-text/SKILL.md
+++ b/skills/regex-vs-llm-structured-text/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: regex-vs-llm-structured-text
 description: Decision framework for choosing between regex and LLM when parsing structured text — start with regex, add LLM only for low-confidence edge cases.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Regex vs LLM for Structured Text Parsing

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: repo-scan
 description: Cross-stack source code asset audit — classifies every file, detects embedded third-party libraries, and delivers actionable four-level verdicts per module with interactive HTML reports.
-origin: community
+metadata:
+  origin: community
 ---
 
 # repo-scan

--- a/skills/research-ops/SKILL.md
+++ b/skills/research-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: research-ops
 description: Evidence-first current-state research workflow for ECC. Use when the user wants fresh facts, comparisons, enrichment, or a recommendation built from current public evidence and any supplied local context.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Research Ops

--- a/skills/returns-reverse-logistics/SKILL.md
+++ b/skills/returns-reverse-logistics/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: Apache-2.0
 version: 1.0.0
 homepage: https://github.com/affaan-m/everything-claude-code
-origin: ECC
 metadata:
+  origin: ECC
   author: evos
   clawdbot:
     emoji: ""

--- a/skills/rules-distill/SKILL.md
+++ b/skills/rules-distill/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: rules-distill
 description: "Scan skills to extract cross-cutting principles and distill them into rules — append, revise, or create new rule files"
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Rules Distill

--- a/skills/rust-patterns/SKILL.md
+++ b/skills/rust-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: rust-patterns
 description: Idiomatic Rust patterns, ownership, error handling, traits, concurrency, and best practices for building safe, performant applications.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Rust Development Patterns

--- a/skills/rust-testing/SKILL.md
+++ b/skills/rust-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: rust-testing
 description: Rust testing patterns including unit tests, integration tests, async testing, property-based testing, mocking, and coverage. Follows TDD methodology.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Rust Testing Patterns

--- a/skills/safety-guard/SKILL.md
+++ b/skills/safety-guard/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: safety-guard
 description: Use this skill to prevent destructive operations when working on production systems or running agents autonomously.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Safety Guard — Prevent Destructive Operations

--- a/skills/santa-method/SKILL.md
+++ b/skills/santa-method/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: santa-method
 description: "Multi-agent adversarial verification with convergence loop. Two independent review agents must both pass before output ships."
-origin: "Ronald Skelton - Founder, RapportScore.ai"
+metadata:
+  origin: "Ronald Skelton - Founder, RapportScore.ai"
 ---
 
 # Santa Method

--- a/skills/scientific-db-pubmed-database/SKILL.md
+++ b/skills/scientific-db-pubmed-database/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: pubmed-database
 description: Direct PubMed and NCBI E-utilities search workflows for biomedical literature, MeSH queries, PMID lookup, citation retrieval, and API-backed literature monitoring.
-origin: community
+metadata:
+  origin: community
 ---
 
 # PubMed Database

--- a/skills/scientific-db-uspto-database/SKILL.md
+++ b/skills/scientific-db-uspto-database/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: uspto-database
 description: USPTO patent and trademark data workflow for official record lookup, PatentSearch queries, TSDR checks, assignment data, and reproducible IP research logs.
-origin: community
+metadata:
+  origin: community
 ---
 
 # USPTO Database

--- a/skills/scientific-pkg-gget/SKILL.md
+++ b/skills/scientific-pkg-gget/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gget
 description: gget CLI and Python workflow for quick genomic database queries, sequence lookup, BLAST-style searches, enrichment checks, and reproducible bioinformatics evidence logs.
-origin: community
+metadata:
+  origin: community
 ---
 
 # gget

--- a/skills/scientific-thinking-literature-review/SKILL.md
+++ b/skills/scientific-thinking-literature-review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: literature-review
 description: Systematic literature-review workflow for academic, biomedical, technical, and scientific topics, including search planning, source screening, synthesis, citation checks, and evidence logging.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Literature Review

--- a/skills/scientific-thinking-scholar-evaluation/SKILL.md
+++ b/skills/scientific-thinking-scholar-evaluation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: scholar-evaluation
 description: Structured scholarly-work evaluation for papers, proposals, literature reviews, methods sections, evidence quality, citation support, and research-writing feedback.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Scholar Evaluation

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: search-first
 description: Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # /search-first — Research Before You Code

--- a/skills/security-bounty-hunter/SKILL.md
+++ b/skills/security-bounty-hunter/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: security-bounty-hunter
 description: Hunt for exploitable, bounty-worthy security issues in repositories. Focuses on remotely reachable vulnerabilities that qualify for real reports instead of noisy local-only findings.
-origin: ECC direct-port adaptation
+metadata:
+  origin: ECC direct-port adaptation
 version: "1.0.0"
 ---
 

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: security-review
 description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Security Review Skill

--- a/skills/security-scan/SKILL.md
+++ b/skills/security-scan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: security-scan
 description: Scan your Claude Code configuration (.claude/ directory) for security vulnerabilities, misconfigurations, and injection risks using AgentShield. Checks CLAUDE.md, settings.json, MCP servers, hooks, and agent definitions.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Security Scan Skill

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: seo
 description: Audit, plan, and implement SEO improvements across technical SEO, on-page optimization, structured data, Core Web Vitals, and content strategy. Use when the user wants better search visibility, SEO remediation, schema markup, sitemap/robots work, or keyword mapping.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # SEO

--- a/skills/skill-comply/SKILL.md
+++ b/skills/skill-comply/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: skill-comply
 description: Visualize whether skills, rules, and agent definitions are actually followed — auto-generates scenarios at 3 prompt strictness levels, runs agents, classifies behavioral sequences, and reports compliance rates with full tool call timelines
-origin: ECC
+metadata:
+  origin: ECC
 tools: Read, Bash
 ---
 

--- a/skills/skill-scout/SKILL.md
+++ b/skills/skill-scout/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: skill-scout
 description: Search existing local, marketplace, GitHub, and web skill sources before creating a new skill. Use when the user wants to create, build, fork, or find a skill for a workflow.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Skill Scout

--- a/skills/skill-stocktake/SKILL.md
+++ b/skills/skill-stocktake/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: skill-stocktake
 description: "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # skill-stocktake

--- a/skills/social-graph-ranker/SKILL.md
+++ b/skills/social-graph-ranker/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: social-graph-ranker
 description: Weighted social-graph ranking for warm intro discovery, bridge scoring, and network gap analysis across X and LinkedIn. Use when the user wants the reusable graph-ranking engine itself, not the broader outreach or network-maintenance workflow layered on top of it.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Social Graph Ranker

--- a/skills/social-publisher/SKILL.md
+++ b/skills/social-publisher/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: social-publisher
 description: Agent-driven scheduling and publishing of social media posts across 13 platforms via SocialClaw. Use when the user wants to publish to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, or Pinterest — or when managing campaigns, uploading media, or monitoring post delivery status.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Social Publisher (SocialClaw)

--- a/skills/springboot-patterns/SKILL.md
+++ b/skills/springboot-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: springboot-patterns
 description: Spring Boot architecture patterns, REST API design, layered services, data access, caching, async processing, and logging. Use for Java Spring Boot backend work.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Spring Boot Development Patterns

--- a/skills/springboot-security/SKILL.md
+++ b/skills/springboot-security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: springboot-security
 description: Spring Security best practices for authn/authz, validation, CSRF, secrets, headers, rate limiting, and dependency security in Java Spring Boot services.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Spring Boot Security Review

--- a/skills/springboot-tdd/SKILL.md
+++ b/skills/springboot-tdd/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: springboot-tdd
 description: Test-driven development for Spring Boot using JUnit 5, Mockito, MockMvc, Testcontainers, and JaCoCo. Use when adding features, fixing bugs, or refactoring.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Spring Boot TDD Workflow

--- a/skills/springboot-verification/SKILL.md
+++ b/skills/springboot-verification/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: springboot-verification
 description: "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Spring Boot Verification Loop

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: strategic-compact
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Strategic Compact Skill

--- a/skills/swift-actor-persistence/SKILL.md
+++ b/skills/swift-actor-persistence/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: swift-actor-persistence
 description: Thread-safe data persistence in Swift using actors — in-memory cache with file-backed storage, eliminating data races by design.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Swift Actors for Thread-Safe Persistence

--- a/skills/swift-protocol-di-testing/SKILL.md
+++ b/skills/swift-protocol-di-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: swift-protocol-di-testing
 description: Protocol-based dependency injection for testable Swift code — mock file system, network, and external APIs using focused protocols and Swift Testing.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Swift Protocol-Based Dependency Injection for Testing

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: tdd-workflow
 description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Test-Driven Development Workflow

--- a/skills/team-agent-orchestration/SKILL.md
+++ b/skills/team-agent-orchestration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: team-agent-orchestration
 description: "Run team-based orchestration for agent squads using work items, ownership, agent Kanban, merge gates, and control pane handoffs."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Team Agent Orchestration

--- a/skills/team-builder/SKILL.md
+++ b/skills/team-builder/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: team-builder
 description: Interactive agent picker for composing and dispatching parallel teams
-origin: community
+metadata:
+  origin: community
 ---
 
 # Team Builder

--- a/skills/terminal-ops/SKILL.md
+++ b/skills/terminal-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: terminal-ops
 description: Evidence-first repo execution workflow for ECC. Use when the user wants a command run, a repo checked, a CI failure debugged, or a narrow fix pushed with exact proof of what was executed and verified.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Terminal Ops

--- a/skills/tinystruct-patterns/SKILL.md
+++ b/skills/tinystruct-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: tinystruct-patterns
 description: Expert guidance for developing with the tinystruct Java framework. Use when working on the tinystruct codebase or any project built on tinystruct — including creating Application classes, @Action-mapped routes, unit tests, ActionRegistry, HTTP/CLI dual-mode handling, the built-in HTTP server, the event system, JSON with Builder/Builders, database persistence with AbstractData, POJO generation, Server-Sent Events (SSE), file uploads, and outbound HTTP networking.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # tinystruct Development Patterns

--- a/skills/token-budget-advisor/SKILL.md
+++ b/skills/token-budget-advisor/SKILL.md
@@ -13,7 +13,8 @@ description: >-
   DO NOT TRIGGER when: user has already specified a level in the current
   session (maintain it), the request is clearly a one-word answer, or
   "token" refers to auth/session/payment tokens rather than response size.
-origin: community
+metadata:
+  origin: community
 ---
 
 # Token Budget Advisor (TBA)

--- a/skills/ui-demo/SKILL.md
+++ b/skills/ui-demo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ui-demo
 description: Record polished UI demo videos using Playwright. Use when the user asks to create a demo, walkthrough, screen recording, or tutorial video of a web application. Produces WebM videos with visible cursor, natural pacing, and professional feel.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # UI Demo Video Recorder

--- a/skills/ui-to-vue/SKILL.md
+++ b/skills/ui-to-vue/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ui-to-vue
 description: Use when the user has UI screenshots or design exports that need batch conversion into Vue 3 components, especially with Vant, Element Plus, or Ant Design Vue.
-origin: community
+metadata:
+  origin: community
 ---
 
 # UI To Vue

--- a/skills/uncloud/SKILL.md
+++ b/skills/uncloud/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: uncloud
 description: Use when managing an Uncloud cluster — deploying services, configuring Caddy ingress, adding static proxy routes for non-cluster devices, publishing ports, scaling, inspecting logs, or managing machines and volumes with the `uc` CLI.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Uncloud Cluster Management

--- a/skills/unified-notifications-ops/SKILL.md
+++ b/skills/unified-notifications-ops/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: unified-notifications-ops
 description: Operate notifications as one ECC-native workflow across GitHub, Linear, desktop alerts, hooks, and connected communication surfaces. Use when the real problem is alert routing, deduplication, escalation, or inbox collapse.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Unified Notifications Ops

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: verification-loop
 description: "A comprehensive verification system for Claude Code sessions."
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Verification Loop Skill

--- a/skills/video-editing/SKILL.md
+++ b/skills/video-editing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: video-editing
 description: AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Video Editing

--- a/skills/videodb/SKILL.md
+++ b/skills/videodb/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: videodb
 description: See, Understand, Act on video and audio. See- ingest from local files, URLs, RTSP/live feeds, or live record desktop; return realtime context and playable stream links. Understand- extract frames, build visual/semantic/temporal indexes, and search moments with timestamps and auto-clips. Act- transcode and normalize (codec, fps, resolution, aspect ratio), perform timeline edits (subtitles, text/image overlays, branding, audio overlays, dubbing, translation), generate media assets (image, audio, video), and create real time alerts for events from live streams or desktop capture.
-origin: ECC
+metadata:
+  origin: ECC
 allowed-tools: Read Grep Glob Bash(python:*)
 argument-hint: "[task description]"
 ---

--- a/skills/vite-patterns/SKILL.md
+++ b/skills/vite-patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: vite-patterns
 description: Vite build tool patterns including config, plugins, HMR, env variables, proxy setup, SSR, library mode, dependency pre-bundling, and build optimization. Activate when working with vite.config.ts, Vite plugins, or Vite-based projects.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Vite Patterns

--- a/skills/windows-desktop-e2e/SKILL.md
+++ b/skills/windows-desktop-e2e/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: windows-desktop-e2e
 description: E2E testing for Windows native desktop apps (WPF, WinForms, Win32/MFC, Qt) using pywinauto and Windows UI Automation.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Windows Desktop E2E Testing

--- a/skills/workspace-surface-audit/SKILL.md
+++ b/skills/workspace-surface-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: workspace-surface-audit
 description: Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value ECC-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # Workspace Surface Audit

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: x-api
 description: X/Twitter API integration for posting tweets, threads, reading timelines, search, and analytics. Covers OAuth auth patterns, rate limits, and platform-native content posting. Use when the user wants to interact with X programmatically.
-origin: ECC
+metadata:
+  origin: ECC
 ---
 
 # X API


### PR DESCRIPTION
Addresses #2233.

## What

Moves the top-level `origin:` frontmatter key under `metadata:` across the canonical `skills/` tree, so skills pass the official Agent Skills validator.

```yaml
# before
origin: ECC

# after
metadata:
  origin: ECC
```

## Why

The official Agent Skills spec (https://agentskills.io/specification) whitelists exactly six top-level frontmatter keys: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`. The official validator enforces it — `anthropics/skills`' `skill-creator/scripts/quick_validate.py` defines `ALLOWED_PROPERTIES = {name, description, license, allowed-tools, metadata, compatibility}` and rejects any other top-level key (`skills-ref validate` does the same). `origin` isn't in that set, so skills carrying it fail validation and can't be uploaded to Claude.ai / the Claude API Skills endpoint as-is. `metadata` is the spec's intended home for arbitrary provenance.

## Scope & safety

- **251 `SKILL.md` updated** (242 get a new `metadata:` block, 9 append `origin` to an existing one).
- **`origin` values preserved verbatim** — verified 251/251, no value lost (covers `ECC`, `community`, `ECC direct-port adaptation`, contributor names, etc.).
- **Frontmatter-only, minimal diff** — bodies untouched.
- **YAML validated** on every changed file; existing `metadata` children (e.g. `author`, nested `clawdbot`) are preserved with correct indentation.
- **Scoped to canonical `skills/` only.** Translations under `docs/<lang>/skills/` and tool mirrors (`.cursor/`, `.kiro/`, `.agents/`) are left untouched on the assumption they're regenerated from the canonical tree. Happy to extend or adjust scope if you'd prefer the mirrors handled here too.

Other non-whitelist top-level keys exist in some files (`version`, `homepage`, and nested non-string `metadata` values), but those are out of scope for this PR — kept focused on `origin` per #2233.