### PR TITLE
docs(commands): generate discoverable <name>/SKILL.md skills, not inert flat files

### DIFF
--- a/commands/learn-eval.md
+++ b/commands/learn-eval.md
@@ -52,12 +52,12 @@ origin: auto-extracted
 [Trigger conditions]
 ```
 
-   **Description rules (the `description` is the ONLY discovery surface):**
+**Description rules (the `description` is the ONLY discovery surface):**
 
-   - Claude scans only `name` + `description` at session start and loads the body on a match — so the description must name the *when*, not just the *what*.
-   - Lead with "Use when ..." followed by concrete, observable triggers (file patterns, error strings, task verbs, review situations) — the same conditions as the `## When to Use` section, compressed.
-   - Up to 1024 chars are allowed; spend them on triggers, not philosophy. Vague descriptions ("best practices for X") never match.
-   - `name` must equal the skill's directory name exactly.
+- Claude scans only `name` + `description` at session start and loads the body on a match — so the description must name the *when*, not just the *what*.
+- Lead with "Use when ..." followed by concrete, observable triggers (file patterns, error strings, task verbs, review situations) — the same conditions as the `## When to Use` section, compressed.
+- Up to 1024 chars are allowed; spend them on triggers, not philosophy. Vague descriptions ("best practices for X") never match.
+- `name` must equal the skill's directory name exactly.
 
 5. **Quality gate — Checklist + Holistic verdict**
 

--- a/commands/learn-eval.md
+++ b/commands/learn-eval.md
@@ -22,16 +22,17 @@ Look for:
 
 3. **Determine save location:**
    - Ask: "Would this pattern be useful in a different project?"
-   - **Global** (`~/.claude/skills/learned/`): Generic patterns usable across 2+ projects (bash compatibility, LLM API behavior, debugging techniques, etc.)
-   - **Project** (`.claude/skills/learned/` in current project): Project-specific knowledge (quirks of a particular config file, project-specific architecture decisions, etc.)
+   - **Global** (`~/.claude/skills/<pattern-name>/SKILL.md`): Generic patterns usable across 2+ projects (bash compatibility, LLM API behavior, debugging techniques, etc.)
+   - **Project** (`.claude/skills/<pattern-name>/SKILL.md` in current project): Project-specific knowledge (quirks of a particular config file, project-specific architecture decisions, etc.)
    - When in doubt, choose Global (moving Global → Project is easier than the reverse)
+   - **Directory format is mandatory.** Claude Code only auto-discovers skills at `<name>/SKILL.md` with frontmatter — at session start it scans each skill's `name` + `description` and loads the body only on a match (progressive disclosure). A flat `<name>.md` (e.g. in a `skills/learned/` archive) is **inert**: never scanned, never matched, never loaded. Always write the directory form so the skill is actually reachable.
 
 4. Draft the skill file using this format:
 
 ```markdown
 ---
 name: pattern-name
-description: "Under 130 characters"
+description: "Use when <observable trigger condition>, or when <second trigger> — <one-line essence of the pattern>"
 user-invocable: false
 origin: auto-extracted
 ---
@@ -50,6 +51,13 @@ origin: auto-extracted
 ## When to Use
 [Trigger conditions]
 ```
+
+   **Description rules (the `description` is the ONLY discovery surface):**
+
+   - Claude scans only `name` + `description` at session start and loads the body on a match — so the description must name the *when*, not just the *what*.
+   - Lead with "Use when ..." followed by concrete, observable triggers (file patterns, error strings, task verbs, review situations) — the same conditions as the `## When to Use` section, compressed.
+   - Up to 1024 chars are allowed; spend them on triggers, not philosophy. Vague descriptions ("best practices for X") never match.
+   - `name` must equal the skill's directory name exactly.
 
 5. **Quality gate — Checklist + Holistic verdict**
 
