### PR TITLE
docs(continuous-learning-v2): observer.md promotion uses avg confidence, not per-instance

### DIFF
--- a/docs/zh-CN/skills/continuous-learning-v2/agents/observer.md
+++ b/docs/zh-CN/skills/continuous-learning-v2/agents/observer.md
@@ -164,7 +164,7 @@ Validate and sanitize all user input before processing.
 当一个本能满足以下条件时，应从项目作用域提升到全局：
 
 1. **相同模式**（通过 id 或类似触发器）存在于 **2 个以上不同的项目**中
-2. 每个实例的置信度 **>= 0.8**
+2. 各实例的平均置信度 **>= 0.8**
 3. 其领域属于全局友好列表（安全、通用最佳实践、工作流）
 
 提升操作由 `instinct-cli.py promote` 命令或 `/evolve` 分析处理。

--- a/skills/continuous-learning-v2/agents/observer.md
+++ b/skills/continuous-learning-v2/agents/observer.md
@@ -142,7 +142,7 @@ Confidence adjusts over time:
 
 An instinct should be promoted from project-scoped to global when:
 1. The **same pattern** (by id or similar trigger) exists in **2+ different projects**
-2. Each instance has confidence **>= 0.8**
+2. Average confidence across instances is **>= 0.8**
 3. The domain is in the global-friendly list (security, general-best-practices, workflow)
 
 Promotion is handled by the `instinct-cli.py promote` command or the `/evolve` analysis.


### PR DESCRIPTION
## Summary

- observer.md said promotion requires "Each instance has confidence >= 0.8", but `_promote_auto` gates on `avg_conf >= PROMOTE_CONFIDENCE_THRESHOLD` (= 0.8)
- SKILL.md (EN + zh-CN/ko-KR/tr) already uses avg-confidence semantics; observer.md (EN + zh-CN) was missed
- same drift pattern as #2274

## Verification

- `node scripts/ci/validate-skills.js`
- `npx markdownlint` on both changed files
- `git grep -nE 'each instance|每个实例'` — no remaining promotion-criteria drift

## Note on overlap

- #2408 (open bundle PR) includes an equivalent EN edit for `observer.md` as part of a larger cluster; the zh-CN translation is not covered there. If #2408 lands first, the EN hunk here rebases out trivially.

Closes #2298.