### PR TITLE
feat(workflows): add orch-review native Workflow pilot

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -34,18 +34,22 @@ Workflow({
 })
 ```
 
+Invalid input throws (the gate **fails closed**): a missing/empty `diff`, malformed JSON, or a non-array `changedFiles` is rejected with a clear error rather than silently approving an unreviewed payload.
+
 ### Returns
 
 ```jsonc
 {
-  "verdict": "APPROVE" | "CHANGES_REQUESTED",
+  "verdict": "APPROVE" | "CHANGES_REQUESTED", // CHANGES_REQUESTED if any blocker OR a dimension failed
+  "incomplete": false,            // true when one or more review dimensions failed to run
+  "failedDimensions": [ /* { dimension, error } — e.g. a security reviewer that died */ ],
   "blocking": [ /* confirmed CRITICAL/HIGH — must clear before Gate 2 */ ],
   "advisory": [ /* MEDIUM/LOW + adversarially-refuted findings */ ],
-  "stats": { "dimensions": 3, "raw": 11, "unique": 4, "verified": 4, "refuted": 0 }
+  "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4, "verified": 4, "refuted": 0 }
 }
 ```
 
-The main loop presents `blocking` at Gate 2; the human still approves the commit.
+The main loop presents `blocking` at Gate 2; the human still approves the commit. If a reviewer agent dies (terminal error or skip), that dimension is recorded in `failedDimensions` and the verdict never reports a clean `APPROVE` — an unreviewed security dimension must not pass as approved.
 
 ## Not in this PR (follow-ups)
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -43,13 +43,13 @@ Invalid input throws (the gate **fails closed**): a missing/empty `diff`, malfor
   "verdict": "APPROVE" | "CHANGES_REQUESTED", // CHANGES_REQUESTED if any blocker OR a dimension failed
   "incomplete": false,            // true when one or more review dimensions failed to run
   "failedDimensions": [ /* { dimension, error } — e.g. a security reviewer that died */ ],
-  "blocking": [ /* confirmed CRITICAL/HIGH — must clear before Gate 2 */ ],
+  "blocking": [ /* confirmed CRITICAL/HIGH + unverifiable ones — must clear before Gate 2 */ ],
   "advisory": [ /* MEDIUM/LOW + adversarially-refuted findings */ ],
-  "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4, "confirmed": 4, "refuted": 0 }
+  "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4, "confirmed": 4, "unverified": 0, "refuted": 0 }
 }
 ```
 
-The main loop presents `blocking` at Gate 2; the human still approves the commit. If a reviewer agent dies (terminal error or skip), that dimension is recorded in `failedDimensions` and the verdict never reports a clean `APPROVE` — an unreviewed security dimension must not pass as approved.
+The main loop presents `blocking` at Gate 2; the human still approves the commit. The gate fails closed at every stage: if a reviewer dies the dimension is recorded in `failedDimensions` (verdict never a clean `APPROVE`), and if a *verifier* dies or returns null the blocker is kept in `blocking` (tagged "could not be verified") rather than demoted to advisory — an unreviewed security dimension or an unverifiable CRITICAL must not pass as approved.
 
 ## Not in this PR (follow-ups)
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -45,7 +45,7 @@ Invalid input throws (the gate **fails closed**): a missing/empty `diff`, malfor
   "failedDimensions": [ /* { dimension, error } — e.g. a security reviewer that died */ ],
   "blocking": [ /* confirmed CRITICAL/HIGH — must clear before Gate 2 */ ],
   "advisory": [ /* MEDIUM/LOW + adversarially-refuted findings */ ],