@@ -87,7 +95,11 @@ origin: auto-extracted
 - **Absorb into [X]**: Present target path + additions (diff format) + checklist results + verdict rationale → append after user confirmation
 - **Drop**: Show checklist results + reasoning only (no confirmation needed)
 
-7. Save / Absorb to the determined location
+7. Save / Absorb to the determined location — for a **Save** verdict, write `<location>/<pattern-name>/SKILL.md` (directory form, never a flat file); for **Absorb**, append to the existing skill's `SKILL.md`.
+
+8. **Verify discoverability after writing** (Save verdict only):
+   - `ls <location>/<pattern-name>/SKILL.md` — confirm the path is `<name>/SKILL.md`, not a flat file
+   - confirm the frontmatter parses: starts with `---`, has `name:` matching the directory and a non-empty `description:`
 
 ## Output Format for Step 5
 

--- a/commands/learn-eval.md
+++ b/commands/learn-eval.md
@@ -33,7 +33,6 @@ Look for:
 ---
 name: pattern-name
 description: "Use when <observable trigger condition>, or when <second trigger> — <one-line essence of the pattern>"
-user-invocable: false
 origin: auto-extracted
 ---
 

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -43,7 +43,6 @@ Create a skill at `~/.claude/skills/<pattern-name>/SKILL.md` (directory format â
 ---
 name: pattern-name
 description: "Use when <observable trigger condition> â€” <one-line essence of the pattern>"
-user-invocable: false
 origin: auto-extracted
 ---
 

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -37,9 +37,16 @@ Look for:
 
 ## Output Format
 
-Create a skill file at `~/.claude/skills/learned/[pattern-name].md`:
+Create a skill at `~/.claude/skills/<pattern-name>/SKILL.md` (directory format — see the Process note below):
 
 ```markdown
+---
+name: pattern-name
+description: "Use when <observable trigger condition> — <one-line essence of the pattern>"
+user-invocable: false
+origin: auto-extracted
+---
+
 # [Descriptive Pattern Name]
 
 **Extracted:** [Date]
@@ -64,7 +71,7 @@ Create a skill file at `~/.claude/skills/learned/[pattern-name].md`:
 2. Identify the most valuable/reusable insight
 3. Draft the skill file
 4. Ask user to confirm before saving
-5. Save to `~/.claude/skills/learned/`
+5. Save to `~/.claude/skills/<pattern-name>/SKILL.md` — **directory format with frontmatter**. Claude Code only auto-discovers a skill at `<name>/SKILL.md` carrying a `name` + `description`; a flat `skills/learned/<name>.md` (or any file missing frontmatter) is **inert** — never scanned, matched, or loaded. The `description` is the only discovery surface, so lead it with "Use when ..." naming the trigger.
 
 ## Notes
 

--- a/commands/skill-create.md
+++ b/commands/skill-create.md
@@ -53,12 +53,20 @@ Look for these pattern types:
 
 ### Step 3: Generate SKILL.md
 
+**Output path — directory format is mandatory**: write to
+`<output-dir>/<skill-name>/SKILL.md`, defaulting to
+`.claude/skills/{repo-name}-patterns/SKILL.md` for a project skill (or
+`~/.claude/skills/<skill-name>/SKILL.md` for a global one). Claude Code only
+auto-discovers skills at `<name>/SKILL.md` with parseable frontmatter; a flat
+`<name>.md` (or anything dropped into a `learned/` archive directory) is
+**inert** — never scanned, matched, or loaded.
+
 Output format:
 
 ```markdown
 ---
 name: {repo-name}-patterns
-description: Coding patterns extracted from {repo-name}
+description: Use when starting a coding session in {repo-name}, or before naming a branch, writing a commit message, placing a test file, or running closeout — conventions and co-change pairs measured from git history
 version: 1.0.0
 source: local-git-analysis
 analyzed_commits: {count}
@@ -77,6 +85,24 @@ analyzed_commits: {count}
 
 ## Testing Patterns
 {detected test conventions}
+```
+
+**Description rules (the `description` is the ONLY discovery surface):**
+
+- At session start Claude scans only `name` + `description` and loads the body
+  on a match — the description must name the *when*, not just the *what*.
+- Lead with "Use when ..." followed by concrete, observable trigger moments
+  (session start in this repo, naming a branch, writing a commit, placing a
+  test file, editing hot modules, running closeout).
+- Up to 1024 chars are allowed; spend them on triggers, not summary prose.
+  "Coding patterns extracted from X" matches almost nothing.
+- `name` must equal the skill's directory name exactly.
+
+**Verify discoverability after writing** (do not skip):
+
+```bash
+ls <output-dir>/<skill-name>/SKILL.md          # path shape is <name>/SKILL.md
+head -8 <output-dir>/<skill-name>/SKILL.md      # starts with ---, has name: + description:
 ```
 
 ### Step 4: Generate Instincts (if --instincts)
@@ -104,12 +130,12 @@ Prefix commits with: feat:, fix:, chore:, docs:, test:, refactor:
 
 ## Example Output
 
-Running `/skill-create` on a TypeScript project might produce:
+Running `/skill-create` on a TypeScript project might produce `.claude/skills/my-app-patterns/SKILL.md`:
 
 ```markdown
 ---
 name: my-app-patterns
-description: Coding patterns from my-app repository
+description: Use when starting a coding session in my-app, or before naming a branch, writing a commit message, adding a component, or placing a test file — conventions measured from 150 commits of git history
 version: 1.0.0
 source: local-git-analysis
 analyzed_commits: 150


### PR DESCRIPTION
## Problem

`/learn`, `/learn-eval`, and `/skill-create` instruct users to save generated skills as **flat files** under `~/.claude/skills/learned/<name>.md` — and `/learn`'s template has **no frontmatter at all**.

Claude Code only auto-discovers a skill when it lives at `<name>/SKILL.md` **and** has YAML frontmatter with a `description`. At session start the harness scans each skill's `name` + `description` (~100 tokens) and loads the body only when the prompt matches that description — "progressive disclosure." Flat files, and files missing frontmatter, are **never scanned, matched, or loaded**. So the skills these three commands tell users to create are inert: they capture knowledge but wire up zero discovery.

This is an internal inconsistency, not a behavior question — ECC's own shipped skills already use the `<name>/SKILL.md` directory format. Only the generator commands teach the broken pattern. In practice it accumulates silently: a user can end up with dozens of orphaned `skills/learned/*.md` files that never load, with no error to signal it.

## Fix

Surgical edits to the three English command sources:

- **Save / output paths** use `<name>/SKILL.md` directory format instead of a flat file / `skills/learned/` archive.
- **`/learn`'s skill template** gains the required frontmatter (it had none).
- **Descriptions are trigger-first** — `"Use when <observable condition> — <essence>"`. The description is the only discovery surface, so it must name the *when*, not just the *what*; vague summaries like `"Coding patterns extracted from {repo}"` match almost nothing. Up to 1024 chars, spent on triggers.
- A **post-write discoverability verification step** (`ls` the `<name>/SKILL.md` path + confirm frontmatter parses).

Does **not** touch `learn-eval`'s checklist/verdict system — only the save-location, frontmatter, and description guidance.

## Out of scope / suggested follow-up

- **Translations**: `docs/{es,ja-JP,ko-KR,pt-BR,tr,zh-CN,zh-TW}/commands/{learn,learn-eval,skill-create}.md` carry the same wording and should be regenerated from these English sources via the existing i18n pipeline. Left untouched here since they're machine-generated.
- **`.opencode/commands/skill-create.md`** differs from the canonical command and may want the same treatment.

## Why it matters

Without this, `/learn` and friends are effectively write-only — the whole continuous-learning value proposition (capture a pattern, have it resurface in a future session) silently never fires, because the output isn't in a discoverable shape.
