### PR TITLE
feat: add Rails 8 application CLAUDE.md example

### DIFF
--- a/examples/rails-app-CLAUDE.md
+++ b/examples/rails-app-CLAUDE.md
@@ -25,7 +25,7 @@
 
 - Eager load associations by default to prevent N+1 queries
 - Avoid `default_scope`; use named scopes that callers opt into
-- Use `select_related` equivalents: `.includes`, `.preload`, or `.eager_load` depending on need
+- Use `.includes`, `.preload`, or `.eager_load` depending on need to avoid N+1 queries
 - Counter caches on any `has_many` where the count is displayed in lists
 - Callbacks for data normalization only (`before_validation :normalize_email`); anything with side effects belongs in a service
 - Migrations are reversible by default; document any one-way migration explicitly
@@ -33,11 +33,11 @@
 ```ruby
 # BAD: N+1 query
 posts = Post.published
-posts.each { |post| puts post.author.name }  # one query per post
+posts.each { |post| post.author.name }  # one query per post
 
 # GOOD: Single query with eager load
 posts = Post.published.includes(:author)
-posts.each { |post| puts post.author.name }
+posts.each { |post| post.author.name }
 ```
 
 ### Authentication and Authorization
@@ -153,9 +153,9 @@ module Invoices
 
       ApplicationRecord.transaction do
         invoice.save!
-        send_notifications(invoice)
       end
 
+      send_notifications(invoice)
       Result.new(success?: true, invoice: invoice, errors: nil)
     rescue ActiveRecord::RecordInvalid => e
       Result.new(success?: false, invoice: e.record, errors: e.record.errors)
