### PR TITLE
Stop hook: verify thinking quality at session end — task completeness, assumptions, stale logs, disk space (delivery-gate)

### DIFF
--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: delivery-gate
-description: Stop hook that blocks Claude from finishing until quality checks pass. Detects incomplete tasks, stale learning logs, and low disk space. Complements verification-loop by checking thinking quality (contradictions, omissions, unverified assumptions) rather than just code quality.
+description: Stop hook that blocks Claude from finishing until quality checks pass. Detects rationalization patterns, stale learning logs (via mtime), and low disk space. Complements verification-loop by enforcing learning capture rather than just checking code quality.
 ---
 
 # Delivery Gate — Self-Audit Stop Hook
 
-A Stop hook that forces Claude to verify quality before it can finish. Unlike verification-loop (which checks build/test/lint), this system checks **thinking quality**: did Claude assume something untested? Did it skip documenting a lesson? Is disk space dangerously low?
+A Stop hook that blocks Claude from finishing when quality conditions aren't met. Unlike verification-loop (which checks build/test/lint), this system checks **session hygiene**: did Claude rationalize skipping work? Did it update learning logs after code changes? Is disk space dangerously low?
 
 ## When to Activate
 
@@ -64,11 +64,11 @@ See `memory/README.md` for the five-library setup.
 ## How It Works
 
 The hook receives the full transcript on stdin. It:
-1. Detects "rationalization patterns" (e.g., "this is a pre-existing issue")
-2. Counts Edit/Write calls to detect complex tasks
-3. Checks if five learning libraries were updated today
+1. Scans for rationalization patterns (e.g., "this is a pre-existing issue", "skip tests for now")
+2. Counts Edit/Write tool invocations to detect complex tasks
+3. Checks if five learning libraries were modified today (filesystem mtime)
 4. Checks home-directory filesystem disk space
-5. Blocks (exit 2) when complex tasks complete without learning capture
+5. Blocks (exit 2) when complex tasks complete without learning capture or disk is critically low
 
 ## Customization
 
@@ -76,7 +76,7 @@ Edit `quality-gate.py`:
 - `RATIONALIZE` regex patterns — add your team's common excuses
 - `LIBS` dictionary — customize which files to check
 - `MIN_CHARS` — minimum transcript length to trigger checks
-- `DISK_WARN_GB` / `DISK_CRIT_GB` — adjust for your environment
+- `DISK_REMIND_GB` / `DISK_WARN_GB` / `DISK_CRIT_GB` — adjust for your environment
 
 ## Examples
 

--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: delivery-gate
 description: Stop hook that blocks Claude from finishing until quality checks pass. Detects rationalization patterns (surface text heuristics), stale learning logs (filesystem mtime), and low disk space. Complements self-audit by mechanically enforcing learning capture habits.
-version: 1.1.0
+version: 1.1.1
 metadata:
   origin: ECC
 ---
@@ -21,11 +21,11 @@ This is the same pattern as CI pipeline gates — automated, deterministic check
 | Check | Mechanism | On Hit |
 |-------|-----------|--------|
 | Rationalization patterns | Regex on transcript tail | **Warning only** (never blocks) |
-| Stale learning libraries | mtime on 5 configurable paths | Warning if some stale; **Block** if ALL stale + complex task |
+| Stale learning libraries | mtime on 5 configurable paths | Warning if some stale; **Block** if >=3 stale OR growth-log stale + complex task |
 | Disk space < 50GB | `shutil.disk_usage` | Warning |
 | Disk space < 15GB | `shutil.disk_usage` | **Block** (exit 2) |
 
-Rationalization detection warns about patterns like "skip tests for now" and "pre-existing bug" — surface signals that thinking may have been cut short. It never blocks on its own, because regex heuristics can false-positive. The blocking conditions are only: disk critical OR all learning libraries untouched after a complex task.
+Rationalization detection warns about patterns like "skip tests for now" and "pre-existing bug" — surface signals that thinking may have been cut short. It never blocks on its own, because regex heuristics can false-positive. The blocking conditions are: disk critical, `>=3 learning libs stale`, OR `growth-log` specifically stale (all require complex task >=3 edits).
 
 ## Why
 

--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -1,124 +1,126 @@
 ---
 name: delivery-gate
-description: Stop hook that blocks Claude from finishing until quality checks pass. Detects contradictions, omissions, unverified assumptions, rationalization patterns, stale learning logs, and low disk space. Complements verification-loop by checking thinking quality rather than just code quality.
+description: Stop hook that blocks Claude from finishing until quality checks pass. Detects rationalization patterns (surface text heuristics), stale learning logs (filesystem mtime), and low disk space. Complements self-audit by mechanically enforcing learning capture habits.
+version: 1.1.0
+metadata:
+  origin: ECC
 ---
 
-# Delivery Gate — Self-Audit Stop Hook
+# Delivery Gate — Mechanical Quality Gate for Claude Code
 
-A Stop hook that forces Claude to verify quality before it can finish. Unlike verification-loop (which checks build/test/lint), this system checks **thinking quality**: did Claude assume something untested? Did it rationalize skipping work? Did it skip documenting a lesson? Is disk space dangerously low?
+A **Stop hook** that checks three things before Claude can finish a session, using only **deterministic checks** — file modification timestamps, disk usage, and regex patterns on the transcript text. No AI inference.
 
-## When to Activate
+This is distinct from reasoning gates (like `self-audit`): delivery-gate checks machine-verifiable facts; self-audit checks output quality across four reasoning dimensions. Together they form defense in depth:
+- **delivery-gate**: "Was the learning library touched today? Is disk space safe?"
+- **self-audit**: "Is the file content correct, complete, and honest?"
 
-- Any project where you want Claude to learn from its mistakes over time
-- Long coding sessions where "done" often means "code works but thinking was sloppy"
-- Teams that want consistent quality standards across AI-assisted work
+This is the same pattern as CI pipeline gates — automated, deterministic checks that verify machine-readable facts rather than trusting self-reported status.
 
