### PR TITLE
fix(marketplace): use object source so Claude Cowork remote sync succeeds (#2542)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,10 @@
   "plugins": [
     {
       "name": "ecc",
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "affaan-m/ECC"
+      },
       "description": "Harness-native ECC operator layer - 67 agents, 281 skills, 94 legacy command shims, reusable hooks, rules, selective install profiles, and production-ready workflows for Claude Code, Codex, OpenCode, Cursor, and related agent harnesses",
       "version": "2.1.0",
       "author": {

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -250,6 +250,20 @@ test('claude marketplace.json plugin version matches package.json', () => {
   assert.strictEqual(claudeMarketplace.plugins[0].version, expectedVersion);
 });
 
+test('claude marketplace.json plugin source is a remote-sync object, not a string (#2542)', () => {
+  // Claude Cowork's REMOTE marketplace sync (server-side clone) rejects string
+  // sources such as "./" with:
+  //   External plugin sources must be objects with a 'source' field
+  //   (github, url, or git-subdir).
+  // Local `/plugin marketplace add` tolerates the string shorthand, which is why
+  // the CLI succeeds while Cowork fails. Keep the object form so remote sync works.
+  const src = claudeMarketplace.plugins[0].source;
+  assert.ok(src && typeof src === 'object' && !Array.isArray(src), `Expected plugins[0].source to be an object, got: ${JSON.stringify(src)}`);
+  // Assert the exact expected remote-sync object so an incomplete/partial object
+  // form (missing `repo`, wrong `source`, or extra keys) cannot satisfy the test.
+  assert.deepStrictEqual(src, { source: 'github', repo: 'affaan-m/ECC' }, `Expected plugins[0].source to be exactly { source: 'github', repo: 'affaan-m/ECC' }, got: ${JSON.stringify(src)}`);
+});
+
 // ── Codex plugin manifest ─────────────────────────────────────────────────────
 // Per official docs: https://platform.openai.com/docs/codex/plugins
 // - .codex-plugin/plugin.json is the required manifest


### PR DESCRIPTION
Fixes #2542

## What Changed

`.claude-plugin/marketplace.json` — the single plugin entry's `source` changes
from the string `"./"` to the object form:

```json
"source": { "source": "github", "repo": "affaan-m/ECC" }
```

Plus a regression assertion in `tests/plugin-manifest.test.js`.

## Why This Change

Adding the ECC marketplace in Claude Desktop (CoWork) fails with:

> Marketplace Sync failed. Check the repository-URL and try again.

The manifest itself is not broken: a local `/plugin marketplace add
affaan-m/ECC` (and `https://github.com/affaan-m/ECC`) in the Claude Code CLI
**succeeds**, and `claude plugin validate .claude-plugin/marketplace.json`
passes. The failure is specific to CoWork's **remote** sync, which clones the
repo server-side and validates with a stricter rule. Its logs
(`~/Library/Logs/Claude/claude.ai-web.log`) report:

```
MARKETPLACE_ERROR:REMOTE_SYNC_FAILED [remoteMarketplaceOps] sync did not succeed
(status: failed_content): {"plugins":[{"name":"ecc","error":"External plugin
sources must be objects with a 'source' field (github, url, or git-subdir)."}]}
```

Remote sync rejects **string/relative** plugin sources; it requires each
plugin's `source` to be an **object** whose `source` field is one of `github`,
`url`, or `git-subdir`. The local CLI tolerates the `"./"` shorthand — which is
exactly why the CLI works while CoWork does not. The ECC plugin lives at the
repository root, so `github` (whole-repo) is the correct object source; no
`path`/`git-subdir` is needed.

This is the same class of fix applied for Codex in #2128 (which moved
`.agents/plugins/marketplace.json` off a `"./"` root source), now applied to the
Claude manifest. Confirmed against the same failure/fix pattern reported in
other plugin repos (e.g. `Kntnt/kntnt-text-skills#46`, `Kntnt/kntnt-code-skills#11`).

## Testing Done

- `node tests/plugin-manifest.test.js` → 64 passed (incl. new `#2542`
  source-shape assertion and all existing marketplace/version assertions).
- `node tests/docs/install-identifiers.test.js` → 26 passed.
- `node scripts/ci/validate-install-manifests.js` → OK.
- `node tests/ci/validators.test.js` → 166 passed.
- `claude plugin validate .claude-plugin/marketplace.json` → Validation passed.
- Regression (local CLI, isolated `CLAUDE_CONFIG_DIR`):
  `claude plugin marketplace add <clone>` → Successfully added; then
  `claude plugin install ecc@ecc` → Successfully installed. No regression to the
  local add/install path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Security & Quality Checklist

- [x] Change is limited to a manifest field + a test assertion; no executable
  code paths touched.
- [x] All other manifest fields unchanged (name, version, description, author,
  keywords, category, tags, strict).
- [x] No secrets, tokens, or new dependencies introduced.
- [x] Object source pins to public GitHub coordinates matching this repo.

## Documentation

No docs change required — install identifiers (`ecc@ecc`) and the documented
`/plugin marketplace add https://github.com/affaan-m/ECC` flow are unchanged;
only the resolution shape used by CoWork's remote sync is corrected. Existing
`install-identifiers` doc tests remain green.