@@ -185,7 +185,7 @@ end
 ```ruby
 # app/controllers/invoices_controller.rb
 class InvoicesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :require_authentication  # Rails 8 generator default; use authenticate_user! with Devise
 
   def create
     authorize Invoice

--- a/examples/rails-app-CLAUDE.md
+++ b/examples/rails-app-CLAUDE.md
@@ -258,7 +258,7 @@ class ExportAccountingJob < ApplicationJob
 
   def perform(invoice_id)
     invoice = Invoice.find(invoice_id)
-    return if invoice.exported?  # local idempotency check
+    return if invoice.exported_at.present?  # local idempotency check
 
     idempotency_key = "invoice-export-#{invoice.id}"
     AccountingApi.export(invoice, idempotency_key: idempotency_key)

--- a/examples/rails-app-CLAUDE.md
+++ b/examples/rails-app-CLAUDE.md
@@ -51,10 +51,11 @@ posts.each { |post| post.author.name }
 ### Background Jobs
 
 - SolidQueue is the default in Rails 8; Sidekiq remains acceptable for high-throughput cases
-- Pass IDs to jobs, never records; records do not serialize cleanly
+- Pass IDs to jobs, not records; this avoids `ActiveJob::DeserializationError` when records are deleted between enqueue and execute
 - `perform` methods must be idempotent; assume they will run more than once
 - Declare retry behavior explicitly with `retry_on` and `discard_on`
 - Name jobs by action (`SendInvoiceJob`, `ExportAccountingJob`), not by noun
+- For jobs touching external systems, pair the local idempotency check with an API-level idempotency token, and consider row-level locking (`with_lock`) for high-concurrency scenarios
 
 ### Views and Hotwire
 
@@ -155,7 +156,12 @@ module Invoices
         invoice.save!
       end
 
-      send_notifications(invoice)
+      begin
+        send_notifications(invoice)
+      rescue StandardError => e
+        Rails.logger.error("Notification dispatch failed for invoice #{invoice.id}: #{e.message}")
+      end
+
       Result.new(success?: true, invoice: invoice, errors: nil)
     rescue ActiveRecord::RecordInvalid => e
       Result.new(success?: false, invoice: e.record, errors: e.record.errors)
@@ -252,9 +258,10 @@ class ExportAccountingJob < ApplicationJob
 
   def perform(invoice_id)
     invoice = Invoice.find(invoice_id)
-    return if invoice.exported?  # idempotency check
+    return if invoice.exported?  # local idempotency check
 
-    AccountingApi.export(invoice)
+    idempotency_key = "invoice-export-#{invoice.id}"
+    AccountingApi.export(invoice, idempotency_key: idempotency_key)
     invoice.update!(exported_at: Time.current)
   end
 end

--- a/examples/rails-app-CLAUDE.md
+++ b/examples/rails-app-CLAUDE.md
@@ -1,0 +1,380 @@
+# Rails Application: Project CLAUDE.md
+
+> Real-world example for a Rails 8 monolithic web application with Hotwire, ViewComponent, and the Solid stack.
+> Copy this to your project root and customize for your service.
+
+## Project Overview
+
+**Stack:** Ruby 3.3+, Rails 8.x, PostgreSQL 16, SolidQueue, SolidCache, SolidCable, Hotwire (Turbo + Stimulus), ViewComponent, Tailwind CSS, RSpec, FactoryBot, Capybara, Kamal
+
+**Architecture:** Full-stack Rails monolith. Server-rendered with Hotwire for interactivity rather than an SPA. Database-backed Solid stack replaces Redis for background jobs, cache, and WebSockets. ViewComponent for testable view logic. Service objects for business operations. Deployed via Kamal to self-managed Linux hosts.
+
+## Critical Rules
+
+### Ruby Conventions
+
+- `# frozen_string_literal: true` at the top of every Ruby file
+- Modern hash syntax (`key:`) over hash rockets (`:key =>`) unless the key is not a symbol
+- Double quotes by default; single quotes only when the string contains a double quote
+- Two-space indentation, no tabs
+- Use `bin/` wrappers (`bin/rails`, `bin/rspec`, `bin/rubocop`) instead of `bundle exec` directly
+- RuboCop is authoritative; either fix the code or update the config in a PR that explains why
+- No `puts`, `pp`, `debugger`, or `binding.pry` in committed code; use `Rails.logger.<level>` for logging
+
+### Database
+
+- Eager load associations by default to prevent N+1 queries
+- Avoid `default_scope`; use named scopes that callers opt into
+- Use `select_related` equivalents: `.includes`, `.preload`, or `.eager_load` depending on need
+- Counter caches on any `has_many` where the count is displayed in lists
+- Callbacks for data normalization only (`before_validation :normalize_email`); anything with side effects belongs in a service
+- Migrations are reversible by default; document any one-way migration explicitly
+
+```ruby
+# BAD: N+1 query
+posts = Post.published
+posts.each { |post| puts post.author.name }  # one query per post
+
+# GOOD: Single query with eager load
+posts = Post.published.includes(:author)
+posts.each { |post| puts post.author.name }
+```
+
+### Authentication and Authorization
+
+- Authentication via the Rails 8 generated authentication system (`bin/rails generate authentication`) or Devise for more complex flows
+- Session-based auth for full-stack pages, token-based for any embedded API endpoints
+- Authorization via Pundit; every controller action has an `authorize` call or an explicit `skip_authorization` with a documented reason
+- Strong parameters always; never `params.permit!`
+- CSRF protection enabled by default; only disable per action with explicit justification
+
+### Background Jobs
+
+- SolidQueue is the default in Rails 8; Sidekiq remains acceptable for high-throughput cases
+- Pass IDs to jobs, never records; records do not serialize cleanly
+- `perform` methods must be idempotent; assume they will run more than once
+- Declare retry behavior explicitly with `retry_on` and `discard_on`
+- Name jobs by action (`SendInvoiceJob`, `ExportAccountingJob`), not by noun
+
+### Views and Hotwire
+
+- Hotwire (Turbo + Stimulus) before reaching for a JavaScript framework
+- ViewComponent for any view logic that has conditionals, accepts multiple parameters, or appears in more than three places
+- ERB partials for simple presentation; no business logic in views
+- Tailwind utility classes for styling; avoid custom CSS unless utilities cannot express the design
+- Turbo Frames for partial page updates; Turbo Streams for server-driven multi-update responses
+
+### Real-time and ActionCable
+
+- SolidCable is the Rails 8 default pub/sub backend; no Redis required
+- Authenticate connections in `ApplicationCable::Connection#connect`; never trust the client to identify itself
+- Authorize subscriptions in each channel's `subscribed` method before calling `stream_from`
+- Prefer Turbo Stream broadcasts (`broadcasts_to`, `broadcast_replace_later_to`) for view updates over hand-written channels
+- Treat ActionCable broadcasts as public; never include sensitive data the subscriber should not see
+
+### Deployment Setup
+
+Production deploys via Kamal:
+
+- `config/deploy.yml` is the source of truth for servers, registry, and environment config
+- `.kamal/secrets` references secrets from the host environment; the file is committed, the secrets are not
+- Production hosts are Docker-capable machines (typically Linux) with SSH access from the deploying machine
+- Migrations run as part of the deploy lifecycle; no manual migration step
+
+### Error Handling
+
+- Service objects return Result objects on success and failure; do not raise across service boundaries
+- Rescue expected errors inside the service and capture them on the result
+- Custom domain errors live in a dedicated location (`app/errors/` or `lib/errors/`, autoloaded as configured); one error class per failure mode
+- Never expose internal error details to clients; user-facing errors come from explicit messages, not exception strings
+- Use `rescue_from` sparingly in controllers; let the default Rails error handling do its job
+
+### Code Style
+
+- No emojis in code or comments
+- Max line length 120 characters (RuboCop default)
+- Classes PascalCase, methods and variables snake_case, constants UPPER_SNAKE_CASE
+- Controllers stay under 80 lines; models stay under 200 lines; anything longer needs extraction
+- Service objects under `app/services/`, namespaced by domain (`Invoices::Create`, not `InvoiceCreator`)
+
+## File Structure
+
+```
+app/
+  models/                # ActiveRecord models. Persistence and domain logic close to the data.
+  controllers/           # HTTP request handling. Thin orchestration only.
+  views/                 # ERB templates. No business logic.
+  components/            # ViewComponent classes. View logic that needs tests.
+  services/              # Service objects under domain namespaces.
+  forms/                 # Form objects for multi-model forms.
+  queries/               # Query objects for reusable, composable ActiveRecord queries.
+  jobs/                  # Background jobs. SolidQueue or Sidekiq.
+  mailers/               # ActionMailer classes.
+  channels/              # ActionCable channels. Real-time WebSocket connections.
+  policies/              # Pundit authorization policies, one per resource.
+  errors/                # Custom domain error classes.
+config/
+  routes.rb
+  database.yml
+  credentials/
+    production.yml.enc   # Encrypted production credentials.
+  deploy.yml             # Kamal deploy configuration.
+db/
+  migrate/               # Migrations, committed and reversible.
+  seeds.rb
+spec/
+  models/
+  services/
+  components/
+  system/                # Capybara system tests.
+  factories/             # FactoryBot definitions.
+  support/               # Shared spec helpers.
+```
+
+## Key Patterns
+
+### Service Object Pattern
+
+```ruby
+# app/services/invoices/create.rb
+module Invoices
+  class Create
+    Result = Data.define(:success?, :invoice, :errors)
+
+    def self.call(...) = new(...).call
+
+    def initialize(params:, user:)
+      @params = params
+      @user = user
+    end
+
+    def call
+      invoice = build_invoice
+
+      ApplicationRecord.transaction do
+        invoice.save!
+        send_notifications(invoice)
+      end
+
+      Result.new(success?: true, invoice: invoice, errors: nil)
+    rescue ActiveRecord::RecordInvalid => e
+      Result.new(success?: false, invoice: e.record, errors: e.record.errors)
+    end
+
+    private
+
+    attr_reader :params, :user
+
+    def build_invoice
+      invoice = user.invoices.new(params.except(:line_items))
+      invoice.line_items.build(params[:line_items])
+      invoice.total = invoice.line_items.sum(&:amount)
+      invoice
+    end
+
+    def send_notifications(invoice)
+      InvoiceMailer.created(invoice).deliver_later
+      ExportAccountingJob.perform_later(invoice.id)
+    end
+  end
+end
+```
+
+### Skinny Controller Pattern
+
+```ruby
+# app/controllers/invoices_controller.rb
+class InvoicesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    authorize Invoice
+
+    result = Invoices::Create.call(params: invoice_params, user: current_user)
+
+    if result.success?
+      redirect_to result.invoice, notice: "Invoice created"
+    else
+      @invoice = result.invoice
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def invoice_params
+    params.require(:invoice).permit(:customer_id, line_items: %i[description amount])
+  end
+end
+```
+
+### Query Object Pattern
+
+```ruby
+# app/queries/invoices/overdue.rb
+module Invoices
+  class Overdue
+    def self.call(...) = new(...).call
+
+    def initialize(scope: Invoice.all, as_of: Time.current)
+      @scope = scope
+      @as_of = as_of
+    end
+
+    def call
+      scope
+        .where(status: :sent)
+        .where(due_date: ..as_of)
+        .where.not(id: paid_invoice_ids)
+        .includes(:customer, :line_items)
+    end
+
+    private
+
+    attr_reader :scope, :as_of
+
+    def paid_invoice_ids
+      Payment.where(created_at: ..as_of).pluck(:invoice_id)
+    end
+  end
+end
+```
+
+### Background Job Pattern
+
+```ruby
+# app/jobs/export_accounting_job.rb
+class ExportAccountingJob < ApplicationJob
+  queue_as :exports
+
+  retry_on AccountingApi::TransientError, wait: :polynomially_longer, attempts: 5
+  discard_on AccountingApi::PermanentError
+
+  def perform(invoice_id)
+    invoice = Invoice.find(invoice_id)
+    return if invoice.exported?  # idempotency check
+
+    AccountingApi.export(invoice)
+    invoice.update!(exported_at: Time.current)
+  end
+end
+```
+
+### Test Pattern (RSpec)
+
+```ruby
+# spec/services/invoices/create_spec.rb
+require "rails_helper"
+
+RSpec.describe Invoices::Create do
+  let(:user) { create(:user) }
+  let(:customer) { create(:customer, user: user) }
+  let(:params) do
+    {
+      customer_id: customer.id,
+      line_items: [{ description: "Consulting", amount: 100_000 }]  # $1,000.00 in cents
+    }
+  end
+
+  describe ".call" do
+    it "creates an invoice with the expected total" do
+      result = described_class.call(params: params, user: user)
+
+      expect(result).to be_success
+      expect(result.invoice).to be_persisted
+      expect(result.invoice.total).to eq(100_000)
+    end
+
+    it "enqueues a notification email" do
+      expect {
+        described_class.call(params: params, user: user)
+      }.to have_enqueued_mail(InvoiceMailer, :created)
+    end
+
+    it "returns errors when validation fails" do
+      result = described_class.call(params: params.merge(customer_id: nil), user: user)
+
+      expect(result).not_to be_success
+      expect(result.errors[:customer]).to include("must exist")
+    end
+  end
+end
+```
+
+## Environment Variables
+
+```bash
+# Rails
+RAILS_ENV=production
+RAILS_MASTER_KEY=                  # decrypts config/credentials/production.yml.enc
+SECRET_KEY_BASE=                   # auto-generated; never commit
+
+# Database
+DATABASE_URL=postgres://user:pass@host:5432/myapp_production
+
+# SolidQueue, SolidCache, SolidCable
+# These default to the primary database; configure a separate one for higher load:
+QUEUE_DATABASE_URL=postgres://user:pass@host:5432/myapp_queue
+CACHE_DATABASE_URL=postgres://user:pass@host:5432/myapp_cache
+
+# Kamal deploy
+KAMAL_REGISTRY_PASSWORD=
+KAMAL_DEPLOY_USER=
+
+# Application secrets (also storable in Rails encrypted credentials)
+STRIPE_API_KEY=
+SENTRY_DSN=
+```
+
+For most secrets, prefer Rails encrypted credentials (`bin/rails credentials:edit -e production`) over environment variables. ENV vars are appropriate for infrastructure config that varies per host; credentials are appropriate for application secrets that travel with the codebase.
+
+## Testing Strategy
+
+```bash
+# Run the full suite
+bin/rspec
+
+# Run a single file or directory
+bin/rspec spec/services/invoices/
+bin/rspec spec/services/invoices/create_spec.rb
+
+# Run only the last failures
+bin/rspec --only-failures
+
+# Run with random ordering (default) seeded for reproducibility
+bin/rspec --seed 12345
+
+# Run system tests
+bin/rspec spec/system/
+
+# Coverage report (SimpleCov)
+COVERAGE=true bin/rspec
+```
+
+Coverage target is 90% line coverage as a floor, not a goal. Sharp tests with 85% beat exhaustive tests with 100%. System tests use Capybara with the rack_test driver by default and switch to headless Chrome only when JavaScript is required.
+
+## ECC Workflow
+
+```bash
+# Planning
+/plan "Add invoice PDF export with line item subtotals"
+
+# Test-first development
+/tdd                    # RSpec-based TDD workflow
+
+# Review
+/code-review            # General quality check
+/security-scan          # Brakeman + dependency audit
+
+# Verification
+/verify                 # Lint, type-check, test, security scan in one pass
+```
+
+## Git Workflow
+
+- Branch from `main`, named `<type>/<short-description>` (e.g., `feat/invoice-pdf-export`, `fix/n-plus-one-on-dashboard`)
+- Conventional commits style: `feat:` new features, `fix:` bug fixes, `refactor:` code changes
+- Pull requests required for changes to `main`; review according to your team's policy and CI must be green to merge
+- Squash on merge; the merged commit message must be coherent and well-formed
+- Never force-push to `main`; force-pushing feature branches is fine
+- CI runs RuboCop, Brakeman, RSpec, and bundle audit on every PR


