### PR TITLE
fix(rules): correct relative link to common/coding-style.md

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -136,7 +136,7 @@ When language-specific rules and common rules conflict, **language-specific rule
 
 `common/coding-style.md` recommends immutability as a default principle. A language-specific `golang/coding-style.md` can override this:
 
-> Idiomatic Go uses pointer receivers for struct mutation — see [common/coding-style.md](../common/coding-style.md) for the general principle, but Go-idiomatic mutation is preferred here.
+> Idiomatic Go uses pointer receivers for struct mutation — see [common/coding-style.md](common/coding-style.md) for the general principle, but Go-idiomatic mutation is preferred here.
 
 ### Common rules with override notes
 


### PR DESCRIPTION
## Summary
- Fixes a broken relative link in `rules/README.md`. The Go example pointed to `../common/coding-style.md`, which (since the README lives inside `rules/`) resolves to a nonexistent `common/coding-style.md` at the repo root instead of `rules/common/coding-style.md`.
- The `../common/` prefix is correct for language-specific files like `rules/golang/coding-style.md` (sibling of `common/`), but not for `rules/README.md` itself, where `common/` is a direct child directory.

## Test plan
- [x] Confirmed `rules/common/coding-style.md` exists and the corrected relative link resolves to it.
- [x] Docs-only change; no code or tests affected.
