### PR TITLE
feat(llm): add MiniMax provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,11 +37,13 @@ ATLAS_API_KEY=
 # ATLAS_BASE_URL=https://api.atlascloud.ai/v1
 # ATLAS_MODEL=anthropic/claude-sonnet-4.6
 
-# --- Optional: MiniMax (OpenAI-compatible) ----------------------------------
-# OpenAI-compatible endpoint: https://api.minimax.io/v1
-# Anthropic-compatible endpoint: https://api.minimax.io/anthropic/v1
+# --- Optional: MiniMax (OpenAI- and Anthropic-compatible) -------------------
+# OpenAI SDK: global https://api.minimax.io/v1
+# OpenAI SDK: China  https://api.minimaxi.com/v1
+# Anthropic SDK: global https://api.minimax.io/anthropic
+# Anthropic SDK: China  https://api.minimaxi.com/anthropic
 MINIMAX_API_KEY=
-# MINIMAX_MODEL=MiniMax-M3
+# MINIMAX_MODEL=MiniMax-M3  # Also supports MiniMax-M2.7
 # MINIMAX_BASE_URL=https://api.minimax.io/v1
 
 # ─── ECC agent data (multi-harness isolation) ───────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,13 @@ ATLAS_API_KEY=
 # ATLAS_BASE_URL=https://api.atlascloud.ai/v1
 # ATLAS_MODEL=anthropic/claude-sonnet-4.6
 
+# --- Optional: MiniMax (OpenAI-compatible) ----------------------------------
+# OpenAI-compatible endpoint: https://api.minimax.io/v1
+# Anthropic-compatible endpoint: https://api.minimax.io/anthropic/v1
+MINIMAX_API_KEY=
+# MINIMAX_MODEL=MiniMax-M3
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
+
 # ─── ECC agent data (multi-harness isolation) ───────────────────────────────
 # Memory hooks (sessions, learned skills, aliases, metrics). Default: ~/.claude
 # Use a separate root when running ECC in Cursor alongside Claude Code:

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -21,6 +21,7 @@ class ProviderType(str, Enum):
     ASTRAFLOW = "astraflow"
     ASTRAFLOW_CN = "astraflow_cn"
     ATLAS = "atlas"
+    MINIMAX = "minimax"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -3,6 +3,7 @@
 from llm.providers.astraflow import AstraflowCNProvider, AstraflowProvider
 from llm.providers.atlas import AtlasProvider
 from llm.providers.claude import ClaudeProvider
+from llm.providers.minimax import MiniMaxProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
 from llm.providers.resolver import get_provider, register_provider
@@ -12,6 +13,7 @@ __all__ = (
     "AstraflowProvider",
     "AtlasProvider",
     "ClaudeProvider",
+    "MiniMaxProvider",
     "OpenAIProvider",
     "OllamaProvider",
     "get_provider",

--- a/src/llm/providers/minimax.py
+++ b/src/llm/providers/minimax.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit
 
 from anthropic import Anthropic
 from openai import OpenAI
@@ -28,15 +28,7 @@ DEFAULT_MINIMAX_ANTHROPIC_MAX_TOKENS = 16_000
 
 def _uses_anthropic_messages(base_url: str) -> bool:
     path = urlsplit(base_url).path.rstrip("/")
-    return path.endswith(("/anthropic", "/anthropic/v1"))
-
-
-def _anthropic_sdk_base_url(base_url: str) -> str:
-    parsed = urlsplit(base_url.rstrip("/"))
-    path = parsed.path.rstrip("/")
-    if path.endswith("/anthropic/v1"):
-        path = path.removesuffix("/v1")
-    return urlunsplit(parsed._replace(path=path))
+    return path.endswith("/anthropic")
 
 
 def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
@@ -73,11 +65,7 @@ class MiniMaxProvider(LLMProvider):
             self.base_url_env, self.default_base_url
         )
         self._uses_anthropic = _uses_anthropic_messages(configured_base_url)
-        self.base_url = (
-            _anthropic_sdk_base_url(configured_base_url)
-            if self._uses_anthropic
-            else configured_base_url
-        )
+        self.base_url = configured_base_url
         self.default_model = (
             default_model or os.environ.get(self.model_env) or DEFAULT_MINIMAX_MODEL
         )

--- a/src/llm/providers/minimax.py
+++ b/src/llm/providers/minimax.py
@@ -28,7 +28,7 @@ DEFAULT_MINIMAX_ANTHROPIC_MAX_TOKENS = 16_000
 
 def _uses_anthropic_messages(base_url: str) -> bool:
     path = urlsplit(base_url).path.rstrip("/")
