### PR TITLE
refactor(commands): remove duplicated content in skill-create and learn-eval

### DIFF
--- a/commands/learn-eval.md
+++ b/commands/learn-eval.md
@@ -64,14 +64,14 @@ origin: auto-extracted
 
    ### 5b. Holistic verdict
 
-   Synthesize the checklist results and draft quality, then choose **one** of the following:
+   Synthesize the checklist results and draft quality, then choose **one** of the following (Step 6 defines the action each verdict triggers):
 
-   | Verdict | Meaning | Next Action |
-   |---------|---------|-------------|
-   | **Save** | Unique, specific, well-scoped | Proceed to Step 6 |
-   | **Improve then Save** | Valuable but needs refinement | List improvements → revise → re-evaluate (once) |
-   | **Absorb into [X]** | Should be appended to an existing skill | Show target skill and additions → Step 6 |
-   | **Drop** | Trivial, redundant, or too abstract | Explain reasoning and stop |
+   | Verdict | Meaning |
+   |---------|---------|
+   | **Save** | Unique, specific, well-scoped |
+   | **Improve then Save** | Valuable but needs refinement |
+   | **Absorb into [X]** | Should be appended to an existing skill |
+   | **Drop** | Trivial, redundant, or too abstract |
 
 **Guideline dimensions** (informing the verdict, not scored):
 

--- a/commands/skill-create.md
+++ b/commands/skill-create.md
@@ -102,59 +102,6 @@ Prefix commits with: feat:, fix:, chore:, docs:, test:, refactor:
 - {percentage}% follow conventional commit format
 ```
 
-## Example Output
-
-Running `/skill-create` on a TypeScript project might produce:
-
-```markdown
----
-name: my-app-patterns
-description: Coding patterns from my-app repository
-version: 1.0.0
-source: local-git-analysis
-analyzed_commits: 150
----
-
-# My App Patterns
-
-## Commit Conventions
-
-This project uses **conventional commits**:
-- `feat:` - New features
-- `fix:` - Bug fixes
-- `chore:` - Maintenance tasks
-- `docs:` - Documentation updates
-
-## Code Architecture
-
-```
-src/
-├── components/     # React components (PascalCase.tsx)
-├── hooks/          # Custom hooks (use*.ts)
-├── utils/          # Utility functions
-├── types/          # TypeScript type definitions
-└── services/       # API and external services
-```
-
-## Workflows
-
-### Adding a New Component
-1. Create `src/components/ComponentName.tsx`
-2. Add tests in `src/components/__tests__/ComponentName.test.tsx`
-3. Export from `src/components/index.ts`
-
-### Database Migration
-1. Modify `src/db/schema.ts`
-2. Run `pnpm db:generate`
-3. Run `pnpm db:migrate`
-
-## Testing Patterns
-
-- Test files: `__tests__/` directories or `.test.ts` suffix
-- Coverage target: 80%+
-- Framework: Vitest
-```
-
 ## GitHub App Integration
 
 For advanced features (10k+ commits, team sharing, auto-PRs), use the [Skill Creator GitHub App](https://github.com/apps/skill-creator):


### PR DESCRIPTION
## What Changed

Removed duplicated content from two workflow-extraction command docs:

- **`commands/skill-create.md`** — dropped the `## Example Output` section (53 lines). The `Step 3: Generate SKILL.md` template already defines the output structure (`name` / `description` frontmatter, Commit Conventions, Code Architecture, Workflows, Testing Patterns); the Example Output just re-rendered the same skeleton with filled-in `my-app` values.
- **`commands/learn-eval.md`** — dropped the `Next Action` column from the 5b verdict table. It duplicated Step 6's "Verdict-specific confirmation flow". The table now carries `Verdict | Meaning`, and the intro points to Step 6 as the single source for each verdict's action.

Net: −53 lines, no information lost (each removed piece is still defined exactly once elsewhere in the same file).

## Why This Change

Both files state the same thing twice, which invites drift — editing the template or Step 6 without updating its duplicate. Removing the redundant copy keeps a single source of truth and aligns with CONTRIBUTING's "focused, modular" guidance. Pure cleanup; no behavior or design changes.

## Testing Done

- [x] `node scripts/ci/validate-commands.js` — 92 command files validated, exit 0
- [x] `npm run command-registry:check` — registry up to date (no frontmatter changes)
- [x] `npx markdownlint commands/learn-eval.md commands/skill-create.md` — clean
- [x] Reviewed the rendered diff — removed content is duplicated elsewhere in each file

## Type of Change

- [x] `refactor:` Code refactoring (documentation dedup)

## Notes

Intentionally left taste-level content untouched (e.g. learn-eval's "Design Rationale" decision record). No frontmatter, behavior, or runtime changes.
