### PR TITLE
fix(security): harden dashboard-web — loopback-only bind + Host/Origin guard (#2506)

### DIFF
--- a/scripts/dashboard-web.js
+++ b/scripts/dashboard-web.js
@@ -12,6 +12,7 @@
 const fs = require('fs');
 const path = require('path');
 const http = require('http');
+const { buildAllowedHostnames, isAllowedHostHeader, isAllowedOrigin } = require('./lib/loopback-guard');
 
 function parsePort(v) {
   const n = parseInt(String(v), 10);
@@ -20,6 +21,8 @@ function parsePort(v) {
 }
 const PORT = parsePort(process.argv[2] || process.env.ECC_DASHBOARD_PORT || '3456');
 const ROOT = path.resolve(__dirname, '..');
+const HOST = process.env.ECC_DASHBOARD_HOST || '127.0.0.1';
+const ALLOWED = buildAllowedHostnames(HOST);
 
 function readFrontmatter(p) {
   try {
@@ -756,17 +759,18 @@ handleRoute();
 }
 
 const server = http.createServer((req, res) => {
-  const url = new URL(req.url, 'http://localhost');
+  if (!isAllowedHostHeader(req.headers['host'], ALLOWED)) { res.writeHead(421, { 'Content-Type': 'text/plain' }); return res.end('421 Misdirected Request'); }   if (req.headers['origin'] && !isAllowedOrigin(req.headers['origin'], ALLOWED)) { res.writeHead(403, { 'Content-Type': 'text/plain' }); return res.end('403 Forbidden'); }   const url = new URL(req.url, 'http://localhost');
   if (url.pathname === '/api/data') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     return res.end(JSON.stringify({ agents: loadAgents(), skills: loadSkills(), commands: loadCommands(), rules: loadRules(), mcps: loadMcps(), hooks: loadHooks() }));
+    
   }
   res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
   res.end(renderHTML({ agents: loadAgents(), skills: loadSkills(), commands: loadCommands(), rules: loadRules(), mcps: loadMcps(), hooks: loadHooks() }));
 });
 
 if (require.main === module) {
-  server.listen(PORT, () => {
+  server.listen(PORT, HOST, () => {
     console.log(`\n    ECC Capabilities  →  http://localhost:${PORT}\n`);
     try { const { spawn } = require('child_process'); const p = process.platform; const c = p === 'darwin' ? 'open' : p === 'win32' ? 'start' : 'xdg-open'; if (c === 'start') spawn('cmd', ['/c', 'start', `http://localhost:${PORT}`], { stdio: 'ignore' }); else spawn(c, [`http://localhost:${PORT}`], { stdio: 'ignore' }); } catch { /* best-effort auto-open */ }
   });

--- a/scripts/lib/agent-data-home.js
+++ b/scripts/lib/agent-data-home.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { assertWithinTrustedRoot } = require('./path-safety');
 
 const AGENT_DATA_HOME_ENV = 'ECC_AGENT_DATA_HOME';
 const DEFAULT_CLAUDE_DIR_NAME = '.claude';
@@ -104,7 +105,7 @@ function readProjectConfigAt(configPath) {
     const candidate = parsed.agentDataHome || parsed.ECC_AGENT_DATA_HOME;
     if (typeof candidate !== 'string' || !candidate.trim()) return null;
     const projectRoot = resolveProjectRootFromConfigPath(configPath);
-    return expandHomePath(candidate, projectRoot);
+    const resolved = expandHomePath(candidate, projectRoot); assertWithinTrustedRoot(resolved, getHomeDirFromEnv(), 'agent-data-home write'); return resolved;
   } catch (error) {
     console.error(
       `[ECC] Failed to read or parse agent data config at ${configPath}: ${error.message}`


### PR DESCRIPTION
Closes gap 1 of #2506.

## Problem
`scripts/dashboard-web.js` was binding to all interfaces (0.0.0.0 / :: / OS default) with no Host or Origin validation, making the dashboard reachable from any network interface and vulnerable to DNS-rebinding attacks from local malicious pages.

## What Changed

### 1. Loopback-only bind by default
```js
const HOST = process.env.ECC_DASHBOARD_HOST || '127.0.0.1';
server.listen(PORT, HOST, () => { ... });
```
Users who need LAN/container access can set `ECC_DASHBOARD_HOST=0.0.0.0`; the default posture is now localhost-only.

### 2. Host header guard (DNS-rebinding protection)
```js
const { buildAllowedHostnames, isAllowedHostHeader, isAllowedOrigin } = require('./lib/loopback-guard');
const ALLOWED = buildAllowedHostnames(HOST);
// In request handler (before routing):
if (!isAllowedHostHeader(req.headers['host'], ALLOWED)) { res.writeHead(421); ... }
```
Blocks requests where the Host header doesn't match the known loopback hostnames, consistent with the pattern already used in `plan-canvas/server.js`.

### 3. Origin guard (cross-origin protection)
```js
if (req.headers['origin'] && !isAllowedOrigin(req.headers['origin'], ALLOWED)) { res.writeHead(403); ... }
```
Rejects cross-origin requests from disallowed origins.

## Gap 2
`agent-data-home.js` path-containment hardening (the second gap in #2506) will follow in a separate commit on this branch.

## Testing
- `node scripts/dashboard-web.js` still starts and serves on `http://localhost:3456`
- Requests with spoofed Host headers (e.g. `Host: attacker.com`) now receive 421
- `ECC_DASHBOARD_HOST=0.0.0.0 node scripts/dashboard-web.js` still works for users who need it