### PR TITLE
fix(config-protection): match protected filenames case-insensitively

### DIFF
--- a/scripts/hooks/config-protection.js
+++ b/scripts/hooks/config-protection.js
@@ -94,7 +94,14 @@ function run(inputOrRaw, options = {}) {
   if (!filePath) return { exitCode: 0 };
 
   const basename = path.basename(filePath);
-  if (PROTECTED_FILES.has(basename)) {
+  // Match case-insensitively. Every PROTECTED_FILES entry is lowercase, and on
+  // case-insensitive filesystems (macOS APFS/HFS+, Windows NTFS) a write to
+  // `.ESLINTRC.JS` lands on the very same inode as `.eslintrc.js`. A
+  // case-sensitive Set lookup therefore let a single case-variant Write
+  // silently overwrite the real config while the guard returned exit 0.
+  // On genuinely case-sensitive filesystems this only costs a false positive
+  // on a distinct file that differs from a protected name by case alone.
+  if (PROTECTED_FILES.has(basename) || PROTECTED_FILES.has(basename.toLowerCase())) {
     // Allow first-time creation — there's no existing config to weaken.
     // The hook's purpose is blocking modifications; writing a brand-new
     // config file in a project that has none is a legitimate bootstrap

--- a/tests/hooks/config-protection.test.js
+++ b/tests/hooks/config-protection.test.js
@@ -234,10 +234,52 @@ function runTests() {
         const result = runHook(input);
         assert.strictEqual(result.code, 2, `Expected exit 2 for dangling symlink, got ${result.code}; stderr: ${result.stderr}`);
         assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
-        assert.ok(
-          result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'),
-          `Expected block message, got: ${result.stderr}`
-        );
+        assert.ok(result.stderr.includes('BLOCKED: Modifying .eslintrc.js is not allowed.'), `Expected block message, got: ${result.stderr}`);
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('blocks case-variant writes that resolve to an existing protected config', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-config-protect-'));
+      try {
+        const realPath = path.join(tmpDir, '.eslintrc.js');
+        const variantPath = path.join(tmpDir, '.ESLINTRC.JS');
+        fs.writeFileSync(realPath, 'module.exports = { rules: { "no-explicit-any": "error" } };');
+
+        // Only meaningful on a case-insensitive filesystem (macOS APFS/HFS+,
+        // Windows NTFS), where the uppercase path is the SAME inode. On a
+        // case-sensitive filesystem the variant is a genuinely different file
+        // and the write is harmless, so skip rather than assert.
+        let sameFile = false;
+        try {
+          sameFile = fs.lstatSync(variantPath).ino === fs.lstatSync(realPath).ino;
+        } catch {
+          sameFile = false;
+        }
+        if (!sameFile) {
+          console.log('    (skipped: case-sensitive filesystem)');
+          return;
+        }
+
+        const result = runHook({
+          tool_name: 'Write',
+          tool_input: {
+            file_path: variantPath,
+            content: 'module.exports = { rules: {} }; // WEAKENED'
+          }
+        });
+
+        assert.strictEqual(result.code, 2, `Case-variant write must be blocked: it overwrites ${path.basename(realPath)} on this filesystem. Got ${result.code}; stderr: ${result.stderr}`);
+        assert.strictEqual(result.stdout, '', 'Blocked hook should not echo raw input');
       } finally {
         try {
           fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## The bug

On a case-insensitive filesystem (macOS APFS/HFS+, Windows NTFS), a write to `.ESLINTRC.JS` lands on the **same inode** as `.eslintrc.js`. But `config-protection.js:97` looked the basename up with a case-sensitive `Set.has`:

```js
if (PROTECTED_FILES.has(basename)) {
```

Every entry in `PROTECTED_FILES` is lowercase, so a case-variant path missed the branch entirely and the hook returned exit 0. **One `Write` silently overwrote a live config while the guard reported success.**

Reproduced on macOS APFS:

```
402669136 .eslintrc.js
402669136 .ESLINTRC.JS      <- same inode

exit=2  BLOCKED  .eslintrc.js
exit=0  allowed  .ESLINTRC.JS    <- overwrites the real config
exit=0  allowed  .Eslintrc.js
```

After the uppercase write, `cat .eslintrc.js` returned the weakened contents and `ls -a | grep -i eslintrc` showed a single file.

This is a **one-step bypass of the entire guard**, needing no shell access — unlike the delete-then-recreate route, which requires Bash and two steps.

## The fix

Also test `basename.toLowerCase()`. All 32 `PROTECTED_FILES` entries are already lowercase, so the fallback is exact. On a genuinely case-sensitive filesystem the only cost is a false positive on a distinct file differing from a protected name by case alone — which seems clearly the right side to err on for a guard like this.

**Deliberately unchanged:** first-time creation is still allowed (the documented bootstrap affordance for `eslint --init` in a fresh repo), non-config paths still pass through, and the `lstat`/ENOENT fail-closed semantics are untouched.

## Verification

Proven in **both** directions, since a guard only ever observed passing isn't a proven guard:

| | result |
|---|---|
| New test vs **unpatched** hook | ✗ fails — `Got 0; 0 !== 2` |
| New test vs **patched** hook | ✓ passes |
| Full suite | **9/9 passed, 0 failed** |

Live end-to-end after the fix:

```
exit=2  BLOCKED  .eslintrc.js
exit=2  BLOCKED  .ESLINTRC.JS
exit=2  BLOCKED  .Eslintrc.js
exit=0  allowed  src/app.ts
exit=0  allowed  README.md
```

Bootstrap path confirmed intact: `eslint.config.MJS` returns exit 0 when no config exists, exit 2 when `eslint.config.mjs` is present.

The new test guards itself with an inode comparison and skips on case-sensitive filesystems rather than asserting something untrue there, so it stays honest in CI on Linux.

## Note

`scripts/hooks/config-protection.js` and `tests/hooks/config-protection.test.js` are byte-identical between `5b173d2` and current `main`, so this applies cleanly.