### PR TITLE
chore: add shared deny list for dangerous bash commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(chmod 777 *)",
+      "Bash(ssh *)",
+      "Bash(* > /dev/*)"
+    ]
+  }
+}


### PR DESCRIPTION
## What Changed
Adds a tracked `.claude/settings.json` with a permissions `deny` list blocking dangerous Bash commands: `rm -rf *`, `sudo *`, `chmod 777 *`, `ssh *`, and redirects to `/dev/*`.

## Why This Change
An AgentShield scan (`npx ecc-agentshield scan`) flagged the permissions surface (score 36/100) with a HIGH "No deny list configured" finding. Previously only personal allow rules existed in the gitignored `settings.local.json`, leaving no shared guardrail. Promoting the deny rules to a tracked file applies the hardening team-wide while personal allow rules stay local. Deny overrides allow, so these dangerous patterns are blocked regardless of allow scope.

After hardening, the permissions sub-score rose 36 → 58 and overall grade 65 → 70, with zero remaining permissions HIGH findings.

## Testing Done
- [x] Manual testing completed (re-ran AgentShield scan, verified before/after scores)
- [ ] Automated tests pass locally (`node tests/run-all.js`) — no code changed; config-only
- [x] Edge cases considered (deny overrides allow; verified JSON validates)

## Type of Change
- [x] `chore:` Maintenance/tooling

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Self-documenting config; no doc changes needed