### PR TITLE
docs(codex): warn that mutating CLI commands reformat config.toml

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,6 +8,11 @@
 # Official docs:
 # - https://developers.openai.com/codex/config-reference
 # - https://developers.openai.com/codex/multi-agent
+#
+# Caution: mutating Codex CLI subcommands (e.g. `codex mcp add`) rewrite this
+# file in place and strip comments/formatting when they persist a change. Add
+# personal MCP servers or local overrides to your own ~/.codex/config.toml
+# instead of editing this project-local template with those commands.
 
 # Model selection
 # Leave `model` and `model_provider` unset so Codex CLI uses its current
@@ -86,6 +91,10 @@ startup_timeout_sec = 30
 # [mcp_servers.cloudflare]
 # command = "npx"
 # args = ["-y", "@cloudflare/mcp-server-cloudflare"]
+#
+# [mcp_servers.chrome-devtools]
+# command = "npx"
+# args = ["-y", "chrome-devtools-mcp@latest"]
 
 [features]
 # Codex multi-agent collaboration is stable and on by default in current builds.


### PR DESCRIPTION
## Summary
`.codex/config.toml` kept showing up as locally modified with no intentional edit behind it: running a mutating Codex CLI subcommand (e.g. `codex mcp add chrome-devtools ...`) rewrites the file in place, stripping every comment and reflowing the TOML formatting — pure tool-driven drift on whoever's machine ran the command, not a real change.

- Added a caution note in the header directing personal MCP servers and local overrides to the user's own `~/.codex/config.toml` instead of editing this project-local template with mutating CLI commands.
- Added `chrome-devtools` as a new commented-out optional entry alongside the existing `supabase`/`firecrawl`/`fal-ai`/`cloudflare` examples — it's a genuinely useful MCP server worth documenting the same way as its siblings.

Diff is a comment-only addition — 9 lines, no functional config changes.

## Test plan
- [x] `node tests/codex-config.test.js` — 5/5 pass
- [x] Parsed the file with `@iarna/toml` to confirm it's still valid TOML and `chrome-devtools` stays inert (commented out, not a parsed table)
- [x] `node tests/run-all.js` — 3110/3110 pass