### PR TITLE
fix(install): dedupe copy-file operations sharing a destination

### DIFF
--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -688,6 +688,32 @@ function materializeScaffoldOperation(sourceRoot, operation) {
   });
 }
 
+function dedupeCopyFileOperations(operations) {
+  // A `copy-file` operation fully overwrites its destination, so when several
+  // of them target the same path (e.g. a generic `commands/<name>.md` shadowed
+  // by an OpenCode `.opencode/commands/<name>.md` override) only the last one
+  // actually determines the installed content. Recording the shadowed earlier
+  // writes in install-state makes `doctor` report perpetual drift and drives
+  // `repair` to clobber the override with the generic source (issue #2414).
+  // Keep only the last `copy-file` per destination — matching the sequential
+  // apply order in applyInstallPlan — and leave every other operation kind
+  // (e.g. accumulating `merge-json` writes into a shared config) untouched and
+  // in order.
+  const lastCopyIndexByDestination = new Map();
+  operations.forEach((operation, index) => {
+    if (operation.kind === 'copy-file' && operation.destinationPath) {
+      lastCopyIndexByDestination.set(operation.destinationPath, index);
+    }
+  });
+
+  return operations.filter((operation, index) => {
+    if (operation.kind !== 'copy-file' || !operation.destinationPath) {
+      return true;
+    }
+    return lastCopyIndexByDestination.get(operation.destinationPath) === index;
+  });
+}
+
 function createManifestInstallPlan(options = {}) {
   const sourceRoot = options.sourceRoot || getSourceRoot();
   const projectRoot = options.projectRoot || process.cwd();
@@ -716,7 +742,9 @@ function createManifestInstallPlan(options = {}) {
     target
   });
   const adapter = getInstallTargetAdapter(target);
