### PR TITLE
chore(continuous-learning-v2): standardize shell shebangs to env bash

### DIFF
--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Continuous Learning v2 - Observer Agent Launcher
 #
 # Starts the background observer agent that analyzes observations

--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Continuous Learning v2 - Observation Hook
 #
 # Captures tool use events for pattern analysis.

--- a/skills/continuous-learning-v2/scripts/detect-project.sh
+++ b/skills/continuous-learning-v2/scripts/detect-project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Continuous Learning v2 - Project Detection Helper
 #
 # Shared logic for detecting current project context.

--- a/tests/hooks/continuous-learning-shebang-consistency.test.js
+++ b/tests/hooks/continuous-learning-shebang-consistency.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for shebang consistency across continuous-learning-v2 shell scripts
+ *
+ * Every `*.sh` script under skills/continuous-learning-v2/ must use the
+ * portable `#!/usr/bin/env bash` shebang rather than the hardcoded
+ * `#!/bin/bash`. The hardcoded interpreter path fails on systems where bash
+ * is not installed at /bin/bash (NixOS, some Homebrew layouts, FreeBSD), and
+ * observe.sh runs on every hook invocation. This guards against the
+ * inconsistency (#2303) reappearing.
+ *
+ * Run with: node tests/hooks/continuous-learning-shebang-consistency.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    failed++;
+  }
+}
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const skillDir = path.join(repoRoot, 'skills', 'continuous-learning-v2');
+const PORTABLE_SHEBANG = '#!/usr/bin/env bash';
+const HARDCODED_SHEBANG = '#!/bin/bash';
+
+function collectShellScripts(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectShellScripts(fullPath, acc);
+    } else if (entry.isFile() && entry.name.endsWith('.sh')) {
+      acc.push(fullPath);
+    }
+  }
+  return acc;
+}
+
+function firstLine(filePath) {
+  return fs.readFileSync(filePath, 'utf8').split('\n', 1)[0];
+}
+
+console.log('\n=== continuous-learning-v2 shebang consistency ===\n');
+
+const scripts = collectShellScripts(skillDir);
+
+test('skill directory contains shell scripts to check', () => {
+  assert.ok(scripts.length > 0, `expected at least one .sh under ${skillDir}`);
+});
+
+for (const scriptPath of scripts) {
+  const rel = path.relative(repoRoot, scriptPath).split(path.sep).join('/');
+  test(`${rel} uses portable '#!/usr/bin/env bash'`, () => {
+    assert.strictEqual(
+      firstLine(scriptPath),
+      PORTABLE_SHEBANG,
+      `${rel} should start with '${PORTABLE_SHEBANG}'`
+    );
+  });
+}
+
+test('no continuous-learning-v2 script uses hardcoded #!/bin/bash', () => {
+  const offenders = scripts
+    .filter(scriptPath => firstLine(scriptPath) === HARDCODED_SHEBANG)
+    .map(scriptPath => path.relative(repoRoot, scriptPath).split(path.sep).join('/'));
+  assert.strictEqual(
+    offenders.length,
+    0,
+    `hardcoded #!/bin/bash found in: ${offenders.join(', ')}`
+  );
+});
+
+// ──────────────────────────────────────────────────────
+// Summary
+// ──────────────────────────────────────────────────────
+
+console.log('\n=== Test Results ===');
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+console.log(`Total:  ${passed + failed}\n`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/continuous-learning-shebang-consistency.test.js
+++ b/tests/hooks/continuous-learning-shebang-consistency.test.js
@@ -41,6 +41,12 @@ function collectShellScripts(dir, acc = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      // Skip hidden/runtime directories (e.g. the observer's `.observer-tmp`)
+      // so an untracked local artifact cannot trigger a false failure; only
+      // committed skill scripts are checked.
+      if (entry.name.startsWith('.')) {
+        continue;
+      }
       collectShellScripts(fullPath, acc);
     } else if (entry.isFile() && entry.name.endsWith('.sh')) {
       acc.push(fullPath);

--- a/tests/hooks/continuous-learning-shebang-consistency.test.js
+++ b/tests/hooks/continuous-learning-shebang-consistency.test.js
@@ -23,11 +23,11 @@ let failed = 0;
 function test(name, fn) {
   try {
     fn();
-    console.log(`  ✓ ${name}`);
+    process.stdout.write(`  ✓ ${name}\n`);
     passed++;
   } catch (err) {
-    console.log(`  ✗ ${name}`);
-    console.log(`    Error: ${err.message}`);
+    process.stderr.write(`  ✗ ${name}\n`);
+    process.stderr.write(`    ${err && err.stack ? err.stack : String(err)}\n`);
     failed++;
   }
 }
@@ -50,7 +50,7 @@ function collectShellScripts(dir, acc = []) {
 }
 
 function firstLine(filePath) {
-  return fs.readFileSync(filePath, 'utf8').split('\n', 1)[0];
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/, 1)[0];
 }
 
 console.log('\n=== continuous-learning-v2 shebang consistency ===\n');


### PR DESCRIPTION
## What Changed

Standardized the shebang line in three `skills/continuous-learning-v2/` shell
scripts from the hardcoded `#!/bin/bash` to the portable `#!/usr/bin/env bash`:

- `hooks/observe.sh`
- `scripts/detect-project.sh`
- `agents/start-observer.sh`

The other four scripts in this skill already used `#!/usr/bin/env bash`, so this
brings the whole directory to a single convention. Also added a regression test
(`tests/hooks/continuous-learning-shebang-consistency.test.js`) that asserts
every `*.sh` under the skill uses the portable shebang.

## Why This Change

The hardcoded `#!/bin/bash` path fails to execute on systems where bash is not
installed at `/bin/bash` — NixOS, some Homebrew layouts, and FreeBSD. `observe.sh`
runs on every PreToolUse/PostToolUse hook invocation, so it is the highest-impact
offender. `#!/usr/bin/env bash` resolves bash via `PATH`, which is the portable
form and already the repo-wide majority convention.

## Testing Done

- `node tests/run-all.js` — **2946 passed, 0 failed** (includes the new test).
- New `continuous-learning-shebang-consistency.test.js` standalone: 9/9 pass.
- `npx eslint scripts/**/*.js tests/**/*.js` — clean.
- `node scripts/ci/validate-skills.js` — 277 skill dirs validated.
- `node scripts/ci/check-unicode-safety.js` — passed.
- `node scripts/ci/validate-no-personal-paths.js` — passed.

## Type of Change

- [x] Chore / maintenance (portability, no behavior change on systems where bash is at `/bin/bash`)

## Security & Quality Checklist

- [x] No secrets, credentials, or personal absolute paths added
- [x] Surgical scope: only the three inconsistent shebangs + one regression test
- [x] No functional change to script logic (line 1 only)
- [x] Regression test prevents reintroduction
- [x] Full test suite + lint + validators green

## Documentation

No documentation changes required — shebang normalization is internal to the
skill's shell scripts.

Fixes #2303
