### PR TITLE
fix(opencode): resolve command agent ids to registered opencode agents

### DIFF
--- a/.opencode/MIGRATION.md
+++ b/.opencode/MIGRATION.md
@@ -184,7 +184,7 @@ Create a detailed implementation plan for: {input}
 ```markdown
 ---
 description: Create implementation plan
-agent: everything-claude-code:planner
+agent: planner
 ---
 
 Create a detailed implementation plan for: $ARGUMENTS

--- a/.opencode/commands/build-fix.md
+++ b/.opencode/commands/build-fix.md
@@ -1,6 +1,6 @@
 ---
 description: Fix build and TypeScript errors with minimal changes
-agent: everything-claude-code:build-error-resolver
+agent: build-error-resolver
 subtask: true
 ---
 

--- a/.opencode/commands/checkpoint.md
+++ b/.opencode/commands/checkpoint.md
@@ -1,6 +1,6 @@
 ---
 description: Save verification state and progress checkpoint
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Checkpoint Command

--- a/.opencode/commands/code-review.md
+++ b/.opencode/commands/code-review.md
@@ -1,6 +1,6 @@
 ---
 description: Review code for quality, security, and maintainability
-agent: everything-claude-code:code-reviewer
+agent: code-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/e2e.md
+++ b/.opencode/commands/e2e.md
@@ -1,6 +1,6 @@
 ---
 description: Generate and run E2E tests with Playwright
-agent: everything-claude-code:e2e-runner
+agent: e2e-runner
 subtask: true
 ---
 

--- a/.opencode/commands/eval.md
+++ b/.opencode/commands/eval.md
@@ -1,6 +1,6 @@
 ---
 description: Run evaluation against acceptance criteria
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Eval Command

--- a/.opencode/commands/evolve.md
+++ b/.opencode/commands/evolve.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze instincts and suggest or generate evolved structures
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Evolve Command

--- a/.opencode/commands/go-build.md
+++ b/.opencode/commands/go-build.md
@@ -1,6 +1,6 @@
 ---
 description: Fix Go build and vet errors
-agent: everything-claude-code:go-build-resolver
+agent: go-build-resolver
 subtask: true
 ---
 

--- a/.opencode/commands/go-review.md
+++ b/.opencode/commands/go-review.md
@@ -1,6 +1,6 @@
 ---
 description: Go code review for idiomatic patterns
-agent: everything-claude-code:go-reviewer
+agent: go-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/go-test.md
+++ b/.opencode/commands/go-test.md
@@ -1,6 +1,6 @@
 ---
 description: Go TDD workflow with table-driven tests
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/instinct-export.md
+++ b/.opencode/commands/instinct-export.md
@@ -1,6 +1,6 @@
 ---
 description: Export instincts for sharing
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Instinct Export Command

--- a/.opencode/commands/instinct-import.md
+++ b/.opencode/commands/instinct-import.md
@@ -1,6 +1,6 @@
 ---
 description: Import instincts from external sources
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Instinct Import Command

--- a/.opencode/commands/instinct-status.md
+++ b/.opencode/commands/instinct-status.md
@@ -1,6 +1,6 @@
 ---
 description: Show learned instincts (project + global) with confidence
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Instinct Status Command

--- a/.opencode/commands/learn.md
+++ b/.opencode/commands/learn.md
@@ -1,6 +1,6 @@
 ---
 description: Extract patterns and learnings from current session
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Learn Command

--- a/.opencode/commands/orchestrate.md
+++ b/.opencode/commands/orchestrate.md
@@ -1,6 +1,6 @@
 ---
 description: Orchestrate multiple agents for complex tasks
-agent: everything-claude-code:planner
+agent: planner
 subtask: true
 ---
 

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -1,6 +1,6 @@
 ---
 description: Create implementation plan with risk assessment
-agent: everything-claude-code:planner
+agent: planner
 subtask: true
 ---
 

--- a/.opencode/commands/projects.md
+++ b/.opencode/commands/projects.md
@@ -1,6 +1,6 @@
 ---
 description: List registered projects and instinct counts
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Projects Command

--- a/.opencode/commands/promote.md
+++ b/.opencode/commands/promote.md
@@ -1,6 +1,6 @@
 ---
 description: Promote project instincts to global scope
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Promote Command

--- a/.opencode/commands/refactor-clean.md
+++ b/.opencode/commands/refactor-clean.md
@@ -1,6 +1,6 @@
 ---
 description: Remove dead code and consolidate duplicates
-agent: everything-claude-code:refactor-cleaner
+agent: refactor-cleaner
 subtask: true
 ---
 

--- a/.opencode/commands/rust-build.md
+++ b/.opencode/commands/rust-build.md
@@ -1,6 +1,6 @@
 ---
 description: Fix Rust build errors and borrow checker issues
-agent: everything-claude-code:rust-build-resolver
+agent: rust-build-resolver
 subtask: true
 ---
 

--- a/.opencode/commands/rust-review.md
+++ b/.opencode/commands/rust-review.md
@@ -1,6 +1,6 @@
 ---
 description: Rust code review for ownership, safety, and idiomatic patterns
-agent: everything-claude-code:rust-reviewer
+agent: rust-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/rust-test.md
+++ b/.opencode/commands/rust-test.md
@@ -1,6 +1,6 @@
 ---
 description: Rust TDD workflow with unit and property tests
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/security-scan.md
+++ b/.opencode/commands/security-scan.md
@@ -1,6 +1,6 @@
 ---
 description: Run AgentShield against agent, hook, MCP, permission, and secret surfaces.
-agent: everything-claude-code:security-reviewer
+agent: security-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/security.md
+++ b/.opencode/commands/security.md
@@ -1,6 +1,6 @@
 ---
 description: Run comprehensive security review
-agent: everything-claude-code:security-reviewer
+agent: security-reviewer
 subtask: true
 ---
 

--- a/.opencode/commands/setup-pm.md
+++ b/.opencode/commands/setup-pm.md
@@ -1,6 +1,6 @@
 ---
 description: Configure package manager preference
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Setup Package Manager Command

--- a/.opencode/commands/skill-create.md
+++ b/.opencode/commands/skill-create.md
@@ -1,6 +1,6 @@
 ---
 description: Generate skills from git history analysis
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Skill Create Command

--- a/.opencode/commands/tdd.md
+++ b/.opencode/commands/tdd.md
@@ -1,6 +1,6 @@
 ---
 description: Enforce TDD workflow with 80%+ coverage
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/test-coverage.md
+++ b/.opencode/commands/test-coverage.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze and improve test coverage
-agent: everything-claude-code:tdd-guide
+agent: tdd-guide
 subtask: true
 ---
 

--- a/.opencode/commands/update-codemaps.md
+++ b/.opencode/commands/update-codemaps.md
@@ -1,6 +1,6 @@
 ---
 description: Update codemaps for codebase navigation
-agent: everything-claude-code:doc-updater
+agent: doc-updater
 subtask: true
 ---
 

--- a/.opencode/commands/update-docs.md
+++ b/.opencode/commands/update-docs.md
@@ -1,6 +1,6 @@
 ---
 description: Update documentation for recent changes
-agent: everything-claude-code:doc-updater
+agent: doc-updater
 subtask: true
 ---
 

--- a/.opencode/commands/verify.md
+++ b/.opencode/commands/verify.md
@@ -1,6 +1,6 @@
 ---
 description: Run verification loop to validate implementation
-agent: everything-claude-code:build
+agent: build
 ---
 
 # Verify Command

--- a/tests/opencode-config.test.js
+++ b/tests/opencode-config.test.js
@@ -96,13 +96,14 @@ if (
 
       const agentId = match[1].trim().replace(/^['"]|['"]$/g, '');
 
-      // Regression guard for #2477: the Claude Code plugin namespace
-      // (`everything-claude-code:`) is not a valid opencode agent scope.
-      // OpenCode registers these agents unscoped in opencode.json's `agent`
-      // map, so a scoped id fails to resolve ("Agent not found") and hard-
-      // breaks subtask commands like /code-review on opencode.
+      // Regression guard for #2477: opencode registers these agents unscoped
+      // in opencode.json's `agent` map, so ANY namespace-scoped id
+      // (`<plugin>:<agent>` — e.g. the Claude Code `everything-claude-code:`
+      // prefix) fails to resolve ("Agent not found") and hard-breaks subtask
+      // commands like /code-review on opencode. Reject the whole scoped class,
+      // not just the one legacy prefix.
       assert.ok(
-        !agentId.includes('everything-claude-code:'),
+        !agentId.includes(':'),
         `${entry}: command agent must be an unscoped opencode agent id, got: ${agentId}`
       );
 

--- a/tests/opencode-config.test.js
+++ b/tests/opencode-config.test.js
@@ -77,10 +77,16 @@ if (
 else failed++;
 
 if (
-  test('command markdown frontmatter uses plugin-scoped agent ids', () => {
+  test('command markdown frontmatter agent ids resolve to a registered opencode agent', () => {
     const commandsDir = path.join(opencodeDir, 'commands');
+    const registeredAgents = new Set(Object.keys(config.agent || {}));
+    assert.ok(registeredAgents.size > 0, 'Expected opencode.json to register at least one agent');
 
     for (const entry of fs.readdirSync(commandsDir)) {
+      if (!entry.endsWith('.md')) {
+        continue;
+      }
+
       const body = fs.readFileSync(path.join(commandsDir, entry), 'utf8');
       const match = body.match(/^agent:\s*(.+)$/m);
 
@@ -88,9 +94,21 @@ if (
         continue;
       }
 
+      const agentId = match[1].trim().replace(/^['"]|['"]$/g, '');
+
+      // Regression guard for #2477: the Claude Code plugin namespace
+      // (`everything-claude-code:`) is not a valid opencode agent scope.
+      // OpenCode registers these agents unscoped in opencode.json's `agent`
+      // map, so a scoped id fails to resolve ("Agent not found") and hard-
+      // breaks subtask commands like /code-review on opencode.
       assert.ok(
-        match[1].startsWith('everything-claude-code:'),
-        `Expected plugin-scoped agent id in ${entry}, got: ${match[1]}`
+        !agentId.includes('everything-claude-code:'),
+        `${entry}: command agent must be an unscoped opencode agent id, got: ${agentId}`
+      );
+
+      assert.ok(
+        registeredAgents.has(agentId),
+        `${entry}: command agent "${agentId}" is not registered in opencode.json's agent map`
       );
     }
   })


