### PR TITLE
Add growth-log skill: methodology for effective learning capture

### DIFF
--- a/skills/growth-log/SKILL.md
+++ b/skills/growth-log/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: growth-log
-description: "Use when completing a complex task, after a failure or mistake, when the delivery gate flags stale learning logs, or when reviewing what was learned over a period. Teaches how to write growth logs that extract reusable patterns — not diary entries."
+description: "Use after a complex task, failure, or when reviewing what was learned. Teaches how to write growth logs that extract reusable patterns — not diary entries."
+version: 1.1.0
 metadata:
   origin: ECC
 ---
 
 # Growth Log Skill
 
-> **The problem:** Most developers write "fixed a bug in X" as a growth log. That's a diary entry, not a learning artifact. A real growth log extracts the *pattern* so you recognize it next time.
+> **The problem:** Most people write "fixed a bug in X" as a learning log. That's a diary entry, not a learning artifact. A real growth log extracts the *pattern* so you recognize it next time.
 >
-> **This skill teaches:** How to write growth logs that compound across sessions.
+> **This skill teaches:** How to write learning entries that compound across sessions. Works with any note-taking system — Markdown files, Notion, Obsidian, plain text. Templates are generic; adapt to your setup.
 
 ## When to Activate
 
-Activate this skill:
 - After completing a complex task (multi-file, new feature, architecture change)
 - After a failure, mistake, or "that was harder than expected" moment
-- When the delivery gate flags stale learning libraries
 - When you want to review what you've learned over a period
 
 **When NOT to activate:** Trivial changes (typo fixes, single-line tweaks, config value changes with no debugging). The threshold: *did this task involve debugging, redoing, rollback, or a non-obvious decision?* If yes → write an entry. If no → skip.
@@ -28,19 +27,18 @@ Activate this skill:
 A failure is nutritionally denser than a success. One bug that took 2 hours to find teaches more than 3 features that worked first try.
 
 **Bad:** "Successfully implemented the login flow."
-**Good (web dev):** "Login flow: session token wasn't persisting because the cookie `SameSite` defaulted to `Lax` in Chrome 128+. Pattern: always explicitly set `SameSite=None; Secure` when cross-origin. Signal to recognize: auth breaks after browser upgrade or when crossing origin boundaries (localhost:3000 → api.example.com)."
+**Good (web dev):** "Login flow: session token wasn't persisting because the cookie `SameSite` defaulted to `Lax` in Chrome 128+. Pattern: always explicitly set `SameSite=None; Secure` when cross-origin. Signal to recognize: auth breaks after browser upgrade or when crossing origin boundaries."
 **Good (data pipeline):** "CSV import failed silently on empty rows because `pandas.read_csv(dropna=False)` keeps zero-width rows that `len()` counts as valid. Pattern: always `df.dropna(how='all', inplace=True)` before row-count validation."
 
 ### Rule 2: The Bole Principle (伯乐原则)
 
 Before writing a new entry, ask: *"Is this fundamentally the same as something I already recorded?"*
 
-Same root cause, different symptom → **merge**, don't duplicate.
-New root cause → new entry.
+Same root cause, different symptom → **merge**, don't duplicate. New root cause → new entry.
 
-**How to check:** Before writing, search existing entries for keywords from your root cause. Example: `grep -ri 'capture' growth-log/` or maintain a one-line `patterns-index.md` listing every entry's pattern sentence. If you find a match, add your new symptom as an additional example under the existing entry rather than creating a duplicate.
+**How to check:** Search existing entries for keywords from your root cause before writing. If you find a match, add your new symptom as an additional example under the existing entry rather than creating a duplicate.
 
-**Example:** "Forgot to update output-index after creating a file" and "Forgot to update ratings-tracker after a task" — same root cause (no automatic capture trigger). Merge into one entry about "post-task capture gaps."
+**Example:** "Forgot to update the output index after creating a file" and "Forgot to update skill ratings after a task" — same root cause (no automatic capture trigger). Merge into one entry about "post-task capture gaps."
 
 ### Rule 3: Must Be Transferable
 