-  "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4, "verified": 4, "refuted": 0 }
+  "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4, "confirmed": 4, "refuted": 0 }
 }
 ```
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,54 @@
+# ECC native workflows (pilot)
+
+Scripts in this directory are [Claude Code **Workflow** tool](https://docs.claude.com/en/docs/claude-code) scripts — deterministic, multi-agent orchestration that runs in the background and fans out to subagents.
+
+This is a **pilot**: ECC's orchestration (`orch-*`, `multi-*`, GAN/Santa loops) is currently hand-rolled on top of the `Task`/Agent tool. These scripts port the autonomous, fan-out-heavy segments to the native engine, which gives us barrier-free pipelining, automatic concurrency capping, structured-output validation, and resumability for free.
+
+## `orch-review.workflow.js`
+
+A native port of **orch-pipeline Phase 5 (Review)**.
+
+The gated outer loop (Gate 1 after Plan, Gate 2 before Commit) **stays in the main conversation** — native workflows run autonomously in the background and cannot pause for interactive approval. This script owns only the segment *between* the gates:
+
+1. **Review** — one reviewer agent per dimension, in parallel:
+   - `ecc:code-reviewer` (correctness & quality) — always
+   - the matching `ecc:<language>-reviewer` — when `args.language` maps to one
+   - `ecc:security-reviewer` — only when the orch-pipeline security trigger matches the diff/paths
+2. **Dedup** — independent reviewers routinely flag the same line, so findings are merged across dimensions keyed on the normalized `evidence` snippet (titles and line numbers drift per reviewer; the offending code does not). Each surviving finding records which `dimensions` reported it and keeps the strictest severity.
+3. **Verify** — every *unique* `CRITICAL`/`HIGH` finding is handed to an independent adversarial verifier that defaults to *refuted* on uncertainty. `MEDIUM`/`LOW` pass through as advisory.
+
+The Review→Verify barrier is deliberate: deduping before verification is exactly the case the Workflow guidance calls a justified barrier — it stops the verifier running N times on the same bug (in local testing, 11 raw findings collapsed to 4 unique, roughly halving verifier cost).
+
+### Invocation
+
+The main loop computes the diff, then calls the Workflow tool:
+
+```jsonc
+Workflow({
+  scriptPath: "workflows/orch-review.workflow.js",
+  args: {
+    diff: "<unified git diff text>",   // required
+    language: "typescript",            // optional — selects a language reviewer
+    changedFiles: ["src/auth.ts"]      // optional — feeds the security trigger
+  }
+})
+```
+
+### Returns
+
+```jsonc
+{
+  "verdict": "APPROVE" | "CHANGES_REQUESTED",
+  "blocking": [ /* confirmed CRITICAL/HIGH — must clear before Gate 2 */ ],
+  "advisory": [ /* MEDIUM/LOW + adversarially-refuted findings */ ],
+  "stats": { "dimensions": 3, "raw": 11, "unique": 4, "verified": 4, "refuted": 0 }
+}
+```
+
+The main loop presents `blocking` at Gate 2; the human still approves the commit.
+
+## Not in this PR (follow-ups)
+
+- A `/orch-review` command + skill trigger (plus the mirrored i18n docs and surface tests ECC requires for a new command surface).
+- Installer / manifest wiring so the script ships to `~/.claude/` on install.
+- Porting the **Research** sweep and **Plan** judge-panel segments next.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -42,7 +42,8 @@ Invalid input throws (the gate **fails closed**): a missing/empty `diff`, malfor
 {
   "verdict": "APPROVE" | "CHANGES_REQUESTED", // CHANGES_REQUESTED if any blocker OR a dimension failed
   "incomplete": false,            // true when one or more review dimensions failed to run
-  "failedDimensions": [ /* { dimension, error } — e.g. a security reviewer that died */ ],
+  "failedDimensions": [ /* { dimension, error } — error is a bounded label, never raw subagent text:
+                           "agent returned null (terminal failure or skip)" | "review agent failed" */ ],
   "blocking": [ /* confirmed CRITICAL/HIGH + unverifiable ones — must clear before Gate 2 */ ],
   "advisory": [ /* MEDIUM/LOW + adversarially-refuted findings */ ],
   "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4, "confirmed": 4, "unverified": 0, "refuted": 0 }

--- a/workflows/orch-review.workflow.js
+++ b/workflows/orch-review.workflow.js
@@ -115,8 +115,9 @@ function reviewPrompt(dimensionLabel, diff) {
 
 function verifyPrompt(finding, diff) {
   return [
-    'You are an independent skeptic. Try to REFUTE the finding below by checking it against the actual diff.',
-    'Default to isReal=false when you are uncertain or cannot locate supporting evidence in the diff.',
+    'You are an independent skeptic. Try to REFUTE the finding below by checking it against the diff text provided here — and ONLY that text.',
+    'The diff may be unapplied (a proposed PR), so the referenced file may not exist on disk yet. Do NOT refute a finding merely because the file is absent from the working tree; judge solely from the diff content.',
+    'Default to isReal=false when you are uncertain or cannot locate supporting evidence in the diff text.',
     '',
     `Finding (${finding.severity}) in ${finding.file}: ${finding.title}`,
     `Claimed evidence: ${finding.evidence}`,
@@ -213,15 +214,18 @@ const advisory = unique.filter(f => !isBlocking(f));
 const verified = await parallel(
   unique.filter(isBlocking).map(
     f => () =>
-      agent(verifyPrompt(f, diff), { phase: 'Verify', label: `verify:${f.file}:${normalize(f.evidence).slice(0, 40)}`, schema: VERDICT_SCHEMA }).then(v => ({
-        ...f,
-        verdict: v || { isReal: false, confidence: 0, reasoning: 'verifier failed' }
-      }))
+      agent(verifyPrompt(f, diff), { phase: 'Verify', label: `verify:${f.file}:${normalize(f.evidence).slice(0, 40)}`, schema: VERDICT_SCHEMA })
+        .then(v => ({ ...f, verdict: v || { isReal: false, confidence: 0, reasoning: 'verifier returned null (terminal failure or skip)' } }))
+        // Symmetry with the review stage: a rejected verifier must not crash the
+        // run or null out the slot. Keep the finding as blocking (fail closed) —
+        // an unverifiable CRITICAL must not be silently demoted to advisory.
+        .catch(err => ({ ...f, verdict: { isReal: true, confidence: 0, reasoning: `verifier error, kept as blocking: ${String((err && err.message) || err)}` } }))
   )
 );
 
-const confirmed = verified.filter(f => f.verdict && f.verdict.isReal);
-const refuted = verified.filter(f => !(f.verdict && f.verdict.isReal));
+const verifiedClean = verified.filter(Boolean);
+const confirmed = verifiedClean.filter(f => f.verdict && f.verdict.isReal);
+const refuted = verifiedClean.filter(f => !(f.verdict && f.verdict.isReal));
 
 log(`Done: ${confirmed.length} confirmed blocking, ${refuted.length} refuted, ${advisory.length} advisory.`);
 

--- a/workflows/orch-review.workflow.js
+++ b/workflows/orch-review.workflow.js
@@ -1,0 +1,208 @@
+export const meta = {
+  name: 'orch-review',
+  description:
+    'ECC Review phase as a native Claude Code workflow: multi-dimension review (quality + language + conditional security) then adversarial verification of every CRITICAL/HIGH finding. Returns blocking + advisory findings for Gate 2.',
+  phases: [
+    { title: 'Review', detail: 'one reviewer agent per dimension, in parallel' },
+    { title: 'Verify', detail: 'adversarially refute each CRITICAL/HIGH finding' }
+  ]
+};
+
+// ---------------------------------------------------------------------------
+// Pilot port of orch-pipeline Phase 5 (Review). The gated outer loop stays in
+// the main conversation; this script owns only the autonomous, fan-out-heavy
+// review+verify segment between the two human gates.
+//
+// Caller contract — pass `args` (the main loop computes the diff and language):
+//   {
+//     diff:         string,    // unified `git diff` text to review (required)
+//     language?:    string,    // e.g. "typescript" — selects a language reviewer
+//     changedFiles?: string[], // paths touched, used for the security trigger
+//   }
+//
+// Returns:
+//   { verdict: 'APPROVE' | 'CHANGES_REQUESTED',
+//     blocking: Finding[],   // confirmed CRITICAL/HIGH — must clear before Gate 2
+//     advisory: Finding[],   // MEDIUM/LOW + refuted findings, informational
+//     stats: { dimensions, raw, verified, refuted } }
+// ---------------------------------------------------------------------------
+
+// Language → ECC reviewer agent. Mirrors the agents present in agents/.
+const LANGUAGE_REVIEWER = {
+  typescript: 'ecc:typescript-reviewer',
+  javascript: 'ecc:typescript-reviewer',
+  python: 'ecc:python-reviewer',
+  go: 'ecc:go-reviewer',
+  rust: 'ecc:rust-reviewer',
+  java: 'ecc:java-reviewer',
+  kotlin: 'ecc:kotlin-reviewer',
+  swift: 'ecc:swift-reviewer',
+  php: 'ecc:php-reviewer',
+  csharp: 'ecc:csharp-reviewer',
+  fsharp: 'ecc:fsharp-reviewer',
+  react: 'ecc:react-reviewer',
+  vue: 'ecc:vue-reviewer',
+  flutter: 'ecc:flutter-reviewer',
+  dart: 'ecc:flutter-reviewer',
+  django: 'ecc:django-reviewer',
+  fastapi: 'ecc:fastapi-reviewer',
+  cpp: 'ecc:cpp-reviewer'
+};
+
+// orch-pipeline security trigger: auth/authz, user input, db queries, fs paths,
+// external calls, crypto, secrets. Matched against the diff text + file paths.
+const SECURITY_TRIGGER =
+  /\b(auth|login|password|passwd|token|secret|credential|api[_-]?key|session|jwt|oauth|cookie|sql|query|exec|eval|crypto|cipher|hash|hmac|sign|fs\.|readFile|writeFile|fetch|axios|request|subprocess|os\.system)\b/i;
+
+// A reviewer agent must emit findings in this shape — validated at the tool layer.
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'findings'],
+  properties: {
+    verdict: { type: 'string', enum: ['APPROVE', 'CHANGES_REQUESTED'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'severity', 'file', 'evidence'],
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] },
+          file: { type: 'string' },
+          line: { type: ['integer', 'null'] },
+          evidence: { type: 'string', description: 'the offending snippet or exact location' },
+          proof: { type: 'string', description: 'why it is a real problem (required for HIGH/CRITICAL)' },
+          fix: { type: 'string', description: 'concrete suggested remediation' }
+        }
+      }
+    }
+  }
+};
+
+// Independent skeptic verdict for one finding.
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['isReal', 'confidence', 'reasoning'],
+  properties: {
+    isReal: { type: 'boolean', description: 'true only if the finding genuinely holds against the diff' },
+    confidence: { type: 'number', minimum: 0, maximum: 1 },
+    reasoning: { type: 'string' }
+  }
+};
+
+const SEVERITY_RANK = { LOW: 0, MEDIUM: 1, HIGH: 2, CRITICAL: 3 };
+const isBlocking = f => f.severity === 'CRITICAL' || f.severity === 'HIGH';
+const normalize = s => (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
+
+function reviewPrompt(dimensionLabel, diff) {
+  return [
+    `You are reviewing a unified diff along the "${dimensionLabel}" dimension.`,
+    'Apply your standard checklist. Only report issues you are >80% sure are real problems.',
+    'For any CRITICAL or HIGH finding you MUST supply concrete `evidence` and a `proof` of impact; if you cannot, demote it or drop it.',
+    'Returning zero findings with verdict APPROVE is an acceptable and expected outcome for clean diffs.',
+    '',
+    'DIFF:',
+    diff
+  ].join('\n');
+}
+
+function verifyPrompt(finding, diff) {
+  return [
+    'You are an independent skeptic. Try to REFUTE the finding below by checking it against the actual diff.',
+    'Default to isReal=false when you are uncertain or cannot locate supporting evidence in the diff.',
+    '',
+    `Finding (${finding.severity}) in ${finding.file}: ${finding.title}`,
+    `Claimed evidence: ${finding.evidence}`,
+    finding.proof ? `Claimed proof: ${finding.proof}` : '',
+    '',
+    'DIFF:',
+    diff
+  ].join('\n');
+}
+
+// --- main -----------------------------------------------------------------
+
+// `args` arrives verbatim. Defensively accept a JSON-encoded string too, so the
+// workflow works whether the caller passes an object or a stringified payload.
+const input = typeof args === 'string' ? JSON.parse(args) : args || {};
+
+if (typeof input.diff !== 'string' || input.diff.trim() === '') {
+  log('orch-review: no diff supplied in args.diff — nothing to review.');
+  return { verdict: 'APPROVE', blocking: [], advisory: [], stats: { dimensions: 0, raw: 0, verified: 0, refuted: 0 } };
+}
+
+const diff = input.diff;
+const haystack = `${diff}\n${(input.changedFiles || []).join('\n')}`;
+
+// Build the review dimensions. Quality always runs; language + security are conditional.
+const dimensions = [{ key: 'quality', label: 'correctness & quality', agentType: 'ecc:code-reviewer' }];
+
+const langReviewer = input.language && LANGUAGE_REVIEWER[String(input.language).toLowerCase()];
+if (langReviewer) {
+  dimensions.push({ key: `lang:${input.language}`, label: `${input.language} idioms & pitfalls`, agentType: langReviewer });
+}
+
+if (SECURITY_TRIGGER.test(haystack)) {
+  dimensions.push({ key: 'security', label: 'security (OWASP, secrets, injection)', agentType: 'ecc:security-reviewer' });
+  log('Security trigger matched — adding security-reviewer dimension.');
+}
+
+log(`Reviewing across ${dimensions.length} dimension(s): ${dimensions.map(d => d.key).join(', ')}`);
+
+// Stage 1 — every dimension reviews in parallel. This is a deliberate BARRIER:
+// independent reviewers routinely flag the same line, so we need the full set
+// before we can dedup. Verifying first and deduping later would waste verifier
+// calls on duplicates (e.g. one SQL-injection bug reported by all 3 dimensions).
+const reviews = await parallel(
+  dimensions.map(
+    d => () =>
+      agent(reviewPrompt(d.label, diff), { agentType: d.agentType, phase: 'Review', label: `review:${d.key}`, schema: FINDINGS_SCHEMA }).then(r => ({
+        dim: d.key,
+        findings: (r && r.findings) || []
+      }))
+  )
+);
+
+// Dedup across dimensions. The evidence snippet (the offending code) is the most
+// stable key — titles are phrased differently and line numbers drift per reviewer.
+const tagged = reviews.filter(Boolean).flatMap(r => r.findings.map(f => ({ ...f, dimension: r.dim })));
+const byKey = new Map();
+for (const f of tagged) {
+  const key = `${f.file}::${normalize(f.evidence)}`;
+  const prev = byKey.get(key);
+  if (!prev) {
+    byKey.set(key, { ...f, dimensions: [f.dimension] });
+  } else {
+    if (!prev.dimensions.includes(f.dimension)) prev.dimensions.push(f.dimension);
+    if (SEVERITY_RANK[f.severity] > SEVERITY_RANK[prev.severity]) prev.severity = f.severity; // keep the strictest
+  }
+}
+const unique = [...byKey.values()];
+log(`Reviews returned ${tagged.length} findings → ${unique.length} unique after dedup.`);
+
+// Stage 2 — adversarially verify each unique CRITICAL/HIGH. MEDIUM/LOW are advisory.
+const advisory = unique.filter(f => !isBlocking(f));
+const verified = await parallel(
+  unique.filter(isBlocking).map(
+    f => () =>
+      agent(verifyPrompt(f, diff), { phase: 'Verify', label: `verify:${f.file}`, schema: VERDICT_SCHEMA }).then(v => ({
+        ...f,
+        verdict: v || { isReal: false, confidence: 0, reasoning: 'verifier failed' }
+      }))
+  )
+);
+
+const confirmed = verified.filter(f => f.verdict && f.verdict.isReal);
+const refuted = verified.filter(f => !(f.verdict && f.verdict.isReal));
+
+log(`Done: ${confirmed.length} confirmed blocking, ${refuted.length} refuted, ${advisory.length} advisory.`);
+
+return {
+  verdict: confirmed.length > 0 ? 'CHANGES_REQUESTED' : 'APPROVE',
+  blocking: confirmed,
+  advisory: [...advisory, ...refuted.map(f => ({ ...f, note: 'refuted by adversarial verifier' }))],
+  stats: { dimensions: dimensions.length, raw: tagged.length, unique: unique.length, verified: confirmed.length, refuted: refuted.length }
+};

--- a/workflows/orch-review.workflow.js
+++ b/workflows/orch-review.workflow.js
@@ -28,7 +28,7 @@ export const meta = {
 //     failedDimensions: { dimension, error }[],
 //     blocking: Finding[],        // confirmed CRITICAL/HIGH — must clear before Gate 2
 //     advisory: Finding[],        // MEDIUM/LOW + refuted findings, informational
-//     stats: { dimensions, failed, raw, unique, verified, refuted } }
+//     stats: { dimensions, failed, raw, unique, confirmed, refuted } }
 // ---------------------------------------------------------------------------
 
 // Language → ECC reviewer agent. Mirrors the agents present in agents/.
@@ -76,7 +76,7 @@ const FINDINGS_SCHEMA = {
           severity: { type: 'string', enum: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] },
           file: { type: 'string' },
           line: { type: ['integer', 'null'] },
-          evidence: { type: 'string', description: 'the offending snippet or exact location' },
+          evidence: { type: 'string', minLength: 1, description: 'the offending snippet or exact location' },
           proof: { type: 'string', description: 'why it is a real problem (required for HIGH/CRITICAL)' },
           fix: { type: 'string', description: 'concrete suggested remediation' }
         }
@@ -135,7 +135,7 @@ function verifyPrompt(finding, diff) {
 // payload it could not actually review.
 let input;
 try {
-  input = typeof args === 'string' ? JSON.parse(args) : args ?? {};
+  input = typeof args === 'string' ? JSON.parse(args) : (args ?? {});
 } catch {
   throw new Error('orch-review: args must be an object or valid JSON');
 }
@@ -193,7 +193,10 @@ if (failedDimensions.length > 0) {
 const tagged = reviews.filter(r => r && r.ok).flatMap(r => r.findings.map(f => ({ ...f, dimension: r.dim })));
 const byKey = new Map();
 for (const f of tagged) {
-  const key = `${f.file}::${normalize(f.evidence)}`;
+  // Prefer the evidence snippet; fall back to title+line so empty-evidence
+  // findings in the same file don't all collapse onto one `${file}::` key.
+  const evidenceKey = normalize(f.evidence);
+  const key = evidenceKey ? `${f.file}::${evidenceKey}` : `${f.file}::${normalize(f.title)}::${f.line ?? 'na'}`;
   const prev = byKey.get(key);
   if (!prev) {
     byKey.set(key, { ...f, dimensions: [f.dimension] });
@@ -210,7 +213,7 @@ const advisory = unique.filter(f => !isBlocking(f));
 const verified = await parallel(
   unique.filter(isBlocking).map(
     f => () =>
-      agent(verifyPrompt(f, diff), { phase: 'Verify', label: `verify:${f.file}`, schema: VERDICT_SCHEMA }).then(v => ({
+      agent(verifyPrompt(f, diff), { phase: 'Verify', label: `verify:${f.file}:${normalize(f.evidence).slice(0, 40)}`, schema: VERDICT_SCHEMA }).then(v => ({
         ...f,
         verdict: v || { isReal: false, confidence: 0, reasoning: 'verifier failed' }
       }))
@@ -230,5 +233,5 @@ return {
   failedDimensions,
   blocking: confirmed,
   advisory: [...advisory, ...refuted.map(f => ({ ...f, note: 'refuted by adversarial verifier' }))],
-  stats: { dimensions: dimensions.length, failed: failedDimensions.length, raw: tagged.length, unique: unique.length, verified: confirmed.length, refuted: refuted.length }
+  stats: { dimensions: dimensions.length, failed: failedDimensions.length, raw: tagged.length, unique: unique.length, confirmed: confirmed.length, refuted: refuted.length }
 };

--- a/workflows/orch-review.workflow.js
+++ b/workflows/orch-review.workflow.js
@@ -26,9 +26,9 @@ export const meta = {
 //   { verdict: 'APPROVE' | 'CHANGES_REQUESTED',  // CHANGES_REQUESTED if any blocker OR a dimension failed
 //     incomplete: boolean,        // true when one or more review dimensions failed to run
 //     failedDimensions: { dimension, error }[],
-//     blocking: Finding[],        // confirmed CRITICAL/HIGH — must clear before Gate 2
+//     blocking: Finding[],        // confirmed CRITICAL/HIGH + unverifiable ones — must clear before Gate 2
 //     advisory: Finding[],        // MEDIUM/LOW + refuted findings, informational
-//     stats: { dimensions, failed, raw, unique, confirmed, refuted } }
+//     stats: { dimensions, failed, raw, unique, confirmed, unverified, refuted } }
 // ---------------------------------------------------------------------------
 
 // Language → ECC reviewer agent. Mirrors the agents present in agents/.
@@ -180,7 +180,11 @@ const reviews = await parallel(
     d => () =>
       agent(reviewPrompt(d.label, diff), { agentType: d.agentType, phase: 'Review', label: `review:${d.key}`, schema: FINDINGS_SCHEMA })
         .then(r => (r === null ? { dim: d.key, ok: false, error: 'agent returned null (terminal failure or skip)', findings: [] } : { dim: d.key, ok: true, findings: r.findings || [] }))
-        .catch(err => ({ dim: d.key, ok: false, error: String((err && err.message) || err), findings: [] }))
+        // Log the raw error for operators; never return provider/runtime internals to the caller.
+        .catch(err => {
+          log(`Review dimension ${d.key} failed: ${String((err && err.message) || err)}`);
+          return { dim: d.key, ok: false, error: 'review agent failed', findings: [] };
+        })
   )
 );
 
@@ -215,27 +219,36 @@ const verified = await parallel(
   unique.filter(isBlocking).map(
     f => () =>
       agent(verifyPrompt(f, diff), { phase: 'Verify', label: `verify:${f.file}:${normalize(f.evidence).slice(0, 40)}`, schema: VERDICT_SCHEMA })
-        .then(v => ({ ...f, verdict: v || { isReal: false, confidence: 0, reasoning: 'verifier returned null (terminal failure or skip)' } }))
-        // Symmetry with the review stage: a rejected verifier must not crash the
-        // run or null out the slot. Keep the finding as blocking (fail closed) —
-        // an unverifiable CRITICAL must not be silently demoted to advisory.
-        .catch(err => ({ ...f, verdict: { isReal: true, confidence: 0, reasoning: `verifier error, kept as blocking: ${String((err && err.message) || err)}` } }))
+        // A null return (terminal failure/skip) or a rejection means we could NOT
+        // verify the finding. Mark it `unverified` rather than refuted so it stays
+        // blocking (fail closed) — an unverifiable CRITICAL must never be demoted
+        // to advisory just because the verifier did not run.
+        .then(v => (v ? { ...f, verdict: v } : { ...f, unverified: true, verdict: { isReal: false, confidence: 0, reasoning: 'verifier returned null (terminal failure or skip)' } }))
+        .catch(err => {
+          log(`Verifier failed for ${f.file}: ${String((err && err.message) || err)}`);
+          return { ...f, unverified: true, verdict: { isReal: false, confidence: 0, reasoning: 'verifier error' } };
+        })
   )
 );
 
 const verifiedClean = verified.filter(Boolean);
-const confirmed = verifiedClean.filter(f => f.verdict && f.verdict.isReal);
-const refuted = verifiedClean.filter(f => !(f.verdict && f.verdict.isReal));
+const confirmed = verifiedClean.filter(f => !f.unverified && f.verdict && f.verdict.isReal);
+const unverified = verifiedClean.filter(f => f.unverified);
+const refuted = verifiedClean.filter(f => !f.unverified && !(f.verdict && f.verdict.isReal));
 
-log(`Done: ${confirmed.length} confirmed blocking, ${refuted.length} refuted, ${advisory.length} advisory.`);
+// Unverifiable blockers stay in `blocking` (fail closed), tagged so the human
+// at Gate 2 knows they were not independently confirmed.
+const blocking = [...confirmed, ...unverified.map(f => ({ ...f, note: 'could not be verified — kept as blocking' }))];
 
-// Fail closed: APPROVE only when every dimension actually ran AND nothing blocks.
+log(`Done: ${confirmed.length} confirmed, ${unverified.length} unverified (kept blocking), ${refuted.length} refuted, ${advisory.length} advisory.`);
+
+// Fail closed: APPROVE only when every dimension ran AND nothing blocks.
 const incomplete = failedDimensions.length > 0;
 return {
-  verdict: confirmed.length > 0 || incomplete ? 'CHANGES_REQUESTED' : 'APPROVE',
+  verdict: blocking.length > 0 || incomplete ? 'CHANGES_REQUESTED' : 'APPROVE',
   incomplete,
   failedDimensions,
-  blocking: confirmed,
+  blocking,
   advisory: [...advisory, ...refuted.map(f => ({ ...f, note: 'refuted by adversarial verifier' }))],
-  stats: { dimensions: dimensions.length, failed: failedDimensions.length, raw: tagged.length, unique: unique.length, confirmed: confirmed.length, refuted: refuted.length }
+  stats: { dimensions: dimensions.length, failed: failedDimensions.length, raw: tagged.length, unique: unique.length, confirmed: confirmed.length, unverified: unverified.length, refuted: refuted.length }
 };

--- a/workflows/orch-review.workflow.js
+++ b/workflows/orch-review.workflow.js
@@ -19,12 +19,16 @@ export const meta = {
 //     language?:    string,    // e.g. "typescript" — selects a language reviewer
 //     changedFiles?: string[], // paths touched, used for the security trigger
 //   }
+// Invalid input (missing/empty diff, bad JSON, non-array changedFiles) throws —
+// the gate fails closed rather than silently approving an unreviewed payload.
 //
 // Returns:
-//   { verdict: 'APPROVE' | 'CHANGES_REQUESTED',
-//     blocking: Finding[],   // confirmed CRITICAL/HIGH — must clear before Gate 2
-//     advisory: Finding[],   // MEDIUM/LOW + refuted findings, informational
-//     stats: { dimensions, raw, verified, refuted } }
+//   { verdict: 'APPROVE' | 'CHANGES_REQUESTED',  // CHANGES_REQUESTED if any blocker OR a dimension failed
+//     incomplete: boolean,        // true when one or more review dimensions failed to run
+//     failedDimensions: { dimension, error }[],
+//     blocking: Finding[],        // confirmed CRITICAL/HIGH — must clear before Gate 2
+//     advisory: Finding[],        // MEDIUM/LOW + refuted findings, informational
+//     stats: { dimensions, failed, raw, unique, verified, refuted } }
 // ---------------------------------------------------------------------------
 
 // Language → ECC reviewer agent. Mirrors the agents present in agents/.
@@ -125,13 +129,24 @@ function verifyPrompt(finding, diff) {
 
 // --- main -----------------------------------------------------------------
 
-// `args` arrives verbatim. Defensively accept a JSON-encoded string too, so the
-// workflow works whether the caller passes an object or a stringified payload.
-const input = typeof args === 'string' ? JSON.parse(args) : args || {};
-
+// `args` arrives verbatim. Accept a JSON-encoded string too, so the workflow
+// works whether the caller passes an object or a stringified payload.
+// Fail CLOSED on invalid input: a review gate must never silently APPROVE a
+// payload it could not actually review.
+let input;
+try {
+  input = typeof args === 'string' ? JSON.parse(args) : args ?? {};
+} catch {
+  throw new Error('orch-review: args must be an object or valid JSON');
+}
+if (typeof input !== 'object' || input === null) {
+  throw new Error('orch-review: args must be an object');
+}
 if (typeof input.diff !== 'string' || input.diff.trim() === '') {
-  log('orch-review: no diff supplied in args.diff — nothing to review.');
-  return { verdict: 'APPROVE', blocking: [], advisory: [], stats: { dimensions: 0, raw: 0, verified: 0, refuted: 0 } };
+  throw new Error('orch-review: args.diff must be a non-empty unified diff');
+}
+if (input.changedFiles != null && !Array.isArray(input.changedFiles)) {
+  throw new Error('orch-review: args.changedFiles must be an array of paths');
 }
 
 const diff = input.diff;
@@ -156,19 +171,26 @@ log(`Reviewing across ${dimensions.length} dimension(s): ${dimensions.map(d => d
 // independent reviewers routinely flag the same line, so we need the full set
 // before we can dedup. Verifying first and deduping later would waste verifier
 // calls on duplicates (e.g. one SQL-injection bug reported by all 3 dimensions).
+// A reviewer can fail two ways: agent() returns null on a terminal error/skip,
+// or the thunk rejects. Capture both per-dimension so a lost dimension is never
+// silently dropped — an unreviewed security dimension must not pass as APPROVE.
 const reviews = await parallel(
   dimensions.map(
     d => () =>
-      agent(reviewPrompt(d.label, diff), { agentType: d.agentType, phase: 'Review', label: `review:${d.key}`, schema: FINDINGS_SCHEMA }).then(r => ({
-        dim: d.key,
-        findings: (r && r.findings) || []
-      }))
+      agent(reviewPrompt(d.label, diff), { agentType: d.agentType, phase: 'Review', label: `review:${d.key}`, schema: FINDINGS_SCHEMA })
+        .then(r => (r === null ? { dim: d.key, ok: false, error: 'agent returned null (terminal failure or skip)', findings: [] } : { dim: d.key, ok: true, findings: r.findings || [] }))
+        .catch(err => ({ dim: d.key, ok: false, error: String((err && err.message) || err), findings: [] }))
   )
 );
 
+const failedDimensions = reviews.filter(r => r && !r.ok).map(r => ({ dimension: r.dim, error: r.error }));
+if (failedDimensions.length > 0) {
+  log(`WARNING: ${failedDimensions.length} review dimension(s) failed: ${failedDimensions.map(f => f.dimension).join(', ')}. Verdict will fail closed.`);
+}
+
 // Dedup across dimensions. The evidence snippet (the offending code) is the most
 // stable key — titles are phrased differently and line numbers drift per reviewer.
-const tagged = reviews.filter(Boolean).flatMap(r => r.findings.map(f => ({ ...f, dimension: r.dim })));
+const tagged = reviews.filter(r => r && r.ok).flatMap(r => r.findings.map(f => ({ ...f, dimension: r.dim })));
 const byKey = new Map();
 for (const f of tagged) {
   const key = `${f.file}::${normalize(f.evidence)}`;
@@ -200,9 +222,13 @@ const refuted = verified.filter(f => !(f.verdict && f.verdict.isReal));
 
 log(`Done: ${confirmed.length} confirmed blocking, ${refuted.length} refuted, ${advisory.length} advisory.`);
 
+// Fail closed: APPROVE only when every dimension actually ran AND nothing blocks.
+const incomplete = failedDimensions.length > 0;
 return {
-  verdict: confirmed.length > 0 ? 'CHANGES_REQUESTED' : 'APPROVE',
+  verdict: confirmed.length > 0 || incomplete ? 'CHANGES_REQUESTED' : 'APPROVE',
+  incomplete,
+  failedDimensions,
   blocking: confirmed,
   advisory: [...advisory, ...refuted.map(f => ({ ...f, note: 'refuted by adversarial verifier' }))],
-  stats: { dimensions: dimensions.length, raw: tagged.length, unique: unique.length, verified: confirmed.length, refuted: refuted.length }
+  stats: { dimensions: dimensions.length, failed: failedDimensions.length, raw: tagged.length, unique: unique.length, verified: confirmed.length, refuted: refuted.length }
 };


### PR DESCRIPTION
## What Changed

Adds the first **native Claude Code Workflow** script to ECC, under a new `workflows/` directory:

- `workflows/orch-review.workflow.js` — a port of **orch-pipeline Phase 5 (Review)** to the native Workflow engine.
- `workflows/README.md` — invocation contract, returns shape, and follow-up scope.

The gated outer loop (Gate 1 after Plan, Gate 2 before Commit) **stays in the main conversation** — native workflows run autonomously in the background and cannot pause for interactive approval. The script owns only the autonomous segment between the gates:

1. **Review** — reviewers fan out in parallel: `ecc:code-reviewer` always, `ecc:<language>-reviewer` when `args.language` maps to one, and `ecc:security-reviewer` only when the orch-pipeline security trigger matches the diff/paths.
2. **Dedup** — findings are merged across dimensions keyed on the normalized `evidence` snippet, since independent reviewers routinely flag the same line with different titles/line numbers.
3. **Verify** — each *unique* CRITICAL/HIGH finding goes to an independent adversarial verifier (defaults to *refuted* on uncertainty); MEDIUM/LOW pass through as advisory.

Existing ECC reviewer subagents are reused via `agentType`, and reviewer output is validated by JSON schema instead of parsed from text.

## Why This Change

ECC's orchestration (`orch-*`, `multi-*`, GAN/Santa) is hand-rolled on top of the `Task`/Agent tool. This is a **pilot** showing one autonomous, fan-out-heavy segment ported to the native Workflow tool, which provides automatic concurrency capping, structured-output validation, and resumability. Scope is deliberately one segment to keep blast radius small.

## Testing Done

Per the clarified meaning of "test locally" — the workflow itself was run end-to-end (not just the repo suite):

- [x] Manual testing completed — ran `Workflow({scriptPath, args})` against a synthetic vulnerable TypeScript diff twice.
- [x] Edge cases considered and tested — empty/stringified `args` guard; security trigger on/off; cross-dimension duplicate findings.
- [x] Automated tests pass locally (`node tests/run-all.js`) — N/A: change is isolated to a new `workflows/` dir; CI eslint/markdownlint are scoped to `scripts/`, `tests/`, `agents/`, `skills/`, `commands/`, `rules/`. Validated instead with `node --check` (JS) and `markdownlint` (README).

Result of the end-to-end runs: all 3 dimensions fired, verdict `CHANGES_REQUESTED`, and dedup collapsed **11 raw findings → 4 unique** (3 real vulnerabilities + 1 TS-only), cutting verifier calls and tokens roughly in half (12 agents/~300k tokens → 7 agents/~155k tokens).

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed (the `sk-live-…` string lives only in the *test invocation* args, never in the repo)
- [x] JSON files validate cleanly (no JSON files added)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Added comments for complex logic (barrier rationale, dedup key choice)
- [x] README added (`workflows/README.md`)

## Follow-ups (not in this PR)

- A `/orch-review` command + skill trigger (plus mirrored i18n docs and surface tests ECC requires for a new command surface).
- Installer/manifest wiring so the script ships to `~/.claude/` on install.
- Port the Research sweep and Plan judge-panel segments next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)