### PR TITLE
fix(observer): use _clv2_resolve_homunculus_dir in start-observer.sh

### DIFF
--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -37,7 +37,7 @@ PYTHON_CMD="${CLV2_PYTHON_CMD:-}"
 
 # shellcheck disable=SC1091
 . "${SKILL_ROOT}/scripts/lib/homunculus-dir.sh"
-CONFIG_DIR="$(_ecc_resolve_homunculus_dir)"
+CONFIG_DIR="$(_clv2_resolve_homunculus_dir)"
 if [ -n "${CLV2_CONFIG:-}" ]; then
   CONFIG_FILE="$CLV2_CONFIG"
 elif [ -f "${CONFIG_DIR}/config.json" ]; then


### PR DESCRIPTION
## Bug

`agents/start-observer.sh:40` calls `_ecc_resolve_homunculus_dir`, but `scripts/lib/homunculus-dir.sh` only exports `_clv2_resolve_homunculus_dir`. Result:

```
start-observer.sh: line 40: _ecc_resolve_homunculus_dir: command not found
```

## Root cause

Commit `2d40baac` (PR #2304) was titled "rename _ecc_* -> _clv2_*" but only updated the lib export and three of four callers. `start-observer.sh:40` was missed. Diff for that commit on this file shows shebang + PID-poll changes only — the function call was never renamed.

## Symptom

- `observe.sh` (the hook) uses the correct `_clv2_` name and continues to write observations fine.
- The hook's lazy-start branch invokes `start-observer.sh start` via `nohup` to `observer-start.log`. The launcher exits with `127` (`command not found`), but the parent hook process returns 0 and the error never surfaces to the user.
- No PID file gets written → observer never starts → `SIGUSR1` from the hook has no target → distillation loop silently dead.
- Net effect: `observations.jsonl` grows indefinitely, no new instincts written. Looks identical to "no patterns detected".

Default `observer.enabled: false` masks the bug for new users. Opt-in users hit it on the first `start-observer.sh start` after enabling.

## Reproduction

1. Set `~/.local/share/ecc-homunculus/config.json` to `{"observer": {"enabled": true}}`.
2. Trigger any tool call to fire the `observe.sh` hook (or run `agents/start-observer.sh start` directly).
3. Observe `observer-start.log` contains `start-observer.sh: line 40: _ecc_resolve_homunculus_dir: command not found`.
4. No PID file at `~/.local/share/ecc-homunculus/projects/<hash>/.observer.pid`.

Confirmed on `affaan-m/ECC@40927950c` (HEAD of main), local marketplace copy, and cache `ecc/ecc/2.0.0`.

## Fix

Rename the one call site from `_ecc_resolve_homunculus_dir` to `_clv2_resolve_homunculus_dir` to match the lib export. This is the same call every other file in the skill makes (`observe.sh:138`, `detect-project.sh:24`, `migrate-homunculus.sh:10`).

```diff
- CONFIG_DIR="$(_ecc_resolve_homunculus_dir)"
+ CONFIG_DIR="$(_clv2_resolve_homunculus_dir)"
```

No other changes.

## Suggested follow-up (out of scope here)

- Add an end-to-end test that runs `start-observer.sh start` with `enabled: true` and asserts a PID file appears. Would have caught this.
- Consider adding `set -u` or a `command -v` precondition after sourcing shared libs to fail loudly on undefined helpers, instead of silently exiting under `nohup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)