### PR TITLE
ci: isolate OMP workflow verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,28 @@ jobs:
         run: node scripts/ci/validate-no-personal-paths.js
         continue-on-error: false
 
+  python-tests:
+    name: Python Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e '.[dev]'
+
+      - name: Run Python tests
+        run: python -m pytest tests/test_*.py -m "not integration"
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest
@@ -246,8 +268,5 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Run ESLint
-        run: npx eslint scripts/**/*.js tests/**/*.js
-
-      - name: Run markdownlint
-        run: npx markdownlint "agents/**/*.md" "skills/**/*.md" "commands/**/*.md" "rules/**/*.md"
+      - name: Run lint
+        run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Verify OpenCode package payload
         run: node tests/scripts/build-opencode.test.js
 
+      - name: Verify OMP adapter payload
+        run: node tests/omp/omp-plugin.test.js
+
       - name: Validate version tag
         run: |
           if ! [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Verify OpenCode package payload
         run: node tests/scripts/build-opencode.test.js
 
+      - name: Verify OMP adapter payload
+        run: node tests/omp/omp-plugin.test.js
+
       - name: Validate version tag
         env:
           INPUT_TAG: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary
This PR isolates the CI/release workflow changes that were removed from #2270.

It contains only workflow YAML updates:
- adds a dedicated `python-tests` job to `.github/workflows/ci.yml`
- replaces the duplicated CI lint steps with a single `npm run lint`
- adds `node tests/omp/omp-plugin.test.js` to the release verification steps in:
  - `.github/workflows/release.yml`
  - `.github/workflows/reusable-release.yml`

## Why
The OMP harness-contract code in #2270 was split into its own PR per maintainer feedback.
This follow-up keeps the workflow/release verification changes separate so they can be reviewed on their own supply-chain/security merits.

## Security / workflow rationale
- all third-party actions remain pinned by full SHA
- checkout keeps `persist-credentials: false`
- no new write-scoped permissions were introduced
- no new cache usage was introduced
- release workflows keep the existing publish ordering and npm provenance protections
- the new OMP verification step is read-only test execution before release validation/publish

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] CI / workflow follow-up

## Testing
Commands run locally:
- `node tests/scripts/release.test.js`
- `node tests/scripts/release-publish.test.js`
- `node scripts/ci/validate-workflow-security.js`

## Checklist
- [x] Follows format guidelines
- [x] Tested locally
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
