### PR TITLE
fix(opencode): sync plugin metadata counts

### DIFF
--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -48,9 +48,9 @@ export const metadata = {
   description: "Everything Claude Code plugin for OpenCode",
   author: "affaan-m",
   features: {
-    agents: 13,
-    commands: 31,
-    skills: 37,
+    agents: 65,
+    commands: 85,
+    skills: 262,
     hookEvents: [
       "file.edited",
       "tool.execute.before",

--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -48,9 +48,9 @@ export const metadata = {
   description: "Everything Claude Code plugin for OpenCode",
   author: "affaan-m",
   features: {
-    agents: 65,
-    commands: 85,
-    skills: 262,
+    agents: 16,
+    commands: 40,
+    skills: 65,
     hookEvents: [
       "file.edited",
       "tool.execute.before",


### PR DESCRIPTION
## Summary
Sync plugin metadata feature counts in `.opencode/index.ts` with current repository capabilities.

## Why
The previous values were stale and could mislead users/tools that read plugin metadata.

## Changes
- Updated `metadata.features.agents`
- Updated `metadata.features.commands`
- Updated `metadata.features.skills`

## Validation
- Verified file diff contains only `.opencode/index.ts`