### PR TITLE
feat(session-start): make instinct injection count and confidence threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,12 @@ export ECC_SESSION_START_CONTEXT=off
 # Set to 0, off, false, disabled, never, or none to keep all sessions (disable pruning).
 export ECC_SESSION_RETENTION_DAYS=14
 
+# Cap how many learned instincts SessionStart injects into context (default: 6)
+export ECC_MAX_INJECTED_INSTINCTS=6
+
+# Minimum confidence an instinct needs to be injected, 0-1 (default: 0.7)
+export ECC_INSTINCT_CONFIDENCE_THRESHOLD=0.7
+
 # Keep context/scope/loop warnings but suppress API-rate cost estimates
 export ECC_CONTEXT_MONITOR_COST_WARNINGS=off
 ```

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -128,7 +128,13 @@ function getInstinctConfidenceThreshold() {
   const raw = process.env.ECC_INSTINCT_CONFIDENCE_THRESHOLD;
   if (!raw) return DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
 
-  const parsed = Number.parseFloat(raw);
+  // Use Number() (not parseFloat) so a malformed value like "0.7x" or
+  // "0.7 " with trailing junk is rejected whole rather than silently
+  // accepting the numeric prefix.
+  const normalized = raw.trim();
+  if (!normalized) return DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
+
+  const parsed = Number(normalized);
   return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
     ? parsed
     : DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
@@ -146,7 +152,13 @@ function getMaxInjectedInstincts() {
   const raw = process.env.ECC_MAX_INJECTED_INSTINCTS;
   if (!raw) return DEFAULT_MAX_INJECTED_INSTINCTS;
 
-  const parsed = Number.parseInt(raw, 10);
+  // Use Number() (not parseInt) so a non-integer or partial value like
+  // "3.9" or "6abc" is rejected whole and falls back to the default,
+  // rather than parseInt silently truncating to 3 / 6.
+  const normalized = raw.trim();
+  if (!normalized) return DEFAULT_MAX_INJECTED_INSTINCTS;
+
+  const parsed = Number(normalized);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INJECTED_INSTINCTS;
 }
 

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -27,8 +27,8 @@ const { detectProjectType } = require('../lib/project-detect');
 const path = require('path');
 const fs = require('fs');
 
-const INSTINCT_CONFIDENCE_THRESHOLD = 0.7;
-const MAX_INJECTED_INSTINCTS = 6;
+const DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD = 0.7;
+const DEFAULT_MAX_INJECTED_INSTINCTS = 6;
 const MAX_INJECTED_LEARNED_SKILLS = 6;
 const MAX_LEARNED_SKILL_SUMMARY_CHARS = 220;
 const DEFAULT_SESSION_START_CONTEXT_MAX_CHARS = 8000;
@@ -114,6 +114,40 @@ function getSessionStartMaxContextChars() {
 
   const parsed = Number.parseInt(raw, 10);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : DEFAULT_SESSION_START_CONTEXT_MAX_CHARS;
+}
+
+/**
+ * Resolve the minimum confidence an instinct needs to be injected at
+ * SessionStart. Overridable via `ECC_INSTINCT_CONFIDENCE_THRESHOLD`
+ * (a number in [0, 1]); falsy or out-of-range values fall back to
+ * {@link DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD}.
+ *
+ * @returns {number} The confidence floor for injected instincts.
+ */
+function getInstinctConfidenceThreshold() {
+  const raw = process.env.ECC_INSTINCT_CONFIDENCE_THRESHOLD;
+  if (!raw) return DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
+
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
+    ? parsed
+    : DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
+}
+
+/**
+ * Resolve the maximum number of instincts injected at SessionStart.
+ * Overridable via `ECC_MAX_INJECTED_INSTINCTS` (a positive integer);
+ * falsy or invalid values fall back to
+ * {@link DEFAULT_MAX_INJECTED_INSTINCTS}.
+ *
+ * @returns {number} The cap on injected instincts.
+ */
+function getMaxInjectedInstincts() {
+  const raw = process.env.ECC_MAX_INJECTED_INSTINCTS;
+  if (!raw) return DEFAULT_MAX_INJECTED_INSTINCTS;
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INJECTED_INSTINCTS;
 }
 
 function getSessionStartMode(rawInput) {
@@ -373,9 +407,12 @@ function summarizeActiveInstincts(observerContext) {
     ...globalDirs.flatMap(({ dir, scope }) => readInstinctsFromDir(dir, scope)),
   ];
 
+  const confidenceThreshold = getInstinctConfidenceThreshold();
+  const maxInjected = getMaxInjectedInstincts();
+
   const deduped = new Map();
   for (const instinct of scopedInstincts) {
-    if (!instinct.id || instinct.confidence < INSTINCT_CONFIDENCE_THRESHOLD) continue;
+    if (!instinct.id || instinct.confidence < confidenceThreshold) continue;
     const existing = deduped.get(instinct.id);
     if (!existing || (existing._scopeLabel !== 'project' && instinct._scopeLabel === 'project')) {
       deduped.set(instinct.id, instinct);
@@ -393,7 +430,7 @@ function summarizeActiveInstincts(observerContext) {
       if (left._scopeLabel !== right._scopeLabel) return left._scopeLabel === 'project' ? -1 : 1;
       return String(left.id).localeCompare(String(right.id));
     })
-    .slice(0, MAX_INJECTED_INSTINCTS);
+    .slice(0, maxInjected);
 
   if (ranked.length === 0) {
     return '';

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -128,11 +128,11 @@ function getInstinctConfidenceThreshold() {
   const raw = process.env.ECC_INSTINCT_CONFIDENCE_THRESHOLD;
   if (!raw) return DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
 
-  // Use Number() (not parseFloat) so a malformed value like "0.7x" or
-  // "0.7 " with trailing junk is rejected whole rather than silently
-  // accepting the numeric prefix.
+  // Require a plain decimal (e.g. "0.7", "1", "0.95") so trailing junk
+  // ("0.7x") and non-decimal numeric syntax like "0x1" (hex) or "1e2"
+  // (exponent) are rejected whole rather than silently accepted by Number().
   const normalized = raw.trim();
-  if (!normalized) return DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
+  if (!/^\d+(\.\d+)?$/.test(normalized)) return DEFAULT_INSTINCT_CONFIDENCE_THRESHOLD;
 
   const parsed = Number(normalized);
   return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
@@ -152,11 +152,11 @@ function getMaxInjectedInstincts() {
   const raw = process.env.ECC_MAX_INJECTED_INSTINCTS;
   if (!raw) return DEFAULT_MAX_INJECTED_INSTINCTS;
 
-  // Use Number() (not parseInt) so a non-integer or partial value like
-  // "3.9" or "6abc" is rejected whole and falls back to the default,
-  // rather than parseInt silently truncating to 3 / 6.
+  // Require a plain non-negative integer so "3.9", "6abc", "0x1" (hex),
+  // and "1e2" (exponent) are rejected whole and fall back to the default,
+  // rather than parseInt truncating or Number() accepting alternate syntax.
   const normalized = raw.trim();
-  if (!normalized) return DEFAULT_MAX_INJECTED_INSTINCTS;
+  if (!/^\d+$/.test(normalized)) return DEFAULT_MAX_INJECTED_INSTINCTS;
 
   const parsed = Number(normalized);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INJECTED_INSTINCTS;

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -542,6 +542,13 @@ async function runTests() {
         const partial = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_MAX_INJECTED_INSTINCTS: '3.9' });
         assert.strictEqual(partial.code, 0);
         assert.ok(partial.stderr.includes('Injecting 6 instinct(s)'), `non-integer override (3.9) should fall back to default 6, not truncate to 3, stderr: ${partial.stderr}`);
+
+        // Non-decimal numeric syntax (exponent, hex) must be rejected too.
+        // If "1e2" were accepted as 100, all 8 fixtures would inject; the
+        // default cap of 6 proves it fell back.
+        const exponent = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_MAX_INJECTED_INSTINCTS: '1e2' });
+        assert.strictEqual(exponent.code, 0);
+        assert.ok(exponent.stderr.includes('Injecting 6 instinct(s)'), `exponent override (1e2) should fall back to default 6, stderr: ${exponent.stderr}`);
       } finally {
         fs.rmSync(isoHome, { recursive: true, force: true });
       }
@@ -578,6 +585,13 @@ async function runTests() {
         const lowered = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_INSTINCT_CONFIDENCE_THRESHOLD: '0.5' });
         assert.strictEqual(lowered.code, 0);
         assert.ok(lowered.stderr.includes('Injecting 6 instinct(s)'), `0.5 threshold should pass all eight but cap at the default 6, stderr: ${lowered.stderr}`);
+
+        // Non-decimal syntax must fall back to the default 0.7, not be read
+        // as hex. If "0x1" were accepted as 1.0, zero instincts would inject
+        // (none are at full confidence); the default 0.7 injects the four 0.9s.
+        const hex = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_INSTINCT_CONFIDENCE_THRESHOLD: '0x1' });
+        assert.strictEqual(hex.code, 0);
+        assert.ok(hex.stderr.includes('Injecting 4 instinct(s)'), `hex threshold (0x1) should fall back to the 0.7 default and inject the four 0.9 instincts, stderr: ${hex.stderr}`);
       } finally {
         fs.rmSync(isoHome, { recursive: true, force: true });
       }

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -537,6 +537,11 @@ async function runTests() {
         const garbage = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_MAX_INJECTED_INSTINCTS: 'not-a-number' });
         assert.strictEqual(garbage.code, 0);
         assert.ok(garbage.stderr.includes('Injecting 6 instinct(s)'), `garbage override should fall back to default 6, stderr: ${garbage.stderr}`);
+
+        // A partial/non-integer value must be rejected whole, not truncated.
+        const partial = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_MAX_INJECTED_INSTINCTS: '3.9' });
+        assert.strictEqual(partial.code, 0);
+        assert.ok(partial.stderr.includes('Injecting 6 instinct(s)'), `non-integer override (3.9) should fall back to default 6, not truncate to 3, stderr: ${partial.stderr}`);
       } finally {
         fs.rmSync(isoHome, { recursive: true, force: true });
       }

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -512,6 +512,76 @@ async function runTests() {
   else failed++;
 
   if (
+    await asyncTest('honors ECC_MAX_INJECTED_INSTINCTS for injected instincts', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-max-instincts-${Date.now()}`);
+      const homunculusDir = path.join(isoHome, 'homunculus');
+      const instinctsDir = path.join(homunculusDir, 'instincts', 'personal');
+      fs.mkdirSync(instinctsDir, { recursive: true });
+      for (let i = 1; i <= 8; i++) {
+        fs.writeFileSync(
+          path.join(instinctsDir, `instinct-${i}.md`),
+          `---\nid: max-instinct-${i}\nconfidence: 0.9\n---\n## Action\nDo configurable thing number ${i}.\n`
+        );
+      }
+      const baseEnv = { HOME: isoHome, USERPROFILE: isoHome, CLV2_HOMUNCULUS_DIR: homunculusDir };
+
+      try {
+        const def = await runScript(path.join(scriptsDir, 'session-start.js'), '', baseEnv);
+        assert.strictEqual(def.code, 0);
+        assert.ok(def.stderr.includes('Injecting 6 instinct(s)'), `default cap should inject 6, stderr: ${def.stderr}`);
+
+        const capped = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_MAX_INJECTED_INSTINCTS: '3' });
+        assert.strictEqual(capped.code, 0);
+        assert.ok(capped.stderr.includes('Injecting 3 instinct(s)'), `override should inject 3, stderr: ${capped.stderr}`);
+
+        const garbage = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_MAX_INJECTED_INSTINCTS: 'not-a-number' });
+        assert.strictEqual(garbage.code, 0);
+        assert.ok(garbage.stderr.includes('Injecting 6 instinct(s)'), `garbage override should fall back to default 6, stderr: ${garbage.stderr}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await asyncTest('honors ECC_INSTINCT_CONFIDENCE_THRESHOLD for injected instincts', async () => {
+      const isoHome = path.join(os.tmpdir(), `ecc-instinct-threshold-${Date.now()}`);
+      const homunculusDir = path.join(isoHome, 'homunculus');
+      const instinctsDir = path.join(homunculusDir, 'instincts', 'personal');
+      fs.mkdirSync(instinctsDir, { recursive: true });
+      // 4 high-confidence (0.9) + 4 low-confidence (0.6) instincts.
+      for (let i = 1; i <= 8; i++) {
+        const confidence = i <= 4 ? '0.9' : '0.6';
+        fs.writeFileSync(
+          path.join(instinctsDir, `instinct-${i}.md`),
+          `---\nid: thr-instinct-${i}\nconfidence: ${confidence}\n---\n## Action\nDo threshold thing number ${i}.\n`
+        );
+      }
+      const baseEnv = { HOME: isoHome, USERPROFILE: isoHome, CLV2_HOMUNCULUS_DIR: homunculusDir };
+
+      try {
+        const def = await runScript(path.join(scriptsDir, 'session-start.js'), '', baseEnv);
+        assert.strictEqual(def.code, 0);
+        assert.ok(def.stderr.includes('Injecting 4 instinct(s)'), `default 0.7 threshold should inject only the four 0.9 instincts, stderr: ${def.stderr}`);
+
+        const raised = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_INSTINCT_CONFIDENCE_THRESHOLD: '0.95' });
+        assert.strictEqual(raised.code, 0);
+        assert.ok(!raised.stderr.includes('instinct(s) into session context'), `0.95 threshold should filter out all instincts, stderr: ${raised.stderr}`);
+
+        const lowered = await runScript(path.join(scriptsDir, 'session-start.js'), '', { ...baseEnv, ECC_INSTINCT_CONFIDENCE_THRESHOLD: '0.5' });
+        assert.strictEqual(lowered.code, 0);
+        assert.ok(lowered.stderr.includes('Injecting 6 instinct(s)'), `0.5 threshold should pass all eight but cap at the default 6, stderr: ${lowered.stderr}`);
+      } finally {
+        fs.rmSync(isoHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     await asyncTest('disables session-start additional context when requested', async () => {
       const isoHome = path.join(os.tmpdir(), `ecc-disabled-start-${Date.now()}`);
       const sessionsDir = getLegacySessionsDir(isoHome);


### PR DESCRIPTION
## What Changed

Makes the two SessionStart instinct-injection knobs in
`scripts/hooks/session-start.js` configurable via environment, keeping the
current values as defaults:

- **`ECC_MAX_INJECTED_INSTINCTS`** — cap on how many learned instincts get
  injected into context at SessionStart (default `6`).
- **`ECC_INSTINCT_CONFIDENCE_THRESHOLD`** — minimum confidence, in `[0, 1]`,
  an instinct needs to be injected (default `0.7`).

The two hardcoded constants (`MAX_INJECTED_INSTINCTS`,
`INSTINCT_CONFIDENCE_THRESHOLD`) become `DEFAULT_`-prefixed fallbacks and are
now resolved through `getMaxInjectedInstincts()` /
`getInstinctConfidenceThreshold()`, mirroring the file's existing
`getSessionRetentionDays()` / `getSessionStartMaxContextChars()` env-override
pattern. Invalid or out-of-range values fall back to the defaults.

This is **part (a)** of #2371 — the smaller, self-contained change the issue
author offered to land first ("Happy to scope it to just (a) first if you
prefer the smaller change"). Part (b) (confidence + stack/project relevance
ranking) is intentionally left for a separate PR to keep this one surgical.

## Why This Change

Instinct selection is currently confidence-only with a hardcoded count and
threshold, so tuning injection behavior requires editing (and re-editing after
every update) source constants. Exposing them as env vars removes that friction
— e.g. lower `ECC_MAX_INJECTED_INSTINCTS` for low-context/local-model setups, or
raise `ECC_INSTINCT_CONFIDENCE_THRESHOLD` to inject only high-confidence
instincts — with zero behavior change when the vars are unset.

## Testing Done

- [x] `node tests/run-all.js` — **2939/2939 pass** (clean env, `CLAUDE_PLUGIN_ROOT` unset)
- [x] Added `tests/hooks/hooks.test.js` subprocess coverage:
  - default cap injects 6; `ECC_MAX_INJECTED_INSTINCTS=3` injects 3; garbage value falls back to 6
  - default `0.7` threshold injects only above-floor instincts; `0.95` filters all out; `0.5` passes all (still capped at 6)
- [x] `npx eslint scripts/hooks/session-start.js tests/hooks/hooks.test.js` — clean
- [x] `npx markdownlint README.md` — clean
- [x] `scripts/ci/validate-no-personal-paths.js`, `check-unicode-safety.js`, `validate-hooks.js` — all pass

## Type of Change

- [x] New feature (non-breaking; env-gated, defaults preserved)

## Security & Quality Checklist

- [x] No new dependencies
- [x] No secrets, no network calls, no personal absolute paths
- [x] Env values validated (`Number.parseInt` / `Number.parseFloat` + range checks) with safe fallback
- [x] Surgical scope — one concern, single production file + its test + a doc note
- [x] Behavior unchanged when the new env vars are unset

## Documentation

- README "Hook Runtime Controls" section documents both new variables in the
  existing comment+export style.

Part of #2371 — implements part (a) (env-configurable knobs). Part (b)
(confidence + stack/project relevance ranking) is left as a follow-up; happy
to open that separately or fold it in if you'd prefer a single PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based controls for learned instinct injection at session start, including a configurable maximum count and confidence threshold.

* **Bug Fixes**
  * More reliable handling of invalid environment values by falling back to safe defaults.
  * Injection behavior now consistently applies both the confidence threshold and the maximum injection cap.

* **Documentation**
  * Updated README with the new environment variables and their default values.

* **Tests**
  * Added edge-case tests covering defaulting, invalid overrides, threshold filtering, and max-limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->