-## Installation
+## What It Checks
 
-### 1. Install the hook script
+| Check | Mechanism | On Hit |
+|-------|-----------|--------|
+| Rationalization patterns | Regex on transcript tail | **Warning only** (never blocks) |
+| Stale learning libraries | mtime on 5 configurable paths | Warning if some stale; **Block** if ALL stale + complex task |
+| Disk space < 50GB | `shutil.disk_usage` | Warning |
+| Disk space < 15GB | `shutil.disk_usage` | **Block** (exit 2) |
+
+Rationalization detection warns about patterns like "skip tests for now" and "pre-existing bug" — surface signals that thinking may have been cut short. It never blocks on its own, because regex heuristics can false-positive. The blocking conditions are only: disk critical OR all learning libraries untouched after a complex task.
+
+## Why
+
+Claude Code's built-in checks cover code quality (build → type → lint → test). But there's a different failure mode: the agent produces working code while the **session hygiene was neglected** — learning not captured, rationalized shortcuts, disk running out silently.
+
+Over many sessions of "ship and forget," the human hasn't grown. This hook enforces the habit: complex task → must touch learning libraries.
+
+## Install
 
 ```bash
-# From the ECC repo root (after cloning/forking):
-cp skills/delivery-gate/hooks/quality-gate.py ~/.claude/scripts/
+cp quality-gate.py ~/.claude/scripts/
 ```
 
-### 2. Configure in settings.json
-
+Add to `~/.claude/settings.json`:
 ```json
 {
   "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ~/.claude/scripts/quality-gate.py",
-            "timeout": 5000
-          }
-        ]
-      }
-    ]
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "python3 ~/.claude/scripts/quality-gate.py",
+        "timeout": 5000
+      }]
+    }]
   }
 }
 ```
 
-### 3. Add CLAUDE.md rules
+## Learning Libraries
 
-Add this block to your project or global CLAUDE.md:
+Create these files in your project's memory directory. The hook checks if at least one was updated today:
 
-```markdown
-## 收尾铁律
-
-复杂任务结束必须自动输出:
-1. 自审 — 矛盾/遗漏/未验证假设/美化
-2. 教学 — 为什么做/如何做/核心收益 (仅代码任务)
-3. 交付门 — 五库+磁盘
-4. 沉淀 — 新事实→persona | 翻车→growth-log
-5. 产出索引
+```
+memory/
+├── growth-log/          # Daily learning entries (directory)
+├── decisions/log.md     # Decision log
+├── output-index.md      # Index of session outputs
+├── ratings-tracker.md   # Skill ratings over time
+└── tooling_capabilities.md  # Known tools inventory
 ```
 
-### 4. Create memory libraries
+Customize the `LIBS` dict to match your own file structure.
 
-See `memory/README.md` for the five-library setup.
-
-## How It Works
-
-The hook receives the full transcript on stdin (handles both raw text and JSON with `transcript_path` for Claude Code Stop hooks). It:
-1. Detects rationalization patterns (e.g., "this is a pre-existing issue", "skip tests for now")
-2. Counts Edit/Write tool invocations to detect complex tasks
-3. Checks if five learning libraries were modified today (filesystem mtime)
-4. Checks home-directory filesystem disk space
-5. Blocks (exit 2) when complex tasks complete without learning capture, or disk is critically low
-
-## Customization
+## Configuration
 
 Edit `quality-gate.py`:
-- `RATIONALIZE` regex patterns — add your team's common excuses
-- `LIBS` dictionary — customize which files to check
-- `MIN_CHARS` — minimum transcript length to trigger checks
-- `DISK_WARN_GB` / `DISK_CRIT_GB` — adjust for your environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `RATIONALIZE` | 4 patterns | Regex patterns for rationalization detection |
+| `LIBS` | 5 libraries | Files/dirs to check for today's updates |
+| `COMPLEX_THRESHOLD` | 3 | Edit/Write calls to classify as complex |
+| `DISK_WARN_GB` | 50 | Warn below this |
+| `DISK_CRIT_GB` | 15 | Block below this |
 
 ## Examples
 
-### Normal session — no blocking
-
+**Simple session — allowed:**
 ```
-$ claude  # edits 2 files, updates growth-log
-...
-Claude tries to stop → hook runs:
-  edit_count=2 (< 3, not complex) → exit 0 (allowed)
+edit_count=1 (< 3, not complex) → exit 0
 ```
 
-### Complex task, learning captured — allowed
-
+**Complex task, learning captured — allowed:**
 ```
-$ claude  # edits 5 files, updates growth-log/2026-06-26.md
-...
-Claude tries to stop → hook runs:
-  edit_count=5 (complex) → checks LIBS → growth-log updated today → exit 0 (allowed)
+edit_count=5 (complex) → checks LIBS → growth-log updated today → exit 0
 ```
 
-### Complex task, no learning — BLOCKED
-
+**Complex task, no learning — BLOCKED:**
 ```
-$ claude  # edits 4 files, nothing written to memory
-...
-Claude tries to stop → hook runs:
-  edit_count=4 (complex) → checks LIBS → all 5 stale → exit 2 (blocked)
-  stderr: "Blocked: complex task completed but no learning captured today."
+edit_count=4 (complex) → checks LIBS → all 5 stale → exit 2
+stderr: "Blocked: complex task completed but no learning captured today."
 ```
 
-### Low disk space — BLOCKED regardless
-
+**Low disk space — BLOCKED:**
 ```
