### PR TITLE
fix(agents): read-only reviewer contract + model re-tiering (#2442) + soften data-scraper prose (#2428)

### DIFF
--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -2,7 +2,7 @@
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
 tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
-model: opus
+model: sonnet
 ---
 
 ## Prompt Defense Baseline

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 description: Analyze code comments for accuracy, completeness, maintainability, and comment rot risk.
-model: sonnet
+model: haiku
 tools: [Read, Grep, Glob]
 ---
 

--- a/agents/conversation-analyzer.md
+++ b/agents/conversation-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: conversation-analyzer
 description: Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Triggered by /hookify without arguments.
-model: sonnet
+model: haiku
 tools: [Read, Grep]
 ---
 

--- a/agents/database-reviewer.md
+++ b/agents/database-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: database-reviewer
 description: PostgreSQL database specialist for query optimization, schema design, security, and performance. Use PROACTIVELY when writing SQL, creating migrations, designing schemas, or troubleshooting database performance. Incorporates Supabase best practices.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
 ---
 

--- a/agents/docs-lookup.md
+++ b/agents/docs-lookup.md
@@ -2,7 +2,7 @@
 name: docs-lookup
 description: When the user asks how to use a library, framework, or API or needs up-to-date code examples, use Context7 MCP to fetch current documentation and return answers with examples. Invoke for docs/API/setup questions.
 tools: ["Read", "Grep", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
-model: sonnet
+model: haiku
 ---
 
 ## Prompt Defense Baseline

--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -2,7 +2,7 @@
 name: gan-evaluator
 description: "GAN Harness — Evaluator agent. Tests the live running application via Playwright, scores against rubric, and provides actionable feedback to the Generator."
 tools: ["Read", "Write", "Bash", "Grep", "Glob"]
-model: opus
+model: sonnet
 color: red
 ---
 

--- a/agents/gan-generator.md
+++ b/agents/gan-generator.md
@@ -2,7 +2,7 @@
 name: gan-generator
 description: "GAN Harness — Generator agent. Implements features according to the spec, reads evaluator feedback, and iterates until quality threshold is met."
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: opus
+model: sonnet
 color: green
 ---
 

--- a/agents/gan-planner.md
+++ b/agents/gan-planner.md
@@ -2,7 +2,7 @@
 name: gan-planner
 description: "GAN Harness — Planner agent. Expands a one-line prompt into a full product specification with features, sprints, evaluation criteria, and design direction."
 tools: ["Read", "Write", "Grep", "Glob"]
-model: opus
+model: sonnet
 color: purple
 ---
 

--- a/agents/opensource-forker.md
+++ b/agents/opensource-forker.md
@@ -2,7 +2,7 @@
 name: opensource-forker
 description: Fork any project for open-sourcing. Copies files, strips secrets and credentials (20+ patterns), replaces internal references with placeholders, generates .env.example, and cleans git history. First stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: sonnet
+model: haiku
 ---
 
 ## Prompt Defense Baseline

--- a/agents/opensource-packager.md
+++ b/agents/opensource-packager.md
@@ -2,7 +2,7 @@
 name: opensource-packager
 description: Generate complete open-source packaging for a sanitized project. Produces CLAUDE.md, setup.sh, README.md, LICENSE, CONTRIBUTING.md, and GitHub issue templates. Makes any repo immediately usable with Claude Code. Third stage of the opensource-pipeline skill.
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: sonnet
+model: haiku
 ---
 
 ## Prompt Defense Baseline

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection and remediation specialist. Use PROACTIVELY after writing code that handles user input, authentication, API endpoints, or sensitive data. Flags secrets, SSRF, injection, unsafe crypto, and OWASP Top 10 vulnerabilities.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
 ---
 

--- a/skills/data-scraper-agent/SKILL.md
+++ b/skills/data-scraper-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-scraper-agent
-description: Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Scrapes on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.
+description: Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Runs on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.
 metadata:
   origin: community
 ---
@@ -14,7 +14,7 @@ Runs on a schedule, enriches results with a free LLM, stores to a database, and 
 
 ## When to Activate
 
-- User wants to scrape or monitor any public website or API
+- User wants to gather or monitor any public website or API
 - User says "build a bot that checks...", "monitor X for me", "collect data from..."
 - User wants to track jobs, prices, news, repos, sports scores, events, listings
 - User asks how to automate data collection without paying for hosting
@@ -24,7 +24,7 @@ Runs on a schedule, enriches results with a free LLM, stores to a database, and 
 
 ### The Three Layers
 
-Every data scraper agent has three layers:
+Every data collection agent has three layers:
 
 ```
 COLLECT → ENRICH → STORE
@@ -40,7 +40,7 @@ schedule   summarises Sheets /
 | Layer | Tool | Why |
 |---|---|---|
 | **Scraping** | `requests` + `BeautifulSoup` | No cost, covers 80% of public sites |
-| **JS-rendered sites** | `playwright` (free) | When HTML scraping fails |
+| **JS-rendered sites** | `playwright` (free) | When HTML fetching fails |
 | **AI enrichment** | Gemini Flash via REST API | 500 req/day, 1M tokens/day — free |
 | **Storage** | Notion API | Free tier, great UI for review |
 | **Schedule** | GitHub Actions cron | Free for public repos |
@@ -95,7 +95,7 @@ Common examples to prompt:
 
 ---
 
-### Step 2: Design the Agent Architecture
+### Step 2: Design the Collection Architecture
 
 Generate this directory structure for the user:
 
@@ -133,14 +133,14 @@ my-agent/
 
 ---
 
-### Step 3: Build the Scraper Source
+### Step 3: Build the Source Connector
 
 Template for any data source:
 
 ```python
 # scraper/sources/my_source.py
 """
-[Source Name] — scrapes [what] from [where].
+[Source Name] — gathers [what] from [where].
 Method: [REST API / HTML scraping / RSS feed]
 """
 import requests
@@ -182,7 +182,7 @@ def _normalise(raw: dict) -> dict:
     }
 ```
 
-**HTML scraping pattern:**
+**HTML fetch pattern:**
 ```python
 soup = BeautifulSoup(resp.text, "lxml")
 for card in soup.select("[class*='listing']"):
@@ -760,6 +760,6 @@ Before marking the agent complete:
 
 ## Reference Implementation
 
-A complete working agent built with this exact architecture would scrape 4+ sources,
+A complete working agent built with this exact architecture would collect from 4+ sources,
 batch Gemini calls, learn from Applied/Rejected decisions stored in Notion, and run
 100% free on GitHub Actions. Follow Steps 1–9 above to build your own.


### PR DESCRIPTION
## What Changed

Frontmatter-only agent audit from #2442, plus an AV [REDACTED SECRET]-positive reword for #2428. No agent prose/behavior changed.

**#2442 — tool-scoping (restore the read-only `*-reviewer` contract).** Two reviewers carried `Write`+`Edit` while every other `*-reviewer` is read-only; dropped them so "review" is a trustable read-only role across the board:

| Agent | tools before → after |
|---|---|
| `security-reviewer` | `["Read","Write","Edit","Bash","Grep","Glob"]` → `["Read","Grep","Glob","Bash"]` |
| `database-reviewer` | `["Read","Write","Edit","Bash","Grep","Glob"]` → `["Read","Grep","Glob","Bash"]` |

**#2442 — model re-tiering (evidence-backed cost tuning from the issue):**

| Agent | model before → after | Why |
|---|---|---|
| `gan-generator` | opus → sonnet | code-writing, runs every GAN iteration |
| `gan-evaluator` | opus → sonnet | rubric QA against fixed spec, every iteration |
| `gan-planner` | opus → sonnet | one-shot expansion into fixed template |
| `chief-of-staff` | opus → sonnet | bounded classification + templated drafts |
| `docs-lookup` | sonnet → haiku | pure MCP retrieval + formatting |
| `comment-analyzer` | sonnet → haiku | read-only comment/style checks |
| `conversation-analyzer` | sonnet → haiku | transcript pattern-matching |
| `opensource-forker` | sonnet → haiku | mechanical copy + regex secret-strip |
| `opensource-packager` | sonnet → haiku | templated boilerplate generation |

Out of scope: `a11y-architect` also carries Write/Edit but it is an architect/implementer (not a `*-reviewer`), so its tools are intentionally left as-is. The `gan-style-harness` SKILL.md `GAN_*_MODEL` opus defaults were left unchanged to keep this PR strictly frontmatter-only (env override already exists) — can be a follow-up.

**#2428 — AV [REDACTED SECRET]-positive mitigation.** ESET flags `skills/data-scraper-agent/SKILL.md` as `GenAISkill.IC` (a generic heuristic). Minimally, semantically-neutrally reworded scrape-heavy prose toward collect/monitor/gather/fetch (`scrap` occurrences 18 → 12). No code identifiers, commands, code blocks, or the `name:` frontmatter were touched — meaning and structure are unchanged. This is a best-effort [REDACTED SECRET]-positive dodge, not a behavior change.

## Why This Change

Reviewers that can modify files break the read-only contract orchestrators rely on when dispatching a "review" role. The re-tierings drop model cost on high-frequency, bounded-scope agents with no capability loss. The data-scraper reword tries to clear a [REDACTED SECRET] AV signature that was deleting the file on users' machines.

## Testing Done
- [x] Automated tests pass locally (`node tests/run-all.js` — 3105 passed, 0 failed), including `ci/catalog.test.js` and `ci/agent-yaml-surface.test.js` (catalog counts unchanged)
- [x] `npm run lint` clean
- [x] Diff is frontmatter-only for agents; data-scraper change is prose-only

## Type of Change
- [x] `fix:` Bug fix
- [x] `refactor:` Code refactoring
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] Follows conventional commits format
- [x] Frontmatter-only agent edits; no catalog/count changes; no new components registered


Link to Devin session: https://app.devin.ai/sessions/408d7d92c162491d98c736d2a144a96c
Requested by: @[REDACTED SECRET]-m