### PR TITLE
docs(rules): add Delegation Completion Contract to agent orchestration rules

### DIFF
--- a/rules/common/agents.md
+++ b/rules/common/agents.md
@@ -40,6 +40,16 @@ Launch 3 agents in parallel:
 First agent 1, then agent 2, then agent 3
 ```
 
+## Delegation Completion Contract
+
+Applies to every agent at every depth (parent, child, grandchild):
+
+1. **Your final message IS the deliverable.** Never end your turn with "waiting for background agents" — a spawned task is not a completed task. Ending your turn while children are running orphans their results (completed children cannot notify a parent whose turn has ended).
+2. **If you delegate, you own collection.** Wait for results, integrate them, then return. Fire-and-forget delegation is forbidden.
+3. **Decompose only when the work cannot fit in one context.** Do not re-delegate a task already sized for a single agent — depth is an outcome, not a plan.
+
+> Rationale: observed failure mode — research agents followed "Parallel Task Execution" above, spawned children, and returned "waiting" as their final answer. All children completed successfully but their results were orphaned. The parallel rule without a completion contract produces zombie tasks.
+
 ## Multi-Perspective Analysis
 
 For complex problems, use split role sub-agents:


### PR DESCRIPTION
## Summary

`rules/common/agents.md` tells agents to "ALWAYS use parallel Task execution for independent operations", but defines no completion contract for delegation. This PR adds a **Delegation Completion Contract** section right after the parallel-execution rule.

## The failure mode this prevents

Observed in practice with parallel research agents:

1. Parent spawns 4 research agents (children), each with a well-scoped task
2. 3 of 4 children — following the parallel-execution rule — spawn their **own** children (grandchildren) instead of doing the work
3. The children then end their turn with *"waiting for background agents to complete"* as their final answer
4. All grandchildren complete their research successfully, but their results are **orphaned**: a parent whose turn has ended cannot receive completion notifications
5. Result: zombie "running" tasks in the UI, lost work, and children that returned no deliverable

The root cause is not delegation itself (the grandchildren's output quality was fine) and not task decomposition (the same 4-way split succeeded when re-run with a completion constraint). It is the missing **lifecycle contract**: a subagent's final message IS its return value, so "waiting" is an abandoned return value.

## What this adds

Three rules that apply at every delegation depth:

1. **Your final message IS the deliverable.** Never end your turn with "waiting for background agents" — a spawned task is not a completed task.
2. **If you delegate, you own collection.** Wait for results, integrate them, then return. Fire-and-forget delegation is forbidden.
3. **Decompose only when the work cannot fit in one context.** Depth is an outcome, not a plan.

With this contract in place, the same parallel research fan-out completed with zero orphaned tasks.

## Changes

- `rules/common/agents.md`: +10 lines (new "Delegation Completion Contract" section between "Parallel Task Execution" and "Multi-Perspective Analysis")
