### PR TITLE
feat(skills): complete Codex skill surface for source-command scaffolds

### DIFF
--- a/.agents/skills/source-command-add-language-rules/SKILL.md
+++ b/.agents/skills/source-command-add-language-rules/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: source-command-add-language-rules
+description: Workflow command scaffold for add-language-rules in everything-claude-code.
+---
+
+# source-command-add-language-rules
+
+Use this skill when the user asks to run the migrated source command `add-language-rules`.
+
+## Command Template
+
+# /add-language-rules
+
+Use this workflow when working on **add-language-rules** in `everything-claude-code`.
+
+## Goal
+
+Adds a new programming language to the rules system, including coding style, hooks, patterns, security, and testing guidelines.
+
+## Common Files
+
+- `rules/*/coding-style.md`
+- `rules/*/hooks.md`
+- `rules/*/patterns.md`
+- `rules/*/security.md`
+- `rules/*/testing.md`
+
+## Suggested Sequence
+
+1. Understand the current state and failure mode before editing.
+2. Make the smallest coherent change that satisfies the workflow goal.
+3. Run the most relevant verification for touched files.
+4. Summarize what changed and what still needs review.
+
+## Typical Commit Signals
+
+- Create a new directory under rules/{language}/
+- Add coding-style.md, hooks.md, patterns.md, security.md, and testing.md files with language-specific content
+- Optionally reference or link to related skills
+
+## Notes
+
+- Treat this as a scaffold, not a hard-coded script.
+- Update the command if the workflow evolves materially.

--- a/.agents/skills/source-command-add-language-rules/agents/openai.yaml
+++ b/.agents/skills/source-command-add-language-rules/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Add Language Rules (Legacy Command)"
+  short_description: "Legacy /add-language-rules workflow scaffold"
+  brand_color: "#2563EB"
+  default_prompt: "Use $source-command-add-language-rules to add a new language's rules pack."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/source-command-database-migration/SKILL.md
+++ b/.agents/skills/source-command-database-migration/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: source-command-database-migration
+description: Workflow command scaffold for database-migration in everything-claude-code.
+---
+
+# source-command-database-migration
+
+Use this skill when the user asks to run the migrated source command `database-migration`.
+
+## Command Template
+
+# /database-migration
+
+Use this workflow when working on **database-migration** in `everything-claude-code`.
+
+## Goal
+
+Database schema changes with migration files
+
+## Common Files
+
+- `**/schema.*`
+- `migrations/*`
+
+## Suggested Sequence
+
+1. Understand the current state and failure mode before editing.
+2. Make the smallest coherent change that satisfies the workflow goal.
+3. Run the most relevant verification for touched files.
+4. Summarize what changed and what still needs review.
+
+## Typical Commit Signals
+
+- Create migration file
+- Update schema definitions
+- Generate/update types
+
+## Notes
+
+- Treat this as a scaffold, not a hard-coded script.
+- Update the command if the workflow evolves materially.

--- a/.agents/skills/source-command-database-migration/agents/openai.yaml
+++ b/.agents/skills/source-command-database-migration/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Database Migration (Legacy Command)"
+  short_description: "Legacy /database-migration workflow scaffold"
+  brand_color: "#2563EB"
+  default_prompt: "Use $source-command-database-migration to plan a database schema migration."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/source-command-feature-development/SKILL.md
+++ b/.agents/skills/source-command-feature-development/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: source-command-feature-development
+description: Workflow command scaffold for feature-development in everything-claude-code.
+---
+
+# source-command-feature-development
+
+Use this skill when the user asks to run the migrated source command `feature-development`.
+
+## Command Template
+
+# /feature-development
+
+Use this workflow when working on **feature-development** in `everything-claude-code`.
+
+## Goal
+
+Standard feature implementation workflow
+
+## Common Files
+
+- `manifests/*`
+- `schemas/*`
+- `**/*.test.*`
+- `**/api/**`
+
+## Suggested Sequence
+
+1. Understand the current state and failure mode before editing.
+2. Make the smallest coherent change that satisfies the workflow goal.
+3. Run the most relevant verification for touched files.
+4. Summarize what changed and what still needs review.
+
+## Typical Commit Signals
+
+- Add feature implementation
+- Add tests for feature
+- Update documentation
+
+## Notes
+
+- Treat this as a scaffold, not a hard-coded script.
+- Update the command if the workflow evolves materially.

--- a/.agents/skills/source-command-feature-development/agents/openai.yaml
+++ b/.agents/skills/source-command-feature-development/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Feature Development (Legacy Command)"
+  short_description: "Legacy /feature-development workflow scaffold"
+  brand_color: "#2563EB"
+  default_prompt: "Use $source-command-feature-development to implement a standard feature end to end."
+policy:
+  allow_implicit_invocation: true

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -11,6 +11,9 @@ const { applyInstallPlan } = require('../../scripts/lib/install/apply');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-apply.js');
 const DEFAULT_INSTALL_APPLY_TIMEOUT_MS = process.platform === 'win32' ? 30000 : 10000;
+// Full-profile --json dry-runs list every managed file; Node's execFileSync
+// default (1MB) has no headroom as the repo grows, so raise it explicitly.
+const INSTALL_APPLY_MAX_BUFFER = 16 * 1024 * 1024;
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -40,6 +43,7 @@ function run(args = [], options = {}) {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: options.timeout || DEFAULT_INSTALL_APPLY_TIMEOUT_MS,
+      maxBuffer: INSTALL_APPLY_MAX_BUFFER,
     });
 
     return { code: 0, stdout, stderr: '' };


### PR DESCRIPTION
## Summary
`tests/run-all.js` was failing on 3 untracked `.agents/skills/source-command-*` scaffolds (`add-language-rules`, `database-migration`, `feature-development`) left behind by a botched generator run:

- `SKILL.md`'s `name:` field was quoted (`tests/ci/codex-skill-surface.test.js` requires it unquoted and matching the folder name exactly).
- The content baked in the wrong project name — `"...in everything-Codex"` instead of `everything-claude-code` (the source `.claude/commands/*.md` files these were mirrored from already had it right).
- The required `agents/openai.yaml` companion file was missing entirely.

Fixed all three: unquoted the frontmatter, corrected the project name in both the description and body text, and added `agents/openai.yaml` with `display_name`/`short_description`/`default_prompt` so each scaffold satisfies the Codex skill surface contract.

While verifying, this surfaced a latent bug in `tests/scripts/install-apply.test.js`: it spawns the full-profile `--json` dry-run via `execFileSync` with no `maxBuffer` override, so it inherits Node's 1MB default. That dry-run lists every managed file in the repo, and adding these 6 files pushed its output past the limit (`spawnSync ENOBUFS`) — any future skill/agent addition could trip the same wall. Fixed with an explicit 16MB `maxBuffer`.

Diff is intentionally minimal — 7 files, 153 insertions, 0 deletions.

## Test plan
- [x] `node tests/ci/codex-skill-surface.test.js` — 4/4 pass (was failing 2/4 before this change)
- [x] `node tests/scripts/install-apply.test.js` — 30/30 pass (was failing 1/30 before the maxBuffer fix, reproduced consistently across repeated runs)
- [x] `node scripts/ci/validate-commands.js` — 94/94 clean
- [x] `node tests/run-all.js` — 3110/3110 pass