### PR TITLE
fix(observer): replace hardcoded sleep 2 with PID file poll in start-observer.sh

### DIFF
--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -215,7 +215,11 @@ case "$ACTION" in
       CLV2_OBSERVER_PROMPT_PATTERN="$CLV2_OBSERVER_PROMPT_PATTERN" \
       "$OBSERVER_LOOP_SCRIPT" >> "$LOG_FILE" 2>&1 &
 
-    # Wait for PID file (poll up to 10s, exits early when it appears)
+    # Wait for PID file (poll up to 10s, exits early when it appears).
+    # Trade-off vs the old `sleep 2`: healthy startups return in iteration 1
+    # (no fixed latency), but a loop that crashes before writing the PID file
+    # is now detected in ~10s instead of ~2s. The longer ceiling is needed to
+    # tolerate slow filesystems where 2s under-waited and false-negatived.
     for _i in $(seq 1 50); do [ -f "$PID_FILE" ] && break; sleep 0.2; done
 
     # Check for confirmation-seeking output in the observer log

--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -215,8 +215,8 @@ case "$ACTION" in
       CLV2_OBSERVER_PROMPT_PATTERN="$CLV2_OBSERVER_PROMPT_PATTERN" \
       "$OBSERVER_LOOP_SCRIPT" >> "$LOG_FILE" 2>&1 &
 
-    # Wait for PID file
-    sleep 2
+    # Wait for PID file (poll up to 10s, exits early when it appears)
+    for _i in $(seq 1 50); do [ -f "$PID_FILE" ] && break; sleep 0.2; done
 
     # Check for confirmation-seeking output in the observer log
     if tail -n +"$((start_line + 1))" "$LOG_FILE" 2>/dev/null | grep -E -i -q "$CLV2_OBSERVER_PROMPT_PATTERN"; then

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -3156,7 +3156,9 @@ async function runTests() {
       const startObserverSource = fs.readFileSync(path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'agents', 'start-observer.sh'), 'utf8');
 
       assert.ok(!/^\s*sleep 2\s*$/m.test(startObserverSource), 'start-observer.sh should not use the fixed `sleep 2` wait after spawning the observer loop');
-      assert.ok(/for _i in \$\(seq 1 50\); do \[ -f "\$PID_FILE" \] && break; sleep 0\.2; done/.test(startObserverSource), 'start-observer.sh should poll $PID_FILE (50 × 0.2s) so startup tolerates slow filesystems');
+      assert.ok(/\bseq 1 \d+\b/.test(startObserverSource), 'start-observer.sh should bound PID-file polling to a finite iteration count');
+      assert.ok(/\[ -f "\$PID_FILE" \] && break/.test(startObserverSource), 'start-observer.sh should exit polling as soon as $PID_FILE appears');
+      assert.ok(/sleep 0\.\d+/.test(startObserverSource), 'start-observer.sh should poll at sub-second intervals so healthy startups do not pay multi-second latency');
     })
   )
     passed++;

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -3151,6 +3151,17 @@ async function runTests() {
     passed++;
   else failed++;
 
+  if (
+    test('start-observer waits for PID file via poll instead of fixed sleep (#2295)', () => {
+      const startObserverSource = fs.readFileSync(path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'agents', 'start-observer.sh'), 'utf8');
+
+      assert.ok(!/^\s*sleep 2\s*$/m.test(startObserverSource), 'start-observer.sh should not use the fixed `sleep 2` wait after spawning the observer loop');
+      assert.ok(/for _i in \$\(seq 1 50\); do \[ -f "\$PID_FILE" \] && break; sleep 0\.2; done/.test(startObserverSource), 'start-observer.sh should poll $PID_FILE (50 × 0.2s) so startup tolerates slow filesystems');
+    })
+  )
+    passed++;
+  else failed++;
+
   if (SKIP_BASH) {
     console.log('  ⊘ detect-project exports the resolved Python command (skipped on Windows)');
     passed++;


### PR DESCRIPTION
## Summary

- `start-observer.sh` waited for the spawned observer loop to write `$PID_FILE` with a hardcoded `sleep 2`. On slow filesystems / loaded hosts that's not always enough — the subsequent `[ -f "$PID_FILE" ]` check false-negatives and the script prints "Failed to start observer" even though the loop is alive. On healthy systems the 2 s is pure latency.
- Replace with a 50-iteration poll that exits as soon as the file appears: `for _i in $(seq 1 50); do [ -f "$PID_FILE" ] && break; sleep 0.2; done` (10 s max wait, typically returns in iteration 1).
- The snippet is taken verbatim from the issue. `set -e` interaction is safe — LHS of `&&` is exempt.
- Adds 1 regression test in `tests/hooks/hooks.test.js`, sibling to the existing `observer-loop` invariant-guard block, asserting the script never reverts to `sleep 2` and keeps the poll line.

Closes #2295

## Test plan

- [x] `node tests/run-all.js` on Node v22.18.0 → **2892 passed / 0 failed** (including the new regression test)
- [x] `shellcheck skills/continuous-learning-v2/agents/start-observer.sh` → clean on the changed lines (only a pre-existing SC1091 info at line 31, unrelated)
- [x] Manual: `start-observer.sh start` / `stop` / `status` cycle on macOS — PID file consistently observed in iteration 1