-  const operations = plan.operations.flatMap(operation => materializeScaffoldOperation(sourceRoot, operation));
+  const operations = dedupeCopyFileOperations(
+    plan.operations.flatMap(operation => materializeScaffoldOperation(sourceRoot, operation))
+  );
   const source = {
     repoVersion: getPackageVersion(sourceRoot),
     repoCommit: getRepoCommit(sourceRoot),
@@ -776,6 +804,7 @@ module.exports = {
   createLegacyCompatInstallPlan,
   createManifestInstallPlan,
   createLegacyInstallPlan,
+  dedupeCopyFileOperations,
   getSourceRoot,
   listAvailableLanguages,
   parseInstallArgs

--- a/tests/lib/install-executor.test.js
+++ b/tests/lib/install-executor.test.js
@@ -14,6 +14,7 @@ const {
   createLegacyCompatInstallPlan,
   createLegacyInstallPlan,
   createManifestInstallPlan,
+  dedupeCopyFileOperations,
   listAvailableLanguages,
 } = require('../../scripts/lib/install-executor');
 
@@ -426,6 +427,59 @@ function runTests() {
       cleanup(sourceRoot);
       cleanup(homeDir);
     }
+  })) passed++; else failed++;
+
+  if (test('dedupeCopyFileOperations keeps the last writer per destination (issue #2414)', () => {
+    // Mirrors the OpenCode command scenario: a generic commands/<name>.md source
+    // (preserve-relative-path) and an override .opencode/commands/<name>.md source
+    // (sync-root-children) both write the same destination. Before the fix both
+    // ops were recorded, so `doctor` reported perpetual drift and `repair`
+    // clobbered the override. Only the last writer (the override) should survive.
+    const dest = '/home/.opencode/commands/build-fix.md';
+    const operations = [
+      { kind: 'copy-file', sourceRelativePath: 'commands/build-fix.md', destinationPath: dest, strategy: 'preserve-relative-path' },
+      { kind: 'copy-file', sourceRelativePath: '.opencode/commands/build-fix.md', destinationPath: dest, strategy: 'sync-root-children' },
+      { kind: 'copy-file', sourceRelativePath: 'commands/other.md', destinationPath: '/home/.opencode/commands/other.md', strategy: 'preserve-relative-path' },
+    ];
+
+    const deduped = dedupeCopyFileOperations(operations);
+
+    const destinations = deduped
+      .filter(operation => operation.kind === 'copy-file')
+      .map(operation => operation.destinationPath);
+    assert.deepStrictEqual(
+      destinations,
+      [dest, '/home/.opencode/commands/other.md'],
+      'each copy-file destination must appear exactly once'
+    );
+    const survivor = deduped.find(operation => operation.destinationPath === dest);
+    assert.strictEqual(
+      survivor.sourceRelativePath,
+      '.opencode/commands/build-fix.md',
+      'the last writer (override) must win, not the generic source'
+    );
+  })) passed++; else failed++;
+
+  if (test('dedupeCopyFileOperations leaves non copy-file operations and order intact', () => {
+    // merge-json operations legitimately accumulate into a shared config file, so
+    // multiple writes to one destination must be preserved; only redundant
+    // copy-file writes are collapsed, and surviving ops keep their relative order.
+    const mergeDest = '/home/.opencode/opencode.json';
+    const operations = [
+      { kind: 'merge-json', sourceRelativePath: 'a.json', destinationPath: mergeDest },
+      { kind: 'copy-file', sourceRelativePath: 'src/x.md', destinationPath: '/home/x.md' },
+      { kind: 'merge-json', sourceRelativePath: 'b.json', destinationPath: mergeDest },
+      { kind: 'copy-file', sourceRelativePath: 'other/x.md', destinationPath: '/home/x.md' },
+      { kind: 'remove', destinationPath: '/home/legacy.md' },
+    ];
+
+    const deduped = dedupeCopyFileOperations(operations);
+
+    assert.deepStrictEqual(
+      deduped.map(operation => `${operation.kind}:${operation.sourceRelativePath || operation.destinationPath}`),
+      ['merge-json:a.json', 'merge-json:b.json', 'copy-file:other/x.md', 'remove:/home/legacy.md'],
+      'both merge-json writes and the remove op survive; only the shadowed copy-file is dropped, order preserved'
+    );
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## What Changed

Extracted a small pure helper, `dedupeCopyFileOperations`, and applied it in
`createManifestInstallPlan` so a plan carries at most one `copy-file` operation
per destination — keeping the **last** writer, which matches the sequential
apply order that already determines what lands on disk. Every other operation
kind (e.g. `merge-json` writes that accumulate into a shared config) is left
untouched and in order.

## Why This Change

For OpenCode installs, 29 command files ship a harness-specific override under
`.opencode/commands/<name>.md` that shadows the generic `commands/<name>.md`.
The plan recorded **both** managed `copy-file` operations against the same
destination `~/.opencode/commands/<name>.md`. The override is applied last so
the install is correct on disk, but the stale generic operation leaked into
install-state, which broke lifecycle:

- `node scripts/ecc.js doctor` compared the generic source against the
  installed override content and reported `drifted-managed-files` for all 29
  files — forever.
- `node scripts/ecc.js repair` "repaired" that phantom drift by copying the
  generic `commands/<name>.md` over the correct override, **corrupting** the
  installed command, and `doctor` still showed the same warnings on the next
  run.

With one operation per destination, a fresh install is clean and `repair`
restores the correct override instead of clobbering it.

## Testing Done

Reproduced end-to-end against a sandbox `HOME` (`ecc install --target opencode
--profile core`):

- Before: `doctor` → 27 `drifted-managed-files`; `repair` → "Repaired paths:
  27" (exit 0) but `doctor` → the identical 27 warnings, and the command files
  were overwritten with the generic variant.
- After: `doctor` → `warnings=0 errors=0 status=ok`; `repair` → 0 repairs
  (nothing drifted); `doctor` → still `ok`.

Automated (in `tests/lib/install-executor.test.js`):
- Two hermetic unit tests for `dedupeCopyFileOperations` over fixed operation
  arrays (no live-repo layout coupling): last writer wins (the `.opencode/commands`
  override beats the generic `commands/` source), and `merge-json` accumulation
  plus operation order are preserved. Both fail on `main` (helper absent) and
  pass with this change.
- `node tests/lib/install-executor.test.js` 12/12, `install-lifecycle` 30/30,
  `install-targets` 41/41, `selective-install` 46/46, and the opencode /
  plugin-manifest suites all green.
- `npx eslint scripts/lib/install-executor.js tests/lib/install-executor.test.js`
  clean.

Note: the regression is tested against the pure plan-shaping helper rather than
a `target: opencode` plan build, because the OpenCode adapter requires the
git-ignored compiled `.opencode/dist` payload, which is unbuilt on a fresh CI
checkout.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Security & Quality Checklist

- [x] Surgical: one shared plan builder + a pure helper + unit tests (no
      lockfile, no generated `.opencode/dist`, no unrelated refactors)
- [x] No new dependencies
- [x] Behaviour-preserving on disk (last writer already won); only the dead
      shadowed write is dropped from install-state
- [x] `merge-json` accumulation into shared config files is unaffected (only
      `copy-file` ops are collapsed)
- [x] No personal absolute paths introduced

## Documentation

No user-facing docs change required; behaviour now matches the documented
`doctor`/`repair` contract.

Fixes #2414
