### PR TITLE
fix(suggest-compact): recognize default-1M models without a [1m] marker (#2461)

### DIFF
--- a/.agents/skills/strategic-compact/SKILL.md
+++ b/.agents/skills/strategic-compact/SKILL.md
@@ -31,7 +31,7 @@ Strategic compaction at logical boundaries:
 
 The `suggest-compact.js` script runs on PreToolUse (Edit/Write) and combines two signals:
 
-1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at a window-scaled threshold — 160k tokens on a 200k window, 250k on a 1M window (detected from a `[1m]` model marker, or inferred when observed tokens already exceed 200k) — and re-reminds after every additional 60k tokens of context growth
+1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at a window-scaled threshold — 160k tokens on a 200k window, 250k on a 1M window (detected from a `[1m]` model marker, a known default-1M model family, or inferred when observed tokens already exceed 200k) — and re-reminds after every additional 60k tokens of context growth
 2. **Tool-call count (secondary)** — Counts tool invocations in session; suggests at a configurable threshold (default: 50 calls), then every 25 calls after
 
 ## Hook Setup

--- a/scripts/lib/transcript-context.js
+++ b/scripts/lib/transcript-context.js
@@ -6,9 +6,9 @@
  *
  * - `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
  *   partition the prompt, so their sum is the true context size of the turn.
- * - The context window is detected from the model id (`[1m]` marker) or from
- *   the observed token count (anything above 200k implies a 1M window even
- *   when logs drop the suffix).
+ * - The context window is detected from the model id (`[1m]` marker or a
+ *   known large-window model family) or from the observed token count
+ *   (anything above 200k implies a 1M window even when logs drop the suffix).
  * - Thresholds are window-scaled and env-overridable; re-reminders fire in
  *   fixed token "buckets" above the threshold so the suggestion only repeats
  *   after real context growth.
@@ -27,6 +27,16 @@ const DEFAULT_CONTEXT_INTERVAL_TOKENS = 60000;
 const DEFAULT_TRANSCRIPT_TAIL_BYTES = 256 * 1024;
 const MAX_TOKEN_SETTING = 10000000;
 const LARGE_WINDOW_MODEL_MARKER = '[1m]';
+// Model families whose default (not opt-in) context window is 1M, so their ids
+// never carry the `[1m]` marker (#2461). Checked in order, first match wins.
+// Deliberately excludes families where 1M is opt-in (e.g. Opus/Sonnet 4.x) —
+// those signal the large window via the `[1m]` marker when it is active.
+// Best-effort and expected to lag new releases; the env overrides below remain
+// the escape hatch for unlisted models.
+const KNOWN_MODEL_WINDOW_TOKENS = [
+  ['claude-fable-5', LARGE_CONTEXT_WINDOW_TOKENS],
+  ['claude-mythos-5', LARGE_CONTEXT_WINDOW_TOKENS]
+];
 
 /**
  * Read the trailing `tailBytes` of a file as UTF-8.
@@ -132,9 +142,10 @@ function readLatestContextTokens(transcriptPath, options = {}) {
 
 /**
  * Detect the context window size for a turn.
- * 1M when the model id carries the `[1m]` marker, or when the observed token
- * count already exceeds the standard 200k window (covers logs that drop the
- * suffix); otherwise the standard 200k window.
+ * 1M when the model id carries the `[1m]` marker or belongs to a known
+ * default-1M model family (#2461), or when the observed token count already
+ * exceeds the standard 200k window (covers logs that drop the suffix);
+ * otherwise the standard 200k window.
  */
 function resolveContextWindowTokens(tokens, model) {
   // Explicit window override wins: 400k models (e.g. Opus 4.x) match neither the
@@ -146,8 +157,18 @@ function resolveContextWindowTokens(tokens, model) {
     return envWindow;
   }
 
-  if (typeof model === 'string' && model.includes(LARGE_WINDOW_MODEL_MARKER)) {
-    return LARGE_CONTEXT_WINDOW_TOKENS;
+  if (typeof model === 'string') {
+    if (model.includes(LARGE_WINDOW_MODEL_MARKER)) {
+      return LARGE_CONTEXT_WINDOW_TOKENS;
+    }
+
+    // Newer large-window families ship without the [1m] marker and would
+    // otherwise fall through to the 200k default until usage crosses 200k,
+    // overstating context percentage ~5x (#2461).
+    const known = KNOWN_MODEL_WINDOW_TOKENS.find(([substring]) => model.includes(substring));
+    if (known) {
+      return known[1];
+    }
   }
 
   if (Number.isFinite(tokens) && tokens > STANDARD_CONTEXT_WINDOW_TOKENS) {

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -33,7 +33,7 @@ Strategic compaction at logical boundaries:
 
 The `suggest-compact.js` script runs on PreToolUse (Edit/Write) and combines two signals:
 
-1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at a window-scaled threshold — 160k tokens on a 200k window, 250k on a 1M window (detected from a `[1m]` model marker, or inferred when observed tokens already exceed 200k) — and re-reminds after every additional 60k tokens of context growth
+1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at a window-scaled threshold — 160k tokens on a 200k window, 250k on a 1M window (detected from a `[1m]` model marker, a known default-1M model family, or inferred when observed tokens already exceed 200k) — and re-reminds after every additional 60k tokens of context growth
 2. **Tool-call count (secondary)** — Counts tool invocations in session; suggests at a configurable threshold (default: 50 calls), then every 25 calls after
 
 Tool count alone is a weak proxy for window pressure: a few large file reads or MCP responses can fill the window in very few calls, while many tiny calls can cross 50 with a near-empty window. The context-size signal fires when it actually matters.

--- a/tests/lib/transcript-context.test.js
+++ b/tests/lib/transcript-context.test.js
@@ -180,6 +180,15 @@ test('detects a 1M window when observed tokens exceed 200k (marker dropped)', ()
   assert.strictEqual(resolveContextWindowTokens(220000, 'claude-opus-4-5'), LARGE_CONTEXT_WINDOW_TOKENS);
 });
 
+test('detects a 1M window for known large-window models without a [1m] marker (#2461)', () => {
+  assert.strictEqual(resolveContextWindowTokens(187000, 'claude-fable-5'), LARGE_CONTEXT_WINDOW_TOKENS);
+  assert.strictEqual(resolveContextWindowTokens(50000, 'claude-mythos-5'), LARGE_CONTEXT_WINDOW_TOKENS);
+});
+
+test('still defaults unknown models at low token counts to the 200k window (no false positives)', () => {
+  assert.strictEqual(resolveContextWindowTokens(187000, 'claude-haiku-4-5'), STANDARD_CONTEXT_WINDOW_TOKENS);
+});
+
 test('treats an empty model id as standard window', () => {
   assert.strictEqual(resolveContextWindowTokens(100000, ''), STANDARD_CONTEXT_WINDOW_TOKENS);
 });


### PR DESCRIPTION
## Summary
- `resolveContextWindowTokens()` only detected a large window via the env overrides (#2290), the `[1m]` model-id marker, or observed tokens already above 200k — newer families whose default window is 1M (e.g. `claude-fable-5`) carry no marker, so below 200k of usage the hook reported ~187k of real usage as 93% of a 200k window when real usage was ~19% of 1M (~5x overstated)
- add a small `KNOWN_MODEL_WINDOW_TOKENS` substring → window table, checked after the `[1m]` marker and before the >200k heuristic
- the table deliberately lists only families where 1M is the default rather than an opt-in (fable/mythos 5); opt-in families (Opus/Sonnet 4.x) keep signaling via `[1m]`, so 200k-default sessions on those are not overstated in the other direction
- env overrides remain the escape hatch for unlisted large-window models
- sync the window-detection description in both strategic-compact SKILL.md copies with the new detection path; the broader README callout suggested in the issue is left out deliberately — the env-override docs from #2290 already cover unlisted models

## Verification
- new test: `claude-fable-5` at 187k tokens resolves to the 1M window (so the hook reports ~19% instead of 93%)
- new test: an unknown model at the same token count still falls back to the 200k window (no false positives)
- `node tests/run-all.js` on node 22: 2973 passed, 0 failed

Fixes #2461