-    return path.endswith("/anthropic") or path.endswith("/anthropic/v1")
+    return path.endswith(("/anthropic", "/anthropic/v1"))
 
 
 def _anthropic_sdk_base_url(base_url: str) -> str:
@@ -210,6 +210,8 @@ class MiniMaxProvider(LLMProvider):
                 params[key] = llm_input.metadata[key]
 
         response = self.client.messages.create(**params)
+        if not response.content:
+            raise ValueError(EMPTY_FILTERED_RESPONSE_ERROR)
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
         for block in response.content or []:

--- a/src/llm/providers/minimax.py
+++ b/src/llm/providers/minimax.py
@@ -1,0 +1,129 @@
+"""MiniMax OpenAI-compatible provider adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+from llm.core.interface import (
+    AuthenticationError,
+    ContextLengthError,
+    LLMProvider,
+    RateLimitError,
+)
+from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
+from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic/v1"
+DEFAULT_MINIMAX_MODEL = "MiniMax-M3"
+
+
+def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
+    if not raw_arguments:
+        return {}
+
+    try:
+        arguments = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {"raw": raw_arguments}
+
+    if isinstance(arguments, dict):
+        return arguments
+    return {"value": arguments}
+
+
+class MiniMaxProvider(LLMProvider):
+    """MiniMax endpoint using OpenAI-compatible chat completions."""
+
+    provider_type = ProviderType.MINIMAX
+    api_key_env = "MINIMAX_API_KEY"
+    base_url_env = "MINIMAX_BASE_URL"
+    model_env = "MINIMAX_MODEL"
+    default_base_url = MINIMAX_BASE_URL
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_model: str | None = None,
+    ) -> None:
+        self.api_key = api_key or os.environ.get(self.api_key_env) or ""
+        self.base_url = base_url or os.environ.get(self.base_url_env, self.default_base_url)
+        self.default_model = default_model or os.environ.get(self.model_env) or DEFAULT_MINIMAX_MODEL
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url, _enforce_credentials=False)
+        self._models = [
+            ModelInfo(
+                name=DEFAULT_MINIMAX_MODEL,
+                provider=self.provider_type,
+                supports_tools=True,
+                supports_vision=False,
+                context_window=1_000_000,
+            )
+        ]
+
+    def generate(self, llm_input: LLMInput) -> LLMOutput:
+        try:
+            params: dict[str, Any] = {
+                "model": llm_input.model or self.default_model,
+                "messages": [msg.to_dict() for msg in llm_input.messages],
+            }
+            if llm_input.temperature != 1.0:
+                params["temperature"] = llm_input.temperature
+            if llm_input.max_tokens is not None:
+                params["max_tokens"] = llm_input.max_tokens
+            if llm_input.tools:
+                params["tools"] = [tool.to_openai_tool() for tool in llm_input.tools]
+
+            response = self.client.chat.completions.create(**params)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError(EMPTY_FILTERED_RESPONSE_ERROR)
+            choice = response.choices[0]
+
+            tool_calls = None
+            if choice.message.tool_calls:
+                tool_calls = [
+                    ToolCall(
+                        id=tc.id or "",
+                        name=tc.function.name,
+                        arguments=_parse_tool_arguments(tc.function.arguments),
+                    )
+                    for tc in choice.message.tool_calls
+                ]
+
+            usage = None
+            if response.usage:
+                usage = {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+
+            return LLMOutput(
+                content=choice.message.content or "",
+                tool_calls=tool_calls,
+                model=response.model,
+                usage=usage,
+                stop_reason=choice.finish_reason,
+            )
+        except Exception as e:
+            msg = str(e)
+            if "401" in msg or "authentication" in msg.lower():
+                raise AuthenticationError(msg, provider=self.provider_type) from e
+            if "429" in msg or "rate_limit" in msg.lower():
+                raise RateLimitError(msg, provider=self.provider_type) from e
+            if "context" in msg.lower() and "length" in msg.lower():
+                raise ContextLengthError(msg, provider=self.provider_type) from e
+            raise
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return bool(self.api_key)
+
+    def get_default_model(self) -> str:
+        return self.default_model

--- a/src/llm/providers/minimax.py
+++ b/src/llm/providers/minimax.py
@@ -1,11 +1,13 @@
-"""MiniMax OpenAI-compatible provider adapter."""
+"""MiniMax OpenAI- and Anthropic-compatible provider adapter."""
 
 from __future__ import annotations
 
 import json
 import os
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
+from anthropic import Anthropic
 from openai import OpenAI
 
 from llm.core.interface import (
@@ -14,12 +16,27 @@ from llm.core.interface import (
     LLMProvider,
     RateLimitError,
 )
-from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
+from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, Role, ToolCall
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
 
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic/v1"
+MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic"
 DEFAULT_MINIMAX_MODEL = "MiniMax-M3"
+MINIMAX_M2_7_MODEL = "MiniMax-M2.7"
+DEFAULT_MINIMAX_ANTHROPIC_MAX_TOKENS = 16_000
+
+
+def _uses_anthropic_messages(base_url: str) -> bool:
+    path = urlsplit(base_url).path.rstrip("/")
+    return path.endswith("/anthropic") or path.endswith("/anthropic/v1")
+
+
+def _anthropic_sdk_base_url(base_url: str) -> str:
+    parsed = urlsplit(base_url.rstrip("/"))
+    path = parsed.path.rstrip("/")
+    if path.endswith("/anthropic/v1"):
+        path = path.removesuffix("/v1")
+    return urlunsplit(parsed._replace(path=path))
 
 
 def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
@@ -37,7 +54,7 @@ def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
 
 
 class MiniMaxProvider(LLMProvider):
-    """MiniMax endpoint using OpenAI-compatible chat completions."""
+    """MiniMax endpoint using OpenAI chat completions or Anthropic messages."""
 
     provider_type = ProviderType.MINIMAX
     api_key_env = "MINIMAX_API_KEY"
@@ -52,63 +69,59 @@ class MiniMaxProvider(LLMProvider):
         default_model: str | None = None,
     ) -> None:
         self.api_key = api_key or os.environ.get(self.api_key_env) or ""
-        self.base_url = base_url or os.environ.get(self.base_url_env, self.default_base_url)
-        self.default_model = default_model or os.environ.get(self.model_env) or DEFAULT_MINIMAX_MODEL
-        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url, _enforce_credentials=False)
+        configured_base_url = base_url or os.environ.get(
+            self.base_url_env, self.default_base_url
+        )
+        self._uses_anthropic = _uses_anthropic_messages(configured_base_url)
+        self.base_url = (
+            _anthropic_sdk_base_url(configured_base_url)
+            if self._uses_anthropic
+            else configured_base_url
+        )
+        self.default_model = (
+            default_model or os.environ.get(self.model_env) or DEFAULT_MINIMAX_MODEL
+        )
+        self.client: Any
+        if self._uses_anthropic:
+            self.client = Anthropic(api_key=self.api_key, base_url=self.base_url)
+        else:
+            self.client = OpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url,
+                _enforce_credentials=False,
+            )
         self._models = [
             ModelInfo(
                 name=DEFAULT_MINIMAX_MODEL,
                 provider=self.provider_type,
                 supports_tools=True,
-                supports_vision=False,
+                supports_vision=True,
+                max_tokens=524_288,
                 context_window=1_000_000,
-            )
+            ),
+            ModelInfo(
+                name=MINIMAX_M2_7_MODEL,
+                provider=self.provider_type,
+                supports_tools=True,
+                supports_vision=False,
+                max_tokens=204_800,
+                context_window=204_800,
+            ),
         ]
+        if self.default_model not in {model.name for model in self._models}:
+            self._models.append(
+                ModelInfo(
+                    name=self.default_model,
+                    provider=self.provider_type,
+                    supports_tools=True,
+                )
+            )
 
     def generate(self, llm_input: LLMInput) -> LLMOutput:
         try:
-            params: dict[str, Any] = {
-                "model": llm_input.model or self.default_model,
-                "messages": [msg.to_dict() for msg in llm_input.messages],
-            }
-            if llm_input.temperature != 1.0:
-                params["temperature"] = llm_input.temperature
-            if llm_input.max_tokens is not None:
-                params["max_tokens"] = llm_input.max_tokens
-            if llm_input.tools:
-                params["tools"] = [tool.to_openai_tool() for tool in llm_input.tools]
-
-            response = self.client.chat.completions.create(**params)
-            if not response.choices or response.choices[0].message is None:
-                raise ValueError(EMPTY_FILTERED_RESPONSE_ERROR)
-            choice = response.choices[0]
-
-            tool_calls = None
-            if choice.message.tool_calls:
-                tool_calls = [
-                    ToolCall(
-                        id=tc.id or "",
-                        name=tc.function.name,
-                        arguments=_parse_tool_arguments(tc.function.arguments),
-                    )
-                    for tc in choice.message.tool_calls
-                ]
-
-            usage = None
-            if response.usage:
-                usage = {
-                    "prompt_tokens": response.usage.prompt_tokens,
-                    "completion_tokens": response.usage.completion_tokens,
-                    "total_tokens": response.usage.total_tokens,
-                }
-
-            return LLMOutput(
-                content=choice.message.content or "",
-                tool_calls=tool_calls,
-                model=response.model,
-                usage=usage,
-                stop_reason=choice.finish_reason,
-            )
+            if self._uses_anthropic:
+                return self._generate_anthropic(llm_input)
+            return self._generate_openai(llm_input)
         except Exception as e:
             msg = str(e)
             if "401" in msg or "authentication" in msg.lower():
@@ -118,6 +131,132 @@ class MiniMaxProvider(LLMProvider):
             if "context" in msg.lower() and "length" in msg.lower():
                 raise ContextLengthError(msg, provider=self.provider_type) from e
             raise
+
+    def _generate_openai(self, llm_input: LLMInput) -> LLMOutput:
+        params: dict[str, Any] = {
+            "model": llm_input.model or self.default_model,
+            "messages": [msg.to_dict() for msg in llm_input.messages],
+        }
+        if llm_input.temperature != 1.0:
+            params["temperature"] = llm_input.temperature
+        if llm_input.max_tokens is not None:
+            params["max_tokens"] = llm_input.max_tokens
+        if llm_input.tools:
+            params["tools"] = [tool.to_openai_tool() for tool in llm_input.tools]
+
+        extra_body = {
+            key: llm_input.metadata[key]
+            for key in ("thinking", "reasoning_split", "service_tier")
+            if key in llm_input.metadata
+        }
+        if extra_body:
+            params["extra_body"] = extra_body
+
+        response = self.client.chat.completions.create(**params)
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError(EMPTY_FILTERED_RESPONSE_ERROR)
+        choice = response.choices[0]
+
+        tool_calls = None
+        if choice.message.tool_calls:
+            tool_calls = [
+                ToolCall(
+                    id=tc.id or "",
+                    name=tc.function.name,
+                    arguments=_parse_tool_arguments(tc.function.arguments),
+                )
+                for tc in choice.message.tool_calls
+            ]
+
+        usage = None
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        return LLMOutput(
+            content=choice.message.content or "",
+            tool_calls=tool_calls,
+            model=response.model,
+            usage=usage,
+            stop_reason=choice.finish_reason,
+        )
+
+    def _generate_anthropic(self, llm_input: LLMInput) -> LLMOutput:
+        system_parts = [
+            msg.content for msg in llm_input.messages if msg.role == Role.SYSTEM
+        ]
+        params: dict[str, Any] = {
+            "model": llm_input.model or self.default_model,
+            "messages": [
+                msg.to_dict() for msg in llm_input.messages if msg.role != Role.SYSTEM
+            ],
+            "max_tokens": (
+                llm_input.max_tokens
+                if llm_input.max_tokens is not None
+                else DEFAULT_MINIMAX_ANTHROPIC_MAX_TOKENS
+            ),
+        }
+        if system_parts:
+            params["system"] = "\n\n".join(system_parts)
+        if llm_input.temperature != 1.0:
+            params["temperature"] = llm_input.temperature
+        if llm_input.tools:
+            params["tools"] = [tool.to_anthropic_tool() for tool in llm_input.tools]
+        for key in ("thinking", "service_tier"):
+            if key in llm_input.metadata:
+                params[key] = llm_input.metadata[key]
+
+        response = self.client.messages.create(**params)
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        for block in response.content or []:
+            block_type = getattr(block, "type", None)
+            if block_type == "text":
+                text = getattr(block, "text", "")
+                if text:
+                    text_parts.append(text)
+            elif block_type == "tool_use":
+                raw_arguments = getattr(block, "input", {})
+                arguments = (
+                    raw_arguments.copy()
+                    if isinstance(raw_arguments, dict)
+                    else getattr(raw_arguments, "__dict__", {}).copy()
+                )
+                tool_calls.append(
+                    ToolCall(
+                        id=getattr(block, "id", ""),
+                        name=getattr(block, "name", ""),
+                        arguments=arguments,
+                    )
+                )
+
+        usage = None
+        if response.usage:
+            usage = {
+                "input_tokens": response.usage.input_tokens,
+                "output_tokens": response.usage.output_tokens,
+                "cache_creation_input_tokens": getattr(
+                    response.usage,
+                    "cache_creation_input_tokens",
+                    0,
+                ),
+                "cache_read_input_tokens": getattr(
+                    response.usage,
+                    "cache_read_input_tokens",
+                    0,
+                ),
+            }
+
+        return LLMOutput(
+            content="".join(text_parts),
+            tool_calls=tool_calls or None,
+            model=response.model,
+            usage=usage,
+            stop_reason=response.stop_reason,
+        )
 
     def list_models(self) -> list[ModelInfo]:
         return self._models.copy()

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -10,6 +10,7 @@ from llm.core.types import ProviderType
 from llm.providers.astraflow import AstraflowCNProvider, AstraflowProvider
 from llm.providers.atlas import AtlasProvider
 from llm.providers.claude import ClaudeProvider
+from llm.providers.minimax import MiniMaxProvider
 from llm.providers.openai import OpenAIProvider
 from llm.providers.ollama import OllamaProvider
 
@@ -19,6 +20,7 @@ _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.ASTRAFLOW_CN: AstraflowCNProvider,
     ProviderType.ATLAS: AtlasProvider,
     ProviderType.CLAUDE: ClaudeProvider,
+    ProviderType.MINIMAX: MiniMaxProvider,
     ProviderType.OPENAI: OpenAIProvider,
     ProviderType.OLLAMA: OllamaProvider,
 }

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import cast
 
 import httpx
 import pytest
@@ -20,7 +21,7 @@ class _OpenAICompletions:
     def __init__(self) -> None:
         self.params = None
 
-    def create(self, **params):
+    def create(self, **params: object) -> SimpleNamespace:
         self.params = params
         return SimpleNamespace(
             choices=[
@@ -41,12 +42,13 @@ class _OpenAIClient:
 
 
 class _AnthropicMessages:
-    def __init__(self) -> None:
+    def __init__(self, response: SimpleNamespace | None = None) -> None:
         self.params = None
+        self.response = response
 
-    def create(self, **params):
+    def create(self, **params: object) -> SimpleNamespace:
         self.params = params
-        return SimpleNamespace(
+        return self.response or SimpleNamespace(
             content=[SimpleNamespace(type="text", text="ok")],
             model=params["model"],
             usage=SimpleNamespace(input_tokens=1, output_tokens=2),
@@ -55,8 +57,8 @@ class _AnthropicMessages:
 
 
 class _AnthropicClient:
-    def __init__(self) -> None:
-        self.messages = _AnthropicMessages()
+    def __init__(self, response: SimpleNamespace | None = None) -> None:
+        self.messages = _AnthropicMessages(response)
 
 
 def _tool() -> ToolDefinition:
@@ -67,7 +69,7 @@ def _tool() -> ToolDefinition:
     )
 
 
-def test_minimax_provider_exposes_both_target_models(monkeypatch):
+def test_minimax_provider_exposes_both_target_models(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
     monkeypatch.delenv("MINIMAX_MODEL", raising=False)
@@ -98,7 +100,7 @@ def test_minimax_provider_lists_custom_default_model():
 
 
 def test_minimax_provider_uses_openai_chat_completions():
-    provider = MiniMaxProvider(api_key="test")
+    provider = MiniMaxProvider(api_key="test", base_url=MINIMAX_BASE_URL)
     client = _OpenAIClient()
     provider.client = client
 
@@ -154,6 +156,21 @@ def test_minimax_provider_uses_anthropic_messages():
     assert client.messages.params["tools"][0]["input_schema"]["type"] == "object"
 
 
+def test_minimax_anthropic_provider_rejects_empty_responses():
+    provider = MiniMaxProvider(api_key="test", base_url=MINIMAX_ANTHROPIC_BASE_URL)
+    provider.client = _AnthropicClient(
+        SimpleNamespace(
+            content=[],
+            model=DEFAULT_MINIMAX_MODEL,
+            usage=SimpleNamespace(input_tokens=1, output_tokens=0),
+            stop_reason="end_turn",
+        )
+    )
+
+    with pytest.raises(ValueError, match="empty or filtered response"):
+        provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+
 @pytest.mark.parametrize(
     ("base_url", "expected_host"),
     [
@@ -162,9 +179,9 @@ def test_minimax_provider_uses_anthropic_messages():
     ],
 )
 def test_openai_base_url_yields_one_chat_completions_path(
-    monkeypatch,
-    base_url,
-    expected_host,
+    monkeypatch: pytest.MonkeyPatch,
+    base_url: str,
+    expected_host: str,
 ):
     requests: list[httpx.Request] = []
 
@@ -194,10 +211,10 @@ def test_openai_base_url_yields_one_chat_completions_path(
 
     http_client = httpx.Client(transport=httpx.MockTransport(handler))
 
-    def openai_client(**kwargs):
+    def openai_client(**kwargs: object) -> OpenAISDK:
         return OpenAISDK(
-            api_key=kwargs["api_key"],
-            base_url=kwargs["base_url"],
+            api_key=cast(str, kwargs["api_key"]),
+            base_url=cast(str, kwargs["base_url"]),
             http_client=http_client,
         )
 
@@ -225,9 +242,9 @@ def test_openai_base_url_yields_one_chat_completions_path(
     ],
 )
 def test_anthropic_base_url_yields_one_v1_messages_path(
-    monkeypatch,
-    configured_base_url,
-    expected_host,
+    monkeypatch: pytest.MonkeyPatch,
+    configured_base_url: str,
+    expected_host: str,
 ):
     requests: list[httpx.Request] = []
 
@@ -249,10 +266,10 @@ def test_anthropic_base_url_yields_one_v1_messages_path(
 
     http_client = httpx.Client(transport=httpx.MockTransport(handler))
 
-    def anthropic_client(**kwargs):
+    def anthropic_client(**kwargs: object) -> AnthropicSDK:
         return AnthropicSDK(
-            api_key=kwargs["api_key"],
-            base_url=kwargs["base_url"],
+            api_key=cast(str, kwargs["api_key"]),
+            base_url=cast(str, kwargs["base_url"]),
             http_client=http_client,
         )
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,270 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from anthropic import Anthropic as AnthropicSDK
+from openai import OpenAI as OpenAISDK
+
+import llm.providers.minimax as minimax_module
+from llm.core.types import LLMInput, Message, ProviderType, Role, ToolDefinition
+from llm.providers.minimax import (
+    DEFAULT_MINIMAX_MODEL,
+    MINIMAX_ANTHROPIC_BASE_URL,
+    MINIMAX_BASE_URL,
+    MINIMAX_M2_7_MODEL,
+    MiniMaxProvider,
+)
+
+
+class _OpenAICompletions:
+    def __init__(self) -> None:
+        self.params = None
+
+    def create(self, **params):
+        self.params = params
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            model=params["model"],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+        )
+
+
+class _OpenAIClient:
+    def __init__(self) -> None:
+        self.completions = _OpenAICompletions()
+        self.chat = SimpleNamespace(completions=self.completions)
+
+
+class _AnthropicMessages:
+    def __init__(self) -> None:
+        self.params = None
+
+    def create(self, **params):
+        self.params = params
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            model=params["model"],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=2),
+            stop_reason="end_turn",
+        )
+
+
+class _AnthropicClient:
+    def __init__(self) -> None:
+        self.messages = _AnthropicMessages()
+
+
+def _tool() -> ToolDefinition:
+    return ToolDefinition(
+        name="search",
+        description="Search",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+
+
+def test_minimax_provider_exposes_both_target_models(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+    monkeypatch.delenv("MINIMAX_MODEL", raising=False)
+
+    provider = MiniMaxProvider()
+    models = {model.name: model for model in provider.list_models()}
+
+    assert provider.provider_type == ProviderType.MINIMAX
+    assert provider.base_url == MINIMAX_BASE_URL
+    assert provider.get_default_model() == DEFAULT_MINIMAX_MODEL
+    assert provider.validate_config() is False
+    assert models[DEFAULT_MINIMAX_MODEL].context_window == 1_000_000
+    assert models[DEFAULT_MINIMAX_MODEL].max_tokens == 524_288
+    assert models[DEFAULT_MINIMAX_MODEL].supports_vision is True
+    assert models[MINIMAX_M2_7_MODEL].context_window == 204_800
+    assert models[MINIMAX_M2_7_MODEL].max_tokens == 204_800
+    assert models[MINIMAX_M2_7_MODEL].supports_vision is False
+
+
+def test_minimax_provider_lists_custom_default_model():
+    provider = MiniMaxProvider(api_key="test", default_model="custom-model")
+
+    assert {model.name for model in provider.list_models()} == {
+        DEFAULT_MINIMAX_MODEL,
+        MINIMAX_M2_7_MODEL,
+        "custom-model",
+    }
+
+
+def test_minimax_provider_uses_openai_chat_completions():
+    provider = MiniMaxProvider(api_key="test")
+    client = _OpenAIClient()
+    provider.client = client
+
+    output = provider.generate(
+        LLMInput(
+            messages=[Message(role=Role.USER, content="hi")],
+            tools=[_tool()],
+            metadata={"thinking": {"type": "disabled"}},
+        )
+    )
+
+    assert output.content == "ok"
+    assert output.usage == {
+        "prompt_tokens": 1,
+        "completion_tokens": 2,
+        "total_tokens": 3,
+    }
+    assert client.completions.params["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert client.completions.params["tools"][0]["type"] == "function"
+
+
+def test_minimax_provider_uses_anthropic_messages():
+    provider = MiniMaxProvider(
+        api_key="test", base_url=f"{MINIMAX_ANTHROPIC_BASE_URL}/v1"
+    )
+    client = _AnthropicClient()
+    provider.client = client
+
+    output = provider.generate(
+        LLMInput(
+            messages=[
+                Message(role=Role.SYSTEM, content="Be concise."),
+                Message(role=Role.USER, content="hi"),
+            ],
+            max_tokens=128,
+            tools=[_tool()],
+            metadata={"thinking": {"type": "adaptive"}},
+        )
+    )
+
+    assert provider.base_url == MINIMAX_ANTHROPIC_BASE_URL
+    assert output.content == "ok"
+    assert output.usage == {
+        "input_tokens": 1,
+        "output_tokens": 2,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+    assert client.messages.params["system"] == "Be concise."
+    assert client.messages.params["messages"] == [{"role": "user", "content": "hi"}]
+    assert client.messages.params["max_tokens"] == 128
+    assert client.messages.params["thinking"] == {"type": "adaptive"}
+    assert client.messages.params["tools"][0]["input_schema"]["type"] == "object"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_host"),
+    [
+        ("https://api.minimax.io/v1", "api.minimax.io"),
+        ("https://api.minimaxi.com/v1", "api.minimaxi.com"),
+    ],
+)
+def test_openai_base_url_yields_one_chat_completions_path(
+    monkeypatch,
+    base_url,
+    expected_host,
+):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl_test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": DEFAULT_MINIMAX_MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    def openai_client(**kwargs):
+        return OpenAISDK(
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            http_client=http_client,
+        )
+
+    monkeypatch.setattr(minimax_module, "OpenAI", openai_client)
+    provider = MiniMaxProvider(api_key="test", base_url=base_url)
+
+    try:
+        provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+    finally:
+        http_client.close()
+
+    assert len(requests) == 1
+    assert requests[0].url.host == expected_host
+    assert requests[0].url.path == "/v1/chat/completions"
+    assert requests[0].url.path.count("/v1/chat/completions") == 1
+
+
+@pytest.mark.parametrize(
+    ("configured_base_url", "expected_host"),
+    [
+        ("https://api.minimax.io/anthropic", "api.minimax.io"),
+        ("https://api.minimax.io/anthropic/v1", "api.minimax.io"),
+        ("https://api.minimaxi.com/anthropic", "api.minimaxi.com"),
+        ("https://api.minimaxi.com/anthropic/v1", "api.minimaxi.com"),
+    ],
+)
+def test_anthropic_base_url_yields_one_v1_messages_path(
+    monkeypatch,
+    configured_base_url,
+    expected_host,
+):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": DEFAULT_MINIMAX_MODEL,
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    def anthropic_client(**kwargs):
+        return AnthropicSDK(
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            http_client=http_client,
+        )
+
+    monkeypatch.setattr(minimax_module, "Anthropic", anthropic_client)
+    provider = MiniMaxProvider(api_key="test", base_url=configured_base_url)
+
+    try:
+        provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+    finally:
+        http_client.close()
+
+    assert len(requests) == 1
+    assert requests[0].url.host == expected_host
+    assert requests[0].url.path == "/anthropic/v1/messages"
+    assert requests[0].url.path.count("/v1/messages") == 1

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -127,9 +127,7 @@ def test_minimax_provider_uses_openai_chat_completions() -> None:
 
 
 def test_minimax_provider_uses_anthropic_messages() -> None:
-    provider = MiniMaxProvider(
-        api_key="test", base_url=f"{MINIMAX_ANTHROPIC_BASE_URL}/v1"
-    )
+    provider = MiniMaxProvider(api_key="test", base_url=MINIMAX_ANTHROPIC_BASE_URL)
     client = _AnthropicClient()
     provider.client = client
 
@@ -240,9 +238,7 @@ def test_openai_base_url_yields_one_chat_completions_path(
     ("configured_base_url", "expected_host"),
     [
         ("https://api.minimax.io/anthropic", "api.minimax.io"),
-        ("https://api.minimax.io/anthropic/v1", "api.minimax.io"),
         ("https://api.minimaxi.com/anthropic", "api.minimaxi.com"),
-        ("https://api.minimaxi.com/anthropic/v1", "api.minimaxi.com"),
     ],
 )
 def test_anthropic_base_url_yields_one_v1_messages_path(

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -16,6 +16,8 @@ from llm.providers.minimax import (
     MiniMaxProvider,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class _OpenAICompletions:
     def __init__(self) -> None:
@@ -69,7 +71,9 @@ def _tool() -> ToolDefinition:
     )
 
 
-def test_minimax_provider_exposes_both_target_models(monkeypatch: pytest.MonkeyPatch):
+def test_minimax_provider_exposes_both_target_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
     monkeypatch.delenv("MINIMAX_MODEL", raising=False)
@@ -89,7 +93,7 @@ def test_minimax_provider_exposes_both_target_models(monkeypatch: pytest.MonkeyP
     assert models[MINIMAX_M2_7_MODEL].supports_vision is False
 
 
-def test_minimax_provider_lists_custom_default_model():
+def test_minimax_provider_lists_custom_default_model() -> None:
     provider = MiniMaxProvider(api_key="test", default_model="custom-model")
 
     assert {model.name for model in provider.list_models()} == {
@@ -99,7 +103,7 @@ def test_minimax_provider_lists_custom_default_model():
     }
 
 
-def test_minimax_provider_uses_openai_chat_completions():
+def test_minimax_provider_uses_openai_chat_completions() -> None:
     provider = MiniMaxProvider(api_key="test", base_url=MINIMAX_BASE_URL)
     client = _OpenAIClient()
     provider.client = client
@@ -122,7 +126,7 @@ def test_minimax_provider_uses_openai_chat_completions():
     assert client.completions.params["tools"][0]["type"] == "function"
 
 
-def test_minimax_provider_uses_anthropic_messages():
+def test_minimax_provider_uses_anthropic_messages() -> None:
     provider = MiniMaxProvider(
         api_key="test", base_url=f"{MINIMAX_ANTHROPIC_BASE_URL}/v1"
     )
@@ -156,7 +160,7 @@ def test_minimax_provider_uses_anthropic_messages():
     assert client.messages.params["tools"][0]["input_schema"]["type"] == "object"
 
 
-def test_minimax_anthropic_provider_rejects_empty_responses():
+def test_minimax_anthropic_provider_rejects_empty_responses() -> None:
     provider = MiniMaxProvider(api_key="test", base_url=MINIMAX_ANTHROPIC_BASE_URL)
     provider.client = _AnthropicClient(
         SimpleNamespace(
@@ -182,7 +186,7 @@ def test_openai_base_url_yields_one_chat_completions_path(
     monkeypatch: pytest.MonkeyPatch,
     base_url: str,
     expected_host: str,
-):
+) -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -245,7 +249,7 @@ def test_anthropic_base_url_yields_one_v1_messages_path(
     monkeypatch: pytest.MonkeyPatch,
     configured_base_url: str,
     expected_host: str,
-):
+) -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,16 @@
 import pytest
+
 from llm.core.types import ProviderType
-from llm.providers import AstraflowCNProvider, AstraflowProvider, AtlasProvider, ClaudeProvider, MiniMaxProvider, OpenAIProvider, OllamaProvider, get_provider
+from llm.providers import (
+    AstraflowCNProvider,
+    AstraflowProvider,
+    AtlasProvider,
+    ClaudeProvider,
+    MiniMaxProvider,
+    OllamaProvider,
+    OpenAIProvider,
+    get_provider,
+)
 
 
 class TestGetProvider:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,6 @@
 import pytest
 from llm.core.types import ProviderType
-from llm.providers import AstraflowCNProvider, AstraflowProvider, AtlasProvider, ClaudeProvider, OpenAIProvider, OllamaProvider, get_provider
+from llm.providers import AstraflowCNProvider, AstraflowProvider, AtlasProvider, ClaudeProvider, MiniMaxProvider, OpenAIProvider, OllamaProvider, get_provider
 
 
 class TestGetProvider:
@@ -33,6 +33,11 @@ class TestGetProvider:
         provider = get_provider("atlas")
         assert isinstance(provider, AtlasProvider)
         assert provider.provider_type == ProviderType.ATLAS
+
+    def test_get_minimax_provider(self):
+        provider = get_provider("minimax")
+        assert isinstance(provider, MiniMaxProvider)
+        assert provider.provider_type == ProviderType.MINIMAX
 
     def test_get_provider_by_enum(self):
         provider = get_provider(ProviderType.CLAUDE)


### PR DESCRIPTION
Reason: add target provider/model to the existing provider registry.

## Summary
- Register MiniMax as an LLM provider with MiniMax-M3 as the default.
- Expose MiniMax-M3 and MiniMax-M2.7 with their verified context and modality metadata.
- Support configurable global and China endpoints through the existing `MINIMAX_BASE_URL`.
- Route OpenAI-compatible URLs to chat completions and Anthropic-compatible URLs to messages while normalizing the SDK base so the final path contains one `/v1/messages`.
- Reject empty responses consistently across both protocol paths.

## Test plan
- `.venv/bin/python -m pytest -q` (101 passed)
- Isolated Ruff lint, annotation, and format checks for the affected Python files
- `.venv/bin/mypy src/llm/providers/minimax.py`
