### PR TITLE
docs: add official-sources security warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ![Markdown](https://img.shields.io/badge/-Markdown-000000?logo=markdown&logoColor=white)
 
 > [!WARNING]
-> **Official sources only.** This repository — [github.com/affaan-m/ECC](https://github.com/affaan-m/ECC) — and the npm packages [`ecc-universal`](https://www.npmjs.com/package/ecc-universal) and [`ecc-agentshield`](https://www.npmjs.com/package/ecc-agentshield) are the only verified distribution channels. Third-party re-uploads and unofficial mirrors are not maintained or reviewed by the project and may contain malware. Always install from the sources above.
+> **Official sources only.** Install ECC only from verified channels: the GitHub repository [github.com/affaan-m/ECC](https://github.com/affaan-m/ECC), the npm packages [`ecc-universal`](https://www.npmjs.com/package/ecc-universal) and [`ecc-agentshield`](https://www.npmjs.com/package/ecc-agentshield), the [GitHub App](https://github.com/apps/ecc-tools), the plugin slug `ecc@ecc`, and the project website [ecc.tools](https://ecc.tools). Third-party re-uploads and unofficial mirrors are not maintained or reviewed by the project and may contain malware.
 
 > **211.9K+ stars** | **32.5K+ forks** | **230+ contributors** | **12+ language ecosystems** | **Cross-harness agent workflows**
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 ![Perl](https://img.shields.io/badge/-Perl-39457E?logo=perl&logoColor=white)
 ![Markdown](https://img.shields.io/badge/-Markdown-000000?logo=markdown&logoColor=white)
 
+> [!WARNING]
+> **Official sources only.** This repository — [github.com/affaan-m/ECC](https://github.com/affaan-m/ECC) — and the npm packages [`ecc-universal`](https://www.npmjs.com/package/ecc-universal) and [`ecc-agentshield`](https://www.npmjs.com/package/ecc-agentshield) are the only verified distribution channels. Third-party re-uploads and unofficial mirrors are not maintained or reviewed by the project and may contain malware. Always install from the sources above.
+
 > **211.9K+ stars** | **32.5K+ forks** | **230+ contributors** | **12+ language ecosystems** | **Cross-harness agent workflows**
 
 ---


### PR DESCRIPTION
## What Changed

Added a `> [!WARNING]` GFM alert block near the top of `README.md`, immediately after the badge row and before the star/fork summary line. The alert identifies `github.com/affaan-m/ECC`, `ecc-universal`, and `ecc-agentshield` as the only verified distribution channels and warns that third-party re-uploads may contain malware.

## Why This Change

A malicious re-upload of this repository was distributing obfuscated malware through fake download instructions targeting non-technical users. The maintainer acknowledged the issue and committed to making the README more explicit about official sources. This change implements that directly: GitHub renders `[!WARNING]` alerts as a yellow banner, making it immediately visible to anyone landing on the repository page.

Fixes #2242

## Testing Done

- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Verified the warning renders correctly in the GitHub README preview: the `> [!WARNING]` syntax produces a yellow alert banner. The existing badge row, hero image, and language-switcher links are not disrupted. All three official distribution channels are accurately named.

## Type of Change

- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [x] Added comments for complex logic
- [x] README updated (if needed)
