### PR TITLE
fix: canonicalize codex and opencode install payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Default MCP connector set reduced to a single connector (`chrome-devtools`) per the new connector policy (`docs/MCP-CONNECTOR-POLICY.md`). The six previous defaults (`github`, `context7`, `exa`, `memory`, `playwright`, `sequential-thinking`) were retired after the June 2026 audit: their jobs are covered by skills wrapping CLIs/REST APIs (`github-ops`, `documentation-lookup`, `exa-search`, e2e skills) or by harness-native features (memory, extended thinking, web search). All six remain opt-in via `mcp-configs/mcp-servers.json`.
+- Canonicalized Codex and OpenCode install planning so `AGENTS.md` stays unique for Codex and shared `commands/` files no longer duplicate into `~/.opencode/commands/` during native OpenCode sync.
 
 ## 2.0.0 - 2026-06-09
 

--- a/scripts/lib/install-targets/codex-home.js
+++ b/scripts/lib/install-targets/codex-home.js
@@ -1,4 +1,4 @@
-const { createInstallTargetAdapter } = require('./helpers');
+const { createInstallTargetAdapter, isForeignPlatformPath } = require('./helpers');
 
 module.exports = createInstallTargetAdapter({
   id: 'codex-home',
@@ -7,4 +7,29 @@ module.exports = createInstallTargetAdapter({
   rootSegments: ['.codex'],
   installStatePathSegments: ['ecc-install-state.json'],
   nativeRootRelativePath: '.codex',
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .filter(sourceRelativePath => !(
+          module.id === 'agents-core'
+          && sourceRelativePath === 'AGENTS.md'
+        ))
+        .map(sourceRelativePath => adapter.createScaffoldOperation(
+          module.id,
+          sourceRelativePath,
+          planningInput
+        ));
+    });
+  },
 });

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -5,6 +5,8 @@ const path = require('path');
 const {
   buildValidationIssue,
   createInstallTargetAdapter,
+  createManagedOperation,
+  isForeignPlatformPath,
 } = require('./helpers');
 
 const COMPILED_PLUGIN_DIST_DIR = path.join('.opencode', 'dist');
@@ -19,6 +21,78 @@ const BUILD_COMMAND_HINT = 'node scripts/build-opencode.js (or: npm run build:op
 // Anything else (EACCES, EIO, ...) is a genuine system fault we surface to the
 // caller rather than masking as a missing artefact.
 const MISSING_ARTEFACT_ERROR_CODES = new Set(['ENOENT', 'ENOTDIR']);
+
+function listRelativeFiles(dirPath, prefix = '') {
+  if (!fs.existsSync(dirPath)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const files = [];
+
+  for (const entry of entries) {
+    const entryRelativePath = prefix ? path.join(prefix, entry.name) : entry.name;
+    const entryAbsolutePath = path.join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listRelativeFiles(entryAbsolutePath, entryRelativePath));
+    } else if (entry.isFile()) {
+      files.push(entryRelativePath);
+    }
+  }
+
+  return files;
+}
+
+function createOpencodeNativeOperations(moduleId, repoRoot, targetRoot) {
+  const opencodeRoot = path.join(repoRoot, '.opencode');
+  if (!fs.existsSync(opencodeRoot) || !fs.statSync(opencodeRoot).isDirectory()) {
+    return [];
+  }
+
+  const operations = [];
+  const entries = fs.readdirSync(opencodeRoot, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of entries) {
+    if (entry.name === 'commands') {
+      continue;
+    }
+
+    const entryRelativePath = path.join('.opencode', entry.name);
+    const entryAbsolutePath = path.join(opencodeRoot, entry.name);
+
+    if (entry.isDirectory()) {
+      for (const relativeFile of listRelativeFiles(entryAbsolutePath)) {
+        operations.push(createManagedOperation({
+          kind: 'copy-file',
+          moduleId,
+          sourceRelativePath: path.join(entryRelativePath, relativeFile),
+          destinationPath: path.join(targetRoot, entry.name, relativeFile),
+          strategy: 'preserve-relative-path',
+          ownership: 'managed',
+          scaffoldOnly: false,
+        }));
+      }
+      continue;
+    }
+
+    if (entry.isFile()) {
+      operations.push(createManagedOperation({
+        kind: 'copy-file',
+        moduleId,
+        sourceRelativePath: entryRelativePath,
+        destinationPath: path.join(targetRoot, entry.name),
+        strategy: 'preserve-relative-path',
+        ownership: 'managed',
+        scaffoldOnly: false,
+      }));
+    }
+  }
+
+  return operations;
+}
 
 function isExpectedType(absolutePath, expectedType) {
   let stat;
@@ -87,4 +161,28 @@ module.exports = createInstallTargetAdapter({
   installStatePathSegments: ['ecc-install-state.json'],
   nativeRootRelativePath: '.opencode',
   validate: defaultValidateOpencodeHome,
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const planningInput = {
+      repoRoot: input.repoRoot,
+      projectRoot: input.projectRoot,
+      homeDir: input.homeDir,
+    };
+    const targetRoot = adapter.resolveRoot(planningInput);
+
+    return modules.flatMap(module => {
+      const paths = Array.isArray(module.paths) ? module.paths : [];
+      return paths
+        .filter(p => !isForeignPlatformPath(p, adapter.target))
+        .flatMap(sourceRelativePath => {
+          if (sourceRelativePath === '.opencode') {
+            return createOpencodeNativeOperations(module.id, input.repoRoot, targetRoot);
+          }
+
+          return [adapter.createScaffoldOperation(module.id, sourceRelativePath, planningInput)];
+        });
+    });
+  },
 });

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -547,6 +547,42 @@ function runTests() {
     assert.ok(byTarget.supports('qwen-home'));
   })) passed++; else failed++;
 
