### PR TITLE
fix(gateguard): remove control-char regex placeholder (unbreak yarn lint)

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -116,10 +116,9 @@ function getExemptMatchers() {
     .map(glob => {
       const source = glob
         .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex metachars, keep * and ?
-        .replace(/\*\*/g, '\x00')            // ** placeholder (cross-segment)
-        .replace(/\*/g, '[^/]*')               // * -> within a segment
-        .replace(/\x00/g, '.*')              // ** -> across segments
-        .replace(/\?/g, '.');
+        .split('**')                           // ** boundaries (cross-segment)
+        .map(part => part.replace(/\*/g, '[^/]*').replace(/\?/g, '.'))
+        .join('.*');                           // ** -> across segments
       try {
         return new RegExp(source);
       } catch (_) {


### PR DESCRIPTION
Follow-up to #2432: the `**` glob placeholder used a literal NUL byte in a regex, tripping eslint 10's `no-control-regex` and turning `yarn lint` red on main. Replaces the placeholder trick with `split('**')/join('.*')` — semantically identical conversion, verified by the four exempt-glob tests added in #2432. Full suite: 2969/2969 pass, lint clean.