### PR TITLE
fix(omp): harden harness contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ marketing/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.ecc/omp-session/
 
 # Temporary files
 tmp/

--- a/omp/extension.mjs
+++ b/omp/extension.mjs
@@ -1,0 +1,320 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const COMMANDS_DIR = path.resolve(__dirname, '..', 'commands');
+const STATE_DIR_NAME = path.join('.ecc', 'omp-session');
+
+function safeRead(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return null; }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function stateDir(cwd) {
+  return path.join(cwd || process.cwd(), STATE_DIR_NAME);
+}
+
+function stateFile(cwd, name) {
+  return path.join(stateDir(cwd), name);
+}
+
+function parseFrontmatter(markdown) {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) return { data: {}, body: markdown };
+  const data = {};
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const kv = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!kv) continue;
+    let value = kv[2].trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    } else if (value === 'true') {
+      value = true;
+    } else if (value === 'false') {
+      value = false;
+    }
+    data[kv[1]] = value;
+  }
+  return { data, body: markdown.slice(match[0].length) };
+}
+
+function listCommandFiles() {
+  try {
+    return fs.readdirSync(COMMANDS_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .map((entry) => path.join(COMMANDS_DIR, entry.name))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function normalizeArgs(args) {
+  if (typeof args === 'string') return args.trim();
+  if (Array.isArray(args)) return args.join(' ').trim();
+  if (args && typeof args === 'object') {
+    if (typeof args.raw === 'string') return args.raw.trim();
+    if (typeof args.input === 'string') return args.input.trim();
+    if (typeof args.args === 'string') return args.args.trim();
+    return JSON.stringify(args);
+  }
+  return '';
+}
+
+function profile() {
+  const value = process.env.ECC_HOOK_PROFILE;
+  return value === 'minimal' || value === 'strict' ? value : 'standard';
+}
+
+function disabledHooks() {
+  return new Set((process.env.ECC_DISABLED_HOOKS || '').split(',').map((item) => item.trim()).filter(Boolean));
+}
+
+function hookEnabled(id, required = 'standard') {
+  const order = { minimal: 0, standard: 1, strict: 2 };
+  if (disabledHooks().has(id)) return false;
+  const current = order[profile()] ?? order.standard;
+  const requirements = Array.isArray(required) ? required : [required];
+  return requirements.some((item) => current >= (order[item] ?? order.standard));
+}
+
+function toolNameOf(event) {
+  return String(event?.toolName || event?.tool || event?.name || '').toLowerCase();
+}
+
+function inputOf(event) {
+  return event?.input || event?.args || event?.tool_input || event?.params || {};
+}
+
+function commandOf(event) {
+  const input = inputOf(event);
+  if (typeof input === 'string') return input;
+  return String(input.command || input.cmd || '');
+}
+
+function filePathOf(event) {
+  const input = inputOf(event);
+  if (typeof input === 'string') return null;
+  const candidate = input.filePath || input.file_path || input.path || input.target || input.filename;
+  return typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null;
+}
+
+function isEditTool(name) {
+  return ['edit', 'write', 'multiedit', 'notebookedit'].includes(name.toLowerCase());
+}
+
+function isProtectedConfig(filePath) {
+  if (!filePath) return false;
+  const base = path.basename(filePath);
+  return [
+    '.eslintrc', '.eslintrc.js', '.eslintrc.cjs', '.eslintrc.json',
+    'eslint.config.js', 'eslint.config.mjs', 'prettier.config.js', '.prettierrc', '.prettierrc.json',
+    'biome.json', 'biome.jsonc', 'tsconfig.json', 'tsconfig.base.json',
+    'ruff.toml', 'pyproject.toml', 'Cargo.toml', 'go.mod',
+  ].includes(base);
+}
+
+function hasShellBypass(command) {
+  return /(^|\s)git\s+[^\n]*\s--no-verify(\s|$)/.test(command)
+    || /(^|\s)git\s+(commit|merge|cherry-pick|rebase|am)\b[^\n]*\s-n(\s|$)/.test(command);
+}
+
+function hasDestructiveShell(command) {
+  return /\brm\s+-rf\s+(\/|~|\$HOME|\.\.)/.test(command) || /:\(\)\s*\{\s*:\|:&\s*\}/.test(command);
+}
+
+function redact(value) {
+  return String(value)
+    .replace(/sk-[A-Za-z0-9_-]{8,}/g, 'sk-***')
+    .replace(/gh[pousr]_[A-Za-z0-9_]{8,}/g, 'gh*-***')
+    .replace(/AKIA[0-9A-Z]{16}/g, 'AKIA***')
+    .replace(/(Authorization:\s*Bearer\s+)[^\s]+/gi, '$1***')
+    .slice(0, 5000);
+}
+
+function appendJsonLine(cwd, name, entry) {
+  try {
+    ensureDir(stateDir(cwd));
+    fs.appendFileSync(stateFile(cwd, name), `${JSON.stringify(entry)}\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJson(cwd, name, fallback) {
+  try { return JSON.parse(fs.readFileSync(stateFile(cwd, name), 'utf8')); } catch { return fallback; }
+}
+
+function writeJson(cwd, name, value) {
+  try {
+    ensureDir(stateDir(cwd));
+    fs.writeFileSync(stateFile(cwd, name), `${JSON.stringify(value, null, 2)}\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function recordChangedFile(cwd, filePath, changeType) {
+  if (!filePath) return;
+  const normalized = filePath.split(path.sep).join('/');
+  const state = readJson(cwd, 'changed-files.json', { files: [] });
+  const files = Array.isArray(state.files) ? state.files : [];
+  const updatedAt = new Date().toISOString();
+  const nextFiles = files.some((entry) => entry.path === normalized)
+    ? files.map((entry) => (
+      entry.path === normalized
+        ? { ...entry, changeType: entry.changeType || changeType, updatedAt }
+        : entry
+    ))
+    : [...files, { path: normalized, changeType, updatedAt }];
+  writeJson(cwd, 'changed-files.json', { files: nextFiles.slice(-500) });
+}
+
+function warnConsoleLog(ctx, cwd, filePath) {
+  if (!filePath || !/\.(mjs|cjs|js|jsx|ts|tsx)$/.test(filePath)) return;
+  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  const text = safeRead(fullPath);
+  if (!text) return;
+  const count = (text.match(/console\.log\s*\(/g) || []).length;
+  if (count > 0) ctx?.ui?.notify?.(`[ECC] console.log found in ${filePath} (${count})`, 'warn');
+}
+
+function commandPrompt(name, description, body, args) {
+  return [
+    `Run ECC command /${name}.`,
+    description ? `Description: ${description}` : null,
+    args ? `User arguments: ${args}` : null,
+    '',
+    body.trim(),
+  ].filter((line) => line !== null).join('\n');
+}
+
+function registerCommands(pi) {
+  let count = 0;
+  for (const file of listCommandFiles()) {
+    const markdown = safeRead(file);
+    if (!markdown) continue;
+    const name = path.basename(file, '.md');
+    const parsed = parseFrontmatter(markdown);
+    const description = String(parsed.data.description || `Run ECC command /${name}`);
+    pi.registerCommand(name, {
+      description,
+      argumentHint: parsed.data['argument-hint'],
+      handler: async (args, ctx) => {
+        const argText = normalizeArgs(args);
+        const prompt = commandPrompt(name, description, parsed.body, argText);
+        if (typeof pi.sendUserMessage === 'function') {
+          await pi.sendUserMessage(prompt, { deliverAs: 'followUp' });
+        } else if (typeof pi.sendMessage === 'function') {
+          await pi.sendMessage(prompt, { deliverAs: 'followUp' });
+        } else {
+          ctx?.ui?.notify?.(`ECC command /${name} loaded; runtime message injection unavailable.`, 'warn');
+        }
+      },
+    });
+    count += 1;
+  }
+  return count;
+}
+
+function extension(pi) {
+  pi.setLabel?.('ECC for OMP');
+  const commandCount = registerCommands(pi);
+
+  pi.on?.('session_start', async (_event, ctx) => {
+    if (hookEnabled('session:start', 'minimal')) {
+      ctx?.ui?.notify?.(`[ECC] OMP extension loaded (${commandCount} commands). Profile=${profile()}`, 'info');
+    }
+  });
+
+  pi.on?.('tool_call', async (event, ctx) => {
+    const name = toolNameOf(event);
+    const command = commandOf(event);
+    const filePath = filePathOf(event);
+    const cwd = ctx?.cwd || process.cwd();
+
+    if (hookEnabled('pre:config-protection') && isEditTool(name) && isProtectedConfig(filePath)) {
+      return { block: true, reason: `ECC config-protection blocked modification of ${filePath}. Fix source code instead of weakening tool config.` };
+    }
+
+    if (name === 'bash') {
+      if (hookEnabled('pre:bash:block-no-verify') && hasShellBypass(command)) {
+        return { block: true, reason: 'ECC blocked git --no-verify bypass. Fix the failing hook or explicitly disable ECC hook pre:bash:block-no-verify.' };
+      }
+      if (hookEnabled('pre:bash:destructive-guard', 'strict') && hasDestructiveShell(command)) {
+        return { block: true, reason: 'ECC strict profile blocked a destructive shell command.' };
+      }
+    }
+
+    if (process.env.ECC_GOVERNANCE_CAPTURE === '1' && hookEnabled('pre:governance-capture')) {
+      appendJsonLine(cwd, 'governance.jsonl', { phase: 'pre', tool: name, filePath, command: redact(command), at: new Date().toISOString() });
+    }
+
+    return undefined;
+  });
+
+  pi.on?.('tool_result', async (event, ctx) => {
+    const name = toolNameOf(event);
+    const filePath = filePathOf(event);
+    const cwd = ctx?.cwd || process.cwd();
+    if (isEditTool(name) && filePath) {
+      recordChangedFile(cwd, filePath, name === 'write' ? 'added' : 'modified');
+      if (hookEnabled('post:edit:console-warn')) warnConsoleLog(ctx, cwd, filePath);
+    }
+    if (process.env.ECC_GOVERNANCE_CAPTURE === '1' && hookEnabled('post:governance-capture')) {
+      appendJsonLine(cwd, 'governance.jsonl', { phase: 'post', tool: name, filePath, at: new Date().toISOString() });
+    }
+    if (process.env.ECC_OBSERVE === '1' && hookEnabled('post:observe:continuous-learning')) {
+      appendJsonLine(cwd, 'observations.jsonl', { event: 'tool_result', tool: name, filePath, at: new Date().toISOString() });
+    }
+    return undefined;
+  });
+
+  pi.on?.('session_before_compact', async (_event, ctx) => {
+    if (!hookEnabled('pre:compact')) return undefined;
+    const cwd = ctx?.cwd || process.cwd();
+    const changed = readJson(cwd, 'changed-files.json', { files: [] }).files || [];
+    const summary = [
+      '# ECC Context (preserve across compaction)',
+      '',
+      `- OMP extension profile: ${profile()}`,
+      `- Registered commands: ${commandCount}`,
+      '- Runtime tools are provided by omp/tools/index.js',
+      '',
+      '## Recently changed files',
+      ...(changed.length ? changed.slice(-50).map((entry) => `- ${entry.path} (${entry.changeType})`) : ['- None recorded']),
+    ].join('\n');
+    return { compaction: { summary, details: { changedFiles: changed.slice(-50) } } };
+  });
+
+  pi.on?.('turn_end', async (_event, ctx) => {
+    if (process.env.ECC_OMP_METRICS === '1' && hookEnabled('post:ecc-metrics-bridge', 'minimal')) {
+      const cwd = ctx?.cwd || process.cwd();
+      const metrics = readJson(cwd, 'metrics.json', { turns: 0 });
+      const nextMetrics = {
+        ...metrics,
+        turns: Number(metrics.turns || 0) + 1,
+        updatedAt: new Date().toISOString(),
+      };
+      writeJson(cwd, 'metrics.json', nextMetrics);
+    }
+  });
+
+  pi.on?.('session_shutdown', async (_event, ctx) => {
+    if (process.env.ECC_OMP_SESSION_MARKERS === '1' && hookEnabled('session:end:marker', 'minimal')) {
+      appendJsonLine(ctx?.cwd || process.cwd(), 'session-lifecycle.jsonl', { event: 'session_shutdown', at: new Date().toISOString() });
+    }
+  });
+}
+
+export default extension;

--- a/omp/tools/index.js
+++ b/omp/tools/index.js
@@ -1,0 +1,543 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_SCAN_FILES = 1500;
+const MAX_FILE_BYTES = 256 * 1024;
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', 'coverage', '.next', '.turbo', '.cache', '.venv', 'venv', '__pycache__']);
+
+function envelopeResult({
+  status,
+  summary,
+  nextActions = [],
+  artifacts = [],
+  data = null,
+  error = null,
+  text = null,
+}) {
+  const details = {
+    status,
+    summary,
+    next_actions: nextActions,
+    artifacts,
+    data,
+    error,
+  };
+  return { content: [{ type: 'text', text: text || JSON.stringify(details, null, 2) }], details };
+}
+
+function successResult(summary, data, options = {}) {
+  return envelopeResult({ status: 'success', summary, data, ...options });
+}
+
+function warningResult(summary, data, options = {}) {
+  return envelopeResult({ status: 'warning', summary, data, ...options });
+}
+
+function errorResult(summary, data, options = {}) {
+  return envelopeResult({ status: 'error', summary, data, ...options });
+}
+
+function readJsonFile(file) {
+  try {
+    return { ok: true, value: JSON.parse(fs.readFileSync(file, 'utf8')) };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function fileExists(cwd, relativePath) {
+  try {
+    return fs.statSync(path.join(cwd, relativePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function detectPackageManager(cwd) {
+  if (fileExists(cwd, 'bun.lockb') || fileExists(cwd, 'bun.lock')) return 'bun';
+  if (fileExists(cwd, 'pnpm-lock.yaml')) return 'pnpm';
+  if (fileExists(cwd, 'yarn.lock')) return 'yarn';
+  if (fileExists(cwd, 'package-lock.json')) return 'npm';
+  return 'npm';
+}
+
+function readPackageJson(cwd) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function detectTestFramework(cwd) {
+  const pkg = readPackageJson(cwd);
+  if (!pkg) return 'unknown';
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  if (deps.vitest) return 'vitest';
+  if (deps.jest) return 'jest';
+  if (deps.mocha) return 'mocha';
+  if (deps.ava) return 'ava';
+  if (deps.tap) return 'tap';
+  return 'unknown';
+}
+
+function shellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(text)) return text;
+  return `'${text.replace(/'/g, `'"'"'`)}'`;
+}
+
+function detectFormatter(cwd, filePath, override) {
+  if (override) return override;
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  if (['ts', 'tsx', 'js', 'jsx', 'json', 'css', 'scss', 'md', 'yaml', 'yml'].includes(ext)) {
+    if (fileExists(cwd, 'biome.json') || fileExists(cwd, 'biome.jsonc')) return 'biome';
+    return 'prettier';
+  }
+  if (['py', 'pyi'].includes(ext)) return 'black';
+  if (ext === 'go') return 'gofmt';
+  if (ext === 'rs') return 'rustfmt';
+  return null;
+}
+
+function formatterCommand(formatter, filePath) {
+  const target = shellQuote(filePath);
+  if (formatter === 'biome') return `npx @biomejs/biome format --write ${target}`;
+  if (formatter === 'prettier') return `npx prettier --write ${target}`;
+  if (formatter === 'black') return `black ${target}`;
+  if (formatter === 'gofmt') return `gofmt -w ${target}`;
+  if (formatter === 'rustfmt') return `rustfmt ${target}`;
+  return null;
+}
+
+function detectLinter(cwd, override) {
+  if (override) return override;
+  if (fileExists(cwd, 'biome.json') || fileExists(cwd, 'biome.jsonc')) return 'biome';
+  for (const name of ['.eslintrc.json', '.eslintrc.js', '.eslintrc.cjs', 'eslint.config.js', 'eslint.config.mjs']) {
+    if (fileExists(cwd, name)) return 'eslint';
+  }
+  if (fileExists(cwd, 'pyproject.toml')) {
+    let pyproject = '';
+    try {
+      pyproject = fs.readFileSync(path.join(cwd, 'pyproject.toml'), 'utf8');
+    } catch {
+      pyproject = '';
+    }
+    if (pyproject.includes('ruff')) return 'ruff';
+  }
+  if (fileExists(cwd, '.golangci.yml') || fileExists(cwd, '.golangci.yaml')) return 'golangci-lint';
+  return 'eslint';
+}
+
+function linterCommand(linter, target, fix) {
+  const quoted = shellQuote(target || '.');
+  if (linter === 'biome') return `npx @biomejs/biome lint${fix ? ' --write' : ''} ${quoted}`;
+  if (linter === 'eslint') return `npx eslint${fix ? ' --fix' : ''} ${quoted}`;
+  if (linter === 'ruff') return `ruff check${fix ? ' --fix' : ''} ${quoted}`;
+  if (linter === 'pylint') return `pylint ${quoted}`;
+  if (linter === 'golangci-lint') return `golangci-lint run ${quoted}`;
+  return null;
+}
+
+function coverageSummaryFromNyC(data) {
+  const files = [];
+  let covered = 0;
+  let total = 0;
+  for (const [file, entry] of Object.entries(data || {})) {
+    const statements = entry.s || {};
+    const count = Object.keys(statements).length;
+    const hit = Object.values(statements).filter((value) => Number(value) > 0).length;
+    if (count > 0) {
+      files.push({ file, percentage: Math.round((hit / count) * 10000) / 100 });
+      covered += hit;
+      total += count;
+    }
+  }
+  return { total: { percentage: total ? Math.round((covered / total) * 10000) / 100 : 0, covered, total }, files };
+}
+
+function coverageSummary(data) {
+  if (data && data.total) {
+    const pct = data.total.lines?.pct ?? data.total.statements?.pct ?? data.total.branches?.pct ?? data.total.functions?.pct ?? 0;
+    const files = Object.entries(data)
+      .filter(([key, value]) => key !== 'total' && value && typeof value === 'object')
+      .map(([file, value]) => ({ file, percentage: value.lines?.pct ?? value.statements?.pct ?? value.branches?.pct ?? value.functions?.pct ?? 0 }));
+    return { total: { percentage: pct }, files };
+  }
+  return coverageSummaryFromNyC(data);
+}
+
+function walkFiles(root, visitor) {
+  let seen = 0;
+  function walk(dir) {
+    if (seen >= MAX_SCAN_FILES) return;
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (seen >= MAX_SCAN_FILES) return;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(fullPath);
+      } else if (entry.isFile()) {
+        seen += 1;
+        visitor(fullPath);
+      }
+    }
+  }
+  walk(root);
+  return seen;
+}
+
+function scanForSecrets(cwd) {
+  const findings = [];
+  const patterns = [
+    ['OpenAI-style token', /sk-[A-Za-z0-9_-]{20,}/g],
+    ['GitHub token', /gh[pousr]_[A-Za-z0-9_]{20,}/g],
+    ['AWS access key', /AKIA[0-9A-Z]{16}/g],
+    ['Private key block', /-----BEGIN [A-Z ]*PRIVATE KEY-----/g],
+  ];
+  walkFiles(cwd, (file) => {
+    let stat;
+    try { stat = fs.statSync(file); } catch { return; }
+    if (stat.size > MAX_FILE_BYTES) return;
+    const ext = path.extname(file).toLowerCase();
+    if (!['.js', '.ts', '.tsx', '.jsx', '.json', '.env', '.yml', '.yaml', '.toml', '.md', '.py', '.rs', '.go', '.java', '.kt', '.sh'].includes(ext) && !path.basename(file).startsWith('.env')) return;
+    let text;
+    try { text = fs.readFileSync(file, 'utf8'); } catch { return; }
+    for (const [kind, pattern] of patterns) {
+      pattern.lastIndex = 0;
+      if (pattern.test(text)) findings.push({ kind, file: path.relative(cwd, file) });
+    }
+  });
+  return findings.slice(0, 100);
+}
+
+function scanCodeSecurity(cwd) {
+  const findings = [];
+  const rules = [
+    ['shell-string-exec', /\b(exec|execSync)\s*\(\s*`|\b(exec|execSync)\s*\(\s*['"]/],
+    ['dangerous-eval', /\beval\s*\(/],
+    ['disabled-tls-verification', /NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*['"]?0/],
+  ];
+  walkFiles(cwd, (file) => {
+    let stat;
+    try { stat = fs.statSync(file); } catch { return; }
+    if (stat.size > MAX_FILE_BYTES) return;
+    if (!['.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.py', '.sh'].includes(path.extname(file).toLowerCase())) return;
+    let text;
+    try { text = fs.readFileSync(file, 'utf8'); } catch { return; }
+    for (const [rule, pattern] of rules) {
+      if (pattern.test(text)) findings.push({ rule, file: path.relative(cwd, file) });
+    }
+  });
+  return findings.slice(0, 100);
+}
+
+function readChangedFiles(cwd, filter) {
+  const file = path.join(cwd, '.ecc', 'omp-session', 'changed-files.json');
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const files = Array.isArray(parsed.files) ? parsed.files : [];
+    return filter && filter !== 'all' ? files.filter((entry) => entry.changeType === filter) : files;
+  } catch {
+    return [];
+  }
+}
+
+function makeTools(pi) {
+  const z = pi.zod?.z || pi.zod;
+  if (!z || typeof z.object !== 'function') {
+    throw new Error(
+      'OMP runtime did not provide a compatible zod schema helper for ECC tools. Retry with a current OMP build or disable the ECC tool port.'
+    );
+  }
+  const cwdOf = (ctx) => ctx?.cwd || pi.cwd || process.cwd();
+
+  return [
+    {
+      name: 'ecc_run_tests',
+      label: 'ECC Run Tests',
+      description: 'Detect package manager and test framework, then return the exact test command to run.',
+      parameters: z.object({
+        pattern: z.string().optional(),
+        coverage: z.boolean().optional(),
+        watch: z.boolean().optional(),
+        updateSnapshots: z.boolean().optional(),
+      }),
+      async execute(_id, params, _onUpdate, ctx) {
+        const cwd = cwdOf(ctx);
+        const packageManager = detectPackageManager(cwd);
+        const testFramework = detectTestFramework(cwd);
+        const command = [packageManager, packageManager === 'npm' ? 'run test' : 'test'];
+        const args = [];
+        if (params.coverage) args.push('--coverage');
+        if (params.watch) args.push('--watch');
+        if (params.updateSnapshots) args.push('-u');
+        if (params.pattern) {
+          args.push(
+            testFramework === 'jest' || testFramework === 'vitest'
+              ? `--testPathPattern ${shellQuote(params.pattern)}`
+              : shellQuote(params.pattern)
+          );
+        }
+        const fullCommand = `${command.join(' ')}${args.length ? ` ${packageManager === 'npm' ? '-- ' : ''}${args.join(' ')}` : ''}`;
+        return successResult(
+          'Suggested test command detected.',
+          { command: fullCommand, packageManager, testFramework, options: params },
+          { nextActions: [`Run: ${fullCommand}`] }
+        );
+      },
+    },
+    {
+      name: 'ecc_check_coverage',
+      label: 'ECC Check Coverage',
+      description: 'Read common local coverage reports and compare them to a threshold.',
+      parameters: z.object({ threshold: z.number().optional(), showUncovered: z.boolean().optional(), format: z.enum(['summary', 'detailed', 'json']).optional() }),
+      async execute(_id, params, _onUpdate, ctx) {
+        const cwd = cwdOf(ctx);
+        const threshold = params.threshold ?? 80;
+        const candidates = ['coverage/coverage-summary.json', 'coverage/coverage-final.json', '.nyc_output/coverage.json'];
+        for (const candidate of candidates) {
+          const full = path.join(cwd, candidate);
+          if (!fs.existsSync(full)) continue;
+          const parsed = readJsonFile(full);
+          if (!parsed.ok) {
+            return errorResult(
+              `Coverage report at ${candidate} could not be parsed.`,
+              { coverageFile: candidate },
+              {
+                nextActions: ['Regenerate the coverage report and retry.', `Repair or remove the stale file at ${candidate}.`],
+                artifacts: [candidate],
+                error: parsed.error,
+              }
+            );
+          }
+          const summary = coverageSummary(parsed.value);
+          const uncovered = summary.files.filter((entry) => entry.percentage < threshold);
+          const data = {
+            threshold,
+            coverageFile: candidate,
+            total: summary.total,
+            uncoveredFiles: params.showUncovered === false ? undefined : uncovered,
+          };
+          if (summary.total.percentage >= threshold) {
+            return successResult(
+              `Coverage threshold met (${summary.total.percentage}% ≥ ${threshold}%).`,
+              data,
+              { artifacts: [candidate] }
+            );
+          }
+          return warningResult(
+            `Coverage threshold missed (${summary.total.percentage}% < ${threshold}%).`,
+            data,
+            {
+              nextActions: ['Inspect uncovered files before merging.', 'Re-run coverage after adding tests.'],
+              artifacts: [candidate],
+            }
+          );
+        }
+        return warningResult(
+          'No supported coverage report found.',
+          { searchedPaths: candidates },
+          {
+            nextActions: ['Run the project coverage command first and retry.'],
+            artifacts: candidates,
+          }
+        );
+      },
+    },
+    {
+      name: 'ecc_security_audit',
+      label: 'ECC Security Audit',
+      description: 'Run bounded local secret and code-pattern checks without network access or auto-fix.',
+      parameters: z.object({ type: z.enum(['all', 'dependencies', 'secrets', 'code']).optional(), fix: z.boolean().optional(), severity: z.enum(['low', 'moderate', 'high', 'critical']).optional() }),
+      async execute(_id, params, _onUpdate, ctx) {
+        const cwd = cwdOf(ctx);
+        if (params.fix) {
+          return errorResult(
+            'Auto-fix is intentionally not supported by the OMP port.',
+            { requestedFix: true, type: params.type ?? 'all' },
+            {
+              nextActions: ['Re-run with fix=false and apply any changes manually in a controlled shell.'],
+              error: 'unsupported_fix_mode',
+            }
+          );
+        }
+        const type = params.type ?? 'all';
+        const checks = [];
+        if (type === 'all' || type === 'dependencies') checks.push({ name: 'Dependency Vulnerabilities', status: 'manual', command: 'Run npm audit/pnpm audit in a controlled shell if needed.' });
+        if (type === 'all' || type === 'secrets') checks.push({ name: 'Secret Detection', status: 'complete', findings: scanForSecrets(cwd) });
+        if (type === 'all' || type === 'code') checks.push({ name: 'Code Security Patterns', status: 'complete', findings: scanCodeSecurity(cwd) });
+        return successResult(
+          'Security audit completed.',
+          { timestamp: new Date().toISOString(), directory: cwd, severity: params.severity ?? 'moderate', checks },
+          { nextActions: ['Review findings before applying manual fixes.'] }
+        );
+      },
+    },
+    {
+      name: 'ecc_format_code',
+      label: 'ECC Format Code',
+      description: 'Detect formatter for a file and return the exact command to run.',
+      parameters: z.object({ filePath: z.string(), formatter: z.enum(['biome', 'prettier', 'black', 'gofmt', 'rustfmt']).optional() }),
+      async execute(_id, params, _onUpdate, ctx) {
+        const cwd = cwdOf(ctx);
+        const formatter = detectFormatter(cwd, params.filePath, params.formatter);
+        const command = formatter && formatterCommand(formatter, params.filePath);
+        if (!command) {
+          return warningResult(
+            `No formatter detected for ${params.filePath}.`,
+            { filePath: params.filePath },
+            {
+              nextActions: ['Pass an explicit formatter override or add the project formatter config first.'],
+              artifacts: [params.filePath],
+            }
+          );
+        }
+        return successResult(
+          `Formatter detected for ${params.filePath}.`,
+          { formatter, command, filePath: params.filePath },
+          {
+            nextActions: [`Run: ${command}`],
+            artifacts: [params.filePath],
+          }
+        );
+      },
+    },
+    {
+      name: 'ecc_lint_check',
+      label: 'ECC Lint Check',
+      description: 'Detect linter for a target path and return a check or fix command.',
+      parameters: z.object({ target: z.string().optional(), fix: z.boolean().optional(), linter: z.enum(['biome', 'eslint', 'ruff', 'pylint', 'golangci-lint']).optional() }),
+      async execute(_id, params, _onUpdate, ctx) {
+        const cwd = cwdOf(ctx);
+        const target = params.target || '.';
+        const linter = detectLinter(cwd, params.linter);
+        const command = linterCommand(linter, target, Boolean(params.fix));
+        return successResult(
+          `Linter command prepared for ${target}.`,
+          { linter, command, target, fix: Boolean(params.fix) },
+          {
+            nextActions: [`Run: ${command}`],
+            artifacts: [target],
+          }
+        );
+      },
+    },
+    {
+      name: 'ecc_git_summary',
+      label: 'ECC Git Summary',
+      description: 'Generate a git summary with branch, status, recent commits, and optional diff stats using argv-based execution.',
+      parameters: z.object({ depth: z.number().optional(), includeDiff: z.boolean().optional(), baseBranch: z.string().optional() }),
+      async execute(_id, params, _onUpdate, ctx, signal) {
+        const cwd = cwdOf(ctx);
+        const depth = Math.max(1, Math.min(50, Math.floor(params.depth ?? 5)));
+        const baseBranch = params.baseBranch || 'main';
+        if (
+          !/^[A-Za-z0-9._/@+-]+$/.test(baseBranch)
+          || baseBranch.includes('..')
+          || baseBranch.startsWith('.')
+          || baseBranch.startsWith('-')
+        ) {
+          return errorResult(
+            'Invalid baseBranch.',
+            { baseBranch },
+            {
+              nextActions: ['Use a plain branch name without path traversal, leading dots, or leading dashes.'],
+              error: 'baseBranch failed validation',
+            }
+          );
+        }
+        if (typeof pi.exec !== 'function') {
+          return errorResult(
+            'OMP runtime does not provide exec support for git summary.',
+            { baseBranch, depth },
+            {
+              nextActions: ['Run this tool in an OMP runtime with process execution support.'],
+              error: 'missing exec capability',
+            }
+          );
+        }
+        async function git(args) {
+          const result = await pi.exec('git', args, { cwd, signal });
+          return {
+            ok: result.code === 0,
+            stdout: result.stdout.trim(),
+            stderr: (result.stderr || '').trim(),
+            command: `git ${args.join(' ')}`,
+          };
+        }
+        const branch = await git(['branch', '--show-current']);
+        const status = await git(['status', '--short']);
+        const log = await git(['log', '--oneline', `-${depth}`]);
+        const summary = {
+          branch: branch.ok ? (branch.stdout || 'unknown') : 'unknown',
+          status: status.ok ? (status.stdout || 'clean') : 'unknown',
+          log: log.ok ? (log.stdout || 'no commits found') : 'unknown',
+          gitFailures: [],
+        };
+        for (const result of [branch, status, log]) {
+          if (!result.ok) summary.gitFailures.push(result);
+        }
+        if (params.includeDiff !== false) {
+          const stagedDiff = await git(['diff', '--cached', '--stat']);
+          const branchDiff = await git(['diff', `${baseBranch}...HEAD`, '--stat']);
+          summary.stagedDiff = stagedDiff.ok ? stagedDiff.stdout : '';
+          summary.branchDiff = branchDiff.ok ? branchDiff.stdout : '';
+          if (!stagedDiff.ok) summary.gitFailures.push(stagedDiff);
+          if (!branchDiff.ok) summary.gitFailures.push(branchDiff);
+        }
+        if (summary.gitFailures.length > 0) {
+          return warningResult(
+            'Git summary generated with partial failures.',
+            summary,
+            {
+              nextActions: ['Verify the directory is a git repository and that the requested base branch exists locally.'],
+              error: 'One or more git commands failed.',
+            }
+          );
+        }
+        return successResult('Git summary generated.', summary);
+      },
+    },
+    {
+      name: 'ecc_changed_files',
+      label: 'ECC Changed Files',
+      description: 'List files recorded by the ECC OMP extension during this session.',
+      parameters: z.object({ filter: z.enum(['all', 'added', 'modified', 'deleted']).optional(), format: z.enum(['tree', 'json']).optional() }),
+      async execute(_id, params, _onUpdate, ctx) {
+        const files = readChangedFiles(cwdOf(ctx), params.filter || 'all');
+        if ((params.format || 'tree') === 'json') {
+          return successResult('Changed files loaded.', { changed: files.length > 0, files }, { artifacts: files.map((entry) => entry.path) });
+        }
+        if (!files.length) {
+          return successResult(
+            'No files changed in this session.',
+            { changed: false, files: [] },
+            {
+              nextActions: ['Make an edit through the OMP session and retry if you expected tracked changes.'],
+              text: 'No files changed in this session.',
+            }
+          );
+        }
+        return successResult(
+          'Changed files loaded.',
+          { changed: true, files },
+          {
+            artifacts: files.map((entry) => entry.path),
+            text: files.map((entry) => `${entry.changeType || 'modified'}\t${entry.path}`).join('\n'),
+          }
+        );
+      },
+    },
+  ];
+}
+
+module.exports = makeTools;
+module.exports.default = makeTools;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,18 @@
   "bugs": {
     "url": "https://github.com/affaan-m/ECC/issues"
   },
+  "omp": {
+    "description": "OMP-native ECC module exposing curated commands, safe tool ports, and a guarded extension adapter. Claude/OpenCode hooks are translated into OMP extension events; telemetry and risky blocking policies remain opt-in by environment/profile gates.",
+    "extensions": [
+      "./omp/extension.mjs"
+    ],
+    "tools": [
+      "./omp/tools/index.js"
+    ],
+    "commands": [
+      "./commands"
+    ]
+  },
   "files": [
     ".agents/",
     ".claude-plugin/",
@@ -313,6 +325,7 @@
     "skills/windows-desktop-e2e/",
     "skills/workspace-surface-audit/",
     "skills/x-api/",
+    "omp/",
     "the-security-guide.md",
     "!**/__pycache__/**",
     "!**/*.pyc",

--- a/tests/omp/omp-plugin.test.js
+++ b/tests/omp/omp-plugin.test.js
@@ -1,0 +1,314 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { pathToFileURL } = require('url');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const pkg = require(path.join(repoRoot, 'package.json'));
+const toolFactory = require(path.join(repoRoot, 'omp/tools/index.js'));
+const extensionModuleUrl = `${pathToFileURL(path.join(repoRoot, 'omp/extension.mjs')).href}?test=${Date.now()}`;
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function schemaStub() {
+  const chain = () => ({ optional: chain, default: chain, describe: chain });
+  return {
+    object: () => chain(),
+    string: chain,
+    boolean: chain,
+    number: chain,
+    enum: () => chain(),
+  };
+}
+
+async function withEnv(overrides, fn) {
+  const original = {};
+  for (const key of Object.keys(overrides)) {
+    original[key] = process.env[key];
+    if (overrides[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = overrides[key];
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function loadExtension() {
+  const module = await import(extensionModuleUrl);
+  return module.default;
+}
+
+async function captureExtensionHandlers() {
+  const handlers = {};
+  const extension = await loadExtension();
+  extension({
+    zod: schemaStub(),
+    setLabel() {},
+    registerCommand() {},
+    on(event, handler) {
+      handlers[event] = handler;
+    },
+  });
+  return handlers;
+}
+
+function tempWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-omp-plugin-'));
+}
+
+function sessionDir(cwd) {
+  return path.join(cwd, '.ecc', 'omp-session');
+}
+
+function createTools(options = {}) {
+  return toolFactory({
+    cwd: options.cwd || repoRoot,
+    zod: schemaStub(),
+    exec: options.exec || (async () => ({ code: 0, stdout: '', stderr: '' })),
+  });
+}
+
+function getTool(tools, name) {
+  const tool = tools.find((entry) => entry.name === name);
+  assert.ok(tool, `Expected tool ${name}`);
+  return tool;
+}
+
+function assertEnvelope(result, expectedStatus) {
+  assert.ok(result, 'Expected a result object');
+  assert.ok(Array.isArray(result.content), 'Expected content array');
+  assert.strictEqual(typeof result.content[0].text, 'string');
+  assert.ok(result.details, 'Expected details payload');
+  assert.strictEqual(result.details.status, expectedStatus);
+  assert.strictEqual(typeof result.details.summary, 'string');
+  assert.ok(Array.isArray(result.details.next_actions), 'Expected next_actions array');
+  assert.ok(Array.isArray(result.details.artifacts), 'Expected artifacts array');
+  assert.ok(Object.prototype.hasOwnProperty.call(result.details, 'data'));
+  assert.ok(Object.prototype.hasOwnProperty.call(result.details, 'error'));
+}
+
+console.log('\n=== Testing OMP plugin adapter ===\n');
+
+test('package manifest exposes OMP runtime adapter paths', () => {
+  assert.ok(pkg.omp, 'Expected package.json#omp');
+  assert.deepStrictEqual(pkg.omp.extensions, ['./omp/extension.mjs']);
+  assert.deepStrictEqual(pkg.omp.tools, ['./omp/tools/index.js']);
+  assert.deepStrictEqual(pkg.omp.commands, ['./commands']);
+  assert.ok(!Object.prototype.hasOwnProperty.call(pkg.omp, 'hooks'), 'Expected package.json#omp.hooks to be absent');
+  assert.ok(pkg.files.includes('omp/'), 'Expected npm package files to include omp/');
+});
+
+test('OMP manifest paths exist', () => {
+  for (const entry of [...pkg.omp.extensions, ...pkg.omp.tools, ...pkg.omp.commands]) {
+    assert.ok(fs.existsSync(path.join(repoRoot, entry)), `${entry} should exist`);
+  }
+});
+
+test('tool factory registers seven OMP tools', () => {
+  const tools = createTools();
+  assert.strictEqual(tools.length, 7);
+  assert.deepStrictEqual(tools.map((tool) => tool.name).sort(), [
+    'ecc_changed_files',
+    'ecc_check_coverage',
+    'ecc_format_code',
+    'ecc_git_summary',
+    'ecc_lint_check',
+    'ecc_run_tests',
+    'ecc_security_audit',
+  ].sort());
+});
+
+test('tool factory fails fast without a compatible zod helper', () => {
+  assert.throws(
+    () => toolFactory({ cwd: repoRoot, exec: async () => ({ code: 0, stdout: '', stderr: '' }) }),
+    /compatible zod schema helper/
+  );
+});
+
+test('OMP tools expose stable observation envelopes', async () => {
+  const cwd = tempWorkspace();
+  fs.writeFileSync(path.join(cwd, 'package-lock.json'), '{}\n');
+  fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify({ devDependencies: { jest: '^29.0.0' } }, null, 2));
+  fs.writeFileSync(path.join(cwd, 'eslint.config.js'), 'module.exports = [];');
+
+  const tools = createTools({
+    cwd,
+    exec: async (_command, args) => {
+      const key = args.join(' ');
+      if (key === 'branch --show-current') return { code: 0, stdout: 'main\n', stderr: '' };
+      if (key === 'status --short') return { code: 0, stdout: ' M package.json\n', stderr: '' };
+      if (key === 'log --oneline -5') return { code: 0, stdout: 'abc123 test commit\n', stderr: '' };
+      if (key === 'diff --cached --stat') return { code: 0, stdout: '', stderr: '' };
+      if (key === 'diff main...HEAD --stat') return { code: 0, stdout: ' package.json | 1 +\n', stderr: '' };
+      return { code: 1, stdout: '', stderr: `unexpected exec call: ${key}` };
+    },
+  });
+
+  const runTests = await getTool(tools, 'ecc_run_tests').execute('1', { coverage: true }, null, { cwd });
+  assertEnvelope(runTests, 'success');
+  assert.match(runTests.details.data.command, /^npm run test -- --coverage$/);
+
+  const coverage = await getTool(tools, 'ecc_check_coverage').execute('2', { threshold: 80 }, null, { cwd });
+  assertEnvelope(coverage, 'warning');
+
+  const audit = await getTool(tools, 'ecc_security_audit').execute('3', { type: 'code' }, null, { cwd });
+  assertEnvelope(audit, 'success');
+
+  const format = await getTool(tools, 'ecc_format_code').execute('4', { filePath: 'src/example.js' }, null, { cwd });
+  assertEnvelope(format, 'success');
+
+  const lint = await getTool(tools, 'ecc_lint_check').execute('5', { target: 'src' }, null, { cwd });
+  assertEnvelope(lint, 'success');
+
+  const git = await getTool(tools, 'ecc_git_summary').execute('6', { baseBranch: 'main', depth: 5 }, null, { cwd });
+  assertEnvelope(git, 'success');
+
+  const changed = await getTool(tools, 'ecc_changed_files').execute('7', { format: 'json' }, null, { cwd });
+  assertEnvelope(changed, 'success');
+});
+
+test('coverage parse failures return structured error envelopes', async () => {
+  const cwd = tempWorkspace();
+  fs.mkdirSync(path.join(cwd, 'coverage'), { recursive: true });
+  fs.writeFileSync(path.join(cwd, 'coverage', 'coverage-summary.json'), '{not-json');
+  const tools = createTools({ cwd });
+  const result = await getTool(tools, 'ecc_check_coverage').execute('8', { threshold: 80 }, null, { cwd });
+  assertEnvelope(result, 'error');
+  assert.match(result.details.summary, /could not be parsed/);
+});
+
+test('git summary rejects invalid base branches with a structured error envelope', async () => {
+  const tools = createTools({ cwd: repoRoot });
+  const result = await getTool(tools, 'ecc_git_summary').execute('9', { baseBranch: '../bad' }, null, { cwd: repoRoot });
+  assertEnvelope(result, 'error');
+  assert.match(result.details.summary, /Invalid baseBranch/);
+});
+
+test('extension registers all markdown commands and core hook events', async () => {
+  const extension = await loadExtension();
+  const commands = [];
+  const events = [];
+  const pi = {
+    zod: schemaStub(),
+    setLabel(label) { assert.strictEqual(label, 'ECC for OMP'); },
+    registerCommand(name, definition) {
+      commands.push({ name, definition });
+      assert.ok(definition.description, `${name} should have description`);
+      assert.strictEqual(typeof definition.handler, 'function');
+    },
+    on(event, handler) {
+      events.push(event);
+      assert.strictEqual(typeof handler, 'function');
+    },
+  };
+  extension(pi);
+  const commandFiles = fs.readdirSync(path.join(repoRoot, 'commands')).filter((file) => file.endsWith('.md'));
+  assert.strictEqual(commands.length, commandFiles.length);
+  for (const event of ['session_start', 'tool_call', 'tool_result', 'session_before_compact', 'turn_end', 'session_shutdown']) {
+    assert.ok(events.includes(event), `Expected event ${event}`);
+  }
+});
+
+test('bash no-verify guard scopes shorthand to supported git subcommands', async () => {
+  await withEnv({ ECC_DISABLED_HOOKS: undefined, ECC_HOOK_PROFILE: undefined }, async () => {
+    const cwd = tempWorkspace();
+    const handlers = await captureExtensionHandlers();
+
+    const allowed = await handlers.tool_call(
+      { toolName: 'bash', input: { command: 'git log -n 5' } },
+      { cwd }
+    );
+    const blockedShort = await handlers.tool_call(
+      { toolName: 'bash', input: { command: 'git commit -n -m "test"' } },
+      { cwd }
+    );
+    const blockedLong = await handlers.tool_call(
+      { toolName: 'bash', input: { command: 'git commit --no-verify -m "test"' } },
+      { cwd }
+    );
+
+    assert.strictEqual(allowed, undefined);
+    assert.strictEqual(blockedShort?.block, true);
+    assert.match(blockedShort?.reason || '', /--no-verify bypass/);
+    assert.strictEqual(blockedLong?.block, true);
+    assert.match(blockedLong?.reason || '', /--no-verify bypass/);
+  });
+});
+
+test('lifecycle handlers do not create state files without opt-in env gates', async () => {
+  await withEnv({ ECC_OMP_METRICS: undefined, ECC_OMP_SESSION_MARKERS: undefined, ECC_HOOK_PROFILE: undefined }, async () => {
+    const cwd = tempWorkspace();
+    const handlers = await captureExtensionHandlers();
+    await handlers.session_start({}, { cwd, ui: { notify() {} } });
+    await handlers.session_before_compact({}, { cwd });
+    await handlers.turn_end({}, { cwd });
+    await handlers.session_shutdown({}, { cwd });
+    assert.strictEqual(fs.existsSync(sessionDir(cwd)), false, 'Expected lifecycle handlers to avoid creating .ecc/omp-session by default');
+  });
+});
+
+test('lifecycle telemetry and session markers write state only when opted in', async () => {
+  await withEnv({ ECC_OMP_METRICS: '1', ECC_OMP_SESSION_MARKERS: '1', ECC_HOOK_PROFILE: undefined }, async () => {
+    const cwd = tempWorkspace();
+    const handlers = await captureExtensionHandlers();
+    await handlers.turn_end({}, { cwd });
+    await handlers.session_shutdown({}, { cwd });
+
+    const metrics = JSON.parse(fs.readFileSync(path.join(sessionDir(cwd), 'metrics.json'), 'utf8'));
+    const lifecycle = fs.readFileSync(path.join(sessionDir(cwd), 'session-lifecycle.jsonl'), 'utf8').trim().split('\n');
+    assert.strictEqual(metrics.turns, 1);
+    assert.strictEqual(lifecycle.length, 1);
+    assert.strictEqual(JSON.parse(lifecycle[0]).event, 'session_shutdown');
+  });
+});
+
+test('gitignore excludes OMP runtime session state', () => {
+  const gitignore = fs.readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
+  assert.ok(gitignore.split(/\r?\n/).includes('.ecc/omp-session/'));
+});
+
+async function run() {
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      console.log(`  PASS ${name}`);
+      passed++;
+    } catch (error) {
+      console.log(`  FAIL ${name}`);
+      console.log(`    Error: ${error.message}`);
+      failed++;
+    }
+  }
+
+  if (failed > 0) {
+    console.log(`\nFailed: ${failed}`);
+    process.exit(1);
+  }
+
+  console.log(`\nPassed: ${passed}`);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -73,6 +73,7 @@ function buildExpectedPublishPaths(repoRoot) {
     "scripts/codex/merge-codex-config.js",
     "scripts/codex/merge-mcp-config.js",
     ".codex-plugin",
+    "omp",
     "plugins/ecc",
     ".mcp.json",
     "install.sh",
@@ -152,6 +153,8 @@ function main() {
         "assets/hero.png",
         "schemas/install-state.schema.json",
         "skills/backend-patterns/SKILL.md",
+        "omp/extension.mjs",
+        "omp/tools/index.js",
       ]) {
         assert.ok(
           packagedPaths.has(requiredPath),


### PR DESCRIPTION
## What Changed
- rebased the branch onto latest `main` and reduced this PR to the OMP-only harness-contract slice requested in review
- added the OMP manifest surface in `package.json#omp` with a single native extension entrypoint, curated tool port, and commands directory; `omp.hooks` remains absent
- added `omp/extension.mjs` for native OMP lifecycle handling and guarded `.ecc/omp-session/` state writes
- added `omp/tools/index.js` with deterministic `details` envelopes across all seven ECC OMP tools
- added `tests/omp/omp-plugin.test.js` to cover manifest shape, seven-tool registration, structured success/warning/error envelopes, invalid git-summary base branches, hook registration, and opt-in lifecycle state writes
- updated `tests/scripts/npm-publish-surface.test.js` and `package.json#files` so the published package includes the OMP runtime surface
- narrowed the `git -n` no-verify guard to supported git subcommands and removed in-place mutation from OMP session-state updates
- added `.ecc/omp-session/` to `.gitignore`

## Why This Change
Fixes the OMP harness drift tracked in #2269.

Also updates PR #2270 to match maintainer feedback: this branch now contains only the OMP harness-contract work. Workflow/release, OpenCode, docs, and Python/provider changes were removed from this PR and will need follow-up PRs.

## Testing Done
- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js` via `npm test` / `npm run coverage`)
- [x] Edge cases considered and tested

Commands run:
- `node tests/omp/omp-plugin.test.js`
- `node tests/scripts/npm-publish-surface.test.js`
- `npm run lint`
- `npm run coverage`

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)
