### PR TITLE
fix(scripts): detect modern bun.lock, ignore stray root lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,11 @@ ecc2/target/
 # Generated lock files in tool subdirectories
 .opencode/package-lock.json
 .opencode/node_modules/
+
+# yarn is the canonical package manager for this repo (see package.json
+# "packageManager"); ignore stray lockfiles from running another manager locally
+/bun.lock
+/bun.lockb
 assets/images/security/badrudi-exploit.mp4
 
 .aider*

--- a/scripts/lib/package-manager.js
+++ b/scripts/lib/package-manager.js
@@ -43,7 +43,10 @@ const PACKAGE_MANAGERS = {
   },
   bun: {
     name: 'bun',
-    lockFile: 'bun.lockb',
+    lockFile: 'bun.lock',
+    // Bun switched its default lockfile from the binary bun.lockb to the
+    // text-based bun.lock. Keep recognizing the legacy file too.
+    lockFileAliases: ['bun.lockb'],
     installCmd: 'bun install',
     runCmd: 'bun run',
     execCmd: 'bunx',
@@ -92,9 +95,9 @@ function saveConfig(config) {
 function detectFromLockFile(projectDir = process.cwd()) {
   for (const pmName of DETECTION_PRIORITY) {
     const pm = PACKAGE_MANAGERS[pmName];
-    const lockFilePath = path.join(projectDir, pm.lockFile);
+    const lockFileNames = [pm.lockFile, ...(pm.lockFileAliases || [])];
 
-    if (fs.existsSync(lockFilePath)) {
+    if (lockFileNames.some(lockFileName => fs.existsSync(path.join(projectDir, lockFileName)))) {
       return pmName;
     }
   }

--- a/tests/lib/package-manager.test.js
+++ b/tests/lib/package-manager.test.js
@@ -131,10 +131,22 @@ function runTests() {
   })) passed++;
   else failed++;
 
-  if (test('detects bun from bun.lockb', () => {
+  if (test('detects bun from bun.lockb (legacy binary lockfile)', () => {
     const testDir = createTestDir();
     try {
       fs.writeFileSync(path.join(testDir, 'bun.lockb'), '');
+      const result = pm.detectFromLockFile(testDir);
+      assert.strictEqual(result, 'bun');
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('detects bun from bun.lock (modern text lockfile)', () => {
+    const testDir = createTestDir();
+    try {
+      fs.writeFileSync(path.join(testDir, 'bun.lock'), '');
       const result = pm.detectFromLockFile(testDir);
       assert.strictEqual(result, 'bun');
     } finally {


### PR DESCRIPTION
## Summary
Bun switched its default lockfile from the binary `bun.lockb` to the text-based `bun.lock`, but `detectFromLockFile()` in `scripts/lib/package-manager.js` only ever checked for `bun.lockb` — a project using modern Bun would never be detected as using Bun at all.

- Made `bun.lock` the primary recognized lockfile, kept `bun.lockb` as a recognized legacy alias via a new `lockFileAliases` field, and updated `detectFromLockFile()` to check both.
- Added `/bun.lock` and `/bun.lockb` to `.gitignore` at the repo root — yarn is this repo's canonical package manager (`package.json` `"packageManager"`), so a lockfile from someone running `bun install` locally against this repo shouldn't show up in `git status`.
- Added a regression test for the modern `bun.lock` path alongside the existing `bun.lockb` one.

## Test plan
- [x] `node tests/lib/package-manager.test.js` — 116/116 pass (was 115, added 1 new test)
- [x] `node tests/run-all.js` — 3111/3111 pass