### PR TITLE
fix(plan-orchestrate): detect renamed ecc@ecc marketplace install

### DIFF
--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -103,7 +103,7 @@ A misspelled agent name fails `/orchestrate`. Cross-check against this list befo
    - No marker matched → set `lang=unknown`.
    - `lang=unknown` is a sentinel — it is **not** an agent name. Phase 2 rules 4 and 5 turn it into `code-reviewer` / `build-error-resolver` at chain composition time.
 4. Detect a **PyTorch sub-profile**: when `lang=python` and any of `pyproject.toml` / `requirements.txt` / `uv.lock` declares a dependency on `torch`, set `pytorch=true`. This only affects `build` chain selection (Phase 2 rule below); the reviewer remains `python-reviewer`.
-5. **Normalize any agent names declared in the plan**: if the plan text references agents by a plugin-prefixed form (e.g. `ecc:tdd-guide` or `everything-claude-code:tdd-guide`), strip the `{NS}:` prefix to get the bare catalogue name before validating or composing chains. Re-prefixing happens only at output time per `ECC_MODE` (Phase 4). Never let a pre-prefixed name flow into chain composition — it would double-prefix in plugin mode.
+5. **Normalize any agent names declared in the plan**: if the plan text references agents by a plugin-prefixed form (e.g. `ecc:tdd-guide` or `everything-claude-code:tdd-guide`), strip any known plugin prefix (`ecc:` or `everything-claude-code:`) — not only the currently detected `{NS}:` — to get the bare catalogue name before validating or composing chains. A plan written under one install can be run under another, so a stale prefix that differs from `{NS}` must still be normalized. Re-prefixing happens only at output time per `ECC_MODE` (Phase 4). Never let a pre-prefixed name flow into chain composition — it would double-prefix in plugin mode.
 
 ### Phase 1 — Decompose steps
 

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -45,16 +45,19 @@ Where `{ORCH_CMD}` is determined in Phase 0 (see below). The command string in t
 
 ## ECC install form and namespacing
 
-Two install forms determine the prefix on **both** the slash command and every agent name. The two MUST stay in sync — one form per output, never mixed:
+The install form determines the prefix on **both** the slash command and every agent name. All emitted lines MUST use one form per output, never mixed:
 
 Let `<claude-home>` denote the Claude Code home directory: `~/.claude` on macOS/Linux, `%USERPROFILE%\.claude` on Windows. Resolve it the way the host platform resolves the user home directory (do not hardcode `~`).
 
+Under a plugin install, the prefix is the **marketplace namespace** `{NS}` — the directory name under `<claude-home>/plugins/marketplaces/`. Since 2.0.0 the marketplace is `ecc@ecc`, so `{NS}=ecc`; installs from before the rename used `everything-claude-code`. Phase 0 resolves `{NS}` from the install path once and reuses it everywhere.
+
 | Form | Detection | `{ORCH_CMD}` | Agent name format |
 |---|---|---|---|
-| Plugin install (1.9.0+) | `<claude-home>/plugins/marketplaces/everything-claude-code/` exists | `/everything-claude-code:orchestrate` | `everything-claude-code:<name>` |
-| Legacy bare install | Above absent; agent files under `<claude-home>/agents/` | `/orchestrate` | `<name>` |
+| Plugin install — `ecc@ecc` (2.0.0+, canonical) | `<claude-home>/plugins/marketplaces/ecc/` exists | `/ecc:orchestrate` | `ecc:<name>` |
+| Plugin install — legacy marketplace id (pre-2.0.0) | `<claude-home>/plugins/marketplaces/everything-claude-code/` exists | `/everything-claude-code:orchestrate` | `everything-claude-code:<name>` |
+| Legacy bare install | Both marketplace dirs absent; agent files under `<claude-home>/agents/` | `/orchestrate` | `<name>` |
 
-Why this matters: under the plugin install, agents register as `everything-claude-code:tdd-guide`. Bare names force fuzzy matching, which fails intermittently under parallel calls. Under legacy, the prefixed forms are not registered and fail outright.
+Why this matters: under a plugin install, agents register as `{NS}:tdd-guide` (e.g. `ecc:tdd-guide`). Bare names force fuzzy matching, which fails intermittently under parallel calls. Under legacy, the prefixed forms are not registered and fail outright.
 
 ## Available agent catalogue (must pick from these)
 
