### PR TITLE
feat(commands): add /orch-review surface for the orch-review workflow

### DIFF
--- a/commands/orch-review.md
+++ b/commands/orch-review.md
@@ -1,0 +1,113 @@
+---
+description: Run the orch-review native Workflow over a diff (local changes or a GitHub PR) and report blocking vs advisory findings. Surface for the orch-review workflow.
+argument-hint: [pr-number | pr-url | blank for local uncommitted changes]
+---
+
+# /orch-review
+
+Surface for `workflows/orch-review.workflow.js` — the native Workflow port of
+orch-pipeline Phase 5 (Review). This command computes a diff, hands it to the
+workflow, and presents the result. The workflow owns the fan-out (one reviewer
+per dimension, dedup, adversarial verify); this command owns input and output.
+
+**Input**: $ARGUMENTS
+
+---
+
+## Mode Selection
+
+| Input | Mode |
+|---|---|
+| Blank | **Local Mode** — review uncommitted changes |
+| Number (e.g. `42`) or PR URL | **PR Mode** — review a GitHub PR |
+
+---
+
+## Phase 1 — GATHER
+
+Build the unified diff and the metadata the workflow needs.
+
+**Local Mode:**
+
+```bash
+git diff --name-only HEAD          # changedFiles
+git diff HEAD                      # diff text
+```
+
+If the diff is empty, stop: "Nothing to review."
+
+**PR Mode:**
+
+```bash
+gh pr diff <NUMBER>                       # diff text
+gh pr view <NUMBER> --json files \
+  --jq '.files[].path'                    # changedFiles
+```
+
+If the PR is not found, stop with an error.
+
+Then derive `language` from the dominant changed-file extension (for example
+`.ts`/`.tsx` to `typescript`, `.py` to `python`, `.go` to `go`). Leave it unset
+when the change is mixed or non-code — the workflow simply skips the
+language-specific reviewer.
+
+## Phase 2 — INVOKE
+
+Call the Workflow tool. The workflow validates its own input and fails closed on
+a missing or empty diff, so always pass a non-empty `diff`.
+
+```jsonc
+Workflow({
+  scriptPath: "workflows/orch-review.workflow.js",
+  args: {
+    diff: "<unified diff text from Phase 1>",   // required
+    language: "typescript",                      // optional
+    changedFiles: ["src/auth.ts"]                // optional — feeds the security trigger
+  }
+})
+```
+
+The workflow fans out reviewers in parallel, dedups findings on the normalized
+evidence snippet, and runs an adversarial verifier on every unique CRITICAL/HIGH
+finding. It returns:
+
+```jsonc
+{
+  "verdict": "APPROVE" | "CHANGES_REQUESTED",
+  "incomplete": false,                 // true if a review dimension failed to run
+  "failedDimensions": [ /* { dimension, error } */ ],
+  "blocking": [ /* confirmed CRITICAL/HIGH + unverifiable findings */ ],
+  "advisory": [ /* MEDIUM/LOW + adversarially-refuted findings */ ],
+  "stats": { "dimensions": 3, "failed": 0, "raw": 11, "unique": 4 }
+}
+```
+
+## Phase 3 — REPORT
+
+Present the result to the user (this is the human review gate; the workflow does
+not commit anything):
+
+- Lead with `verdict` and the `stats` line (dimensions, raw to unique collapse).
+- List every `blocking` finding with file, severity, and evidence — these must
+  clear before a commit. Findings tagged "could not be verified" stay in
+  `blocking` by design; call them out as needing manual confirmation.
+- List `advisory` findings briefly (MEDIUM/LOW and verifier-refuted items).
+- If `incomplete` is true, state which dimensions in `failedDimensions` did not
+  run and that the verdict is therefore not a clean approval.
+
+## Fail-Closed Contract
+
+This command must never present a clean APPROVE when the review could not fully
+run. If the Workflow tool itself errors, report the failure — do not fall back to
+a hand-rolled review and do not imply the diff was approved.
+
+---
+
+## Edge Cases
+
+- **No `gh` CLI (PR Mode)**: stop and tell the user PR Mode needs `gh`; suggest
+  Local Mode against a checked-out branch instead.
+- **Very large diff**: the workflow caps reviewer concurrency automatically, so a
+  large diff is slower but safe; warn the user it may take longer.
+- **Binary or generated files**: drop them from `changedFiles` before invoking —
+  they add noise to the security trigger without reviewable content.

--- a/docs/COMMAND-REGISTRY.json
+++ b/docs/COMMAND-REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "totalCommands": 92,
+  "totalCommands": 93,
   "commands": [
     {
       "command": "aside",
@@ -618,6 +618,15 @@
       "path": "commands/orch-refine-code.md"
     },
     {
+      "command": "orch-review",
+      "description": "Run the orch-review native Workflow over a diff (local changes or a GitHub PR) and report blocking vs advisory findings. Surface for the orch-review workflow.",
+      "type": "review",
+      "primaryAgents": [],
+      "allAgents": [],
+      "skills": [],
+      "path": "commands/orch-review.md"
+    },
+    {
       "command": "plan-prd",
       "description": "Generate a lean, problem-first PRD and hand off to /plan for implementation planning.",
       "type": "testing",
@@ -1011,7 +1020,7 @@
       "orchestration": 11,
       "planning": 2,
       "refactoring": 1,
-      "review": 13,
+      "review": 14,
       "testing": 53
     },
     "topAgents": [


### PR DESCRIPTION
## What Changed

Adds `/orch-review` — the command surface for the native Workflow added in the base PR.

- `commands/orch-review.md` — gathers a unified diff (local uncommitted changes **or** a GitHub PR), invokes `workflows/orch-review.workflow.js` via the Workflow tool, and presents the result at the human review gate.
- `docs/COMMAND-REGISTRY.json` — regenerated so `command-registry:check` stays green (new `orch-review` entry, type `review`).

## Why This Change

PR #2363 ships the workflow but no surface to invoke it. This is the thin trigger: it owns **input** (diff + `language` + `changedFiles`) and **output** (the blocking/advisory split), while the workflow owns the fan-out (reviewer per dimension, dedup, adversarial verify). The command does not re-implement any review logic.

The `orch-*` command family wraps a same-named *skill*; `orch-review` is deliberately different — it wraps a native *workflow*, which is the whole point of the pilot (the workflow replaces the hand-rolled skill fan-out).

## Fail-Closed

The command must never present a clean `APPROVE` when the review could not fully run: if the Workflow tool errors it reports the failure rather than falling back to a hand-rolled review, and it surfaces `incomplete` / `failedDimensions` instead of implying approval.

## Testing Done

- [x] `node scripts/ci/validate-commands.js` — 93 command files validated (cross-references clean; technical invocation kept inside code fences).
- [x] `npm run command-registry:check` — registry up to date after regeneration.
- [x] `npx markdownlint commands/orch-review.md` — clean.
- [x] `node tests/commands/command-frontmatter.test.js` — PASS.

## Type of Change

- [x] `feat:` New feature

## Relationship to #2363

Follow-up to #2363 (the orch-review workflow), now merged into `main`. This PR was developed stacked on that branch and rebased onto `main` once it merged, so the diff here is **only** the command + registry — the workflow itself already landed in #2363.

## Follow-ups (not in this PR)

- i18n mirrors under `docs/<locale>/commands/orch-review.md` (not CI-enforced; only a subset of commands are currently translated).
- Wiring `/orch-review` into the `orch-pipeline` Review phase as the native option (touches the already-reviewed engine skill — kept separate on purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