### PR DESCRIPTION
Adds examples/rails-app-CLAUDE.md as a reference template for Rails 8 applications.

- Add examples/rails-app-CLAUDE.md: full-stack Rails 8 template covering Hotwire (Turbo + Stimulus), ViewComponent, the Solid stack (SolidQueue, SolidCache, SolidCable), service objects, query objects, and Pundit authorization
- Aligns with existing rules/ruby/ conventions (Rails Way first, SolidQueue for greenfield, Hotwire-preferred, Rails 8 generated authentication)
- Includes five Key Patterns code blocks: service object, skinny controller, query object, background job, RSpec test

## What Changed

Adds `examples/rails-app-CLAUDE.md`, a project-level CLAUDE.md template for Rails 8 applications. The file follows the structural pattern established by `django-api-CLAUDE.md`, `laravel-api-CLAUDE.md`, and `rust-api-CLAUDE.md`: Project Overview, Critical Rules, File Structure, Key Patterns, Environment Variables, Testing Strategy, ECC Workflow, and Git Workflow.

Coverage includes idiomatic Rails 8 conventions: Hotwire (Turbo + Stimulus) over JavaScript frameworks, the Solid stack (SolidQueue, SolidCache, SolidCable), the Rails 8 generated authentication system as default with Devise for complex flows, service objects namespaced by domain, query objects, ViewComponent for testable view logic, ActionCable conventions, and Kamal deployment setup.