@@ -86,11 +89,12 @@ A misspelled agent name fails `/orchestrate`. Cross-check against this list befo
 ### Phase 0 — Detect ECC mode + language
 
 1. Read `<plan-doc-path>`. If missing or empty, report and stop.
-2. Detect ECC install form once and freeze it into `ECC_MODE`. Algorithm (run in order, stop at the first match):
-   1. If `<claude-home>/plugins/marketplaces/everything-claude-code/` exists → `ECC_MODE=plugin`.
-   2. Else if `<claude-home>/agents/` exists and contains at least one ECC agent file (e.g. `tdd-guide.md`, `code-reviewer.md`) → `ECC_MODE=legacy`.
-   3. Else → default to `ECC_MODE=legacy` and emit a one-line warning at the top of the output: `> Warning: could not detect ECC install; defaulting to legacy form. If you use the plugin install, edit the prefixes manually.`
-   4. If both markers exist (mixed install), `plugin` wins — the plugin namespace is the only one that resolves agent names without fuzzy matching.
+2. Detect ECC install form once and freeze it into `ECC_MODE` and (for plugin installs) the marketplace namespace `{NS}`. Algorithm (run in order, stop at the first match):
+   1. If `<claude-home>/plugins/marketplaces/ecc/` exists → `ECC_MODE=plugin`, `{NS}=ecc` (the canonical `ecc@ecc` marketplace, 2.0.0+).
+   2. Else if `<claude-home>/plugins/marketplaces/everything-claude-code/` exists → `ECC_MODE=plugin`, `{NS}=everything-claude-code` (pre-2.0.0 marketplace id).
+   3. Else if `<claude-home>/agents/` exists and contains at least one ECC agent file (e.g. `tdd-guide.md`, `code-reviewer.md`) → `ECC_MODE=legacy`.
+   4. Else → default to `ECC_MODE=legacy` and emit a one-line warning at the top of the output: `> Warning: could not detect ECC install; defaulting to legacy form. If you use the plugin install, edit the prefixes manually.`
+   5. If more than one marker exists (mixed install), a `plugin` marker wins over legacy — the plugin namespace is the only one that resolves agent names without fuzzy matching. If both marketplace dirs exist, prefer `ecc` (the current identifier).
 
    From this point on, every emitted line uses the matching prefix on **both** the slash command and every agent name. **Never emit both forms in the same output.**
 3. Resolve `--lang`. When `auto`, run a polyglot-aware detection:
@@ -99,7 +103,7 @@ A misspelled agent name fails `/orchestrate`. Cross-check against this list befo
    - No marker matched → set `lang=unknown`.
    - `lang=unknown` is a sentinel — it is **not** an agent name. Phase 2 rules 4 and 5 turn it into `code-reviewer` / `build-error-resolver` at chain composition time.
 4. Detect a **PyTorch sub-profile**: when `lang=python` and any of `pyproject.toml` / `requirements.txt` / `uv.lock` declares a dependency on `torch`, set `pytorch=true`. This only affects `build` chain selection (Phase 2 rule below); the reviewer remains `python-reviewer`.
-5. **Normalize any agent names declared in the plan**: if the plan text references agents by their plugin-prefixed form (e.g. `everything-claude-code:tdd-guide`), strip the prefix to get the bare catalogue name before validating or composing chains. Re-prefixing happens only at output time per `ECC_MODE` (Phase 4). Never let a pre-prefixed name flow into chain composition — it would double-prefix in plugin mode.
+5. **Normalize any agent names declared in the plan**: if the plan text references agents by a plugin-prefixed form (e.g. `ecc:tdd-guide` or `everything-claude-code:tdd-guide`), strip the `{NS}:` prefix to get the bare catalogue name before validating or composing chains. Re-prefixing happens only at output time per `ECC_MODE` (Phase 4). Never let a pre-prefixed name flow into chain composition — it would double-prefix in plugin mode.
 
 ### Phase 1 — Decompose steps
 
@@ -161,8 +165,8 @@ Emit Markdown using **the form determined by `ECC_MODE`**. The output uses one f
 
 Concrete rendering rules:
 
