### PR TITLE
docs(strategic-compact): document context-window override env vars

### DIFF
--- a/.agents/skills/strategic-compact/SKILL.md
+++ b/.agents/skills/strategic-compact/SKILL.md
@@ -61,6 +61,10 @@ Environment variables:
 - `COMPACT_THRESHOLD` — Tool calls before first suggestion (default: 50)
 - `COMPACT_CONTEXT_THRESHOLD` — Context tokens before the context-size suggestion (default: 160000 on a 200k window, 250000 on a 1M window; `0` disables the context signal)
 - `COMPACT_CONTEXT_INTERVAL` — Additional context tokens before the suggestion repeats (default: 60000)
+- `ECC_CONTEXT_WINDOW_TOKENS` — Explicit context-window size, in tokens, overriding auto-detection. Set this for large-window models whose reported id lacks a `[1m]` marker (e.g. 400k Opus 4.x, or a new 1M-window model family) so the threshold scales to the real window instead of defaulting to 200k and overstating context usage.
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` — Claude Code's native window-size override, in tokens; honored as a fallback when `ECC_CONTEXT_WINDOW_TOKENS` is unset.
+
+> The context window is otherwise auto-detected from a `[1m]` model marker or inferred when observed tokens already exceed 200k. On a large-window model that carries neither signal, set one of the overrides above so the `/compact` suggestion fires at the right point.
 
 ## Compaction Decision Guide
 

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -68,6 +68,10 @@ Environment variables:
 - `COMPACT_CONTEXT_THRESHOLD` — Context tokens before the context-size suggestion (default: 160000 on a 200k window, 250000 on a 1M window; `0` disables the context signal)
 - `COMPACT_CONTEXT_INTERVAL` — Additional context tokens before the suggestion repeats (default: 60000)
 - `COMPACT_STATE_TTL_DAYS` — Days before stale per-session state files in the temp dir are swept (default: 14)
+- `ECC_CONTEXT_WINDOW_TOKENS` — Explicit context-window size, in tokens, overriding auto-detection. Set this for large-window models whose reported id lacks a `[1m]` marker (e.g. 400k Opus 4.x, or a new 1M-window model family) so the threshold scales to the real window instead of defaulting to 200k and overstating context usage.
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` — Claude Code's native window-size override, in tokens; honored as a fallback when `ECC_CONTEXT_WINDOW_TOKENS` is unset.
+
+> The context window is otherwise auto-detected from a `[1m]` model marker or inferred when observed tokens already exceed 200k. On a large-window model that carries neither signal, set one of the overrides above so the `/compact` suggestion fires at the right point.
 
 ## Compaction Decision Guide
 


### PR DESCRIPTION
## What

Documents the two context-window override environment variables that
`strategic-compact` already reads but that were undocumented:

- `ECC_CONTEXT_WINDOW_TOKENS`
- `CLAUDE_CODE_AUTO_COMPACT_WINDOW`

Added to the **Configuration** section of both the canonical skill doc
(`skills/strategic-compact/SKILL.md`) and its Codex mirror
(`.agents/skills/strategic-compact/SKILL.md`), plus a short note pointing
users on large-window models at the override.

## Why

`resolveContextWindowTokens()` in `scripts/lib/transcript-context.js` honors
these two env vars as an explicit window-size override:

```js
const envWindow = Number.parseInt(
  env.ECC_CONTEXT_WINDOW_TOKENS || env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '', 10);
if (Number.isInteger(envWindow) && envWindow > 0) {
  return envWindow;
}
```

But the skill's Configuration section only listed `COMPACT_THRESHOLD`,
`COMPACT_CONTEXT_THRESHOLD`, `COMPACT_CONTEXT_INTERVAL`, and
`COMPACT_STATE_TTL_DAYS` — so a user hitting the window-misdetection failure
(#2290 for 400k Opus 4.x, #2461 for a 1M-window model with no `[1m]` marker)
has no documented escape hatch. Window auto-detection only recognizes a
`[1m]` model marker or an observed token count already above 200k; a
large-window model carrying neither signal is misclassified as 200k and the
`/compact` suggestion overstates context usage.

This PR implements the documentation callout explicitly recommended in
#2461 ("worth a doc callout ... telling users on unlisted large-window
models to set `CLAUDE_CODE_AUTO_COMPACT_WINDOW` explicitly"), without any
runtime change. The env-var names, precedence (`ECC_CONTEXT_WINDOW_TOKENS`
first, `CLAUDE_CODE_AUTO_COMPACT_WINDOW` fallback), and "tokens" unit all
match the code verbatim.

## Scope

Docs only — no code change. This covers the escape-hatch documentation part
of #2461; the proposed known-model lookup table and its test are left out of
scope. Refs #2461, #2290.

## Verification

- Confirmed both env vars are read by `scripts/lib/transcript-context.js`.
- Confirmed neither was previously documented in either SKILL.md.
- Body-only edit; `scripts/ci/validate-skills.js` checks frontmatter only,
  and `.markdownlint.json` disables MD013 (line length).