### PR TITLE
fix(ecc_dashboard): repopulate Rules and Commands trees on Refresh Data

### DIFF
--- a/ecc_dashboard.py
+++ b/ecc_dashboard.py
@@ -656,10 +656,17 @@ Usage: This skill is automatically activated when working with related technolog
         scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
         
         # Populate
-        for i, cmd in enumerate(self.commands, 1):
-            self.command_tree.insert('', tk.END, text=str(i), 
+        self.populate_commands(self.commands)
+
+    def populate_commands(self, commands: List[Dict]):
+        """Populate commands list"""
+        for item in self.command_tree.get_children():
+            self.command_tree.delete(item)
+
+        for i, cmd in enumerate(commands, 1):
+            self.command_tree.insert('', tk.END, text=str(i),
                                    values=('/' + cmd['name'], cmd['description']))
-    
+
     # =========================================================================
     # RULES TAB
     # =========================================================================
@@ -868,6 +875,8 @@ Project: github.com/affaan-m/ECC"""
         # Repopulate
         self.populate_agents(self.agents)
         self.populate_skills(self.skills)
+        self.populate_commands(self.commands)
+        self.populate_rules(self.rules)
         
         # Update status
         self.status_label.config(


### PR DESCRIPTION
## What Changed

- Extracted the inline command-tree insertion from `create_commands_tab` into a new `populate_commands(commands)` method, mirroring the existing `populate_agents` / `populate_rules` helpers.
- `create_commands_tab` now calls `self.populate_commands(self.commands)` for its initial population.
- `refresh_data` now calls both `self.populate_commands(self.commands)` and `self.populate_rules(self.rules)` alongside the two existing repopulate calls.

## Why This Change

Clicking **Refresh Data** in the dashboard reloaded the four data lists, updated the four tab-count labels, and displayed "Data refreshed successfully!" — but only agents and skills were actually re-rendered. Rules and Commands trees kept their pre-refresh rows, so the tab count and the visible content diverged and the success popup silently lied. `populate_rules` already existed and was just never called from `refresh_data`; Commands had no reusable populate helper at all.

## Testing Done

- [x] Manual testing completed — walked through the reproduction from #2513: change files under `commands/` and `rules/`, click Refresh Data, observed that both trees now refresh alongside Agents and Skills.
- [x] Automated tests pass locally — `python3 -c 'import ast; ast.parse(open(\"ecc_dashboard.py\").read())'` OK; no unit tests exist for the Tk dashboard.
- [x] Edge cases considered and tested — initial population path (via `create_commands_tab`) still works because it now delegates to the same `populate_commands` helper.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json`

No dependency changes.

## If you added a skill, command, agent, hook, or CLI tool

Not applicable — Tk dashboard code only.

## Documentation

No documented behavior changed. The user-facing "Refresh Data" action now actually refreshes what it claims to.

## Linked issue

Fixes #2513

---

Related independent PRs opened alongside this one (different files, no conflicts):
- fix(llm/providers/claude): cache_control shape — #2512
- fix(hooks): tmux-reminder yarn regex — #2514