### PR TITLE
feat: add ECC as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ECC"]
+	path = ECC
+	url = https://github.com/affaan-m/ECC.git


### PR DESCRIPTION
## Summary

Adds the ECC (Everything Claude Code) repository as a git submodule, making it a tracked dependency within the project.

## Changes

- Added `.gitmodules` configuration for submodule setup
- Submodule points to `affaan-m/ECC` repository

## How to Use

After cloning this repository, initialize and update the submodule:

```bash
git submodule update --init --recursive
```

This will download the ECC repository into the `ECC/` directory.