### PR TITLE
fix(rules): add paths frontmatter to web rule pack

### DIFF
--- a/rules/web/coding-style.md
+++ b/rules/web/coding-style.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/coding-style.md](../common/coding-style.md) with web-specific frontend content.
 
 # Web Coding Style

--- a/rules/web/design-quality.md
+++ b/rules/web/design-quality.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/patterns.md](../common/patterns.md) with web-specific design-quality guidance.
 
 # Web Design Quality Standards

--- a/rules/web/hooks.md
+++ b/rules/web/hooks.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/hooks.md](../common/hooks.md) with web-specific hook recommendations.
 
 # Web Hooks

--- a/rules/web/patterns.md
+++ b/rules/web/patterns.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/patterns.md](../common/patterns.md) with web-specific patterns.
 
 # Web Patterns

--- a/rules/web/performance.md
+++ b/rules/web/performance.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/performance.md](../common/performance.md) with web-specific performance content.
 
 # Web Performance Rules

--- a/rules/web/security.md
+++ b/rules/web/security.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/security.md](../common/security.md) with web-specific security content.
 
 # Web Security Rules

--- a/rules/web/testing.md
+++ b/rules/web/testing.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/testing.md](../common/testing.md) with web-specific testing content.
 
 # Web Testing Rules


### PR DESCRIPTION
## What Changed
Added `paths:` YAML frontmatter to all 7 files in `rules/web/` (coding-style, design-quality, hooks, patterns, performance, security, testing), scoped to web-facing file types: `**/*.css`, `**/*.scss`, `**/*.sass`, `**/*.less`, `**/*.html`, `**/*.tsx`, `**/*.jsx`, `**/*.vue`, `**/*.svelte`.

## Why This Change
`rules/web/` is the only language/framework rule pack shipped without `paths:` frontmatter — every other pack (typescript, react, python, golang, vue, angular, ... 21 in total) has it on all of its files. Per the official Claude Code docs on how rules load (https://code.claude.com/docs/en/memory), rule files without a `paths` field load unconditionally into every session. Installing the web pack under `.claude/rules/` therefore costs ~15.5KB of always-on context in **every** session, including projects with no frontend code at all. (`rules/common/` is intentionally unconditional as the universal layer; `web` looks like an oversight.)

The added frontmatter follows the react pack's convention (block-sequence globs, quoted, 2-space indent) so the web rules now load conditionally, matching the behavior of every other pack.

## Testing Done
- [x] Manual testing completed — this exact change has been running in a local install (`~/.claude/rules/`): the web rules load when web files (css/html/tsx/vue/...) are in context and stay out of non-web sessions.
- [x] Automated tests pass locally (`node tests/run-all.js`) — 2878/2881 pass; the 3 failures are pre-existing Windows environment issues that reproduce identically on unmodified `main` (verified by running the same suites on `main` before the change).
- [x] Edge cases considered and tested — globs are quoted so YAML block-sequence parsing is unambiguous; the two files unique to this pack (`design-quality.md`, `hooks.md`) get the same scoping as the five files with cross-pack counterparts.

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (none touched)
- [x] Shell scripts pass shellcheck (none touched)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation — none needed; the README's layered-pack description already assumes language packs load conditionally
- [ ] Added comments for complex logic (n/a — data-only change)
- [ ] README updated (not needed)