### PR TITLE
docs(skills): fix typo in remotion charts rule

### DIFF
--- a/skills/remotion-video-creation/rules/charts.md
+++ b/skills/remotion-video-creation/rules/charts.md
@@ -17,7 +17,7 @@ Instead, drive all animations from `useCurrentFrame()`.
 
 ## Bar Chart Animations
 
-See [Bar Chart Example](assets/charts/bar-chart.tsx) for a basic example implmentation.
+See [Bar Chart Example](assets/charts/bar-chart.tsx) for a basic example implementation.
 
 ### Staggered Bars
 


### PR DESCRIPTION
## Summary
- Fixes a typo (\"implmentation\" -> \"implementation\") in `skills/remotion-video-creation/rules/charts.md`

## Test plan
- [x] Docs-only change; no build/test impact