### PR TITLE
fix(llm/providers/claude): attach cache_control to system block, not top-level

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -67,10 +67,15 @@ class ClaudeProvider(LLMProvider):
                 "model": model,
                 "messages": api_messages,
                 "max_tokens": input.max_tokens if input.max_tokens else 16000,
-                "cache_control": {"type": "ephemeral"},
             }
             if system_parts:
-                params["system"] = "\n\n".join(system_parts)
+                params["system"] = [
+                    {
+                        "type": "text",
+                        "text": "\n\n".join(system_parts),
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
             if input.tools:
                 params["tools"] = [tool.to_anthropic_tool() for tool in input.tools]
             if not _uses_adaptive_thinking_only(model):

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -135,7 +135,8 @@ def test_generate_does_not_pass_cache_control_as_top_level_param() -> None:
     # When a system prompt is present, cache_control should ride on the last
     # system content block so ephemeral prompt caching still works.
     system = params.get("system")
-    assert isinstance(system, list) and system, "system should be a non-empty list of blocks"
+    assert isinstance(system, list), "system should be sent as a list of content blocks"
+    assert system, "system content-block list should not be empty"
     assert system[-1].get("cache_control") == {"type": "ephemeral"}
 
 

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -10,8 +10,10 @@ from llm.providers.claude import ClaudeProvider
 class FakeMessages:
     def __init__(self, response: SimpleNamespace) -> None:
         self.response = response
+        self.last_params: dict[str, Any] = {}
 
-    def create(self, **_params: object) -> SimpleNamespace:
+    def create(self, **params: object) -> SimpleNamespace:
+        self.last_params = dict(params)
         return self.response
 
 
@@ -109,3 +111,40 @@ def test_generate_text_only_has_no_tool_calls() -> None:
 
     assert output.content == "Hello."
     assert output.tool_calls is None
+
+
+@pytest.mark.unit
+def test_generate_does_not_pass_cache_control_as_top_level_param() -> None:
+    # cache_control is a per-content-block field on the Anthropic Messages API,
+    # not a top-level parameter. Passing it at the top level raises TypeError
+    # in the Anthropic Python SDK (or a 400 from the API).
+    provider = make_provider(make_response([SimpleNamespace(type="text", text="ok")]))
+
+    provider.generate(
+        LLMInput(
+            messages=[
+                Message(role=Role.SYSTEM, content="system prompt"),
+                Message(role=Role.USER, content="hi"),
+            ]
+        )
+    )
+
+    params = provider.client.messages.last_params
+    assert "cache_control" not in params
+
+    # When a system prompt is present, cache_control should ride on the last
+    # system content block so ephemeral prompt caching still works.
+    system = params.get("system")
+    assert isinstance(system, list) and system, "system should be a non-empty list of blocks"
+    assert system[-1].get("cache_control") == {"type": "ephemeral"}
+
+
+@pytest.mark.unit
+def test_generate_without_system_does_not_set_system_or_cache_control() -> None:
+    provider = make_provider(make_response([SimpleNamespace(type="text", text="ok")]))
+
+    provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    params = provider.client.messages.last_params
+    assert "cache_control" not in params
+    assert "system" not in params


### PR DESCRIPTION
## What Changed

- Removed the top-level `cache_control: {\"type\": \"ephemeral\"}` from the params dict in `ClaudeProvider.generate()`.
- When a system prompt is present, `system` is now sent as a list of content blocks with `cache_control` attached to the (single) block, preserving the ephemeral prompt-caching behavior via the API's supported shape.
- Hardened the unit test scaffold: `FakeMessages.create` now records `last_params`, and two new regression tests assert:
  1. `cache_control` never appears as a top-level param.
  2. When a system prompt is set, `cache_control` rides on the last system content block.

## Why This Change

The Anthropic Messages API does not accept `cache_control` as a top-level request parameter — it's a per-content-block field. Passing it top-level raises `TypeError` in the Anthropic Python SDK (kwargs validated against `messages.create()`'s signature) or a `400 unknown_parameter` from the API. Every `ClaudeProvider.generate()` call was failing on the wire.

Existing tests didn't catch this because `FakeMessages.create(**_params)` accepted any kwargs and ignored them.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally — `pytest tests/test_claude_provider.py -v` shows **6/6 passed** (4 existing + 2 new regression tests).
- [x] Edge cases considered and tested — the second regression test asserts the "no system prompt" path does not sneak `cache_control` back in at the top level.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json`

No dependency changes.

## If you added a skill, command, agent, hook, or CLI tool

Not applicable — pure library bugfix in `src/llm/providers/claude.py`.

## Documentation

No documented behavior changed. The public `ClaudeProvider.generate()` signature is unchanged; the wire-level `system` shape now uses the block form the API expects.

## Linked issue

Fixes #2512

---

Related independent PRs opened alongside this one (different files, no conflicts):
- fix(ecc_dashboard): repopulate Rules and Commands trees on Refresh Data — #2513
- fix(hooks): remove stray '?' in tmux-reminder yarn regex — #2514