+  if (test('codex install plan keeps the native .codex AGENTS payload canonical', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'codex',
+      repoRoot,
+      homeDir,
+      modules: [
+        {
+          id: 'agents-core',
+          paths: ['.agents', 'agents', 'AGENTS.md'],
+        },
+        {
+          id: 'platform-configs',
+          paths: ['.codex'],
+        },
+      ],
+    });
+
+    assert.ok(
+      !plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === 'AGENTS.md'
+      )),
+      'Codex installs should not include the generic root AGENTS.md source'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === '.codex'
+        && operation.destinationPath === path.join(homeDir, '.codex')
+        && operation.strategy === 'sync-root-children'
+      )),
+      'Codex installs should sync the native .codex payload into ~/.codex'
+    );
+  })) passed++; else failed++;
+
   if (test('resolves zed adapter root and install-state path from project root', () => {
     const adapter = getInstallTargetAdapter('zed');
     const projectRoot = '/workspace/app';
@@ -996,6 +1032,41 @@ function runTests() {
     } finally {
       fs.rmSync(repoRoot, { recursive: true, force: true });
     }
+  })) passed++; else failed++;
+
+  if (test('opencode install plan keeps the native .opencode payload canonical', () => {
+    const repoRoot = path.join(__dirname, '..', '..');
+    const homeDir = '/Users/example';
+
+    const plan = planInstallTargetScaffold({
+      target: 'opencode',
+      repoRoot,
+      homeDir,
+      modules: [
+        {
+          id: 'commands-core',
+          paths: ['commands'],
+        },
+        {
+          id: 'platform-configs',
+          paths: ['.opencode'],
+        },
+      ],
+    });
+
+    assert.ok(
+      !plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath).startsWith('.opencode/commands')
+      )),
+      'OpenCode installs should not duplicate shared command docs under .opencode/commands'
+    );
+    assert.ok(
+      plan.operations.some(operation => (
+        normalizedRelativePath(operation.sourceRelativePath) === '.opencode/README.md'
+        && operation.destinationPath === path.join(homeDir, '.opencode', 'README.md')
+      )),
+      'OpenCode installs should still sync native .opencode files'
+    );
   })) passed++; else failed++;
 
   if (test('opencode adapter validate reports a partial build (entry present, runtime dirs absent)', () => {


### PR DESCRIPTION
## Summary
- Keep Codex install planning on canonical `.codex` payloads without pulling in foreign platform files
- Keep OpenCode install planning on canonical `.opencode` payloads while avoiding `.opencode/commands` duplication
- Add regression coverage for both payload planners
- Add changelog entry under Unreleased

## Verification
- `node tests/lib/install-targets.test.js`
- `node tests/scripts/doctor.test.js`
- `npm test` → 2939 passed, 0 failed

## Notes
- The repo still reports `2.0.0` in `package.json` and `VERSION`, so the gstack version-bump helper could not parse the base version as a 4-part release. I left the version unchanged and documented the change in `CHANGELOG.md` instead.