### PR DESCRIPTION
## What Changed

- Removed the Claude Code plugin namespace (`everything-claude-code:`) from the
  `agent:` frontmatter of all 30 `.opencode/commands/*.md` files, so each
  command references an agent id that opencode actually registers
  (e.g. `agent: everything-claude-code:code-reviewer` → `agent: code-reviewer`).
- Updated the OpenCode command example in `.opencode/MIGRATION.md` to the same
  unscoped form so the docs stop teaching the failing convention.
- Rewrote the `tests/opencode-config.test.js` frontmatter test: it previously
  *required* the scoped prefix (codifying the bug); it now asserts every
  command's `agent` id is a key in `opencode.json`'s `agent` map.

## Why This Change

`/code-review` on opencode failed with
`Agent not found: "everything-claude-code:code-reviewer"` (issue #2477), while
the reporter's runtime "Available agents" list showed the agents **unscoped**
(`code-reviewer`, `planner`, ...).

Root cause: ECC's opencode integration defines its agents **inline** in
`.opencode/opencode.json`'s `agent` map, where they are registered unscoped, and
that file's own `command` section already references them unscoped
(`"agent": "code-reviewer"`). The command markdown, however, used the Claude
Code plugin namespace. That `everything-claude-code:` scope resolves under **no**
opencode configuration — the opencode plugin package is `ecc-universal` (a plugin
scope would be `ecc-universal:`), and inline-config agents are bare. `subtask: true`
commands spawn the named agent in an isolated subtask and hard-fail when it
can't be resolved; non-subtask commands fall back to the default agent and keep
working — which is exactly why "other commands work fine tho." The inconsistency
has existed since the `.opencode/` integration was first added, and the test
enforced the wrong invariant so CI never caught it.

This change is confined to `.opencode/` (the opencode surface). The top-level
`commands/` and `docs/<lang>/commands/` — the Claude Code surface where the
`everything-claude-code:` namespace is correct — are untouched.

## Testing Done

- `node tests/run-all.js` (clean env): **3105/3105 passed, 0 failed**.
- `tests/opencode-config.test.js`: the rewritten test **fails** against the old
  scoped frontmatter (`command agent must be an unscoped opencode agent id, got:
  everything-claude-code:build-error-resolver`) and **passes** after the fix —
  a fails-before / passes-after regression guard for #2477.
- `node scripts/ci/validate-commands.js` (94 command files) — pass.
- `tests/ci/command-registry.test.js` — pass (registry scans top-level
  `commands/`/`agents/`, unaffected).
- `tests/docs/install-identifiers.test.js` — pass.
- Verified all 13 distinct referenced agent ids are registered in
  `opencode.json`'s `agent` map (0 unregistered).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Security & Quality Checklist

- [x] Change limited to opencode command frontmatter + one doc example + one test
- [x] No behavioral change to the Claude Code command surface (top-level `commands/`)
- [x] No new dependencies; no generated files hand-edited
- [x] Regression test added (fails before, passes after)
- [x] Full suite green in a clean environment

## Documentation

- Updated the OpenCode command example in `.opencode/MIGRATION.md` to the
  unscoped agent form. No other docs required changes.

Fixes #2477