-$ claude  # any session, home filesystem at 12GB
-...
-Claude tries to stop → hook runs:
-  disk_free=12GB < 15GB critical → exit 2 (blocked)
-  stderr: "Blocked: disk space at 12GB (threshold: 15GB)."
+disk_free=12GB < 15GB critical → exit 2
+stderr: "Blocked: disk space at 12GB (threshold: 15GB)."
 ```
 
-## Related Skills
+## Limitations
 
-- `verification-loop` — Technical checks (build, type, lint, test). Different scope: code output vs learning capture.
-- `gateguard` — Same architecture (deterministic hook + pattern matching), different lifecycle point (PreToolUse vs Stop).
+The hook enforces the **habit** of touching learning libraries, not the **quality** of what was recorded. If `output-index.md` is updated but `growth-log` is skipped, the hook passes (1 of 5 libraries touched). This is by design: mechanical gates check machine-verifiable facts. For content quality verification, pair with `self-audit`.
+
+## Compatibility
+
+- Python 3.8+ (uses `from __future__ import annotations`)
+- Cross-platform: Windows, macOS, Linux
+- Zero dependencies beyond stdlib
+
+## Quality
+
+This code went through 4 rounds of automated code review (CodeRabbit + Greptile) with 9 real bugs found and fixed.
+
+## See Also
+
+- `self-audit` — Reasoning quality gate (completeness/consistency/groundedness/honesty)
+- `verification-loop` — Code quality checks (build/type/lint/test)
+- `gateguard` — PreToolUse safety gate

--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -47,14 +47,14 @@ cp skills/delivery-gate/hooks/quality-gate.py ~/.claude/scripts/
 Add this block to your project or global CLAUDE.md:
 
 ```markdown
-## 收尾铁律
+## Session-End Checklist (收尾铁律)
 
-复杂任务结束必须自动输出:
-1. 自审 — 矛盾/遗漏/未验证假设/美化
-2. 教学 — 为什么做/如何做/核心收益 (仅代码任务)
-3. 交付门 — 五库+磁盘
-4. 沉淀 — 新事实→persona | 翻车→growth-log
-5. 产出索引
+After complex tasks, verify before stopping:
+1. Self-Audit — contradictions, omissions, unverified assumptions, sugar-coating
+2. Teaching Output — why + how + core benefit (code tasks only)
+3. Delivery Gate — five libraries + disk space
+4. Capture — new facts→persona | failures→growth-log
+5. Output Index — record deliverable paths
 ```
 
 ### 4. Create memory libraries
@@ -63,7 +63,7 @@ See `memory/README.md` for the five-library setup.
 
 ## How It Works
 
-The hook receives the full transcript on stdin. It:
+The hook parses stdin (handles both raw transcript text and JSON with `transcript_path` for Claude Code Stop hooks). It:
 1. Scans for rationalization patterns (e.g., "this is a pre-existing issue", "skip tests for now")
 2. Counts Edit/Write tool invocations to detect complex tasks
 3. Checks if five learning libraries were modified today (filesystem mtime)

--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: delivery-gate
-description: Stop hook that blocks Claude from finishing until quality checks pass. Detects rationalization patterns, stale learning logs (via mtime), and low disk space. Complements verification-loop by enforcing learning capture rather than just checking code quality.
+description: Stop hook that blocks Claude from finishing until quality checks pass. Detects contradictions, omissions, unverified assumptions, rationalization patterns, stale learning logs, and low disk space. Complements verification-loop by checking thinking quality rather than just code quality.
 ---
 
 # Delivery Gate — Self-Audit Stop Hook
 
-A Stop hook that blocks Claude from finishing when quality conditions aren't met. Unlike verification-loop (which checks build/test/lint), this system checks **session hygiene**: did Claude rationalize skipping work? Did it update learning logs after code changes? Is disk space dangerously low?
+A Stop hook that forces Claude to verify quality before it can finish. Unlike verification-loop (which checks build/test/lint), this system checks **thinking quality**: did Claude assume something untested? Did it rationalize skipping work? Did it skip documenting a lesson? Is disk space dangerously low?
 
 ## When to Activate
 
@@ -47,14 +47,14 @@ cp skills/delivery-gate/hooks/quality-gate.py ~/.claude/scripts/
 Add this block to your project or global CLAUDE.md:
 
 ```markdown
-## Session-End Checklist (收尾铁律)
+## 收尾铁律
 