-- `{ORCH_CMD}` = `/everything-claude-code:orchestrate` under `plugin`, `/orchestrate` under `legacy`.
-- `{AGENT(name)}` = `everything-claude-code:<name>` under `plugin`, `<name>` under `legacy`.
+- `{ORCH_CMD}` = `/{NS}:orchestrate` under `plugin` (e.g. `/ecc:orchestrate`), `/orchestrate` under `legacy`.
+- `{AGENT(name)}` = `{NS}:<name>` under `plugin` (e.g. `ecc:<name>`), `<name>` under `legacy`.
 - The overview-table "Chain" column uses the same `{AGENT(name)}` rendering.
 - Per-step bash blocks contain only the runnable command. **No `# plugin form` or `# legacy form` comments** — the form is implicit and uniform across the whole output.
 
@@ -203,7 +207,7 @@ Append a final "Batch execution" block aggregating every step's command in order
 
 ### Phase 5 — Self-check (run before emitting)
 
-- [ ] Every agent in every chain comes from the catalogue (after stripping any `everything-claude-code:` prefix that appeared in the plan; see Phase 0 step 5).
+- [ ] Every agent in every chain comes from the catalogue (after stripping any plugin `{NS}:` prefix — `ecc:` or `everything-claude-code:` — that appeared in the plan; see Phase 0 step 5).
 - [ ] Resolved `{ORCH_CMD}` and every resolved `{AGENT(...)}` use the **same** form (`plugin` or `legacy`) — never mixed in one output.
 - [ ] No `# plugin form` / `# legacy form` annotations and no "strip the prefix" instructions remain in the rendered output.
 - [ ] No invented `--mode` / `--gate` / `--agents=...` fields.
@@ -221,12 +225,12 @@ Append a final "Batch execution" block aggregating every step's command in order
 - **No clear steps**: prefer H2/H3 splitting; if still ambiguous, report "no structured steps detected" with the document outline and ask the user to confirm running by outline.
 - **Large plan (>1500 lines)**: enter **overview-only mode** — emit only the overview table and ask the user to narrow with `--scope` before re-running for details. In this mode, skip per-step detail blocks and skip the Batch execution block.
 - **Step too broad** (e.g. "complete all backend work"): do not force a single chain. Suggest splitting into N.a and N.b and propose a split.
-- **Plan declares agents** (rare): first **strip any `everything-claude-code:` prefix** to get the bare catalogue name (Phase 0 step 5), then validate against the catalogue. Replace invalid agents and explain under "Chain rationale". The bare name is re-prefixed at output time per `ECC_MODE`.
+- **Plan declares agents** (rare): first **strip any plugin `{NS}:` prefix** (`ecc:` or `everything-claude-code:`) to get the bare catalogue name (Phase 0 step 5), then validate against the catalogue. Replace invalid agents and explain under "Chain rationale". The bare name is re-prefixed at output time per `ECC_MODE`.
 - **Polyglot project where `--lang=auto` cannot pick a winner**: set `lang=unknown`; reviewer resolves to `code-reviewer` and build resolver to `build-error-resolver`. Mention the fallback under "Chain rationale".
 
 ## Examples
 
-### Example 1 — Plugin mode, Python plan
+### Example 1 — Plugin mode (`ecc@ecc`), Python plan
 
 Input:
 ```
@@ -242,7 +246,7 @@ Excerpt of expected output:
 **Chain rationale**: Security-sensitive write path, so `security-reviewer` closes the chain; `database-reviewer` validates the alembic migration; `python-reviewer` covers typing and PEP 8.
 
 ```bash
