### PR TITLE
fix(llm): remove top-level cache_control from Claude provider (fixes #2512)

### DIFF
--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -67,7 +67,6 @@ class ClaudeProvider(LLMProvider):
                 "model": model,
                 "messages": api_messages,
                 "max_tokens": input.max_tokens if input.max_tokens else 16000,
-                "cache_control": {"type": "ephemeral"},
             }
             if system_parts:
                 params["system"] = "\n\n".join(system_parts)


### PR DESCRIPTION
Fixes #2512

The top-level `cache_control: {"type": "ephemeral"}` param was being passed to `Anthropic().messages.create()` which the SDK rejects (cache_control belongs on individual content blocks, not the top-level request). This broke every Claude invocation.

Fix: Remove the top-level cache_control param. Users who need cache control can add it to individual content blocks per the Anthropic API docs.