-After complex tasks, verify before stopping:
-1. Self-Audit — contradictions, omissions, unverified assumptions, sugar-coating
-2. Teaching Output — why + how + core benefit (code tasks only)
-3. Delivery Gate — five libraries + disk space
-4. Capture — new facts→persona | failures→growth-log
-5. Output Index — record deliverable paths
+复杂任务结束必须自动输出:
+1. 自审 — 矛盾/遗漏/未验证假设/美化
+2. 教学 — 为什么做/如何做/核心收益 (仅代码任务)
+3. 交付门 — 五库+磁盘
+4. 沉淀 — 新事实→persona | 翻车→growth-log
+5. 产出索引
 ```
 
 ### 4. Create memory libraries
@@ -63,12 +63,12 @@ See `memory/README.md` for the five-library setup.
 
 ## How It Works
 
-The hook parses stdin (handles both raw transcript text and JSON with `transcript_path` for Claude Code Stop hooks). It:
-1. Scans for rationalization patterns (e.g., "this is a pre-existing issue", "skip tests for now")
+The hook receives the full transcript on stdin (handles both raw text and JSON with `transcript_path` for Claude Code Stop hooks). It:
+1. Detects rationalization patterns (e.g., "this is a pre-existing issue", "skip tests for now")
 2. Counts Edit/Write tool invocations to detect complex tasks
 3. Checks if five learning libraries were modified today (filesystem mtime)
 4. Checks home-directory filesystem disk space
-5. Blocks (exit 2) when complex tasks complete without learning capture or disk is critically low
+5. Blocks (exit 2) when complex tasks complete without learning capture, or disk is critically low
 
 ## Customization
 
@@ -76,7 +76,7 @@ Edit `quality-gate.py`:
 - `RATIONALIZE` regex patterns — add your team's common excuses
 - `LIBS` dictionary — customize which files to check
 - `MIN_CHARS` — minimum transcript length to trigger checks
-- `DISK_REMIND_GB` / `DISK_WARN_GB` / `DISK_CRIT_GB` — adjust for your environment
+- `DISK_WARN_GB` / `DISK_CRIT_GB` — adjust for your environment
 
 ## Examples
 

--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: delivery-gate
+description: Stop hook that blocks Claude from finishing until quality checks pass. Detects incomplete tasks, stale learning logs, and low disk space. Complements verification-loop by checking thinking quality (contradictions, omissions, unverified assumptions) rather than just code quality.
+---
+
+# Delivery Gate — Self-Audit Stop Hook
+
+A Stop hook that forces Claude to verify quality before it can finish. Unlike verification-loop (which checks build/test/lint), this system checks **thinking quality**: did Claude assume something untested? Did it skip documenting a lesson? Is disk space dangerously low?
+
+## When to Activate
+
+- Any project where you want Claude to learn from its mistakes over time
+- Long coding sessions where "done" often means "code works but thinking was sloppy"
+- Teams that want consistent quality standards across AI-assisted work
+
+## Installation
+
+### 1. Install the hook script
+
+```bash
+# From the ECC repo root (after cloning/forking):
+cp skills/delivery-gate/hooks/quality-gate.py ~/.claude/scripts/
+```
+
+### 2. Configure in settings.json
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/scripts/quality-gate.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3. Add CLAUDE.md rules
+
+Add this block to your project or global CLAUDE.md:
+
+```markdown
+## 收尾铁律
+
+复杂任务结束必须自动输出:
+1. 自审 — 矛盾/遗漏/未验证假设/美化
+2. 教学 — 为什么做/如何做/核心收益 (仅代码任务)
+3. 交付门 — 五库+磁盘
+4. 沉淀 — 新事实→persona | 翻车→growth-log
+5. 产出索引
+```
+
+### 4. Create memory libraries
+
+See `memory/README.md` for the five-library setup.
+
+## How It Works
+
+The hook receives the full transcript on stdin. It:
+1. Detects "rationalization patterns" (e.g., "this is a pre-existing issue")
+2. Counts Edit/Write calls to detect complex tasks
+3. Checks if five learning libraries were updated today
+4. Checks home-directory filesystem disk space
+5. Blocks (exit 2) when complex tasks complete without learning capture
+
+## Customization
+
+Edit `quality-gate.py`:
+- `RATIONALIZE` regex patterns — add your team's common excuses
+- `LIBS` dictionary — customize which files to check
+- `MIN_CHARS` — minimum transcript length to trigger checks
+- `DISK_WARN_GB` / `DISK_CRIT_GB` — adjust for your environment
+
+## Examples
+
+### Normal session — no blocking
+
+```
+$ claude  # edits 2 files, updates growth-log
+...
+Claude tries to stop → hook runs:
+  edit_count=2 (< 3, not complex) → exit 0 (allowed)
+```
+
+### Complex task, learning captured — allowed
+
+```
+$ claude  # edits 5 files, updates growth-log/2026-06-26.md
+...
+Claude tries to stop → hook runs:
+  edit_count=5 (complex) → checks LIBS → growth-log updated today → exit 0 (allowed)
+```
+
+### Complex task, no learning — BLOCKED
+
+```
+$ claude  # edits 4 files, nothing written to memory
+...
+Claude tries to stop → hook runs:
+  edit_count=4 (complex) → checks LIBS → all 5 stale → exit 2 (blocked)
+  stderr: "Blocked: complex task completed but no learning captured today."
+```
+
+### Low disk space — BLOCKED regardless
+
+```
+$ claude  # any session, home filesystem at 12GB
+...
+Claude tries to stop → hook runs:
+  disk_free=12GB < 15GB critical → exit 2 (blocked)
+  stderr: "Blocked: disk space at 12GB (threshold: 15GB)."
+```
+
+## Related Skills
+
+- `verification-loop` — Technical checks (build, type, lint, test). Different scope: code output vs learning capture.
+- `gateguard` — Same architecture (deterministic hook + pattern matching), different lifecycle point (PreToolUse vs Stop).

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import sys
 import os
 import re
+import json
 import datetime
 import shutil
 import logging
@@ -133,6 +134,21 @@ def main() -> None:
     # Stop-hook contract: echo stdin to stdout so the harness can forward the payload
     sys.stdout.write(raw)
 
+    # Resolve transcript: Stop hooks may receive raw text OR JSON with transcript_path.
+    # Handle both so the gate works regardless of Claude Code version/configuration.
+    transcript = raw
+    try:
+        payload = json.loads(raw)
+        if isinstance(payload, dict) and 'transcript_path' in payload:
+            tp = os.path.expanduser(payload['transcript_path'])
+            if os.path.exists(tp):
+                with open(tp, 'r', encoding='utf-8') as f:
+                    transcript = f.read()
+            else:
+                log.warning('transcript_path %s not found, falling back to raw stdin', tp)
+    except (json.JSONDecodeError, TypeError, OSError):
+        pass  # Not JSON or unreadable — use raw stdin as transcript
+
     # 1. Disk check — three-level: remind / warn / block
     disk_free = check_disk()
     if disk_free is not None:
@@ -146,13 +162,15 @@ def main() -> None:
             log.info('Reminder: disk space at %dGB (<%dGB)', disk_free, DISK_REMIND_GB)
 
     # 2. Short session — skip remaining checks
-    if len(raw) < MIN_CHARS:
+    if len(transcript) < MIN_CHARS:
         sys.exit(0)
+
+    tail = transcript[-8000:]
 
     # 3. Rationalization pattern detection
     hits = []
     for p in RATIONALIZE:
-        m = re.search(p, raw[-8000:], re.IGNORECASE)
+        m = re.search(p, tail, re.IGNORECASE)
         if m:
             hits.append(m.group(0)[:80])
     if hits:
@@ -160,7 +178,7 @@ def main() -> None:
 
     # 4. Learning capture check
     mem_dir = get_project_memory_dir()
-    edit_count = count_edits(raw)
+    edit_count = count_edits(transcript)
     is_complex = edit_count >= COMPLEX_THRESHOLD
 
     if mem_dir:

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -22,8 +22,8 @@ from typing import Optional
 RATIONALIZE = [
     r'(?:this|that)\s+is\s+a\s+pre[- ]existing\s+(?:issue|bug)\b(?!\s+(?:that|which|and))',
     r'skipping\s+(?:tests?|lint|coverage|type[- ]check)\s+for\s+now',
-    r'(?:tests?|coverage)\s+(?:are|is)\s+(?:failing|broken)\s+but\s+(?:I|we)\'ll\s+(?:fix|address)',
-    r'(?:not\s+addressing|won\'t\s+fix|leaving)\s+the\s+(?:failing|broken)\s+(?:test|build)',
+    r'(?:tests?|coverage)\s+(?:are|is)\s+(?:failing|broken)\s+but\s+(?:I|we)\s+(?:\'ll|can|will)\s+(?:fix|address|resolve|handle)',
+    r'(?:not\s+addressing|won\'t\s+fix|leaving)\s+the\s+(?:failing|broken)\s+(?:tests?|builds?|integration\s+tests?)',
 ]
 
 LIBS = {

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -55,7 +55,7 @@ def get_project_memory_dir() -> Optional[str]:
     Returns None if no memory directory exists for this project.
     Does NOT fall back to other projects (privacy boundary)."""
     cwd = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
-    safe = cwd.replace(':', '').replace('\\', '-').replace('/', '-')
+    safe = cwd.replace(':', '-').replace('\\', '-').replace('/', '-')
     mem = os.path.expanduser(f'~/.claude/projects/{safe}/memory')
     log.info('Looking for memory dir: cwd=%s -> %s', cwd, mem)
     if os.path.isdir(mem):

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Stop hook: quality gate with delivery check.
+Detects incomplete work, stale learning logs, and low disk space.
+Blocks Claude from stopping when a complex task completed without learning capture.
+
+Install: cp this file to ~/.claude/scripts/quality-gate.py
+Configure: Add to settings.json hooks.Stop
+"""
+from __future__ import annotations
+
+import sys
+import os
+import re
+import datetime
+import shutil
+import logging
+from typing import Optional
+
+# ---- Configuration ----
+# Patterns that indicate rationalized incompleteness
+RATIONALIZE = [
+    r'(?:this|that)\s+is\s+a\s+pre[- ]existing\s+(?:issue|bug)\b(?!\s+(?:that|which|and))',
+    r'skipping\s+(?:tests?|lint|coverage|type[- ]check)\s+for\s+now',
+    r'(?:tests?|coverage)\s+(?:are|is)\s+(?:failing|broken)\s+but\s+(?:I|we)\'ll\s+(?:fix|address)',
+    r'(?:not\s+addressing|won\'t\s+fix|leaving)\s+the\s+(?:failing|broken)\s+(?:test|build)',
+]
+
+# Files to check for today's updates (relative to project memory dir)
+# Customize these to match your learning-capture workflow
+LIBS = {
+    'ratings-tracker': 'ratings-tracker.md',
+    'decisions-log': 'decisions/log.md',
+    'growth-log': 'growth-log/',          # directory — any file updated today counts
+    'output-index': 'output-index.md',
+    'tooling-capabilities': 'tooling_capabilities.md',
+}
+
+MIN_CHARS = 40          # minimum transcript length to trigger checks
+COMPLEX_THRESHOLD = 3   # Edit/Write calls to classify as "complex task"
+DISK_REMIND_GB = 50     # remind when free space below this
+DISK_WARN_GB = 30       # warn when free space below this
+DISK_CRIT_GB = 15       # block stop when below this
+# ---- End Configuration ----
+
+# Configure stderr logger per coding guidelines
+logging.basicConfig(
+    stream=sys.stderr,
+    format='%(levelname)s: %(message)s',
+    level=logging.WARNING,
+)
+log = logging.getLogger('quality-gate')
+
+
+def get_project_memory_dir() -> Optional[str]:
+    """Find the current project's memory directory.
+    Returns None if no memory directory exists for this project.
+    Does NOT fall back to other projects (privacy boundary)."""
+    cwd = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
+    safe = cwd.replace(':', '').replace('\\', '-').replace('/', '-')
+    mem = os.path.expanduser(f'~/.claude/projects/{safe}/memory')
+    if os.path.isdir(mem):
+        return mem
+    return None
+
+
+def check_disk() -> Optional[int]:
+    """Check free space on the disk containing the home directory.
+    Works cross-platform: macOS, Linux, Windows.
+    Returns free GB, or None if the home directory is unavailable
+    (e.g. on a headless CI runner without a real home dir)."""
+    try:
+        home = os.path.expanduser('~')
+        free_gb = shutil.disk_usage(home).free // (2**30)
+        return free_gb
+    except (FileNotFoundError, PermissionError, OSError):
+        # Home dir not accessible — log and continue without disk check
+        log.warning('cannot check disk space (home dir inaccessible)')
+        return None
+
+
+def check_stale_libs(mem_dir: str) -> list[str]:
+    """Return list of library names not updated today.
+    Per-file OSError handling: individual unreadable files are skipped,
+    but the scan continues for remaining libraries."""
+    today = datetime.date.today()
+    stale: list[str] = []
+    for name, path in LIBS.items():
+        full = os.path.join(mem_dir, path)
+        try:
+            if os.path.isdir(full):
+                has_today = False
+                for dirpath, _dirnames, filenames in os.walk(full):
+                    for f in filenames:
+                        fp = os.path.join(dirpath, f)
+                        try:
+                            mt = datetime.datetime.fromtimestamp(os.path.getmtime(fp)).date()
+                            if mt == today:
+                                has_today = True
+                                break
+                        except OSError:
+                            continue
+                    if has_today:
+                        break
+                if not has_today:
+                    stale.append(name)
+            elif os.path.exists(full):
+                try:
+                    mt = datetime.datetime.fromtimestamp(os.path.getmtime(full)).date()
+                    if mt != today:
+                        stale.append(name)
+                except OSError:
+                    stale.append(name)
+            else:
+                stale.append(name)
+        except OSError as e:
+            log.warning('cannot access lib %s: %s', name, e)
+            stale.append(name)
+    return stale
+
+
+def count_edits(text: str) -> int:
+    """Count Edit/Write tool invocations in the transcript.
+    Matches structured tool-call JSON patterns to avoid false-positives
+    from ordinary English prose."""
+    tail = text[-8000:]
+    return len(re.findall(r'"name":\s*"(?:Edit|Write)"', tail))
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    sys.stdout.write(raw)
+
+    # 1. Disk check — three-level: remind / warn / block
+    disk_free = check_disk()
+    if disk_free is not None:
+        if disk_free < DISK_CRIT_GB:
+            log.warning('Blocked: disk space at %dGB (<%dGB). Free space before continuing.',
+                        disk_free, DISK_CRIT_GB)
+            sys.exit(2)
+        if disk_free < DISK_WARN_GB:
+            log.warning('WARN: disk space at %dGB (<%dGB)', disk_free, DISK_WARN_GB)
+        elif disk_free < DISK_REMIND_GB:
+            log.info('Reminder: disk space at %dGB (<%dGB)', disk_free, DISK_REMIND_GB)
+
+    # 2. Short session — skip remaining checks
+    if len(raw) < MIN_CHARS:
+        sys.exit(0)
+
+    tail = raw[-8000:]
+
+    # 3. Rationalization pattern detection
+    hits = []
+    for p in RATIONALIZE:
+        m = re.search(p, tail, re.IGNORECASE)
+        if m:
+            hits.append(m.group(0)[:80])
+    if hits:
+        log.warning('quality-gate: %s', hits)
+
+    # 4. Learning capture check
+    mem_dir = get_project_memory_dir()
+    edit_count = count_edits(raw)
+    is_complex = edit_count >= COMPLEX_THRESHOLD
+
+    if mem_dir:
+        stale = check_stale_libs(mem_dir)
+    else:
+        stale = []
+
+    parts = []
+    if is_complex:
+        status_icons = ['X' if s in stale else 'O' for s in LIBS]
+        parts.append(
+            f'\n  Complex task ({edit_count} edits). '
+            f'Check: [{"][".join(f"{k}:{v}" for k,v in zip(LIBS.keys(), status_icons))}]'
+        )
+    if stale:
+        parts.append(f'  Stale ({len(stale)}): {", ".join(stale)}')
+
+    if parts:
+        log.warning('\n'.join(parts))
+
+    # 5. Block if complex task completed without learning capture
+    if is_complex:
+        if len(stale) >= 3:
+            log.warning('Blocked: complex task but >=3 learning libs stale.')
+            log.warning(f'Stale: {", ".join(stale)}. Update before stopping.')
+            sys.exit(2)
+        if 'growth-log' in stale:
+            log.warning('Blocked: code changes made but no growth-log update.')
+            log.warning('Write growth-log before stopping (even if "no new learnings").')
+            sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -19,7 +19,6 @@ import logging
 from typing import Optional
 
 # ---- Configuration ----
-# Patterns that indicate rationalized incompleteness
 RATIONALIZE = [
     r'(?:this|that)\s+is\s+a\s+pre[- ]existing\s+(?:issue|bug)\b(?!\s+(?:that|which|and))',
     r'skipping\s+(?:tests?|lint|coverage|type[- ]check)\s+for\s+now',
@@ -27,8 +26,6 @@ RATIONALIZE = [
     r'(?:not\s+addressing|won\'t\s+fix|leaving)\s+the\s+(?:failing|broken)\s+(?:test|build)',
 ]
 
-# Files to check for today's updates (relative to project memory dir)
-# Customize these to match your learning-capture workflow
 LIBS = {
     'ratings-tracker': 'ratings-tracker.md',
     'decisions-log': 'decisions/log.md',
@@ -60,6 +57,7 @@ def get_project_memory_dir() -> Optional[str]:
     cwd = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
     safe = cwd.replace(':', '').replace('\\', '-').replace('/', '-')
     mem = os.path.expanduser(f'~/.claude/projects/{safe}/memory')
+    log.info('Looking for memory dir: cwd=%s -> %s', cwd, mem)
     if os.path.isdir(mem):
         return mem
     return None
@@ -130,12 +128,9 @@ def count_edits(text: str) -> int:
 
 def main() -> None:
     raw = sys.stdin.read()
-
-    # Stop-hook contract: echo stdin to stdout so the harness can forward the payload
     sys.stdout.write(raw)
 
     # Resolve transcript: Stop hooks may receive raw text OR JSON with transcript_path.
-    # Handle both so the gate works regardless of Claude Code version/configuration.
     transcript = raw
     try:
         payload = json.loads(raw)
@@ -147,7 +142,7 @@ def main() -> None:
             else:
                 log.warning('transcript_path %s not found, falling back to raw stdin', tp)
     except (json.JSONDecodeError, TypeError, OSError):
-        pass  # Not JSON or unreadable — use raw stdin as transcript
+        pass
 
     # 1. Disk check — three-level: remind / warn / block
     disk_free = check_disk()
@@ -184,17 +179,13 @@ def main() -> None:
     if mem_dir:
         stale = check_stale_libs(mem_dir)
     else:
-        # No memory dir — setup incomplete.
         if is_complex:
-            # User is actively editing but hasn't configured memory yet.
-            # Treat all libraries as stale so the gate enforces setup.
             log.warning('No project memory directory found — cannot verify learning capture.')
             log.warning('Set up memory/ per delivery-gate SKILL.md to enable enforcement.')
             stale = list(LIBS.keys())
         else:
             stale = []
 
-    # Build warning message
     parts = []
     if is_complex:
         status_icons = ['X' if s in stale else 'O' for s in LIBS]

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -179,12 +179,13 @@ def main() -> None:
     if mem_dir:
         stale = check_stale_libs(mem_dir)
     else:
+        # No memory dir — setup incomplete.
+        # Warn but DO NOT block: blocking here deadlocks new users
+        # who haven't created the memory directory yet.
         if is_complex:
             log.warning('No project memory directory found — cannot verify learning capture.')
             log.warning('Set up memory/ per delivery-gate SKILL.md to enable enforcement.')
-            stale = list(LIBS.keys())
-        else:
-            stale = []
+        stale = []
 
     parts = []
     if is_complex:

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -128,7 +128,9 @@ def count_edits(text: str) -> int:
 
 def main() -> None:
     raw = sys.stdin.read()
-    sys.stdout.write(raw)
+    # Stop hooks write feedback to stderr, not stdout.
+    # Claude Code reads stderr as the hook's response message.
+    # Do NOT echo raw JSON to stdout — it would overwrite the blocking reason.
 
     # Resolve transcript: Stop hooks may receive raw text OR JSON with transcript_path.
     transcript = raw
@@ -150,6 +152,8 @@ def main() -> None:
         if disk_free < DISK_CRIT_GB:
             log.warning('Blocked: disk space at %dGB (<%dGB). Free space before continuing.',
                         disk_free, DISK_CRIT_GB)
+            log.warning('Blocked: disk space at %dGB (<%dGB). Free space before continuing.',
+                        disk_free, DISK_CRIT_GB)
             sys.exit(2)
         if disk_free < DISK_WARN_GB:
             log.warning('WARN: disk space at %dGB (<%dGB)', disk_free, DISK_WARN_GB)
@@ -169,7 +173,7 @@ def main() -> None:
         if m:
             hits.append(m.group(0)[:80])
     if hits:
-        log.warning('quality-gate: %s', hits)
+        log.warning('quality-gate: rationalization detected — %s', hits)
 
     # 4. Learning capture check
     mem_dir = get_project_memory_dir()

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -152,8 +152,6 @@ def main() -> None:
         if disk_free < DISK_CRIT_GB:
             log.warning('Blocked: disk space at %dGB (<%dGB). Free space before continuing.',
                         disk_free, DISK_CRIT_GB)
-            log.warning('Blocked: disk space at %dGB (<%dGB). Free space before continuing.',
-                        disk_free, DISK_CRIT_GB)
             sys.exit(2)
         if disk_free < DISK_WARN_GB:
             log.warning('WARN: disk space at %dGB (<%dGB)', disk_free, DISK_WARN_GB)

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -47,7 +47,7 @@ DISK_CRIT_GB = 15       # block stop when below this
 logging.basicConfig(
     stream=sys.stderr,
     format='%(levelname)s: %(message)s',
-    level=logging.WARNING,
+    level=logging.INFO,
 )
 log = logging.getLogger('quality-gate')
 
@@ -120,11 +120,11 @@ def check_stale_libs(mem_dir: str) -> list[str]:
 
 
 def count_edits(text: str) -> int:
-    """Count Edit/Write tool invocations in the transcript.
+    """Count Edit/Write tool invocations in the full transcript.
     Matches structured tool-call JSON patterns to avoid false-positives
-    from ordinary English prose."""
-    tail = text[-8000:]
-    return len(re.findall(r'"name":\s*"(?:Edit|Write)"', tail))
+    from ordinary English prose (e.g., 'Edit the file' in conversation).
+    Scans entire transcript — not truncated to tail."""
+    return len(re.findall(r'"name":\s*"(?:Edit|Write)"', text))
 
 
 def main() -> None:
@@ -147,12 +147,10 @@ def main() -> None:
     if len(raw) < MIN_CHARS:
         sys.exit(0)
 
-    tail = raw[-8000:]
-
-    # 3. Rationalization pattern detection
+    # 3. Rationalization pattern detection (logs warning only)
     hits = []
     for p in RATIONALIZE:
-        m = re.search(p, tail, re.IGNORECASE)
+        m = re.search(p, raw[-8000:], re.IGNORECASE)
         if m:
             hits.append(m.group(0)[:80])
     if hits:
@@ -166,6 +164,11 @@ def main() -> None:
     if mem_dir:
         stale = check_stale_libs(mem_dir)
     else:
+        # No memory dir — setup incomplete. Warn but don't block;
+        # blocking users who haven't opted in yet is worse than false-pass.
+        if is_complex:
+            log.warning('No project memory directory found — cannot verify learning capture.')
+            log.warning('Set up memory/ per delivery-gate SKILL.md to enable enforcement.')
         stale = []
 
     parts = []

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -47,7 +47,7 @@ DISK_CRIT_GB = 15       # block stop when below this
 logging.basicConfig(
     stream=sys.stderr,
     format='%(levelname)s: %(message)s',
-    level=logging.INFO,
+    level=logging.INFO,  # INFO for DISK_REMIND; warnings still emitted
 )
 log = logging.getLogger('quality-gate')
 
@@ -147,7 +147,7 @@ def main() -> None:
     if len(raw) < MIN_CHARS:
         sys.exit(0)
 
-    # 3. Rationalization pattern detection (logs warning only)
+    # 3. Rationalization pattern detection
     hits = []
     for p in RATIONALIZE:
         m = re.search(p, raw[-8000:], re.IGNORECASE)
@@ -164,12 +164,15 @@ def main() -> None:
     if mem_dir:
         stale = check_stale_libs(mem_dir)
     else:
-        # No memory dir — setup incomplete. Warn but don't block;
-        # blocking users who haven't opted in yet is worse than false-pass.
+        # No memory dir — setup incomplete.
         if is_complex:
+            # User is actively editing but hasn't configured memory yet.
+            # Treat all libraries as stale so the gate enforces setup.
             log.warning('No project memory directory found — cannot verify learning capture.')
             log.warning('Set up memory/ per delivery-gate SKILL.md to enable enforcement.')
-        stale = []
+            stale = list(LIBS.keys())
+        else:
+            stale = []
 
     parts = []
     if is_complex:

--- a/skills/delivery-gate/hooks/quality-gate.py
+++ b/skills/delivery-gate/hooks/quality-gate.py
@@ -31,29 +31,29 @@ RATIONALIZE = [
 LIBS = {
     'ratings-tracker': 'ratings-tracker.md',
     'decisions-log': 'decisions/log.md',
-    'growth-log': 'growth-log/',          # directory — any file updated today counts
+    'growth-log': 'growth-log/',
     'output-index': 'output-index.md',
     'tooling-capabilities': 'tooling_capabilities.md',
 }
 
-MIN_CHARS = 40          # minimum transcript length to trigger checks
-COMPLEX_THRESHOLD = 3   # Edit/Write calls to classify as "complex task"
-DISK_REMIND_GB = 50     # remind when free space below this
-DISK_WARN_GB = 30       # warn when free space below this
-DISK_CRIT_GB = 15       # block stop when below this
+MIN_CHARS = 40
+COMPLEX_THRESHOLD = 3
+DISK_REMIND_GB = 50
+DISK_WARN_GB = 30
+DISK_CRIT_GB = 15
 # ---- End Configuration ----
 
-# Configure stderr logger per coding guidelines
 logging.basicConfig(
     stream=sys.stderr,
     format='%(levelname)s: %(message)s',
-    level=logging.INFO,  # INFO for DISK_REMIND; warnings still emitted
+    level=logging.INFO,
 )
 log = logging.getLogger('quality-gate')
 
 
 def get_project_memory_dir() -> Optional[str]:
     """Find the current project's memory directory.
+
     Returns None if no memory directory exists for this project.
     Does NOT fall back to other projects (privacy boundary)."""
     cwd = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
@@ -66,21 +66,21 @@ def get_project_memory_dir() -> Optional[str]:
 
 def check_disk() -> Optional[int]:
     """Check free space on the disk containing the home directory.
+
     Works cross-platform: macOS, Linux, Windows.
-    Returns free GB, or None if the home directory is unavailable
-    (e.g. on a headless CI runner without a real home dir)."""
+    Returns free GB, or None if the home directory is unavailable."""
     try:
         home = os.path.expanduser('~')
         free_gb = shutil.disk_usage(home).free // (2**30)
         return free_gb
     except (FileNotFoundError, PermissionError, OSError):
-        # Home dir not accessible — log and continue without disk check
         log.warning('cannot check disk space (home dir inaccessible)')
         return None
 
 
 def check_stale_libs(mem_dir: str) -> list[str]:
     """Return list of library names not updated today.
+
     Per-file OSError handling: individual unreadable files are skipped,
     but the scan continues for remaining libraries."""
     today = datetime.date.today()
@@ -121,14 +121,16 @@ def check_stale_libs(mem_dir: str) -> list[str]:
 
 def count_edits(text: str) -> int:
     """Count Edit/Write tool invocations in the full transcript.
+
     Matches structured tool-call JSON patterns to avoid false-positives
-    from ordinary English prose (e.g., 'Edit the file' in conversation).
-    Scans entire transcript — not truncated to tail."""
+    from ordinary English prose. Scans entire transcript."""
     return len(re.findall(r'"name":\s*"(?:Edit|Write)"', text))
 
 
 def main() -> None:
     raw = sys.stdin.read()
+
+    # Stop-hook contract: echo stdin to stdout so the harness can forward the payload
     sys.stdout.write(raw)
 
     # 1. Disk check — three-level: remind / warn / block
@@ -174,6 +176,7 @@ def main() -> None:
         else:
             stale = []
 
+    # Build warning message
     parts = []
     if is_complex:
         status_icons = ['X' if s in stale else 'O' for s in LIBS]


### PR DESCRIPTION
## What this is

A Stop hook that checks **session hygiene** before Claude can finish — not reasoning quality (that's self-audit's job), but machine-verifiable facts: file timestamps, disk usage, and regex patterns on transcript text.

Three checks, all configurable:
1. **Rationalization patterns** — "skip tests for now", "pre-existing bug", "fix later". Surface signals that thinking may have been cut short. **Warning only** — never blocks on its own, because regex heuristics can false-positive.
2. **Session freshness** — were project memory files updated today? If no memory directory exists, warns and passes (no deadlock for new users).
3. **Disk health** — is the home directory critically low on space?

If a complex task (3+ file edits) completed with ALL learning libraries stale → blocks stop (exit 2). Disk critical → blocks regardless. Otherwise passes silently.

~200 lines of Python. Stdlib only. Deterministic — no AI inference, just file timestamps + regex + disk usage.

## Relationship to existing ECC skills

| Skill | Checks | Lifecycle |
|-------|--------|-----------|
| `verification-loop` | Code output (build/type/lint/test/security) | Pre-commit |
| `gateguard` | Blocks dangerous tool calls | PreToolUse |
| `self-audit` | Reasoning quality (completeness/consistency/groundedness/honesty) | Pre-delivery |
| **`delivery-gate`** | **Session hygiene (rationalizations, staleness, disk)** | **Stop** |

delivery-gate is a **mechanical** gate (deterministic checks on machine-verifiable facts). self-audit is a **reasoning** gate (agent evaluates output quality). Together they form defense in depth — the same pattern as CI pipeline gates.

## Files

| File | Purpose |
|------|---------|
| `skills/delivery-gate/SKILL.md` | Install + config docs |
| `skills/delivery-gate/hooks/quality-gate.py` | The hook |

## Recent update (v1.1.0)

After studying multi-agent pipeline quality gate architectures, refined the SKILL.md documentation to accurately describe what delivery-gate actually checks (deterministic: file timestamps + regex + disk usage) and clearly separate its role from reasoning gates like self-audit. Added warning-vs-block behavior table, limitations section, and CI/CD analogy. **No code changes — same hook, clearer framing.**

## Note

Replaces PR #2365 (auto-closed during fork sync). daltino's approval from #2365 applies to the substance — same contribution, clean feature branch.