### PR TITLE
fix(observer): repair daemon boot (stale resolver name) and close analysis stdin (#2452)

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -248,13 +248,16 @@ PROMPT
   # Pass prompt via -p flag instead of stdin redirect for Windows compatibility (#842).
   # prompt_content is already loaded in-memory so this no longer depends on the
   # mktemp absolute path continuing to resolve after cwd changes (#1296).
+  # stdin is explicitly closed with </dev/null: on Git Bash/MSYS2 the backgrounded
+  # child otherwise inherits an open stdin, and claude waits on it, warns
+  # "no stdin data received", and exits 1 before reading the analysis file (#2452).
   # Model is configurable via ECC_OBSERVER_MODEL (defaults to haiku for cost efficiency);
   # e.g. ECC_OBSERVER_MODEL=opus for higher-quality instinct extraction. Heavier models are
   # slower — consider raising ECC_OBSERVER_TIMEOUT_SECONDS (default 120s) so the watchdog
   # doesn't kill the analysis mid-run.
   ECC_SKIP_OBSERVE=1 ECC_HOOK_PROFILE=minimal claude --model "${ECC_OBSERVER_MODEL:-haiku}" --max-turns "$max_turns" --print \
     --allowedTools "Read,Write" \
-    -p "$prompt_content" >> "$LOG_FILE" 2>&1 &
+    -p "$prompt_content" < /dev/null >> "$LOG_FILE" 2>&1 &
   claude_pid=$!
 
   (

--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -37,7 +37,7 @@ PYTHON_CMD="${CLV2_PYTHON_CMD:-}"
 
 # shellcheck disable=SC1091
 . "${SKILL_ROOT}/scripts/lib/homunculus-dir.sh"
-CONFIG_DIR="$(_ecc_resolve_homunculus_dir)"
+CONFIG_DIR="$(_clv2_resolve_homunculus_dir)"
 if [ -n "${CLV2_CONFIG:-}" ]; then
   CONFIG_FILE="$CLV2_CONFIG"
 elif [ -f "${CONFIG_DIR}/config.json" ]; then

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -3168,6 +3168,40 @@ async function runTests() {
     passed++;
   else failed++;
 
+  if (
+    test('observer scripts only call homunculus resolvers the shared lib defines (#2452)', () => {
+      const skillRoot = path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2');
+      const libSource = fs.readFileSync(path.join(skillRoot, 'scripts', 'lib', 'homunculus-dir.sh'), 'utf8');
+      const definedResolvers = new Set([...libSource.matchAll(/^([A-Za-z_][A-Za-z0-9_]*_resolve_homunculus_dir)\(\)/gm)].map((m) => m[1]));
+      assert.ok(definedResolvers.size > 0, 'homunculus-dir.sh should define a homunculus resolver function');
+
+      const callers = [
+        ['agents', 'start-observer.sh'],
+        ['hooks', 'observe.sh'],
+        ['scripts', 'detect-project.sh'],
+        ['scripts', 'migrate-homunculus.sh']
+      ];
+      for (const rel of callers) {
+        const callerSource = fs.readFileSync(path.join(skillRoot, ...rel), 'utf8');
+        for (const match of callerSource.matchAll(/([A-Za-z_][A-Za-z0-9_]*_resolve_homunculus_dir)\b/g)) {
+          assert.ok(definedResolvers.has(match[1]), `${rel.join('/')} calls ${match[1]}, which homunculus-dir.sh does not define (stale name breaks daemon boot under set -e)`);
+        }
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('observer-loop closes stdin on the backgrounded claude analysis call (#2452)', () => {
+      const observerLoopSource = fs.readFileSync(path.join(__dirname, '..', '..', 'skills', 'continuous-learning-v2', 'agents', 'observer-loop.sh'), 'utf8');
+
+      assert.ok(observerLoopSource.includes('-p "$prompt_content" < /dev/null'), 'observer-loop should close stdin on the backgrounded claude call so Git Bash children do not hang on inherited stdin and exit 1');
+    })
+  )
+    passed++;
+  else failed++;
+
   if (SKIP_BASH) {
     console.log('  ⊘ detect-project exports the resolved Python command (skipped on Windows)');
     passed++;


### PR DESCRIPTION
## Summary
- fix the all-platform observer boot regression: `start-observer.sh:40` still called `_ecc_resolve_homunculus_dir`, but the shared lib was renamed to `_clv2_resolve_homunculus_dir` (observe.sh, detect-project.sh, and migrate-homunculus.sh were updated; start-observer.sh was missed) — under `set -e` every launch dies with exit 127, so this breaks daemon boot everywhere, not only on Windows
- close stdin (`< /dev/null`) on the backgrounded analysis `claude` call in `observer-loop.sh`: on Git Bash/MSYS2 the child inherits an open stdin, waits on it, warns "no stdin data received", and exits 1 before reading the analysis file; this is the only backgrounded claude call site in the repo
- keep the `-p` prompt flag rather than reverting to a stdin redirect, preserving the Windows-compat decision from #842 (the fix suggested in #2452 would undo it)
- add two source invariant guards to `tests/hooks/hooks.test.js`: every `*_resolve_homunculus_dir` call site must match a function the shared lib defines, and the backgrounded claude call must close stdin

## Verification
- pre-fix repro on macOS: `start-observer.sh status` dies with `line 40: _ecc_resolve_homunculus_dir: command not found`, exit 127
- post-fix: full start → status → stop cycle completes in a sandboxed `CLV2_HOMUNCULUS_DIR`
- `node tests/run-all.js` on node 22: 2973 passed, 0 failed
- shellcheck on both scripts: only two pre-existing info-level findings on untouched lines
- note: no Windows machine available — bug 1 is verified end-to-end on macOS (it is platform-independent); bug 2's fix is the standard stdin-close idiom and is behavior-neutral on macOS/Linux, but has not been exercised on Git Bash

Fixes #2452