-/everything-claude-code:orchestrate custom "everything-claude-code:tdd-guide,everything-claude-code:database-reviewer,everything-claude-code:python-reviewer,everything-claude-code:security-reviewer" "[Plan: docs/plan/example-feature.md#step-2] Implement EncryptedString SQLAlchemy type and migrate UserProfile.birth_datetime/location columns; key from ENV APP_DB_KEY; Acceptance: encrypt/decrypt roundtrip tests pass; alembic upgrade/downgrade clean on empty DB; no plaintext in DB after migrate; Out of scope: cross-tenant profile sharing logic"
+/ecc:orchestrate custom "ecc:tdd-guide,ecc:database-reviewer,ecc:python-reviewer,ecc:security-reviewer" "[Plan: docs/plan/example-feature.md#step-2] Implement EncryptedString SQLAlchemy type and migrate UserProfile.birth_datetime/location columns; key from ENV APP_DB_KEY; Acceptance: encrypt/decrypt roundtrip tests pass; alembic upgrade/downgrade clean on empty DB; no plaintext in DB after migrate; Out of scope: cross-tenant profile sharing logic"
 ```
 ````
 

--- a/tests/docs/plan-orchestrate-install-detection.test.js
+++ b/tests/docs/plan-orchestrate-install-detection.test.js
@@ -69,6 +69,35 @@ test('prefers the ecc marketplace over the legacy id (ordering)', () => {
   );
 });
 
+test('the Phase 0 detection algorithm itself checks ecc before the legacy marketplace', () => {
+  // Scope the ordering assertion to the actual detection algorithm so a
+  // future edit cannot regress the algorithm order while the table/examples
+  // keep the whole-document check above green.
+  const start = skill.indexOf('Detect ECC install form once and freeze');
+  assert.ok(start !== -1, 'Expected the Phase 0 detection algorithm block to be present');
+  const after = skill.indexOf('From this point on', start);
+  const algo = skill.slice(start, after === -1 ? undefined : after);
+  const eccIdx = algo.indexOf('marketplaces/ecc/');
+  const legacyIdx = algo.indexOf('marketplaces/everything-claude-code/');
+  assert.ok(
+    eccIdx !== -1 && legacyIdx !== -1,
+    'Expected the detection algorithm to check both marketplace paths'
+  );
+  assert.ok(
+    eccIdx < legacyIdx,
+    'Expected the detection algorithm to match marketplaces/ecc/ before marketplaces/everything-claude-code/'
+  );
+});
+
+test('plan-declared agent normalization strips either known plugin prefix', () => {
+  assert.ok(
+    skill.includes('ecc:tdd-guide') &&
+      skill.includes('everything-claude-code:tdd-guide') &&
+      skill.includes('strip any known plugin prefix'),
+    'Expected Phase 0 step 5 to normalize both ecc: and everything-claude-code: prefixes before catalogue validation'
+  );
+});
+
 test('still documents the legacy bare install and its fallback warning', () => {
   assert.ok(
     skill.includes('Legacy bare install'),

--- a/tests/docs/plan-orchestrate-install-detection.test.js
+++ b/tests/docs/plan-orchestrate-install-detection.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Regression test for #2316: plan-orchestrate must detect the renamed
+// `ecc@ecc` marketplace install (`<claude-home>/plugins/marketplaces/ecc/`)
+// and emit the canonical `ecc:` command/agent namespace, while keeping
+// backward compatibility with the pre-2.0.0 `everything-claude-code`
+// marketplace and the legacy bare install.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const skillPath = path.join(repoRoot, 'skills', 'plan-orchestrate', 'SKILL.md');
+const skill = fs.readFileSync(skillPath, 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+console.log('\n=== Testing plan-orchestrate install detection (#2316) ===\n');
+
+test('detects the canonical ecc@ecc marketplace install path', () => {
+  assert.ok(
+    skill.includes('marketplaces/ecc/'),
+    'Expected Phase 0 detection to recognize <claude-home>/plugins/marketplaces/ecc/ (the ecc@ecc 2.0.0+ install path)'
+  );
+});
+
+test('emits the canonical /ecc:orchestrate plugin command', () => {
+  assert.ok(
+    skill.includes('/ecc:orchestrate'),
+    'Expected the canonical short plugin command namespace /ecc:orchestrate'
+  );
+});
+
+test('emits the canonical ecc: agent namespace', () => {
+  assert.ok(
+    skill.includes('ecc:<name>') || skill.includes('ecc:tdd-guide'),
+    'Expected agent names rendered under the canonical ecc: plugin namespace'
+  );
+});
+
+test('keeps backward-compat detection for the pre-2.0.0 marketplace id', () => {
+  assert.ok(
+    skill.includes('marketplaces/everything-claude-code/'),
+    'Expected detection to still recognize the pre-rename everything-claude-code marketplace path'
+  );
+});
+
+test('prefers the ecc marketplace over the legacy id (ordering)', () => {
+  const eccIdx = skill.indexOf('marketplaces/ecc/');
+  const legacyIdx = skill.indexOf('marketplaces/everything-claude-code/');
+  assert.ok(eccIdx !== -1 && legacyIdx !== -1, 'Expected both marketplace paths to be documented');
+  assert.ok(
+    eccIdx < legacyIdx,
+    'Expected the canonical ecc marketplace to be matched before the legacy everything-claude-code marketplace'
+  );
+});
+
+test('still documents the legacy bare install and its fallback warning', () => {
+  assert.ok(
+    skill.includes('Legacy bare install'),
+    'Expected the legacy bare install form to remain documented'
+  );
+  assert.ok(
+    skill.includes('could not detect ECC install'),
+    'Expected the legacy-fallback warning to remain documented'
+  );
+});
+
+if (failed > 0) {
+  console.log(`\nFailed: ${failed}`);
+  process.exit(1);
+}
+
+console.log(`\nPassed: ${passed}`);


### PR DESCRIPTION
## What Changed

`plan-orchestrate` Phase 0 install detection (`skills/plan-orchestrate/SKILL.md`) now recognizes the renamed `ecc@ecc` marketplace install and resolves the command/agent prefix from the marketplace namespace:

- Added a detection case for `<claude-home>/plugins/marketplaces/ecc/` → `ECC_MODE=plugin`, `{NS}=ecc` (canonical, 2.0.0+).
- Kept `<claude-home>/plugins/marketplaces/everything-claude-code/` → `{NS}=everything-claude-code` for backward compatibility (pre-2.0.0 installs).
- Parameterized the prefix as a Phase 0 token `{NS}`: `{ORCH_CMD}` = `/{NS}:orchestrate`, `{AGENT(name)}` = `{NS}:<name>` under a plugin install; bare under legacy.
- Mixed-install tie-break prefers `ecc` (the current identifier).
- Updated the detection table, rendering rules, Phase 0 step 5 / Phase 5 self-check / "Plan declares agents" edge case to strip either plugin prefix, and switched the canonical example to `/ecc:orchestrate`.
- Added `tests/docs/plan-orchestrate-install-detection.test.js` to pin the behavior.

## Why This Change

After the 2.0.0 marketplace rename to `ecc@ecc`, the install path is `<claude-home>/plugins/marketplaces/ecc/`. The skill only matched the old `everything-claude-code` marketplace path and the legacy bare install, so it always fell through to `ECC_MODE=legacy` — emitting the spurious warning `could not detect ECC install; defaulting to legacy form` and bare, unprefixed `/orchestrate` invocations that do not resolve under the plugin install. This aligns `plan-orchestrate` with the canonical `/ecc:` namespace the repo already enforces for public docs (`tests/docs/install-identifiers.test.js`).

## Testing Done

- `node tests/docs/plan-orchestrate-install-detection.test.js` — 6/6 pass (new).
- `node tests/run-all.js` — 2943/2943 pass, 0 failures.
- `node scripts/ci/validate-skills.js` — 277 skill directories validated.
- `npx eslint scripts/**/*.js tests/**/*.js` — clean.
- `npx markdownlint skills/plan-orchestrate/SKILL.md` — clean.
- `node scripts/ci/validate-no-personal-paths.js` — clean.
- `node scripts/ci/check-unicode-safety.js` — clean.
- `node scripts/ci/catalog.js --text` — counts match.
- `npm run command-registry:check` — registry up to date.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Security & Quality Checklist

- [x] Surgical scope — one skill file plus its regression test.
- [x] No secrets, credentials, or personal absolute paths added.
- [x] No generated files hand-edited.
- [x] Backward compatible — pre-2.0.0 plugin and legacy bare installs still detected.
- [x] Conventional Commit message; PR follows the repo template.

## Documentation

The change is to the `plan-orchestrate` skill instructions themselves; the detection table, Phase 0 algorithm, rendering rules, and Example 1 are all updated in-place to document the `ecc@ecc` form.

Fixes #2316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the orchestration guide to recognize the canonical ECC plugin namespace and show the correct command and agent-name format.
  * Clarified how names are normalized to avoid duplicate prefixes in plugin mode.
  * Refreshed examples to match the new ECC-based output.

* **Tests**
  * Added regression coverage for ECC install detection and namespace rendering, including legacy compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->