### PR TITLE
fix(hooks): stop Bash dispatcher echoing input event (fixes #2239)

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -122,6 +122,12 @@ function normalizeHookResult(previousRaw, output) {
 
 function runHooks(rawInput, hooks) {
   let currentRaw = rawInput;
+  // Track whether a sub-hook deliberately produced stdout (a string or
+  // {stdout}) versus currentRaw still being the untouched input event.
+  // Echoing the unmodified input event back to stdout fails Claude Code's
+  // hook-output JSON schema validation ("(root): Invalid input"), so in the
+  // pass-through case we must emit nothing instead.
+  let rawModified = false;
   let stderr = '';
   let additionalContext = '';
 
@@ -132,6 +138,9 @@ function runHooks(rawInput, hooks) {
 
     try {
       const result = normalizeHookResult(currentRaw, hook.run(currentRaw));
+      if (result.raw !== currentRaw) {
+        rawModified = true;
+      }
       currentRaw = result.raw;
       if (result.stderr) {
         stderr += result.stderr.endsWith('\n') ? result.stderr : `${result.stderr}\n`;
@@ -140,7 +149,12 @@ function runHooks(rawInput, hooks) {
         additionalContext = combineAdditionalContext(additionalContext, result.additionalContext);
       }
       if (result.exitCode !== 0) {
-        return { output: currentRaw, stderr, additionalContext, exitCode: result.exitCode };
+        return {
+          output: rawModified ? currentRaw : '',
+          stderr,
+          additionalContext,
+          exitCode: result.exitCode,
+        };
       }
     } catch (error) {
       stderr += `[Hook] ${hook.id} failed: ${error.message}\n`;
@@ -150,7 +164,9 @@ function runHooks(rawInput, hooks) {
   return {
     output: additionalContext
       ? buildPreToolUseAdditionalContext(additionalContext)
-      : currentRaw,
+      : rawModified
+        ? currentRaw
+        : '',
     stderr,
     additionalContext,
     exitCode: 0,

--- a/tests/hooks/bash-hook-dispatcher.test.js
+++ b/tests/hooks/bash-hook-dispatcher.test.js
@@ -53,6 +53,16 @@ function runTests() {
     assert.strictEqual(result.stdout, '', 'Blocking hook should not pass through stdout');
   })) passed++; else failed++;
 
+  if (test('pre dispatcher emits no stdout for a plain command (regression: issue #2239)', () => {
+    // A pass-through command (no sub-hook adds context) must NOT echo the
+    // input event back to stdout — Claude Code validates hook stdout against
+    // the hook-output schema and the input event fails as "(root): Invalid input".
+    const input = { tool_input: { command: 'ls -la' } };
+    const result = runScript(preDispatcher, input, { ECC_HOOK_PROFILE: 'standard' });
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, '', `Pass-through must emit empty stdout, got: ${result.stdout}`);
+  })) passed++; else failed++;
+
   if (test('pre dispatcher still honors per-hook disable flags', () => {
     const input = { tool_input: { command: 'git push origin main' } };
 
@@ -69,7 +79,7 @@ function runTests() {
       ECC_DISABLED_HOOKS: 'pre:bash:git-push-reminder',
     });
     assert.strictEqual(disabled.status, 0);
-    assert.strictEqual(disabled.stdout, JSON.stringify(input), 'Disabled hook should pass through original input');
+    assert.strictEqual(disabled.stdout, '', 'Disabled hook should emit no stdout (echoing the input event fails hook-output schema validation)');
     assert.ok(!disabled.stderr.includes('Review changes before push'), 'Disabled hook should not emit reminder');
   })) passed++; else failed++;
 
@@ -78,7 +88,7 @@ function runTests() {
     const result = runScript(preDispatcher, input, { ECC_HOOK_PROFILE: 'minimal' });
     assert.strictEqual(result.status, 0);
     assert.strictEqual(result.stderr, '', 'Strict-only reminders should stay disabled in minimal profile');
-    assert.strictEqual(result.stdout, JSON.stringify(input));
+    assert.strictEqual(result.stdout, '', 'Pass-through must emit no stdout, not echo the input event');
   })) passed++; else failed++;
 
   if (test('post dispatcher writes both bash audit and cost logs in one pass', () => {
@@ -91,7 +101,7 @@ function runTests() {
         USERPROFILE: homeDir,
       });
       assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, JSON.stringify(payload));
+      assert.strictEqual(result.stdout, '', 'Post dispatcher pass-through must emit no stdout, not echo the input event');
 
       const auditLog = fs.readFileSync(path.join(homeDir, '.claude', 'bash-commands.log'), 'utf8');
       const costLog = fs.readFileSync(path.join(homeDir, '.claude', 'cost-tracker.log'), 'utf8');


### PR DESCRIPTION
## Summary

The consolidated Bash hook dispatcher (`scripts/hooks/bash-hook-dispatcher.js`) echoed the **input event** back to stdout on every pass-through, which fails Claude Code's hook-output JSON schema validation:

```
PreToolUse:Bash hook error
⎿ Hook JSON output validation failed — (root): Invalid input
```

`runHooks()` returned `currentRaw` (the raw stdin event `{session_id, hook_event_name, tool_name, tool_input, …}`) whenever no sub-hook produced `additionalContext` — i.e. for nearly every command. Claude Code parses hook stdout as JSON and validates it against the hook-**output** schema, so the echoed **input** object is rejected. Commands that *do* add `additionalContext` produce a valid envelope and don't error, which made it look intermittent.

Fixes #2239.

## Change

- Track whether a sub-hook *deliberately* set stdout (a `string` or `{stdout}`, e.g. GateGuard) via a `rawModified` flag.
- In the pass-through case (`rawModified === false`, no `additionalContext`), emit `''` instead of the echoed input — for both the final return and the non-zero-exit early return.
- This preserves:
  - GateGuard's `{stdout}` permission-decision pass-through (`rawModified === true`),
  - `block-no-verify`'s exit-2 blocking (stderr + empty stdout),
  - the `additionalContext` reminder envelope (`hookSpecificOutput`).

## Tests

- Updated the three dispatcher tests that asserted the buggy echo (`disabled hook`, `minimal profile`, `post audit+cost`) to expect empty stdout.
- Added a regression test: a plain pass-through command (`ls -la`) must emit empty stdout.
- `node tests/hooks/bash-hook-dispatcher.test.js` → 6/6 pass. Related suites (`post-bash-hooks`, `pre-bash-dev-server-block`, `pre-bash-reminders`) stay green.

## Manual verification

| Command | Before | After |
|---|---|---|
| `ls -la`, `git status`, `cat`, `echo` | echoes input event → schema error | empty stdout, exit 0 |
| `git commit --no-verify` | (blocked) | still blocked, exit 2 + stderr |
| strict-profile reminders | valid envelope | valid envelope (unchanged) |
