### PR TITLE
fix: detect Anthropic API keys (sk-ant-...) in pre-commit secret scan

### DIFF
--- a/scripts/hooks/pre-bash-commit-quality.js
+++ b/scripts/hooks/pre-bash-commit-quality.js
@@ -108,6 +108,7 @@ function findFileIssues(filePath) {
       
       // Check for hardcoded secrets (basic patterns)
       const secretPatterns = [
+        { pattern: /sk-ant-[a-zA-Z0-9_-]{20,}/, name: 'Anthropic API key' },
         { pattern: /sk-[a-zA-Z0-9]{20,}/, name: 'OpenAI API key' },
         { pattern: /ghp_[a-zA-Z0-9]{36}/, name: 'GitHub PAT' },
         { pattern: /AKIA[A-Z0-9]{16}/, name: 'AWS Access Key' },

--- a/tests/hooks/pre-bash-commit-quality.test.js
+++ b/tests/hooks/pre-bash-commit-quality.test.js
@@ -212,6 +212,7 @@ if (test('blocks commits with staged secret patterns across checkable files', ()
   inTempRepo(repoDir => {
     writeAndStage(repoDir, 'index.js', [
       "const openai = 'sk-abcdefghijklmnopqrstuvwxyz';",
+      "const anthropic = 'sk-ant-api03-AbCdEf-GhIjKlMnOpQrStUvWx_Yz012345';",
       "const token = 'ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ';",
       ''
     ].join('\n'));
@@ -227,6 +228,7 @@ if (test('blocks commits with staged secret patterns across checkable files', ()
     assert.strictEqual(result.output, input);
     assert.strictEqual(result.exitCode, 2);
     assert.ok(stderr.includes('Potential OpenAI API key'), `expected OpenAI secret warning, got: ${stderr}`);
+    assert.ok(stderr.includes('Potential Anthropic API key'), `expected Anthropic key warning, got: ${stderr}`);
     assert.ok(stderr.includes('Potential GitHub PAT'), `expected GitHub PAT warning, got: ${stderr}`);
     assert.ok(stderr.includes('Potential AWS Access Key'), `expected AWS key warning, got: ${stderr}`);
     assert.ok(stderr.includes('Potential API key'), `expected generic API key warning, got: ${stderr}`);


### PR DESCRIPTION
## Problem

The secret scan in `scripts/hooks/pre-bash-commit-quality.js` never matches real Anthropic API keys. Their format is `sk-ant-api03-...` and contains hyphens, which terminate the `sk-[a-zA-Z0-9]{20,}` character class long before the 20-char threshold, so the OpenAI pattern silently passes them through. Keys of the primary Claude Code audience slip into commits unnoticed.

## Fix

- Add a dedicated `sk-ant-[a-zA-Z0-9_-]{20,}` pattern (checked before the generic OpenAI one).
- Extend the staged-secrets test with a realistic Anthropic key fixture and assert the new warning.

## Validation

`node tests/hooks/pre-bash-commit-quality.test.js` -> Passed: 9, Failed: 0. Red-green confirmed: the fixture key is missed by the old pattern and caught by the new one.

Found while running ECC project-scope in production against Claude-API-heavy repos.