### PR TITLE
feat(llm): support configurable provider defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,13 @@ packages = ["src/llm"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 asyncio_mode = "auto"
+addopts = ["--strict-markers"]
+markers = [
+    "unit: fast isolated tests that do not require network or external services",
+    "integration: tests that may exercise provider integrations or external services",
+]
 filterwarnings = ["ignore::DeprecationWarning"]
 
 [tool.coverage.run]
@@ -64,7 +70,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-src-path = ["src"]
+src = ["src"]
 target-version = "py311"
 
 [tool.ruff.lint]
@@ -73,6 +79,6 @@ ignore = ["E501"]
 
 [tool.mypy]
 python_version = "3.11"
-src_paths = ["src"]
+mypy_path = "src"
 warn_return_any = true
 warn_unused_ignores = true

--- a/src/llm/cli/selector.py
+++ b/src/llm/cli/selector.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import os
 import sys
-from enum import Enum
+from enum import StrEnum
 
 
-class Color(str, Enum):
+class Color(StrEnum):
     RESET = "\033[0m"
     BOLD = "\033[1m"
     GREEN = "\033[92m"
@@ -15,6 +15,41 @@ class Color(str, Enum):
     BLUE = "\033[94m"
     CYAN = "\033[96m"
 
+
+_DEFAULT_PROVIDERS: tuple[tuple[str, str], ...] = (
+    ("claude", "Anthropic Claude ( Sonnet, Opus, Haiku)"),
+    ("openai", "OpenAI GPT (4o, 4o-mini, 3.5-turbo)"),
+    ("ollama", "Local Ollama models"),
+    ("astraflow", "UModelVerse global OpenAI-compatible models"),
+    ("astraflow_cn", "UModelVerse China OpenAI-compatible models"),
+)
+
+_DEFAULT_MODELS_PER_PROVIDER: dict[str, tuple[tuple[str, str], ...]] = {
+    "claude": (
+        ("claude-opus-4-5", "Claude Opus 4.5 - Most capable"),
+        ("claude-sonnet-4-7", "Claude Sonnet 4.7 - Balanced"),
+        ("claude-haiku-4-7", "Claude Haiku 4.7 - Fast"),
+    ),
+    "openai": (
+        ("gpt-4o", "GPT-4o - Most capable"),
+        ("gpt-4o-mini", "GPT-4o-mini - Fast & affordable"),
+        ("gpt-4-turbo", "GPT-4 Turbo - Legacy powerful"),
+        ("gpt-3.5-turbo", "GPT-3.5 - Legacy fast"),
+    ),
+    "ollama": (
+        ("llama3.2", "Llama 3.2 - General purpose"),
+        ("mistral", "Mistral - Fast & efficient"),
+        ("codellama", "CodeLlama - Code specialized"),
+    ),
+    "astraflow": (
+        ("gpt-4o-mini", "GPT-4o mini - Default OpenAI-compatible model"),
+        ("deepseek-ai/DeepSeek-V3-0324", "DeepSeek V3 - UModelVerse global"),
+    ),
+    "astraflow_cn": (
+        ("gpt-4o-mini", "GPT-4o mini - Default OpenAI-compatible model"),
+        ("deepseek-ai/DeepSeek-V3-0324", "DeepSeek V3 - UModelVerse China"),
+    ),
+}
 
 def print_banner() -> None:
     banner = f"""{Color.CYAN}
@@ -96,30 +131,12 @@ def interactive_select(
     print_banner()
 
     if providers is None:
-        providers = [
-            ("claude", "Anthropic Claude ( Sonnet, Opus, Haiku)"),
-            ("openai", "OpenAI GPT (4o, 4o-mini, 3.5-turbo)"),
-            ("ollama", "Local Ollama models"),
-        ]
+        providers = list(_DEFAULT_PROVIDERS)
 
     if models_per_provider is None:
         models_per_provider = {
-            "claude": [
-                ("claude-opus-4-5", "Claude Opus 4.5 - Most capable"),
-                ("claude-sonnet-4-7", "Claude Sonnet 4.7 - Balanced"),
-                ("claude-haiku-4-7", "Claude Haiku 4.7 - Fast"),
-            ],
-            "openai": [
-                ("gpt-4o", "GPT-4o - Most capable"),
-                ("gpt-4o-mini", "GPT-4o-mini - Fast & affordable"),
-                ("gpt-4-turbo", "GPT-4 Turbo - Legacy powerful"),
-                ("gpt-3.5-turbo", "GPT-3.5 - Legacy fast"),
-            ],
-            "ollama": [
-                ("llama3.2", "Llama 3.2 - General purpose"),
-                ("mistral", "Mistral - Fast & efficient"),
-                ("codellama", "CodeLlama - Code specialized"),
-            ],
+            provider: list(models)
+            for provider, models in _DEFAULT_MODELS_PER_PROVIDER.items()
         }
 
     provider = select_provider(providers)

--- a/src/llm/prompt/builder.py
+++ b/src/llm/prompt/builder.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from llm.core.types import LLMInput, Message, Role, ToolDefinition
-from llm.providers.claude import ClaudeProvider
-from llm.providers.openai import OpenAIProvider
-from llm.providers.ollama import OllamaProvider
+from llm.core.types import Message, Role, ToolDefinition
 
 
 @dataclass
@@ -36,13 +33,14 @@ class PromptBuilder:
             raise ValueError("Pass either config or PromptBuilder keyword options, not both")
 
         if config is None:
-            overrides = {
-                "system_template": system_template,
-                "user_template": user_template,
-                "include_tools_in_system": include_tools_in_system,
-                "tool_format": tool_format,
-            }
-            config = PromptConfig(**{key: value for key, value in overrides.items() if value is not None})
+            config = PromptConfig(
+                system_template=system_template,
+                user_template=user_template,
+                include_tools_in_system=(
+                    include_tools_in_system if include_tools_in_system is not None else True
+                ),
+                tool_format=tool_format or "native",
+            )
 
         self.config = config
 
@@ -100,6 +98,14 @@ _PROVIDER_TEMPLATE_MAP: dict[str, dict[str, Any]] = {
         "tool_format": "anthropic",
     },
     "openai": {
+        "include_tools_in_system": False,
+        "tool_format": "openai",
+    },
+    "astraflow": {
+        "include_tools_in_system": False,
+        "tool_format": "openai",
+    },
+    "astraflow_cn": {
         "include_tools_in_system": False,
         "tool_format": "openai",
     },

--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -13,13 +13,25 @@ from llm.core.interface import (
     LLMProvider,
     RateLimitError,
 )
-from llm.core.types import LLMInput, LLMOutput, Message, ModelInfo, ProviderType, ToolCall
+from llm.core.types import (
+    LLMInput,
+    LLMOutput,
+    ModelInfo,
+    ProviderType,
+    ToolCall,
+)
 
 
 class ClaudeProvider(LLMProvider):
     provider_type = ProviderType.CLAUDE
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_model: str | None = None,
+    ) -> None:
+        self.default_model = default_model or "claude-sonnet-4-7"
         self.client = Anthropic(api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"), base_url=base_url)
         self._models = [
             ModelInfo(
@@ -51,7 +63,7 @@ class ClaudeProvider(LLMProvider):
     def generate(self, input: LLMInput) -> LLMOutput:
         try:
             params: dict[str, Any] = {
-                "model": input.model or "claude-sonnet-4-7",
+                "model": input.model or self.default_model,
                 "messages": [msg.to_dict() for msg in input.messages],
                 "temperature": input.temperature,
             }
@@ -114,4 +126,4 @@ class ClaudeProvider(LLMProvider):
         return bool(self.client.api_key)
 
     def get_default_model(self) -> str:
-        return "claude-sonnet-4-7"
+        return self.default_model

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -14,14 +14,26 @@ from llm.core.interface import (
     LLMProvider,
     RateLimitError,
 )
-from llm.core.types import LLMInput, LLMOutput, Message, ModelInfo, ProviderType, ToolCall
+from llm.core.types import (
+    LLMInput,
+    LLMOutput,
+    ModelInfo,
+    ProviderType,
+    ToolCall,
+)
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
 
 
 class OpenAIProvider(LLMProvider):
     provider_type = ProviderType.OPENAI
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_model: str | None = None,
+    ) -> None:
+        self.default_model = default_model or "gpt-4o-mini"
         self.client = OpenAI(
             api_key=api_key or os.environ.get("OPENAI_API_KEY"),
             base_url=base_url,
@@ -65,7 +77,7 @@ class OpenAIProvider(LLMProvider):
     def generate(self, input: LLMInput) -> LLMOutput:
         try:
             params: dict[str, Any] = {
-                "model": input.model or "gpt-4o-mini",
+                "model": input.model or self.default_model,
                 "messages": [msg.to_dict() for msg in input.messages],
                 "temperature": input.temperature,
             }
@@ -122,4 +134,4 @@ class OpenAIProvider(LLMProvider):
         return bool(self.client.api_key)
 
     def get_default_model(self) -> str:
-        return "gpt-4o-mini"
+        return self.default_model

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -10,9 +10,8 @@ from llm.core.types import ProviderType
 from llm.providers.astraflow import AstraflowCNProvider, AstraflowProvider
 from llm.providers.atlas import AtlasProvider
 from llm.providers.claude import ClaudeProvider
-from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
-
+from llm.providers.openai import OpenAIProvider
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.ASTRAFLOW: AstraflowProvider,
@@ -48,7 +47,10 @@ def _read_saved_llm_config(env_path: str | Path = LLM_ENV_FILE) -> dict[str, str
     return config
 
 
-def _resolve_provider_type(provider_type: ProviderType | str | None) -> ProviderType | str:
+def _resolve_provider_type(
+    provider_type: ProviderType | str | None,
+    saved_config: dict[str, str] | None = None,
+) -> ProviderType | str:
     if provider_type is not None:
         return provider_type
 
@@ -56,12 +58,28 @@ def _resolve_provider_type(provider_type: ProviderType | str | None) -> Provider
     if env_provider:
         return _strip_env_value(env_provider).lower()
 
+    config = saved_config if saved_config is not None else _read_saved_llm_config()
+    return config.get("LLM_PROVIDER", "claude").lower()
+
+
+def _resolve_default_model(
+    explicit_provider_type: ProviderType | str | None,
+    saved_config: dict[str, str],
+) -> str | None:
+    env_model = os.environ.get("LLM_MODEL")
+    if env_model:
+        return _strip_env_value(env_model)
+
+    if explicit_provider_type is None and not os.environ.get("LLM_PROVIDER"):
+        return saved_config.get("LLM_MODEL")
+
+    return None
+
+
+def get_provider(provider_type: ProviderType | str | None = None, **kwargs: object) -> LLMProvider:
     saved_config = _read_saved_llm_config()
-    return saved_config.get("LLM_PROVIDER", "claude").lower()
-
-
-def get_provider(provider_type: ProviderType | str | None = None, **kwargs: str) -> LLMProvider:
-    provider_type = _resolve_provider_type(provider_type)
+    explicit_provider_type = provider_type
+    provider_type = _resolve_provider_type(provider_type, saved_config)
 
     if isinstance(provider_type, str):
         try:
@@ -72,6 +90,11 @@ def get_provider(provider_type: ProviderType | str | None = None, **kwargs: str)
     provider_cls = _PROVIDER_MAP.get(provider_type)
     if not provider_cls:
         raise ValueError(f"No provider registered for type: {provider_type}")
+
+    if "default_model" not in kwargs:
+        default_model = _resolve_default_model(explicit_provider_type, saved_config)
+        if default_model:
+            kwargs = {**kwargs, "default_model": default_model}
 
     return provider_cls(**kwargs)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,5 +1,6 @@
 import pytest
-from llm.core.types import LLMInput, Message, Role, ToolDefinition
+
+from llm.core.types import Message, Role, ToolDefinition
 from llm.prompt import PromptBuilder, adapt_messages_for_provider
 from llm.prompt.builder import PromptConfig
 
@@ -77,6 +78,16 @@ class TestAdaptMessagesForProvider:
         messages = [Message(role=Role.USER, content="Hello")]
         result = adapt_messages_for_provider(messages, "openai")
         assert len(result) == 1
+
+
+    @pytest.mark.parametrize("provider", ["astraflow", "astraflow_cn"])
+    def test_adapt_for_astraflow_uses_native_openai_tools(self, provider):
+        messages = [Message(role=Role.USER, content="Search for something")]
+        tools = [ToolDefinition(name="search", description="Search the web", parameters={})]
+
+        result = adapt_messages_for_provider(messages, provider, tools)
+
+        assert result == messages
 
     def test_adapt_for_ollama(self):
         messages = [Message(role=Role.USER, content="Hello")]

--- a/tests/test_cli_selector.py
+++ b/tests/test_cli_selector.py
@@ -1,0 +1,16 @@
+from llm.cli.selector import _DEFAULT_MODELS_PER_PROVIDER, _DEFAULT_PROVIDERS
+
+
+def test_default_provider_choices_include_astraflow_endpoints():
+    provider_names = [name for name, _description in _DEFAULT_PROVIDERS]
+
+    assert "astraflow" in provider_names
+    assert "astraflow_cn" in provider_names
+
+
+def test_default_model_choices_include_astraflow_providers():
+    astraflow_models = [name for name, _description in _DEFAULT_MODELS_PER_PROVIDER["astraflow"]]
+    astraflow_cn_models = [name for name, _description in _DEFAULT_MODELS_PER_PROVIDER["astraflow_cn"]]
+
+    assert "gpt-4o-mini" in astraflow_models
+    assert "gpt-4o-mini" in astraflow_cn_models

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -84,6 +84,16 @@ def test_openai_provider_serializes_tools_for_chat_completions():
     ]
 
 
+def test_openai_provider_uses_configured_default_model_for_chat_completions():
+    provider = OpenAIProvider(api_key="test", default_model="gpt-4.1-mini")
+    client = _OpenAIClient()
+    provider.client = client
+
+    provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    assert client.completions.params["model"] == "gpt-4.1-mini"
+
+
 def test_openai_provider_can_be_constructed_without_credentials(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -128,3 +138,13 @@ def test_claude_provider_serializes_tools_for_messages_api():
             "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
         }
     ]
+
+
+def test_claude_provider_uses_configured_default_model_for_messages_api():
+    provider = ClaudeProvider(api_key="test", default_model="claude-opus-4-5")
+    client = _AnthropicClient()
+    provider.client = client
+
+    provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    assert client.messages.params["model"] == "claude-opus-4-5"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,15 @@
 import pytest
+
 from llm.core.types import ProviderType
-from llm.providers import AstraflowCNProvider, AstraflowProvider, AtlasProvider, ClaudeProvider, OpenAIProvider, OllamaProvider, get_provider
+from llm.providers import (
+    AstraflowCNProvider,
+    AstraflowProvider,
+    AtlasProvider,
+    ClaudeProvider,
+    OllamaProvider,
+    OpenAIProvider,
+    get_provider,
+)
 
 
 class TestGetProvider:
@@ -42,23 +51,38 @@ class TestGetProvider:
         with pytest.raises(ValueError, match="Unknown provider type"):
             get_provider("invalid")
 
-    def test_saved_llm_env_selects_provider(self, monkeypatch, tmp_path):
+    def test_saved_llm_env_selects_provider_and_default_model(self, monkeypatch, tmp_path):
         monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        monkeypatch.delenv("LLM_MODEL", raising=False)
         monkeypatch.chdir(tmp_path)
-        tmp_path.joinpath(".llm.env").write_text("LLM_PROVIDER=ollama\nLLM_MODEL=llama3.2\n")
+        tmp_path.joinpath(".llm.env").write_text("LLM_PROVIDER=openai\nLLM_MODEL=gpt-4.1-mini\n")
 
         provider = get_provider()
 
-        assert isinstance(provider, OllamaProvider)
+        assert isinstance(provider, OpenAIProvider)
+        assert provider.get_default_model() == "gpt-4.1-mini"
 
-    def test_env_provider_overrides_saved_llm_env(self, monkeypatch, tmp_path):
+    def test_env_provider_overrides_saved_llm_env_without_saved_model_leakage(self, monkeypatch, tmp_path):
         monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("LLM_MODEL", raising=False)
         monkeypatch.chdir(tmp_path)
-        tmp_path.joinpath(".llm.env").write_text("LLM_PROVIDER=openai\n")
+        tmp_path.joinpath(".llm.env").write_text("LLM_PROVIDER=openai\nLLM_MODEL=gpt-4.1-mini\n")
 
         provider = get_provider()
 
         assert isinstance(provider, OllamaProvider)
+        assert provider.get_default_model() == "llama3.2"
+
+    def test_env_model_sets_provider_default(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "mistral")
+        monkeypatch.chdir(tmp_path)
+        tmp_path.joinpath(".llm.env").write_text("LLM_PROVIDER=openai\nLLM_MODEL=gpt-4.1-mini\n")
+
+        provider = get_provider()
+
+        assert isinstance(provider, OllamaProvider)
+        assert provider.get_default_model() == "mistral"
 
     def test_env_provider_is_normalized(self, monkeypatch):
         monkeypatch.setenv("LLM_PROVIDER", "OLLAMA")


### PR DESCRIPTION
## Summary
This PR isolates the Python/provider changes that were removed from #2270.

It adds configurable provider default-model behavior and wires Astraflow choices into the CLI/prompt adapter surface without touching workflows, release tooling, docs, or OMP code.

## What changed
- `src/llm/providers/openai.py`
  - accept `default_model` in the provider constructor
  - use it when `LLMInput.model` is not supplied
- `src/llm/providers/claude.py`
  - accept `default_model` in the provider constructor
  - use it when `LLMInput.model` is not supplied
- `src/llm/providers/resolver.py`
  - preserve current-main provider map, including Atlas
  - resolve provider type from env / `.llm.env`
  - inject `default_model` from `LLM_MODEL` or saved config when appropriate
- `src/llm/cli/selector.py`
  - add Astraflow and Astraflow CN provider/model defaults
- `src/llm/prompt/builder.py`
  - add Astraflow / Astraflow CN provider template mappings
- `pyproject.toml`
  - fix pytest/ruff/mypy config keys for the current project layout
- tests
  - add coverage for configured default-model behavior, resolver default-model propagation, and Astraflow CLI defaults

## Why
This keeps the Python/LLM provider work in a focused follow-up PR after #2270 was reduced to the OMP-only harness-contract slice.

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Python/provider follow-up

## Testing
Commands run locally:
- `.venv/bin/python -m pytest tests/test_resolver.py tests/test_provider_tools.py tests/test_builder.py tests/test_cli_selector.py -m "not integration"`
- `.venv/bin/ruff check src/llm/cli/selector.py src/llm/prompt/builder.py src/llm/providers/openai.py src/llm/providers/claude.py src/llm/providers/resolver.py tests/test_builder.py tests/test_cli_selector.py tests/test_provider_tools.py tests/test_resolver.py pyproject.toml`
- `.venv/bin/mypy src/llm/cli/selector.py src/llm/prompt/builder.py src/llm/providers/openai.py src/llm/providers/claude.py src/llm/providers/resolver.py`
- `git diff --check`

## Checklist
- [x] Follows format guidelines
- [x] Tested locally
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
