### PR TITLE
feat(install): add Kimi Code CLI install target

### DIFF
--- a/.kimi/README.md
+++ b/.kimi/README.md
@@ -1,0 +1,22 @@
+# ECC for Kimi Code CLI
+
+This directory contains the ECC (Everything Claude Code) configuration for the Kimi Code CLI harness.
+
+## What is installed
+
+- `rules/ecc/` — shared coding rules and guidelines
+- `skills/ecc/` — reusable skills
+- `commands/` — slash commands
+- `AGENTS.md` — agent instructions
+
+## Manual install
+
+```bash
+bash ./install.sh --target kimi --profile minimal
+```
+
+## Notes
+
+- The `kimi` target installs into the project-level `./.kimi/` directory.
+- Kimi Code CLI's own config (`~/.kimi-code/config.toml`, plugins) is **not** touched by ECC install.
+- Use `npx ecc doctor --target kimi` to check install health.

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -18,7 +18,8 @@
         "qwen",
         "zed",
         "hermes",
-        "openclaw"
+        "openclaw",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -45,7 +46,8 @@
         "qwen",
         "zed",
         "hermes",
-        "openclaw"
+        "openclaw",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -72,7 +74,8 @@
         "qwen",
         "zed",
         "hermes",
-        "openclaw"
+        "openclaw",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -116,7 +119,8 @@
         "scripts/auto-update.js",
         "scripts/setup-package-manager.js",
         ".hermes",
-        ".openclaw"
+        ".openclaw",
+        ".kimi"
       ],
       "targets": [
         "claude",
@@ -131,7 +135,8 @@
         "qwen",
         "zed",
         "hermes",
-        "openclaw"
+        "openclaw",
+        "kimi"
       ],
       "dependencies": [],
       "defaultInstall": true,
@@ -288,7 +293,8 @@
         "qwen",
         "zed",
         "hermes",
-        "openclaw"
+        "openclaw",
+        "kimi"
       ],
       "dependencies": [
         "platform-configs"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     ".cursor/",
     ".gemini/",
     ".hermes/",
+    ".kimi/",
     ".opencode/",
     ".openclaw/",
     ".qwen/",

--- a/schemas/ecc-install-config.schema.json
+++ b/schemas/ecc-install-config.schema.json
@@ -30,7 +30,8 @@
         "qwen",
         "zed",
         "hermes",
-        "openclaw"
+        "openclaw",
+        "kimi"
       ]
     },
     "profile": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -60,7 +60,8 @@
                 "qwen",
                 "zed",
                 "hermes",
-                "openclaw"
+                "openclaw",
+                "kimi"
               ]
             }
           },

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -43,6 +43,7 @@ Targets:
   qwen         - Install commands, agents, skills, rules, and Qwen config into ~/.qwen/
   zed          - Install project settings, commands, agents, skills, and flattened rules into ./.zed/
   hermes       - Install shared rules/skills/commands into ~/.hermes/
+  kimi         - Install shared rules/skills/commands into ./.kimi/
   openclaw     - Install shared rules/skills/commands into ~/.openclaw/
 
 Options:

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./install-targets/registry');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed', 'hermes', 'openclaw'];
+const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed', 'hermes', 'openclaw', 'kimi'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',
@@ -81,6 +81,13 @@ const LEGACY_COMPAT_BASE_MODULE_IDS_BY_TARGET = Object.freeze({
     'workflow-quality',
   ],
   openclaw: [
+    'rules-core',
+    'agents-core',
+    'commands-core',
+    'platform-configs',
+    'workflow-quality',
+  ],
+  kimi: [
     'rules-core',
     'agents-core',
     'commands-core',

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -8,6 +8,7 @@ const PLATFORM_SOURCE_PATH_OWNERS = Object.freeze({
   '.cursor': 'cursor',
   '.gemini': 'gemini',
   '.hermes': 'hermes',
+  '.kimi': 'kimi',
   '.joycode': 'joycode',
   '.opencode': 'opencode',
   '.openclaw': 'openclaw',

--- a/scripts/lib/install-targets/kimi-project.js
+++ b/scripts/lib/install-targets/kimi-project.js
@@ -1,0 +1,10 @@
+const { createInstallTargetAdapter } = require('./helpers');
+
+module.exports = createInstallTargetAdapter({
+  id: 'kimi-project',
+  target: 'kimi',
+  kind: 'project',
+  rootSegments: ['.kimi'],
+  installStatePathSegments: ['ecc-install-state.json'],
+  nativeRootRelativePath: '.kimi',
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -7,6 +7,7 @@ const cursorProject = require('./cursor-project');
 const geminiProject = require('./gemini-project');
 const hermesHome = require('./hermes-home');
 const joycodeProject = require('./joycode-project');
+const kimiProject = require('./kimi-project');
 const openclawHome = require('./openclaw-home');
 const opencodeHome = require('./opencode-home');
 const qwenHome = require('./qwen-home');
@@ -24,6 +25,7 @@ const ADAPTERS = Object.freeze([
   openclawHome,
   codebuddyProject,
   joycodeProject,
+  kimiProject,
   qwenHome,
   zedProject,
 ]);


### PR DESCRIPTION
Rebuild of #2154 on current main, following the hermes/openclaw (#2433) adapter recipe — credit to @MoYiC6 for the original adapter design.

**What's included** (61 lines, 10 files):
- `scripts/lib/install-targets/kimi-project.js` — 10-line project-kind adapter (`./.kimi` root), same shape as qwen-home/hermes-home
- Registry + helpers platform-ownership wiring, `SUPPORTED_INSTALL_TARGETS` + legacy-compat modules
- `kimi` target on the 5 shared modules + `.kimi` in platform-configs paths
- Both schema enums (`install-modules`, `ecc-install-config`), npm `files` allowlist, installer help text, `.kimi/README.md` stub

**Deliberately NOT carried over from #2154** (per review): the 4 duplicate `skills/ecc-*` copies (would leak Kimi-specific variants into every harness install), `install-hooks.mjs` v1 (naive denylist previously flagged as a blocker), and `kimi.plugin.json` (worth doing as a follow-up with correct ECC branding once someone validates against a live Kimi CLI).

**Verified:** full suite 2971/2971 + lint clean; `--dry-run` smoke test resolves `Target: kimi / Adapter: kimi-project / root ./.kimi` with all 5 modules planned.