@@ -49,7 +47,7 @@ Every entry must answer: *"Next time I face a similar situation, what do I do di
 If you can't write that sentence, you haven't extracted the pattern yet.
 
 **How to extract a pattern from a concrete event:**
-1. State what happened in one sentence ("The deployment broke because...")
+1. State what happened in one sentence
 2. Ask "why?" iteratively until you reach root cause (usually 3-5 whys)
 3. Generalize: "What class of problem is this?" (not "Chrome 128 bug" but "browser default change breaking existing behavior")
 4. Formulate as: "Next time I see [signal], I will [action]."
@@ -57,7 +55,7 @@ If you can't write that sentence, you haven't extracted the pattern yet.
 
 ## Entry Template
 
-**Scope:** One entry per distinct root cause. Typical length: 4-8 sentences. If it takes >2 minutes to write, you're narrating events instead of extracting a pattern. If <30 seconds, you haven't gone deep enough.
+**Scope:** One entry per distinct root cause. Typical length: 4-8 sentences. If it takes >2 minutes to write, you're narrating events. If <30 seconds, you haven't gone deep enough.
 
 ```markdown
 ## [Title: the pattern, not the event]
@@ -74,7 +72,7 @@ If you can't write that sentence, you haven't extracted the pattern yet.
 - Signal to recognize: [what observable tells me this pattern is active?]
 
 ### Related
-- [entry-name](../growth-log/YYYY-MM-DD.md) (relative Markdown links)
+- [entry-name](../path/to/related-entry.md)
 ```
 
 ## Entry Types
@@ -88,60 +86,43 @@ All four types use the template above. The type determines which sections carry 
 | **Pattern Discovery** | A reusable insight about tools, systems, or thinking | Pattern section | "PR description template: describe the gap, not the feature" |
 | **Capability Change** | A measurable skill improvement | Context (before vs after) | "Git: from clone/push to independent PR with 12 commits" |
 
-## File Convention
-
-Store entries in a `growth-log/` directory. Name files as `YYYY-MM-DD.md` (ISO date). Each file can hold multiple entries separated by `---` horizontal rules. One file per day, regardless of how many entries.
-
-Example structure:
-```
-memory/
-  growth-log/
-    2026-06-25.md   (3 entries from that day)
-    2026-06-26.md   (2 entries: one failure, one methodology)
-    2026-06-28.md   (1 entry)
-  patterns-index.md  (one-line summaries: "SameSite cookies → explicit SameSite=None;Secure")
-```
-
-## Integration with Delivery Gate
-
-The delivery gate (`quality-gate.py`) checks that growth-log files were modified today via filesystem mtime after any code change. This skill teaches *what to write*, not just *that the file was touched*.
-
-```
-Code change → delivery gate checks growth-log file mtime →
-  if stale (no file modified today): block, ask "what did you learn?"
-  if fresh (file touched today): pass (this skill ensures the content is actually useful)
-```
-
-The gate provides infrastructure (freshness enforcement); this skill provides methodology (content quality). Having the gate without the methodology leads to empty/timestamp-only entries; having the methodology without the gate leads to forgotten captures.
-
-## Library Structure
-
-For systematic learning capture, organize into 5 libraries:
-
-| Library | Content | Update Trigger |
-|---------|---------|---------------|
-| `growth-log/` | Methodologies, failures, patterns | After any complex task with debugging/redoing |
-| `decisions/log.md` | Choices + options + logic + outcome + review date | After any irreversible decision |
-| `ratings-tracker.md` | Quantified abilities (0-5 scale) | When a skill demonstrably improves |
-| `output-index.md` | File locations across sessions | After creating any deliverable |
-| `tooling_capabilities.md` | Available tools inventory | After adding/removing any tool |
-
 ## Quality Checklist
 
 Before finalizing a growth log entry:
 
 - [ ] Does the title name the *pattern*, not the event?
 - [ ] Is there a "Next time I will..." sentence?
