### PR TITLE
fix(tests): resolve 10 failing tests on Windows

### DIFF
--- a/scripts/lib/resolve-formatter.js
+++ b/scripts/lib/resolve-formatter.js
@@ -9,6 +9,7 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 // ── Caches (per-process, cleared on next hook invocation) ───────────
@@ -58,8 +59,12 @@ const FORMATTER_PACKAGES = {
 function findProjectRoot(startDir) {
   if (projectRootCache.has(startDir)) return projectRootCache.get(startDir);
 
+  const homeDir = os.homedir();
   let dir = startDir;
   while (dir !== path.dirname(dir)) {
+    // Stop before checking the home directory to avoid treating global
+    // dotfiles (e.g. ~/.prettierrc) as a project root marker.
+    if (dir === homeDir) break;
     for (const marker of PROJECT_ROOT_MARKERS) {
       if (fs.existsSync(path.join(dir, marker))) {
         projectRootCache.set(startDir, dir);

--- a/tests/scripts/instinct-cli-projects.test.js
+++ b/tests/scripts/instinct-cli-projects.test.js
@@ -17,6 +17,23 @@ const cliPath = path.join(
   'instinct-cli.py'
 );
 
+function detectPython3() {
+  for (const bin of ['python3', 'python']) {
+    const r = spawnSync(bin, ['--version'], { encoding: 'utf8' });
+    if (r.status === 0 && /Python 3/.test(r.stdout + r.stderr)) return bin;
+  }
+  return null;
+}
+
+const PYTHON3 = detectPython3();
+if (!PYTHON3) {
+  console.log('\n=== Testing instinct-cli.py projects maintenance ===\n');
+  console.log('  - skipped: Python 3 not found in PATH');
+  console.log('\nPassed: 0');
+  console.log('Failed: 0');
+  process.exit(0);
+}
+
 function test(name, fn) {
   try {
     fn();
@@ -101,7 +118,7 @@ function runGit(cwd, args) {
 }
 
 function runCli(root, args, options = {}) {
-  return spawnSync('python3', [cliPath, ...args], {
+  return spawnSync(PYTHON3, [cliPath, ...args], {
     cwd: options.cwd || repoRoot,
     encoding: 'utf8',
     env: {


### PR DESCRIPTION
## Summary
- `resolve-formatter`: stop `findProjectRoot` walk before `os.homedir()` to avoid mistaking global dotfiles (e.g. `~/.prettierrc`) for a project root on Windows
- `instinct-cli-projects`: detect `python3`/`python` binary at runtime; skip gracefully when Python 3 is unavailable instead of crashing with `null` status
- `command-registry`: regenerate `COMMAND-REGISTRY.json` (was stale)

## Test plan
- [x] `node tests/lib/resolve-formatter.test.js` - 18/18 passing
- [x] `node tests/scripts/instinct-cli-projects.test.js` - 9/9 passing
- [x] `npm test` - 2804/2804 passing

?? Generated with [Claude Code](https://claude.com/claude-code)