## Why This Change

The `examples/` directory has CLAUDE.md templates for Django, Laravel, Rust, Next.js SaaS, Go, and HarmonyOS, but no Rails template. The README's "Ideas for Contributions" section explicitly lists Rails as a wanted framework contribution, and the existing `rules/ruby/` directory establishes Rails-aware coding conventions but no project-level example shows how those rules instantiate in a real Rails 8 application.

The template is positioned as a project-level companion to the existing `rules/ruby/` files. It aligns with conventions in `rules/ruby/patterns.md` (Hotwire-first, SolidQueue for greenfield, Rails 8 authentication generator as default), `rules/ruby/coding-style.md` (Rails Way first, service objects named by business operation), `rules/ruby/hooks.md` (RuboCop and Brakeman in CI), and `rules/ruby/security.md` (CSRF defaults, strong parameters, Rails credentials for secrets).

## Testing Done

Tested in a fresh Rails 8 personal project (a project and phase tracker) over an extended Claude Code session. Across seven distinct feature builds covering authentication setup, scope discipline on multi-concern features, controller naming conventions, dependency-aware work sequencing, N+1 prevention via eager loading, and Hotwire inline interactivity, Claude consistently cited either the project's CLAUDE.md or the ECC Ruby rules pack when applying conventions.

Specific behaviors observed:

- Authentication prompt resulted in Claude explicitly loading the five `rules/ecc/ruby/*.md` files into context and citing *"the Rails 8 authentication generator, which is the right tool for this (per the project's own CLAUDE.md)"* before implementing
- Vague "list of children under each parent" prompt resulted in Claude pre-committing to eager loading (*"eager load phases"*) before any code was written, with no performance cue in the prompt
- Interactive UI prompt resulted in Claude proposing Turbo Frame and Turbo Stream architecture (*"No full reload, no custom JS"*) without mention of any JavaScript framework alternative
- Multi-concern prompt resulted in correct scope separation (Project and Membership as distinct features) without prompting

Full test log with exact prompts and verbatim responses is available on request.

- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [x] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (no JSON files added)
- [x] Shell scripts pass shellcheck (no shell scripts added)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (this template is itself documentation)
- [ ] Added comments for complex logic (template is prose-and-code, not implementation)
- [ ] README updated (if needed) (no README change required for adding to examples/)
