### PR TITLE
fix: switch multi-model frontend routing from Gemini CLI to Antigravity CLI

### DIFF
--- a/commands/multi-execute.md
+++ b/commands/multi-execute.md
@@ -16,7 +16,7 @@ $ARGUMENTS
 
 - **Language Protocol**: Use **English** when interacting with tools/models, communicate with user in their language
 - **Code Sovereignty**: External models have **zero filesystem write access**, all modifications by Claude
-- **Dirty Prototype Refactoring**: Treat Codex/Gemini Unified Diff as "dirty prototype", must refactor to production-grade code
+- **Dirty Prototype Refactoring**: Treat Codex/Antigravity Unified Diff as "dirty prototype", must refactor to production-grade code
 - **Stop-Loss Mechanism**: Do not proceed to next phase until current phase output is validated
 - **Prerequisite**: Only execute after user explicitly replies "Y" to `/ccg:plan` output (if missing, must confirm first)
 
@@ -29,7 +29,7 @@ $ARGUMENTS
 ```
 # Resume session call (recommended) - Implementation Prototype
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|gemini> {{GEMINI_MODEL_FLAG}}resume <SESSION_ID> - \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|antigravity> resume <SESSION_ID> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <task description>
@@ -44,7 +44,7 @@ EOF",
 
 # New session call - Implementation Prototype
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|gemini> {{GEMINI_MODEL_FLAG}}- \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|antigravity> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <task description>
@@ -62,7 +62,7 @@ EOF",
 
 ```
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|gemini> {{GEMINI_MODEL_FLAG}}resume <SESSION_ID> - \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|antigravity> resume <SESSION_ID> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Scope: Audit the final code changes.
@@ -84,14 +84,14 @@ EOF",
 ```
 
 **Model Parameter Notes**:
-- `{{GEMINI_MODEL_FLAG}}`: When using `--backend gemini`, replace with `--gemini-model gemini-3-pro-preview` (note trailing space); use empty string for codex
+- No extra model flag is needed for `--backend antigravity` or `--backend codex`; `codeagent-wrapper` picks each backend's default model.
 
 **Role Prompts**:
 
-| Phase | Codex | Gemini |
+| Phase | Codex | Antigravity |
 |-------|-------|--------|
-| Implementation | `~/.claude/.ccg/prompts/codex/architect.md` | `~/.claude/.ccg/prompts/gemini/frontend.md` |
-| Review | `~/.claude/.ccg/prompts/codex/reviewer.md` | `~/.claude/.ccg/prompts/gemini/reviewer.md` |
+| Implementation | `~/.claude/.ccg/prompts/codex/architect.md` | `~/.claude/.ccg/prompts/antigravity/frontend.md` |
+| Review | `~/.claude/.ccg/prompts/codex/reviewer.md` | `~/.claude/.ccg/prompts/antigravity/reviewer.md` |
 
 **Session Reuse**: If `/ccg:plan` provided SESSION_ID, use `resume <SESSION_ID>` to reuse context.
 
@@ -132,9 +132,9 @@ TaskOutput({ task_id: "<task_id>", block: true, timeout: 600000 })
 
    | Task Type | Detection | Route |
    |-----------|-----------|-------|
-   | **Frontend** | Pages, components, UI, styles, layout | Gemini |
+   | **Frontend** | Pages, components, UI, styles, layout | Antigravity |
    | **Backend** | API, interfaces, database, logic, algorithms | Codex |
-   | **Fullstack** | Contains both frontend and backend | Codex ∥ Gemini parallel |
+   | **Fullstack** | Contains both frontend and backend | Codex ∥ Antigravity parallel |
 
 ---
 
@@ -177,16 +177,16 @@ mcp__ace-tool__search_context({
 
 **Route Based on Task Type**:
 
-#### Route A: Frontend/UI/Styles → Gemini
+#### Route A: Frontend/UI/Styles → Antigravity
 
 **Limit**: Context < 32k tokens
 
-1. Call Gemini (use `~/.claude/.ccg/prompts/gemini/frontend.md`)
+1. Call Antigravity (use `~/.claude/.ccg/prompts/antigravity/frontend.md`)
 2. Input: Plan content + retrieved context + target files
 3. OUTPUT: `Unified Diff Patch ONLY. Strictly prohibit any actual modifications.`
-4. **Gemini is frontend design authority, its CSS/React/Vue prototype is the final visual baseline**
-5. **WARNING**: Ignore Gemini's backend logic suggestions
-6. If plan contains `GEMINI_SESSION`: prefer `resume <GEMINI_SESSION>`
+4. **Antigravity is frontend design authority, its CSS/React/Vue prototype is the final visual baseline**
+5. **WARNING**: Ignore Antigravity's backend logic suggestions
+6. If plan contains `ANTIGRAVITY_SESSION`: prefer `resume <ANTIGRAVITY_SESSION>`
 
 #### Route B: Backend/Logic/Algorithms → Codex
 
@@ -199,7 +199,7 @@ mcp__ace-tool__search_context({
 #### Route C: Fullstack → Parallel Calls
 
 1. **Parallel Calls** (`run_in_background: true`):
-   - Gemini: Handle frontend part
+   - Antigravity: Handle frontend part
    - Codex: Handle backend part
 2. Wait for both models' complete results with `TaskOutput`
 3. Each uses corresponding `SESSION_ID` from plan for `resume` (create new session if missing)
@@ -214,7 +214,7 @@ mcp__ace-tool__search_context({
 
 **Claude as Code Sovereign executes the following steps**:
 
-1. **Read Diff**: Parse Unified Diff Patch returned by Codex/Gemini
+1. **Read Diff**: Parse Unified Diff Patch returned by Codex/Antigravity
 
 2. **Mental Sandbox**:
    - Simulate applying Diff to target files
@@ -248,15 +248,15 @@ mcp__ace-tool__search_context({
 
 #### 5.1 Automatic Audit
 
-**After changes take effect, MUST immediately parallel call** Codex and Gemini for Code Review:
+**After changes take effect, MUST immediately parallel call** Codex and Antigravity for Code Review:
 
 1. **Codex Review** (`run_in_background: true`):
    - ROLE_FILE: `~/.claude/.ccg/prompts/codex/reviewer.md`
    - Input: Changed Diff + target files
    - Focus: Security, performance, error handling, logic correctness
 
-2. **Gemini Review** (`run_in_background: true`):
-   - ROLE_FILE: `~/.claude/.ccg/prompts/gemini/reviewer.md`
+2. **Antigravity Review** (`run_in_background: true`):
+   - ROLE_FILE: `~/.claude/.ccg/prompts/antigravity/reviewer.md`
    - Input: Changed Diff + target files
    - Focus: Accessibility, design consistency, user experience
 
@@ -264,8 +264,8 @@ Wait for both models' complete review results with `TaskOutput`. Prefer reusing 
 
 #### 5.2 Integrate and Fix
 
-1. Synthesize Codex + Gemini review feedback
-2. Weigh by trust rules: Backend follows Codex, Frontend follows Gemini
+1. Synthesize Codex + Antigravity review feedback
+2. Weigh by trust rules: Backend follows Codex, Frontend follows Antigravity
 3. Execute necessary fixes
 4. Repeat Phase 5.1 as needed (until risk is acceptable)
 
@@ -283,7 +283,7 @@ After audit passes, report to user:
 
 ### Audit Results
 - Codex: <Passed/Found N issues>
-- Gemini: <Passed/Found N issues>
+- Antigravity: <Passed/Found N issues>
 
 ### Recommendations
 1. [ ] <Suggested test steps>
@@ -295,8 +295,8 @@ After audit passes, report to user:
 ## Key Rules
 
 1. **Code Sovereignty** – All file modifications by Claude, external models have zero write access
-2. **Dirty Prototype Refactoring** – Codex/Gemini output treated as draft, must refactor
-3. **Trust Rules** – Backend follows Codex, Frontend follows Gemini
+2. **Dirty Prototype Refactoring** – Codex/Antigravity output treated as draft, must refactor
+3. **Trust Rules** – Backend follows Codex, Frontend follows Antigravity
 4. **Minimal Changes** – Only modify necessary code, no side effects
 5. **Mandatory Audit** – Must perform multi-model Code Review after changes
 

--- a/commands/multi-frontend.md
+++ b/commands/multi-frontend.md
@@ -4,7 +4,7 @@ description: Run a frontend-focused multi-model workflow for components, layouts
 
 # Frontend - Frontend-Focused Development
 
-Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimize → Review), Gemini-led.
+Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimize → Review), Antigravity-led.
 
 > **Prerequisite:** Requires the external `ccg-workflow` runtime, which is **not** part of the base ECC install. Initialize it with `npx ccg-workflow` to provision `~/.claude/bin/codeagent-wrapper` and the `~/.claude/.ccg/prompts/*` role files this command depends on. Without that runtime, this command will not run correctly.
 
@@ -17,7 +17,7 @@ Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimi
 ## Context
 
 - Frontend task: $ARGUMENTS
-- Gemini-led, Codex for auxiliary reference
+- Antigravity-led, Codex for auxiliary reference
 - Applicable: Component design, responsive layout, UI animations, style optimization
 
 ## Your Role
@@ -25,7 +25,7 @@ Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimi
 You are the **Frontend Orchestrator**, coordinating multi-model collaboration for UI/UX tasks (Research → Ideation → Plan → Execute → Optimize → Review).
 
 **Collaborative Models**:
-- **Gemini** – Frontend UI/UX (**Frontend authority, trustworthy**)
+- **Antigravity** – Frontend UI/UX (**Frontend authority, trustworthy**)
 - **Codex** – Backend perspective (**Frontend opinions for reference only**)
 - **Claude (self)** – Orchestration, planning, execution, delivery
 
@@ -38,7 +38,7 @@ You are the **Frontend Orchestrator**, coordinating multi-model collaboration fo
 ```
 # New session call
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend gemini --gemini-model gemini-3-pro-preview - \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend antigravity - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <enhanced requirement (or $ARGUMENTS if not enhanced)>
@@ -53,7 +53,7 @@ EOF",
 
 # Resume session call
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend gemini --gemini-model gemini-3-pro-preview resume <SESSION_ID> - \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend antigravity resume <SESSION_ID> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <enhanced requirement (or $ARGUMENTS if not enhanced)>
@@ -69,13 +69,13 @@ EOF",
 
 **Role Prompts**:
 
-| Phase | Gemini |
+| Phase | Antigravity |
 |-------|--------|
-| Analysis | `~/.claude/.ccg/prompts/gemini/analyzer.md` |
-| Planning | `~/.claude/.ccg/prompts/gemini/architect.md` |
-| Review | `~/.claude/.ccg/prompts/gemini/reviewer.md` |
+| Analysis | `~/.claude/.ccg/prompts/antigravity/analyzer.md` |
+| Planning | `~/.claude/.ccg/prompts/antigravity/architect.md` |
+| Review | `~/.claude/.ccg/prompts/antigravity/reviewer.md` |
 
-**Session Reuse**: Each call returns `SESSION_ID: xxx`, use `resume xxx` for subsequent phases. Save `GEMINI_SESSION` in Phase 2, use `resume` in Phases 3 and 5.
+**Session Reuse**: Each call returns `SESSION_ID: xxx`, use `resume xxx` for subsequent phases. Save `ANTIGRAVITY_SESSION` in Phase 2, use `resume` in Phases 3 and 5.
 
 ---
 
@@ -91,7 +91,7 @@ EOF",
 
 ### Phase 0: Prompt Enhancement (Optional)
 
-`[Mode: Prepare]` - If ace-tool MCP available, call `mcp__ace-tool__enhance_prompt`, **replace original $ARGUMENTS with enhanced result for subsequent Gemini calls**. If unavailable, use `$ARGUMENTS` as-is.
+`[Mode: Prepare]` - If ace-tool MCP available, call `mcp__ace-tool__enhance_prompt`, **replace original $ARGUMENTS with enhanced result for subsequent Antigravity calls**. If unavailable, use `$ARGUMENTS` as-is.
 
 ### Phase 1: Research
 
@@ -102,24 +102,24 @@ EOF",
 
 ### Phase 2: Ideation
 
-`[Mode: Ideation]` - Gemini-led analysis
+`[Mode: Ideation]` - Antigravity-led analysis
 
-**MUST call Gemini** (follow call specification above):
-- ROLE_FILE: `~/.claude/.ccg/prompts/gemini/analyzer.md`
+**MUST call Antigravity** (follow call specification above):
+- ROLE_FILE: `~/.claude/.ccg/prompts/antigravity/analyzer.md`
 - Requirement: Enhanced requirement (or $ARGUMENTS if not enhanced)
 - Context: Project context from Phase 1
 - OUTPUT: UI feasibility analysis, recommended solutions (at least 2), UX evaluation
 
-**Save SESSION_ID** (`GEMINI_SESSION`) for subsequent phase reuse.
+**Save SESSION_ID** (`ANTIGRAVITY_SESSION`) for subsequent phase reuse.
 
 Output solutions (at least 2), wait for user selection.
 
 ### Phase 3: Planning
 
-`[Mode: Plan]` - Gemini-led planning
+`[Mode: Plan]` - Antigravity-led planning
 
-**MUST call Gemini** (use `resume <GEMINI_SESSION>` to reuse session):
-- ROLE_FILE: `~/.claude/.ccg/prompts/gemini/architect.md`
+**MUST call Antigravity** (use `resume <ANTIGRAVITY_SESSION>` to reuse session):
+- ROLE_FILE: `~/.claude/.ccg/prompts/antigravity/architect.md`
 - Requirement: User's selected solution
 - Context: Analysis results from Phase 2
 - OUTPUT: Component structure, UI flow, styling approach
@@ -136,10 +136,10 @@ Claude synthesizes plan, save to `.claude/plan/task-name.md` after user approval
 
 ### Phase 5: Optimization
 
-`[Mode: Optimize]` - Gemini-led review
+`[Mode: Optimize]` - Antigravity-led review
 
-**MUST call Gemini** (follow call specification above):
-- ROLE_FILE: `~/.claude/.ccg/prompts/gemini/reviewer.md`
+**MUST call Antigravity** (follow call specification above):
+- ROLE_FILE: `~/.claude/.ccg/prompts/antigravity/reviewer.md`
 - Requirement: Review the following frontend code changes
 - Context: git diff or code content
 - OUTPUT: Accessibility, responsiveness, performance, design consistency issues list
@@ -158,7 +158,7 @@ Integrate review feedback, execute optimization after user confirmation.
 
 ## Key Rules
 
-1. **Gemini frontend opinions are trustworthy**
+1. **Antigravity frontend opinions are trustworthy**
 2. **Codex frontend opinions for reference only**
 3. External models have **zero filesystem write access**
 4. Claude handles all code writes and file operations

--- a/commands/multi-plan.md
+++ b/commands/multi-plan.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 ## Core Protocols
 
 - **Language Protocol**: Use **English** when interacting with tools/models, communicate with user in their language
-- **Mandatory Parallel**: Codex/Gemini calls MUST use `run_in_background: true` (including single model calls, to avoid blocking main thread)
+- **Mandatory Parallel**: Codex/Antigravity calls MUST use `run_in_background: true` (including single model calls, to avoid blocking main thread)
 - **Code Sovereignty**: External models have **zero filesystem write access**, all modifications by Claude
 - **Stop-Loss Mechanism**: Do not proceed to next phase until current phase output is validated
 - **Planning Only**: This command allows reading context and writing to `.claude/plan/*` plan files, but **NEVER modify production code**
@@ -28,7 +28,7 @@ $ARGUMENTS
 
 ```
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|gemini> {{GEMINI_MODEL_FLAG}}- \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|antigravity> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <enhanced requirement>
@@ -43,14 +43,14 @@ EOF",
 ```
 
 **Model Parameter Notes**:
-- `{{GEMINI_MODEL_FLAG}}`: When using `--backend gemini`, replace with `--gemini-model gemini-3-pro-preview` (note trailing space); use empty string for codex
+- No extra model flag is needed for `--backend antigravity` or `--backend codex`; `codeagent-wrapper` picks each backend's default model.
 
 **Role Prompts**:
 
-| Phase | Codex | Gemini |
+| Phase | Codex | Antigravity |
 |-------|-------|--------|
-| Analysis | `~/.claude/.ccg/prompts/codex/analyzer.md` | `~/.claude/.ccg/prompts/gemini/analyzer.md` |
-| Planning | `~/.claude/.ccg/prompts/codex/architect.md` | `~/.claude/.ccg/prompts/gemini/architect.md` |
+| Analysis | `~/.claude/.ccg/prompts/codex/analyzer.md` | `~/.claude/.ccg/prompts/antigravity/analyzer.md` |
+| Planning | `~/.claude/.ccg/prompts/codex/architect.md` | `~/.claude/.ccg/prompts/antigravity/architect.md` |
 
 **Session Reuse**: Each call returns `SESSION_ID: xxx` (typically output by wrapper), **MUST save** for subsequent `/ccg:execute` use.
 
@@ -128,7 +128,7 @@ mcp__ace-tool__search_context({
 
 #### 2.1 Distribute Inputs
 
-**Parallel call** Codex and Gemini (`run_in_background: true`):
+**Parallel call** Codex and Antigravity (`run_in_background: true`):
 
 Distribute **original requirement** (without preset opinions) to both models:
 
@@ -137,12 +137,12 @@ Distribute **original requirement** (without preset opinions) to both models:
    - Focus: Technical feasibility, architecture impact, performance considerations, potential risks
    - OUTPUT: Multi-perspective solutions + pros/cons analysis
 
-2. **Gemini Frontend Analysis**:
-   - ROLE_FILE: `~/.claude/.ccg/prompts/gemini/analyzer.md`
+2. **Antigravity Frontend Analysis**:
+   - ROLE_FILE: `~/.claude/.ccg/prompts/antigravity/analyzer.md`
    - Focus: UI/UX impact, user experience, visual design
    - OUTPUT: Multi-perspective solutions + pros/cons analysis
 
-Wait for both models' complete results with `TaskOutput`. **Save SESSION_ID** (`CODEX_SESSION` and `GEMINI_SESSION`).
+Wait for both models' complete results with `TaskOutput`. **Save SESSION_ID** (`CODEX_SESSION` and `ANTIGRAVITY_SESSION`).
 
 #### 2.2 Cross-Validation
 
@@ -150,7 +150,7 @@ Integrate perspectives and iterate for optimization:
 
 1. **Identify consensus** (strong signal)
 2. **Identify divergence** (needs weighing)
-3. **Complementary strengths**: Backend logic follows Codex, Frontend design follows Gemini
+3. **Complementary strengths**: Backend logic follows Codex, Frontend design follows Antigravity
 4. **Logical reasoning**: Eliminate logical gaps in solutions
 
 #### 2.3 (Optional but Recommended) Dual-Model Plan Draft
@@ -161,8 +161,8 @@ To reduce risk of omissions in Claude's synthesized plan, can parallel have both
    - ROLE_FILE: `~/.claude/.ccg/prompts/codex/architect.md`
    - OUTPUT: Step-by-step plan + pseudo-code (focus: data flow/edge cases/error handling/test strategy)
 
-2. **Gemini Plan Draft** (Frontend authority):
-   - ROLE_FILE: `~/.claude/.ccg/prompts/gemini/architect.md`
+2. **Antigravity Plan Draft** (Frontend authority):
+   - ROLE_FILE: `~/.claude/.ccg/prompts/antigravity/architect.md`
    - OUTPUT: Step-by-step plan + pseudo-code (focus: information architecture/interaction/accessibility/visual consistency)
 
 Wait for both models' complete results with `TaskOutput`, record key differences in their suggestions.
@@ -175,12 +175,12 @@ Synthesize both analyses, generate **Step-by-step Implementation Plan**:
 ## Implementation Plan: <Task Name>
 
 ### Task Type
-- [ ] Frontend (→ Gemini)
+- [ ] Frontend (→ Antigravity)
 - [ ] Backend (→ Codex)
 - [ ] Fullstack (→ Parallel)
 
 ### Technical Solution
-<Optimal solution synthesized from Codex + Gemini analysis>
+<Optimal solution synthesized from Codex + Antigravity analysis>
 
 ### Implementation Steps
 1. <Step 1> - Expected deliverable
@@ -198,7 +198,7 @@ Synthesize both analyses, generate **Step-by-step Implementation Plan**:
 
 ### SESSION_ID (for /ccg:execute use)
 - CODEX_SESSION: <session_id>
-- GEMINI_SESSION: <session_id>
+- ANTIGRAVITY_SESSION: <session_id>
 ```
 
 ### Phase 2 End: Plan Delivery (Not Execution)
@@ -269,6 +269,6 @@ After user approves, **manually** execute:
 
 1. **Plan only, no implementation** – This command does not execute any code changes
 2. **No Y/N prompts** – Only present plan, let user decide next steps
-3. **Trust Rules** – Backend follows Codex, Frontend follows Gemini
+3. **Trust Rules** – Backend follows Codex, Frontend follows Antigravity
 4. External models have **zero filesystem write access**
-5. **SESSION_ID Handoff** – Plan must include `CODEX_SESSION` / `GEMINI_SESSION` at end (for `/ccg:execute resume <SESSION_ID>` use)
+5. **SESSION_ID Handoff** – Plan must include `CODEX_SESSION` / `ANTIGRAVITY_SESSION` at end (for `/ccg:execute resume <SESSION_ID>` use)

--- a/commands/multi-workflow.md
+++ b/commands/multi-workflow.md
@@ -4,7 +4,7 @@ description: Run a full multi-model development workflow with research, planning
 
 # Workflow - Multi-Model Collaborative Development
 
-Multi-model collaborative development workflow (Research → Ideation → Plan → Execute → Optimize → Review), with intelligent routing: Frontend → Gemini, Backend → Codex.
+Multi-model collaborative development workflow (Research → Ideation → Plan → Execute → Optimize → Review), with intelligent routing: Frontend → Antigravity, Backend → Codex.
 
 > **Prerequisite:** Requires the external `ccg-workflow` runtime, which is **not** part of the base ECC install. Initialize it with `npx ccg-workflow` to provision `~/.claude/bin/codeagent-wrapper` and the `~/.claude/.ccg/prompts/*` role files this command depends on. Without that runtime, this command will not run correctly.
 
@@ -20,7 +20,7 @@ Structured development workflow with quality gates, MCP services, and multi-mode
 
 - Task to develop: $ARGUMENTS
 - Structured 6-phase workflow with quality gates
-- Multi-model collaboration: Codex (backend) + Gemini (frontend) + Claude (orchestration)
+- Multi-model collaboration: Codex (backend) + Antigravity (frontend) + Claude (orchestration)
 - MCP service integration (ace-tool, optional) for enhanced capabilities
 
 ## Your Role
@@ -30,7 +30,7 @@ You are the **Orchestrator**, coordinating a multi-model collaborative system (R
 **Collaborative Models**:
 - **ace-tool MCP** (optional) – Code retrieval + Prompt enhancement
 - **Codex** – Backend logic, algorithms, debugging (**Backend authority, trustworthy**)
-- **Gemini** – Frontend UI/UX, visual design (**Frontend expert, backend opinions for reference only**)
+- **Antigravity** – Frontend UI/UX, visual design (**Frontend expert, backend opinions for reference only**)
 - **Claude (self)** – Orchestration, planning, execution, delivery
 
 ---
@@ -42,7 +42,7 @@ You are the **Orchestrator**, coordinating a multi-model collaborative system (R
 ```
 # New session call
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|gemini> {{GEMINI_MODEL_FLAG}}- \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|antigravity> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <enhanced requirement (or $ARGUMENTS if not enhanced)>
@@ -57,7 +57,7 @@ EOF",
 
 # Resume session call
 Bash({
-  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|gemini> {{GEMINI_MODEL_FLAG}}resume <SESSION_ID> - \"$PWD\" <<'EOF'
+  command: "~/.claude/bin/codeagent-wrapper {{LITE_MODE_FLAG}}--backend <codex|antigravity> resume <SESSION_ID> - \"$PWD\" <<'EOF'
 ROLE_FILE: <role prompt path>
 <TASK>
 Requirement: <enhanced requirement (or $ARGUMENTS if not enhanced)>
@@ -72,15 +72,15 @@ EOF",
 ```
 
 **Model Parameter Notes**:
-- `{{GEMINI_MODEL_FLAG}}`: When using `--backend gemini`, replace with `--gemini-model gemini-3-pro-preview` (note trailing space); use empty string for codex
+- No extra model flag is needed for `--backend antigravity` or `--backend codex`; `codeagent-wrapper` picks each backend's default model.
 
 **Role Prompts**:
 
-| Phase | Codex | Gemini |
+| Phase | Codex | Antigravity |
 |-------|-------|--------|
-| Analysis | `~/.claude/.ccg/prompts/codex/analyzer.md` | `~/.claude/.ccg/prompts/gemini/analyzer.md` |
-| Planning | `~/.claude/.ccg/prompts/codex/architect.md` | `~/.claude/.ccg/prompts/gemini/architect.md` |
-| Review | `~/.claude/.ccg/prompts/codex/reviewer.md` | `~/.claude/.ccg/prompts/gemini/reviewer.md` |
+| Analysis | `~/.claude/.ccg/prompts/codex/analyzer.md` | `~/.claude/.ccg/prompts/antigravity/analyzer.md` |
+| Planning | `~/.claude/.ccg/prompts/codex/architect.md` | `~/.claude/.ccg/prompts/antigravity/architect.md` |
+| Review | `~/.claude/.ccg/prompts/codex/reviewer.md` | `~/.claude/.ccg/prompts/antigravity/reviewer.md` |
 
 **Session Reuse**: Each call returns `SESSION_ID: xxx`, use `resume xxx` subcommand for subsequent phases (note: `resume`, not `--resume`).
 
@@ -125,7 +125,7 @@ node scripts/orchestrate-worktrees.js .claude/plan/workflow-e2e-test.json --exec
 
 `[Mode: Research]` - Understand requirements and gather context:
 
-1. **Prompt Enhancement** (if ace-tool MCP available): Call `mcp__ace-tool__enhance_prompt`, **replace original $ARGUMENTS with enhanced result for all subsequent Codex/Gemini calls**. If unavailable, use `$ARGUMENTS` as-is.
+1. **Prompt Enhancement** (if ace-tool MCP available): Call `mcp__ace-tool__enhance_prompt`, **replace original $ARGUMENTS with enhanced result for all subsequent Codex/Antigravity calls**. If unavailable, use `$ARGUMENTS` as-is.
 2. **Context Retrieval** (if ace-tool MCP available): Call `mcp__ace-tool__search_context`. If unavailable, use built-in tools: `Glob` for file discovery, `Grep` for symbol search, `Read` for context gathering, `Task` (Explore agent) for deeper exploration.
 3. **Requirement Completeness Score** (0-10):
    - Goal clarity (0-3), Expected outcome (0-3), Scope boundaries (0-2), Constraints (0-2)
@@ -137,9 +137,9 @@ node scripts/orchestrate-worktrees.js .claude/plan/workflow-e2e-test.json --exec
 
 **Parallel Calls** (`run_in_background: true`):
 - Codex: Use analyzer prompt, output technical feasibility, solutions, risks
-- Gemini: Use analyzer prompt, output UI feasibility, solutions, UX evaluation
+- Antigravity: Use analyzer prompt, output UI feasibility, solutions, UX evaluation
 
-Wait for results with `TaskOutput`. **Save SESSION_ID** (`CODEX_SESSION` and `GEMINI_SESSION`).
+Wait for results with `TaskOutput`. **Save SESSION_ID** (`CODEX_SESSION` and `ANTIGRAVITY_SESSION`).
 
 **Follow the `IMPORTANT` instructions in `Multi-Model Call Specification` above**
 
@@ -151,13 +151,13 @@ Synthesize both analyses, output solution comparison (at least 2 options), wait 
 
 **Parallel Calls** (resume session with `resume <SESSION_ID>`):
 - Codex: Use architect prompt + `resume $CODEX_SESSION`, output backend architecture
-- Gemini: Use architect prompt + `resume $GEMINI_SESSION`, output frontend architecture
+- Antigravity: Use architect prompt + `resume $ANTIGRAVITY_SESSION`, output frontend architecture
 
 Wait for results with `TaskOutput`.
 
 **Follow the `IMPORTANT` instructions in `Multi-Model Call Specification` above**
 
-**Claude Synthesis**: Adopt Codex backend plan + Gemini frontend plan, save to `.claude/plan/task-name.md` after user approval.
+**Claude Synthesis**: Adopt Codex backend plan + Antigravity frontend plan, save to `.claude/plan/task-name.md` after user approval.
 
 ### Phase 4: Implementation
 
@@ -173,7 +173,7 @@ Wait for results with `TaskOutput`.
 
 **Parallel Calls**:
 - Codex: Use reviewer prompt, focus on security, performance, error handling
-- Gemini: Use reviewer prompt, focus on accessibility, design consistency
+- Antigravity: Use reviewer prompt, focus on accessibility, design consistency
 
 Wait for results with `TaskOutput`. Integrate review feedback, execute optimization after user confirmation.
 


### PR DESCRIPTION
## Summary
- Google is sunsetting consumer-tier Gemini CLI access on 2026-06-18 and consolidating tooling into Antigravity CLI (https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).
- `codeagent-wrapper` already ships a working `AntigravityBackend` (verified live: `--backend antigravity` resolves to `agy -p ...` and returns a correct response), and `~/.claude/.ccg/prompts/antigravity/*.md` role prompts already exist in `ccg-workflow`. Only these four command files still hardcoded `--backend gemini`.
- Updates `multi-frontend.md`, `multi-execute.md`, `multi-plan.md`, and `multi-workflow.md` to route frontend calls through `--backend antigravity` instead of `--backend gemini`, point role-prompt paths at `prompts/antigravity/` instead of `prompts/gemini/`, and drop the gemini-only `--gemini-model` flag (antigravity has no CLI equivalent; `codeagent-wrapper` picks its own default model).
- `multi-backend.md` is untouched (codex-only, no frontend routing).
- Translated docs under `docs/*/commands/` are intentionally left as-is (out of scope, maintained separately).

## Test plan
- [x] Live-tested `~/.claude/bin/codeagent-wrapper --backend antigravity "Reply with exactly the word: pong" .` — resolved to `agy -p ...`, returned `pong`, exit 0.
- [x] `grep -ri gemini commands/multi-frontend.md commands/multi-execute.md commands/multi-plan.md commands/multi-workflow.md` — 0 matches.
- [ ] Maintainer to confirm this matches the intended migration path if Antigravity backend support should stay opt-in via `~/.claude/.ccg/config.toml` routing instead of being hardcoded in the command markdown.