### PR TITLE
fix: prevent IOC scanner false positives on hook filenames and scan .cursor configs

### DIFF
--- a/scripts/ci/scan-supply-chain-iocs.js
+++ b/scripts/ci/scan-supply-chain-iocs.js
@@ -414,6 +414,7 @@ function normalizeForMatch(value) {
 function isInSpecialConfigPath(filePath) {
   const normalized = normalizedPath(filePath);
   return /\/\.claude\//.test(normalized)
+    || /\/\.cursor\//.test(normalized)
     || /\/\.vscode\//.test(normalized)
     || /\/\.kiro\/settings\//.test(normalized)
     || /\/Library\/LaunchAgents\//.test(normalized)
@@ -661,21 +662,26 @@ function scanFile(filePath, rootDir, findings) {
 
   for (const indicator of CRITICAL_TEXT_INDICATORS) {
     const normalizedIndicator = normalizeForMatch(indicator);
-    let index = lowerText.indexOf(normalizedIndicator);
-    while (index !== -1) {
-      if (!indexInRanges(index, defensiveClaudeDenyRanges)) {
+    // Require a non-filename character before the indicator so legitimate
+    // names that merely end with an IOC filename (e.g. the stock Cursor hook
+    // `before-shell-execution.js` vs the payload `execution.js`) do not match.
+    const indicatorPattern = new RegExp(
+      `(?<![a-z0-9_-])${escapeRegExp(normalizedIndicator)}`,
+      'g',
+    );
+    let match;
+    while ((match = indicatorPattern.exec(lowerText)) !== null) {
+      if (!indexInRanges(match.index, defensiveClaudeDenyRanges)) {
         addFinding(
           findings,
           'critical',
           relativePath,
-          lineForIndex(text, index),
+          lineForIndex(text, match.index),
           indicator,
           'Known active supply-chain IOC is present',
         );
         break;
       }
-
-      index = lowerText.indexOf(normalizedIndicator, index + normalizedIndicator.length);
     }
   }
 

--- a/tests/ci/scan-supply-chain-iocs.test.js
+++ b/tests/ci/scan-supply-chain-iocs.test.js
@@ -310,6 +310,42 @@ function run() {
     });
   })) passed++; else failed++;
 
+  if (test('does not flag legitimate hook filenames ending in an IOC filename', () => {
+    withFixture({
+      '.cursor/hooks.json': JSON.stringify({
+        hooks: {
+          beforeShellExecution: [{
+            command: 'node .cursor/hooks/before-shell-execution.js',
+          }],
+          afterShellExecution: [{
+            command: 'node .cursor/hooks/after-shell-execution.js',
+          }],
+          beforeMCPExecution: [{
+            command: 'node .cursor/hooks/before-mcp-execution.js',
+          }],
+        },
+      }, null, 2),
+    }, rootDir => {
+      const result = scanSupplyChainIocs({ rootDir });
+      assert.deepStrictEqual(result.findings, []);
+    });
+  })) passed++; else failed++;
+
+  if (test('still flags the bare execution.js payload after a path separator', () => {
+    withFixture({
+      '.cursor/hooks.json': JSON.stringify({
+        hooks: {
+          sessionStart: [{
+            command: 'node .cursor/hooks/execution.js',
+          }],
+        },
+      }, null, 2),
+    }, rootDir => {
+      const result = scanSupplyChainIocs({ rootDir });
+      assert.ok(result.findings.some(finding => finding.indicator === 'execution.js'));
+    });
+  })) passed++; else failed++;
+
   if (test('rejects user-level VS Code task persistence when home scan is enabled', () => {
     withFixture({
       'home/Library/Application Support/Code/User/tasks.json': JSON.stringify({

--- a/tests/ci/scan-supply-chain-iocs.test.js
+++ b/tests/ci/scan-supply-chain-iocs.test.js
@@ -323,6 +323,9 @@ function run() {
           beforeMCPExecution: [{
             command: 'node .cursor/hooks/before-mcp-execution.js',
           }],
+          afterFileEdit: [{
+            command: 'node .cursor/hooks/post_execution.js',
+          }],
         },
       }, null, 2),
     }, rootDir => {


### PR DESCRIPTION
## What Changed

Two fixes to the supply-chain IOC scanner (`scripts/ci/scan-supply-chain-iocs.js`):

1. **Boundary-aware indicator matching.** `CRITICAL_TEXT_INDICATORS` were matched with plain substring search (`indexOf`), so legitimate filenames that merely *end* with a known payload name were flagged as CRITICAL. Concretely, the stock Cursor hooks shipped by this repo (`before-shell-execution.js`, `after-shell-execution.js`, `before-mcp-execution.js`) substring-match the TanStack/Mini Shai-Hulud payload IOC `execution.js`. Matching now requires a non-filename character (`[^a-z0-9_-]`) before the indicator, so `hooks/execution.js` still flags while `before-shell-execution.js` does not.

2. **Scan `.cursor/` configs.** `hooks.json` is listed in `PERSISTENCE_FILENAMES`, but `isInSpecialConfigPath()` did not include `/.cursor/`, so Cursor hook configs (a known persistence vector for these campaigns) were never inspected in a normal checkout. Added `/.cursor/` to the special config paths. On this repo that grows coverage from 14 to 219 inspected files, and the scan stays clean.

Two regression tests added in `tests/ci/scan-supply-chain-iocs.test.js`: legitimate hook filenames produce no findings, and a bare `execution.js` after a path separator is still flagged.

## Why This Change

Running `npm run security:ioc-scan` from a working copy located under a `.claude/` directory (e.g. a Claude Code worktree at `.claude/worktrees/<name>/`) made every file path match the `/\.claude\//` special-config rule, which pulled `.cursor/hooks.json` into the scan and produced a false CRITICAL: `Known active supply-chain IOC is present` for the repo's own stock hooks. The same substring bug would also fire on any user project that names a hook/script `*-execution.js`. Meanwhile, in a normal checkout the Cursor persistence vector was not scanned at all.

## Testing Done

- [x] Manual testing completed (`node scripts/ci/scan-supply-chain-iocs.js` clean at 219 files inspected; reproduced the false positive before the fix)
- [x] Automated tests pass locally (`node tests/run-all.js` — 2737/2737; scanner suite 22/22 including 2 new regression tests)
- [x] Edge cases considered and tested (bare payload filename after `/` still flags; deny-range handling preserved; multi-occurrence scanning preserved)

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable) — n/a, no shell changes
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation — n/a
- [x] Added comments for complex logic
- [ ] README updated (if needed) — n/a
