### PR TITLE
feat(skills): harden the file upload validation section in django-security

### DIFF
--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -412,7 +412,7 @@ def validate_file_type(value):
     value.seek(0)
 
     if mime not in ALLOWED_MIMES:
-        raise ValidationError(f'Unsupported file type: {mime}')
+        raise ValidationError('Unsupported file type.')
 
     ext = os.path.splitext(value.name)[1].lower()
     if ext not in MIME_TO_EXTENSIONS.get(mime, set()):

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -392,27 +392,63 @@ def webhook_view(request):
 
 ```python
 import os
+import magic  # pip install python-magic
 from django.core.exceptions import ValidationError
 
-def validate_file_extension(value):
-    """Validate file extension."""
-    ext = os.path.splitext(value.name)[1]
-    valid_extensions = ['.jpg', '.jpeg', '.png', '.gif', '.pdf']
-    if not ext.lower() in valid_extensions:
-        raise ValidationError('Unsupported file extension.')
+ALLOWED_MIMES = {
+    'image/jpeg', 'image/png', 'image/gif', 'application/pdf',
+}
+
+MIME_TO_EXTENSIONS = {
+    'image/jpeg': {'.jpg', '.jpeg'},
+    'image/png': {'.png'},
+    'image/gif': {'.gif'},
+    'application/pdf': {'.pdf'},
+}
+
+def validate_file_type(value):
+    """Validate file type using magic bytes and cross-check extension."""
+    mime = magic.from_buffer(value.read(2048), mime=True)
+    value.seek(0)
+
+    if mime not in ALLOWED_MIMES:
+        raise ValidationError(f'Unsupported file type: {mime}')
+
+    ext = os.path.splitext(value.name)[1].lower()
+    if ext not in MIME_TO_EXTENSIONS.get(mime, set()):
+        raise ValidationError('File extension does not match file content.')
 
 def validate_file_size(value):
     """Validate file size (max 5MB)."""
-    filesize = value.size
-    if filesize > 5 * 1024 * 1024:
+    if value.size > 5 * 1024 * 1024:
         raise ValidationError('File too large. Max size is 5MB.')
 
 # models.py
 class Document(models.Model):
     file = models.FileField(
         upload_to='documents/',
-        validators=[validate_file_extension, validate_file_size]
+        validators=[validate_file_type, validate_file_size]
     )
+
+```
+
+For environments where installing libmagic is difficult (e.g., minimal containers),
+use the pure-Python `filetype` package as an alternative:
+
+```python
+import filetype  # pip install filetype
+
+def validate_file_type(value):
+    """Validate file type using magic bytes."""
+    kind = filetype.guess(value.read(2048))
+    value.seek(0)
+
+    if kind is None or kind.mime not in ALLOWED_MIMES:
+        raise ValidationError('Unsupported file type.')
+
+    ext = os.path.splitext(value.name)[1].lower()
+    if ext not in MIME_TO_EXTENSIONS.get(kind.mime, set()):
+        raise ValidationError('File extension does not match file content.')
 ```
 
 ### Secure File Storage

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -436,6 +436,20 @@ For environments where installing libmagic is difficult (e.g., minimal container
 use the pure-Python `filetype` package as an alternative:
 
 ```python
+import os
+from django.core.exceptions import ValidationError
+
+ALLOWED_MIMES = {
+    'image/jpeg', 'image/png', 'image/gif', 'application/pdf',
+}
+
+MIME_TO_EXTENSIONS = {
+    'image/jpeg': {'.jpg', '.jpeg'},
+    'image/png': {'.png'},
+    'image/gif': {'.gif'},
+    'application/pdf': {'.pdf'},
+}
+
 import filetype  # pip install filetype
 
 def validate_file_type(value):

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -439,6 +439,8 @@ use the pure-Python `filetype` package as an alternative:
 import os
 from django.core.exceptions import ValidationError
 
+import filetype  # pip install filetype
+
 ALLOWED_MIMES = {
     'image/jpeg', 'image/png', 'image/gif', 'application/pdf',
 }
@@ -449,8 +451,6 @@ MIME_TO_EXTENSIONS = {
     'image/gif': {'.gif'},
     'application/pdf': {'.pdf'},
 }
-
-import filetype  # pip install filetype
 
 def validate_file_type(value):
     """Validate file type using magic bytes."""


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

Replaced the insecure extension-only file validation in the Django Security skill with magic byte validation using python-magic (with a pure-Python filetype alternative). The validator now reads file signatures to determine actual MIME type and cross-checks against the declared extension.

## Why This Change
<!-- Explain the motivation and context for this change -->

Extension-based file validation is trivially bypassed by renaming files. Magic byte inspection verifies the actual file content, providing meaningful upload security rather than a false sense of safety.


## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)