-- [ ] Is the "Signal to recognize" specific enough to trigger the pattern next time? (e.g., "auth breaks after browser upgrade" not "something goes wrong")
+- [ ] Is the "Signal to recognize" specific enough to trigger the pattern next time?
 - [ ] Did I search existing entries for duplicates before writing? (Bole Principle)
 - [ ] Is the root cause distinguished from the symptom?
-- [ ] Are related memories cross-linked (relative Markdown links or wikilinks)?
+- [ ] Are related memories cross-linked?
 - [ ] Is the entry 4-8 sentences? Shorter = too shallow; longer = narrating events.
 
 ## Anti-Patterns
 
-- ❌ "Fixed bug in payment module" (event, not pattern — and too trivial to log)
-- ❌ Copying the git commit message verbatim (different purpose: commits describe what changed, growth logs extract why it matters)
-- ❌ Writing an entry for every commit or every session (only when a pattern emerges)
-- ❌ Skipping the transferable sentence (without it, it's just a diary — this is the non-negotiable core)
+- ❌ "Fixed bug in payment module" (event, not pattern)
+- ❌ Copying the git commit message verbatim (commits describe what changed; logs extract why it matters)
+- ❌ Writing an entry for every commit (only when a pattern emerges)
+- ❌ Skipping the transferable sentence (without it, it's just a diary — this is non-negotiable)
 - ❌ Duplicating the same pattern under different titles (violates Bole Principle — search before writing)
+
+## Storage
+
+Store entries wherever you keep notes. Common patterns:
+- Markdown files in a `growth-log/` directory (one file per day: `YYYY-MM-DD.md`)
+- A dedicated section in Notion, Obsidian, or your note-taking app
+- Plain text files with a consistent naming convention
+
+Pick one convention and stick to it. Searchability matters more than format.
+
+## If You Use Delivery Gate
+
+The `delivery-gate` Stop hook checks that learning files were modified today via filesystem timestamps. This skill teaches *what to write* — so the file that delivery-gate checks actually contains useful patterns, not empty timestamps.
+
+```
+Task completes → delivery-gate checks: was the learning file touched today?
+  → Stale (no file modified): block — "what did you learn?"
+  → Fresh (file touched): pass — this skill ensures the content is useful
+```
+
+Having enforcement without methodology → empty entries. Having methodology without enforcement → forgotten captures. Each is independently useful; together they close the loop.

--- a/skills/growth-log/SKILL.md
+++ b/skills/growth-log/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: growth-log
 description: "Use when completing a complex task, after a failure or mistake, when the delivery gate flags stale learning logs, or when reviewing what was learned over a period. Teaches how to write growth logs that extract reusable patterns — not diary entries."
+metadata:
+  origin: ECC
 ---
 
 # Growth Log Skill

--- a/skills/growth-log/SKILL.md
+++ b/skills/growth-log/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: growth-log
+description: "Use when completing a complex task, after a failure or mistake, when the delivery gate flags stale learning logs, or when reviewing what was learned over a period. Teaches how to write growth logs that extract reusable patterns — not diary entries."
+---
+
+# Growth Log Skill
+
+> **The problem:** Most developers write "fixed a bug in X" as a growth log. That's a diary entry, not a learning artifact. A real growth log extracts the *pattern* so you recognize it next time.
+>
+> **This skill teaches:** How to write growth logs that compound across sessions.
+
+## When to Activate
+
+Activate this skill:
+- After completing a complex task (multi-file, new feature, architecture change)
+- After a failure, mistake, or "that was harder than expected" moment
+- When the delivery gate flags stale learning libraries
+- When you want to review what you've learned over a period
+
+**When NOT to activate:** Trivial changes (typo fixes, single-line tweaks, config value changes with no debugging). The threshold: *did this task involve debugging, redoing, rollback, or a non-obvious decision?* If yes → write an entry. If no → skip.
+
+## The Three Rules
+
+### Rule 1: Failures > Achievements
+
+A failure is nutritionally denser than a success. One bug that took 2 hours to find teaches more than 3 features that worked first try.
+
+**Bad:** "Successfully implemented the login flow."
+**Good (web dev):** "Login flow: session token wasn't persisting because the cookie `SameSite` defaulted to `Lax` in Chrome 128+. Pattern: always explicitly set `SameSite=None; Secure` when cross-origin. Signal to recognize: auth breaks after browser upgrade or when crossing origin boundaries (localhost:3000 → api.example.com)."
+**Good (data pipeline):** "CSV import failed silently on empty rows because `pandas.read_csv(dropna=False)` keeps zero-width rows that `len()` counts as valid. Pattern: always `df.dropna(how='all', inplace=True)` before row-count validation."
+
+### Rule 2: The Bole Principle (伯乐原则)
+
+Before writing a new entry, ask: *"Is this fundamentally the same as something I already recorded?"*
+
+Same root cause, different symptom → **merge**, don't duplicate.
+New root cause → new entry.
+
+**How to check:** Before writing, search existing entries for keywords from your root cause. Example: `grep -ri 'capture' growth-log/` or maintain a one-line `patterns-index.md` listing every entry's pattern sentence. If you find a match, add your new symptom as an additional example under the existing entry rather than creating a duplicate.
+
+**Example:** "Forgot to update output-index after creating a file" and "Forgot to update ratings-tracker after a task" — same root cause (no automatic capture trigger). Merge into one entry about "post-task capture gaps."
+
+### Rule 3: Must Be Transferable
+
+Every entry must answer: *"Next time I face a similar situation, what do I do differently?"*
+
+If you can't write that sentence, you haven't extracted the pattern yet.
+
+**How to extract a pattern from a concrete event:**
+1. State what happened in one sentence ("The deployment broke because...")
+2. Ask "why?" iteratively until you reach root cause (usually 3-5 whys)
+3. Generalize: "What class of problem is this?" (not "Chrome 128 bug" but "browser default change breaking existing behavior")
+4. Formulate as: "Next time I see [signal], I will [action]."
+5. Name the signal: what specific observable tells you this pattern is active?
+
+## Entry Template
+
+**Scope:** One entry per distinct root cause. Typical length: 4-8 sentences. If it takes >2 minutes to write, you're narrating events instead of extracting a pattern. If <30 seconds, you haven't gone deep enough.
+
+```markdown
+## [Title: the pattern, not the event]
+
+### Context
+- What was I trying to do?
+- What went wrong / what worked surprisingly well?
+
+### Root Cause / Core Insight
+- The underlying mechanism, not just the symptom
+
+### The Pattern (transferable)
+- Next time [similar situation], I will [specific action].
+- Signal to recognize: [what observable tells me this pattern is active?]
+
+### Related
+- [entry-name](../growth-log/YYYY-MM-DD.md) (relative Markdown links)
+```
+
+## Entry Types
+
+All four types use the template above. The type determines which sections carry the most weight:
+
+| Type | When to Use | Emphasis | Example Title |
+|------|------------|----------|---------------|
+| **Failure** | Something broke, needed debugging, or required rework | Root Cause | "Config inheritance ≠ behavior inheritance across sessions" |
+| **Methodology** | A repeatable process emerged from the work | Context / Pattern | "PPT → open-book exam study guide: three-layer structure" |
+| **Pattern Discovery** | A reusable insight about tools, systems, or thinking | Pattern section | "PR description template: describe the gap, not the feature" |
+| **Capability Change** | A measurable skill improvement | Context (before vs after) | "Git: from clone/push to independent PR with 12 commits" |
+
+## File Convention
+
+Store entries in a `growth-log/` directory. Name files as `YYYY-MM-DD.md` (ISO date). Each file can hold multiple entries separated by `---` horizontal rules. One file per day, regardless of how many entries.
+
+Example structure:
+```
+memory/
+  growth-log/
+    2026-06-25.md   (3 entries from that day)
+    2026-06-26.md   (2 entries: one failure, one methodology)
+    2026-06-28.md   (1 entry)
+  patterns-index.md  (one-line summaries: "SameSite cookies → explicit SameSite=None;Secure")
+```
+
+## Integration with Delivery Gate
+
+The delivery gate (`quality-gate.py`) checks that growth-log files were modified today via filesystem mtime after any code change. This skill teaches *what to write*, not just *that the file was touched*.
+
+```
+Code change → delivery gate checks growth-log file mtime →
+  if stale (no file modified today): block, ask "what did you learn?"
+  if fresh (file touched today): pass (this skill ensures the content is actually useful)
+```
+
+The gate provides infrastructure (freshness enforcement); this skill provides methodology (content quality). Having the gate without the methodology leads to empty/timestamp-only entries; having the methodology without the gate leads to forgotten captures.
+
+## Library Structure
+
+For systematic learning capture, organize into 5 libraries:
+
+| Library | Content | Update Trigger |
+|---------|---------|---------------|
+| `growth-log/` | Methodologies, failures, patterns | After any complex task with debugging/redoing |
+| `decisions/log.md` | Choices + options + logic + outcome + review date | After any irreversible decision |
+| `ratings-tracker.md` | Quantified abilities (0-5 scale) | When a skill demonstrably improves |
+| `output-index.md` | File locations across sessions | After creating any deliverable |
+| `tooling_capabilities.md` | Available tools inventory | After adding/removing any tool |
+
+## Quality Checklist
+
+Before finalizing a growth log entry:
+
+- [ ] Does the title name the *pattern*, not the event?
+- [ ] Is there a "Next time I will..." sentence?
+- [ ] Is the "Signal to recognize" specific enough to trigger the pattern next time? (e.g., "auth breaks after browser upgrade" not "something goes wrong")
+- [ ] Did I search existing entries for duplicates before writing? (Bole Principle)
+- [ ] Is the root cause distinguished from the symptom?
+- [ ] Are related memories cross-linked (relative Markdown links or wikilinks)?
+- [ ] Is the entry 4-8 sentences? Shorter = too shallow; longer = narrating events.
+
+## Anti-Patterns
+
+- ❌ "Fixed bug in payment module" (event, not pattern — and too trivial to log)
+- ❌ Copying the git commit message verbatim (different purpose: commits describe what changed, growth logs extract why it matters)
+- ❌ Writing an entry for every commit or every session (only when a pattern emerges)
+- ❌ Skipping the transferable sentence (without it, it's just a diary — this is the non-negotiable core)
+- ❌ Duplicating the same pattern under different titles (violates Bole Principle — search before writing)


### PR DESCRIPTION
## What this is

A skill that teaches **how** to write learning entries that are actually useful next session — not diary entries, but extracted patterns. Methodology, not infrastructure.

Three rules:
1. **Failures > Achievements** — bugs teach more than features that worked first try
2. **Bole Principle (伯乐原则)** — same root cause, different symptom → merge, don't duplicate
3. **Must Be Transferable** — every entry answers "next time, what do I do differently?"

**Universal:** Works with any note-taking system — Markdown files, Notion, Obsidian, plain text. Templates are generic; adapt naming conventions and file structure to your setup. No specific tool or format required.

## How it complements ECC

ECC has `verification-loop` (code quality) and `delivery-gate` (#2378) (session hygiene enforcement). Both check **that** something was recorded. Neither teaches **how** to write entries that transfer to the next session.

| Skill | Checks | This adds |
|-------|--------|-----------|
| `verification-loop` | Code output quality | — |
| `delivery-gate` (#2378) | THAT you wrote something (mtime) | **HOW** to write something useful |
| **`growth-log` (this PR)** | — | Entry quality — patterns, not diary |

Having enforcement without methodology → empty entries. Having methodology without enforcement → forgotten captures. These two skills are designed to work together, but **each is independently useful** — you don't need delivery-gate to use this skill, and vice versa.

## Recent update (v1.1.0)

Stripped personal implementation details to make the skill truly universal. Removed a specific five-library structure that was tied to one user's setup. Made file storage a suggestion ("pick one convention") rather than a prescription. Delivery-gate integration reframed as optional companion, not hard dependency. **Core methodology unchanged — three rules, entry template, quality checklist, anti-patterns all preserved.**