### PR TITLE
fix: allow additional read-only git introspection commands

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -781,7 +781,10 @@ function isReadOnlyGitIntrospection(command) {
   }
 
   if (subcommand === 'diff') {
-    return args.length <= 1 && args.every(arg => ['--name-only', '--name-status'].includes(arg));
+    const allowedDiffArgs = new Set(['--name-only', '--name-status', '--cached', '--staged', '--stat']);
+    // git diff without arguments is read-only introspection
+    if (args.length === 0) return true;
+    return args.length <= 2 && args.every(arg => allowedDiffArgs.has(arg));
   }
 
   if (subcommand === 'log') {
@@ -789,7 +792,25 @@ function isReadOnlyGitIntrospection(command) {
   }
 
   if (subcommand === 'show') {
-    return args.length === 1 && !args[0].startsWith('--') && /^[a-zA-Z0-9._:/ -]+$/.test(args[0]);
+    // Permite: git show <ref>, git show --stat, git show --name-only,
+    // git show <ref> --stat, git show <ref> --name-only
+    if (args.length === 0) return false;
+    if (args.length === 1) {
+      const arg = args[0];
+      if (arg === '--stat' || arg === '--name-only') return true;
+      // ref
+      return !arg.startsWith('--') && /^[a-zA-Z0-9._:/ -]+$/.test(arg);
+    }
+    if (args.length === 2) {
+      const [first, second] = args;
+      // ref + flag
+      if (!first.startsWith('--') && /^[a-zA-Z0-9._:/ -]+$/.test(first) &&
+          (second === '--stat' || second === '--name-only')) {
+        return true;
+      }
+      return false;
+    }
+    return false;
   }
 
   if (subcommand === 'branch') {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1745,6 +1745,70 @@ function runTests() {
       'destructive gate is exempt from dampening');
   })) passed++; else failed++;
 
+  // --- Novos comandos Git read-only ---
+  console.log('\n  Novos comandos Git read-only:');
+
+  clearState();
+  if (test('allows git diff --cached', () => {
+    expectAllow('git diff --cached', 'git diff --cached');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git diff --staged', () => {
+    expectAllow('git diff --staged', 'git diff --staged');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git diff --stat', () => {
+    expectAllow('git diff --stat', 'git diff --stat');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git diff --name-only --cached', () => {
+    expectAllow('git diff --name-only --cached', 'git diff --name-only --cached');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git show --stat', () => {
+    expectAllow('git show --stat', 'git show --stat');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git show --name-only', () => {
+    expectAllow('git show --name-only', 'git show --name-only');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git show HEAD --stat', () => {
+    expectAllow('git show HEAD --stat', 'git show HEAD --stat');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('allows git show HEAD --name-only', () => {
+    expectAllow('git show HEAD --name-only', 'git show HEAD --name-only');
+  })) passed++; else failed++;
+
+  // Garantir que comandos destrutivos continuam negados
+  clearState();
+  if (test('still denies git reset --hard', () => {
+    expectDestructiveDeny('git reset --hard', 'git reset --hard');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('still denies git checkout -f', () => {
+    expectDestructiveDeny('git checkout -f main', 'git checkout -f');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('still denies git clean -fd', () => {
+    expectDestructiveDeny('git clean -fd', 'git clean -fd');
+  })) passed++; else failed++;
+
+  clearState();
+  if (test('still denies git push --force', () => {
+    expectDestructiveDeny('git push --force origin main', 'git push --force');
+  })) passed++; else failed++;
+
   // Cleanup only the temp directory created by this test file.
   try {
     if (fs.existsSync(stateDir)) {


### PR DESCRIPTION
## Summary

Expands the gateguard read-only Git introspection allowlist to reduce false positives for safe commands.

Newly allowed commands include:

- `git diff --cached`
- `git diff --staged`
- `git diff --stat`
- `git diff --name-only --cached`
- `git show --stat`
- `git show --name-only`
- `git show HEAD --stat`
- `git show HEAD --name-only`

The existing `git diff` no-argument behavior remains allowed.

Destructive Git commands remain blocked, including:

- `git reset --hard`
- `git checkout -f`
- `git clean -fd`
- `git push --force`

## Validation

Ran:

```bash
node tests/hooks/gateguard-fact-force.test.js