### PR TITLE
docs(code-tour): document the ref field so PR tours don't break with "file not found"

### DIFF
--- a/skills/code-tour/SKILL.md
+++ b/skills/code-tour/SKILL.md
@@ -92,7 +92,24 @@ Before finishing:
 - every referenced path exists
 - every line or selection is valid
 - the first step is anchored to a real file or directory
+- the `ref` points at a branch or commit that actually has every file the tour references (see below)
 - the tour tells a coherent story rather than listing files
+
+## The `ref` Field
+
+`ref` ties the tour to a git branch or commit. It matters more than it looks: when `ref` is not the branch the reader has checked out, CodeTour opens each step's file from that revision in git, not from the files on disk. If a file is not in that revision, the step will not open — the reader sees *"The editor could not be opened because the file was not found"* even though the file is sitting right there. The tour and its comments still show, so the real cause is easy to miss.
+
+Pick `ref` by tour type:
+
+| Tour type | Set `ref` to |
+| --- | --- |
+| PR tour | the PR branch — never the base branch |
+| Onboarding / architecture | the branch the reader will be on (often `main`), or leave it out |
+| Not sure | leave `ref` out, so CodeTour reads files straight from disk |
+
+The PR case is the common trap: a PR usually adds new files, and new files do not exist on the base branch yet. Point `ref` at the base (e.g. `develop`) and every step on a new file fails to open.
+
+Before finishing, confirm each step's file actually exists at the `ref` you chose.
 
 ## Step Types
 


### PR DESCRIPTION
## What this fixes

The `code-tour` skill helps generate CodeTour `.tour` walkthrough files. When someone uses it to make a **PR review tour**, the tour would render in the sidebar — titles, steps, comments all visible — but clicking a step often failed with *"The editor could not be opened because the file was not found,"* even though the file was clearly there on disk. Confusing and hard to diagnose.

## Why it happens

A `.tour` file has a `ref` field that pins it to a git revision. CodeTour doesn't just store that for reference — when `ref` points at a revision other than what you have checked out, it tries to load each step's file **content from that revision in git**, not from your working copy.

The skill only ever showed `ref` in a single example with no explanation. So when generating a "tour this PR against develop" walkthrough, the natural choice was to set `ref` to the base branch (`develop`). But a PR's whole point is that it **adds** files — and those new files don't exist on `develop` yet. So every step pointing at a new file failed to load, while the tour shell still rendered (that part comes from the `.tour` JSON, which is always present).

## The change

Documentation-only update to the skill:

- Adds a **"The `ref` Field"** section explaining how CodeTour resolves files from `ref`, the exact error it causes, and the rule that **PR tours must pin `ref` to the branch head, never the base** (or omit `ref` to always read the working tree).
- Adds a validation step: confirm every referenced file actually exists at the chosen `ref` before finishing.

## Impact

No code, no behavior change in any tool — it teaches the skill to generate correct `ref` values so future PR tours open their files reliably.
