### PR TITLE
Add memxus configuration to mcp-servers.json

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -122,6 +122,14 @@
       "args": ["-y", "@magicuidesign/mcp@latest"],
       "description": "Magic UI components"
     },
+    "memxus": {
+      "type": "http",
+      "url": "https://mcp.memxus.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MEMXUS_API_KEY_HERE"
+      },
+      "description": "Universal persistent memory across Claude Code, Cursor, Gemini CLI and any AI tool — save context once, recall it in every session. Connects GitHub + Notion automatically. Free at memxus.com"
+    },
     "filesystem": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/your/projects"],

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -128,7 +128,7 @@
       "headers": {
         "Authorization": "Bearer YOUR_MEMXUS_API_KEY_HERE"
       },
-      "description": "Universal persistent memory across Claude Code, Cursor, Gemini CLI and any AI tool — save context once, recall it automatically. Note: review stored memories before use in production agents to avoid prompt-injection via memory-poisoning. Free at memxus.com"
+      "description": "Universal persistent memory across Claude Code, Cursor, Gemini CLI and any AI tool — save context once, auto-recalled in every session. Note: review stored memories before use in production agents to avoid prompt-injection via memory-poisoning. Free at memxus.com"
     },
     "filesystem": {
       "command": "npx",

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -128,7 +128,7 @@
       "headers": {
         "Authorization": "Bearer YOUR_MEMXUS_API_KEY_HERE"
       },
-      "description": "Universal persistent memory across Claude Code, Cursor, Gemini CLI and any AI tool — save context once, recall it in every session. Connects GitHub + Notion automatically. Free at memxus.com"
+      "description": "Universal persistent memory across Claude Code, Cursor, Gemini CLI and any AI tool — save context once, recall it automatically. Note: review stored memories before use in production agents to avoid prompt-injection via memory-poisoning. Free at memxus.com"
     },
     "filesystem": {
       "command": "npx",


### PR DESCRIPTION
## What Changed
Added Memxus to `mcp-configs/mcp-servers.json` as a remote HTTP MCP server for persistent memory.

## Why This Change
Memxus is a universal persistent memory layer for AI tools — saves context once across Claude Code, Cursor, Gemini CLI and any MCP-compatible tool, and recalls it automatically in every session. Connects GitHub + Notion as context sources. Free tier available at memxus.com.

Listed on: registry.modelcontextprotocol.io, Glama and Smithery

## Testing Done
- [x] Manual testing completed — endpoint https://mcp.memxus.com/mcp responds correctly
- [x] JSON validates cleanly
- [x] No secrets committed (uses YOUR_MEMXUS_API_KEY_HERE placeholder)

## Type of Change
- [x] `feat:` New feature

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] Follows conventional commits format
