### PR TITLE
fix: instinct promote leaves orphaned project-scoped copy

### DIFF
--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -1327,8 +1327,14 @@ def _remove_instinct_from_source(source_file_str: str, instinct_id: str) -> None
     if not source_file.exists():
         return
 
-    remaining = [i for i in parse_instinct_file(source_file.read_text(encoding="utf-8"))
-                 if i.get('id') != instinct_id]
+    parsed = parse_instinct_file(source_file.read_text(encoding="utf-8"))
+    if not any(i.get('id') == instinct_id for i in parsed):
+        # Target not found in a successful parse - either already removed, or the
+        # file is malformed/foreign content. Either way, don't touch it: a parse
+        # failure must never be treated as proof the file is safe to delete.
+        return
+
+    remaining = [i for i in parsed if i.get('id') != instinct_id]
 
     if not remaining:
         source_file.unlink()

--- a/skills/continuous-learning-v2/scripts/instinct-cli.py
+++ b/skills/continuous-learning-v2/scripts/instinct-cli.py
@@ -1314,6 +1314,39 @@ def _show_promotion_candidates(project: dict) -> None:
         print(f"  Run `instinct-cli.py promote` to promote these to global scope.\n")
 
 
+def _remove_instinct_from_source(source_file_str: str, instinct_id: str) -> None:
+    """Strip one instinct block from its project-scoped source file after promotion.
+
+    Without this, the project copy keeps shadowing the new global copy in
+    load_all_instincts()'s dedup (project wins on ID collision), so `status`
+    silently under-reports the global count until the stale copy is removed by hand.
+    Deletes the file if it was the only instinct in it, otherwise rewrites the
+    remaining blocks in the same frontmatter format.
+    """
+    source_file = Path(source_file_str)
+    if not source_file.exists():
+        return
+
+    remaining = [i for i in parse_instinct_file(source_file.read_text(encoding="utf-8"))
+                 if i.get('id') != instinct_id]
+
+    if not remaining:
+        source_file.unlink()
+        return
+
+    blocks = []
+    for inst in remaining:
+        block = "---\n"
+        for key, value in inst.items():
+            if key == 'content' or key.startswith('_'):
+                continue
+            block += f"{key}: {_yaml_quote(value) if key == 'trigger' else value}\n"
+        block += "---\n\n"
+        block += inst.get('content', '') + "\n"
+        blocks.append(block)
+    source_file.write_text("\n".join(blocks), encoding="utf-8")
+
+
 def cmd_promote(args) -> int:
     """Promote project-scoped instincts to global scope."""
     project = detect_project()
@@ -1376,6 +1409,11 @@ def _promote_specific(project: dict, instinct_id: str, force: bool, dry_run: boo
     output_content += target.get('content', '') + "\n"
 
     output_file.write_text(output_content, encoding="utf-8")
+
+    source_file = target.get('_source_file')
+    if source_file:
+        _remove_instinct_from_source(source_file, instinct_id)
+
     print(f"\nPromoted '{instinct_id}' to global scope.")
     print(f"  Saved to: {output_file}")
     return 0
@@ -1449,6 +1487,12 @@ def _promote_auto(project: dict, force: bool, dry_run: bool) -> int:
         output_content += inst.get('content', '') + "\n"
 
         output_file.write_text(output_content, encoding="utf-8")
+
+        for _, _, entry_inst in cand['entries']:
+            entry_source = entry_inst.get('_source_file')
+            if entry_source:
+                _remove_instinct_from_source(entry_source, cand['id'])
+
         promoted += 1
 
     print(f"\nPromoted {promoted} instincts to global scope.")


### PR DESCRIPTION
## Summary
- `instinct promote <id>` (and the auto cross-project variant) writes the promoted instinct into the global personal dir but never removes it from the project-scoped source file it came from.
- `load_all_instincts()` dedupes by ID with project-scope taking precedence over global on collision, so the leftover project copy silently shadows the new global entry - `status` under-reports the global count (and shows the instinct as still project-scoped) until the stale file is deleted by hand.
- Reproduced by importing a multi-instinct file, promoting one ID by hand, and diffing `status` output before/after manually removing the stale source file.

## Fix
- Adds `_remove_instinct_from_source()`: re-parses the instinct's source file, strips just the promoted block, rewrites the remaining blocks in the same frontmatter format, or deletes the file outright if it was the only instinct in it.
- Wired into `_promote_specific` (single-ID promote).
- Wired into `_promote_auto` as well - it iterates every project entry that contributed to the cross-project candidate, not just the highest-confidence one used for the merged output content, since each project's copy independently shadows the same global ID.

## Test plan
- [x] `py_compile` on the patched file
- [x] Isolated smoke test (`CLV2_HOMUNCULUS_DIR` pointed at a temp dir): imported a 2-instinct file into a scratch git repo, promoted one ID, confirmed the promoted instinct disappears from project scope and appears under global in `status`, while the un-promoted sibling in the same source file survives untouched
- [ ] Maintainers: no existing automated test coverage found for `_promote_specific`/`_promote_auto`; happy to add one if there's a preferred harness/location for `instinct-cli.py` tests