### PR TITLE
feat(skills): add Solana + multi-network x402 via upstream x402 packages

### DIFF
--- a/docs/ja-JP/skills/agent-payment-x402/SKILL.md
+++ b/docs/ja-JP/skills/agent-payment-x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-payment-x402
-description: タスクごとのバジェット、支出コントロール、ノンカストディアルウォレットを備えた x402 決済実行を AI エージェントに追加します。agentwallet-sdk を通じて Base をサポートし、OKX Payments / OKX エージェント決済プロトコルを通じて X Layer をサポートします。
+description: タスクごとのバジェット、支出コントロール、ノンカストディアルウォレットを備えた x402 決済実行を AI エージェントに追加します。agentwallet-sdk を通じて Base を、OKX Payments / OKX エージェント決済プロトコルを通じて X Layer を、PayAI ファシリテーターを通じてガスレスな USDC 決済で Solana をサポートします。
 origin: community
 ---
 
@@ -20,6 +20,8 @@ origin: community
 |------|------------------|
 | エージェントが Base または他の agentwallet 対応チェーンの 402 ゲート API に支払う | 厳格な支出ポリシーで `agentwallet-sdk` を MCP 決済サーバーとして使用 |
 | エージェントが X Layer の 402 ゲート API に支払う | `okx/onchainos-skills` の OKX エージェント決済プロトコルを使用；`okx-x402-payment` は廃止されたレガシーエイリアス |
+| エージェントが Solana の 402 ゲート API に支払う | エージェントの HTTP クライアント（Fetch、Axios、または httpx）を exact-SVM スキームと Solana 署名者でラップし、PayAI ファシリテーター経由で決済する；支払い可能なリソースは PayAI バザールで発見する |
+| API が Solana でエージェントに課金する（TypeScript、Python、または Go） | `@payai/facilitator` をバックエンドとする x402 ミドルウェアを追加 — Express/Hono/Next.js は `@x402/*`、FastAPI は `x402`、Gin は `coinbase/x402/go` |
 | TypeScript API がエージェントに課金する | Express、Hono、Fastify、または Next.js 向け OKX Payments TypeScript セラー SDK ドキュメントを使用 |
 | Go API がエージェントに課金する | Gin、Echo、または `net/http` 向け OKX Payments Go セラー SDK ドキュメントを使用 |
 | Rust API がエージェントに課金する | Axum 向け OKX Payments Rust セラー SDK ドキュメントを使用 |
@@ -30,6 +32,7 @@ origin: community
 
 - `agentwallet-sdk`: 本番使用前に現在のネットワークカバレッジをパッケージドキュメントで確認。Base Sepolia が最も安全な開発デフォルト；Base メインネットがオリジナルスキルで説明されている本番パス。
 - OKX Payments / X Layer: 現在のセラードキュメントは X Layer（`eip155:196`）と USDT0 決済を対象。決済パッケージとファシリテーターの動作が迅速に変わる可能性があるため、本番コードを生成する前に現在の SDK ドキュメントを取得すること。
+- PayAI ファシリテーター / Solana: Solana メインネット（`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`）と Solana デブネット（`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`）で USDC を決済。ファシリテーターがネットワーク手数料を負担するため、支払者は USDC のみを保有すればよく、ガス用の SOL は不要。開発デフォルトは Solana デブネット、本番は Solana メインネットを使用。ファシリテーターはマルチネットワーク対応で複数の EVM チェーンもフロントするため、本番前にここにハードコードするのではなく `/supported` エンドポイントでライブリストを確認すること。
 
 ## 仕組み
 
@@ -97,6 +100,57 @@ X Layer x402、マルチパーティ決済（MPP）、セッション決済、�
 | Java | `https://raw.githubusercontent.com/okx/payments/main/java/SELLER.md` |
 
 現在の OKX リポジトリを確認せずに古いドキュメントの例をコピーしないこと。現在の OKX ガイダンスはディスパッチャーとして `okx-agent-payments-protocol` を使用しており、Java セラードキュメントが利用可能になっています。
+
+### オプション C: PayAI ファシリテーター（Solana）
+
+エージェントが Solana で決済する 402 ゲート API に支払う場合にこのパスを使用します。オプション A・B と異なり、Solana のバイヤーフローは別個の MCP サーバーではありません — エージェント自身の HTTP クライアントを x402 インターセプターでラップし、USDC 転送に署名して [PayAI ファシリテーター](https://facilitator.payai.network) に検証・決済させます。ファシリテーターが手数料支払者となるため、エージェントは USDC のみを消費し、ガス用の SOL は不要です。
+
+**バイヤー側（エージェントが支払う）。** exact-SVM スキームと Solana 署名者で `fetch` をラップします（`@x402/axios` 経由の Axios と `x402` パッケージ経由の Python `httpx` も同じ形です）：
+
+```typescript
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { registerExactSvmScheme } from "@x402/svm/exact/client";
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { base58 } from "@scure/base";
+
+// 署名者のキーはオーケストレーターの env に属する — ハードコードせず、エージェントが書き込めないようにする。
+const svmKey = process.env.SVM_PRIVATE_KEY;
+if (!svmKey) {
+  throw new Error("SVM_PRIVATE_KEY is not set — refusing to start payment client");
+}
+
+const client = new x402Client();
+registerExactSvmScheme(client, {
+  signer: await createKeyPairSignerFromBytes(base58.decode(svmKey)),
+});
+
+// ラップする前にすべての有料呼び出しをフェイルクローズドでゲートする — タスクごと/セッションごとの
+// バジェットと許可リストのホストを、Examples セクションの preToolCheck と同様に強制する。
+await assertWithinBudget({ cost: 0.01, host: "api.example.com" });
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const res = await fetchWithPayment("https://api.example.com/data", { method: "GET" });
+```
+
+ラップされたクライアントは、`network` が登録済みの Solana CAIP-2 id であり、`asset` が期待する USDC ミントであり、`amount` がゲートした価格以内であるチャレンジのみに支払います。不一致はフェイルクローズドとして扱う：署名せず、リトライしない。
+
+**発見。** エンドポイントをハードコードする代わりに、PayAI バザールで支払い可能な Solana リソースを見つけます：
+
+```bash
+curl -s 'https://facilitator.payai.network/discovery/resources' | jq '.'
+```
+
+**セラー側（API がエージェントに課金する）。** `@payai/facilitator` をバックエンドとする x402 ミドルウェアを追加します。各スターターは動作する Solana サーバーまたはクライアントをスキャフォールドします；本番では `@latest` を追うのではなくバージョンを固定すること：
+
+| ランタイム | スキャフォールド |
+|---------|----------|
+| Express サーバー | `npx @payai/x402-express-starter@latest my-server` |
+| Hono サーバー | `npx @payai/x402-hono-starter@latest my-server` |
+| Next.js フルスタック | `npx @payai/x402-next-starter@latest my-app` |
+| Fetch クライアント | `npx @payai/x402-fetch-starter@latest my-client` |
+| Axios クライアント | `npx @payai/x402-axios-starter@latest my-client` |
+
+実際のマーチャントにエージェントを向ける前に、[x402.payai.network](https://x402.payai.network) の PayAI Echo Merchant に対して無料でエンドツーエンドのテストを行ってください — Solana デブネットとメインネットのパスを公開し、トークンを返金し、手数料を負担します。
 
 ## 例
 
@@ -212,7 +266,8 @@ main().catch((err) => {
 - **監査証跡**: タスク後のフックで `list_transactions` を使用して何が使われたかをログに記録する。
 - **フェイルクローズド**: 決済ツールに到達できない場合、有料アクションをブロックする — 課金されないアクセスにフォールバックしない。
 - **security-review と組み合わせる**: 決済ツールは高い権限を持つ。シェルアクセスと同じ精査を適用する。
-- **まずテストネットでテストする**: 開発には Base Sepolia を使用；本番には Base メインネットに切り替える。
+- **まずテストネットでテストする**: 開発には Base Sepolia を使用；本番には Base メインネットに切り替える。Solana では、メインネットの前に Solana デブネット（`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`）と無料の PayAI Echo Merchant を使用する。
+- **Solana では SOL ではなく USDC を資金として入れる**: PayAI ファシリテーターがネットワーク手数料を負担するため、SOL を持たないウォレットでも支払える。署名前に各チャレンジの `asset` が期待する USDC ミントであることを検証する — 任意のアセットに支払うラップクライアントはバジェットの穴になる。
 
 ## 本番リファレンス
 
@@ -222,3 +277,7 @@ main().catch((err) => {
 - **OKX Payments SDK**: [`okx/payments`](https://github.com/okx/payments) — X Layer x402 向け TypeScript、Go、Rust、Java セラー統合
 - **OKX エージェント決済プロトコルスキル**: [`okx/onchainos-skills`](https://github.com/okx/onchainos-skills/tree/main/skills/okx-agent-payments-protocol)
 - **OKX Payments 概要**: [web3.okx.com/onchainos/dev-docs/payments/overview](https://web3.okx.com/onchainos/dev-docs/payments/overview)
+- **PayAI ファシリテーター（Solana x402）**: [facilitator.payai.network](https://facilitator.payai.network) — ガスレスな Solana USDC 決済を備えたマルチネットワークファシリテーター；`/discovery/resources` にライブリソースバザール
+- **PayAI ドキュメント**: [docs.payai.network](https://docs.payai.network)
+- **PayAI スターターと Echo Merchant**: [npm の `@payai`](https://www.npmjs.com/org/payai)；[x402.payai.network](https://x402.payai.network) で無料のエンドツーエンドテスト
+- **GitHub の PayAI**: [`PayAINetwork`](https://github.com/PayAINetwork)

--- a/docs/zh-CN/skills/agent-payment-x402/SKILL.md
+++ b/docs/zh-CN/skills/agent-payment-x402/SKILL.md
@@ -1,41 +1,61 @@
 ---
 name: agent-payment-x402
-description: 将 x402 支付执行添加到 AI 代理中——通过 MCP 工具实现每任务预算、支出控制和非托管钱包。当代理需要为 API、服务或其他代理付费时使用。
+description: 将 x402 支付执行添加到 AI 代理中，具备每任务预算、支出控制和非托管钱包。通过 agentwallet-sdk 支持 Base，通过 OKX Payments / OKX 代理支付协议支持 X Layer，并通过 PayAI 结算器以无 gas 的 USDC 结算支持 Solana。
 origin: community
 ---
 
 # 代理支付执行 (x402)
 
-让AI代理能够自主支付并内置消费控制。使用x402 HTTP支付协议和MCP工具，使代理能够为外部服务、API或其他代理支付，无需托管风险。
+让 AI 代理能够进行策略门控的支付并内置支出控制。使用 x402 HTTP 支付协议和 MCP 工具，使代理能够为外部服务、API 或其他代理付费，无托管风险。
 
 ## 使用场景
 
-适用于：代理需要支付API调用、购买服务、与其他代理结算、强制执行每项任务消费限额，或管理非托管钱包。与成本感知LLM流水线和安全审查技能自然搭配。
+适用于：代理需要支付 API 调用、购买服务、与其他代理结算、强制执行每任务支出限额，或管理非托管钱包。与 cost-aware-llm-pipeline 和 security-review 技能自然搭配。
+
+## 决策树
+
+根据代理是购买对付费 API 的访问权，还是向他人收费，选择集成路径：
+
+| 需求 | 推荐路径 |
+|------|------------------|
+| 代理为 Base 或其他 agentwallet 支持链上的 402 门控 API 付费 | 使用 `agentwallet-sdk` 作为 MCP 支付服务器，并配置严格的支出策略 |
+| 代理为 X Layer 上的 402 门控 API 付费 | 使用 `okx/onchainos-skills` 中的 OKX 代理支付协议；`okx-x402-payment` 是已弃用的旧别名 |
+| 代理为 Solana 上的 402 门控 API 付费 | 用 exact-SVM 方案和 Solana 签名者包装代理的 HTTP 客户端（Fetch、Axios 或 httpx），通过 PayAI 结算器结算；通过 PayAI 集市发现可付费资源 |
+| API 在 Solana 上向代理收费（TypeScript、Python 或 Go） | 添加以 `@payai/facilitator` 为后端的 x402 中间件 —— Express/Hono/Next.js 用 `@x402/*`，FastAPI 用 `x402`，Gin 用 `coinbase/x402/go` |
+| TypeScript API 向代理收费 | 使用面向 Express、Hono、Fastify 或 Next.js 的 OKX Payments TypeScript 卖家 SDK 文档 |
+| Go API 向代理收费 | 使用面向 Gin、Echo 或 `net/http` 的 OKX Payments Go 卖家 SDK 文档 |
+| Rust API 向代理收费 | 使用面向 Axum 的 OKX Payments Rust 卖家 SDK 文档 |
+| Java API 向代理收费 | 使用面向 Spring Boot 2/3、Java EE 或 Jakarta 的 OKX Payments Java 卖家 SDK 文档 |
+| Python API 向代理收费 | 实现前先检查当前 OKX Payments 仓库；可能尚无 Python 卖家指南 |
+
+## 支持的网络
+
+- `agentwallet-sdk`：在生产使用前，通过包文档确认当前网络覆盖范围。Base Sepolia 是最安全的开发默认值；Base 主网是原始技能所述的生产路径。
+- OKX Payments / X Layer：当前卖家文档面向 X Layer（`eip155:196`）和 USDT0 结算。由于支付包和结算器行为可能快速变化，生成生产代码前请获取当前 SDK 文档。
+- PayAI 结算器 / Solana：在 Solana 主网（`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`）和 Solana 开发网（`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`）上结算 USDC。结算器承担网络费用，因此付款方只需持有 USDC，无需 SOL 支付 gas。开发默认使用 Solana 开发网，生产使用 Solana 主网。该结算器支持多网络，也承接若干 EVM 链；生产前请在其 `/supported` 端点确认实时列表，而不要在此硬编码。
 
 ## 工作原理
 
-### x402协议
+### x402 协议
+x402 将 HTTP 402（需要付款）扩展为机器可协商的流程。当服务器返回 `402` 时，代理的支付工具会协商价格、检查预算、签署交易，并仅在编排器设定的策略与确认边界内重试。
 
-x402将HTTP 402（需要付款）扩展为机器可协商的流程。当服务器返回`402`时，代理的支付工具会自动协商价格、检查预算、签署交易并重试——无需人工干预。
-
-### 消费控制
-
-每次支付工具调用都会强制执行`SpendingPolicy`：
-
-* **每任务预算** — 单次代理操作的最大支出
-* **每会话预算** — 整个会话的累计限额
-* **白名单接收方** — 限制代理可支付的地址/服务
-* **速率限制** — 每分钟/小时的最大交易数
+### 支出控制
+每次支付工具调用都会强制执行 `SpendingPolicy`：
+- **每任务预算** — 单次代理操作的最大支出
+- **每会话预算** — 整个会话的累计限额
+- **白名单接收方** — 限制代理可支付的地址/服务
+- **速率限制** — 每分钟/小时的最大交易数
 
 ### 非托管钱包
+代理通过 ERC-4337 智能账户持有自己的密钥。编排器在委托前设置策略；代理只能在限定范围内支出。无资金池，无托管风险。
 
-代理通过ERC-4337智能账户持有自己的密钥。编排器在委托前设置策略；代理只能在限定范围内支出。无资金池，无托管风险。
+## MCP 集成
 
-## MCP集成
+支付层暴露标准 MCP 工具，可无缝接入任何 Claude Code 或代理框架设置。
 
-支付层暴露标准MCP工具，可无缝接入任何Claude Code或代理框架设置。
+> **安全提示**：务必锁定包版本。此工具管理私钥——未锁定的 `npx` 安装会引入供应链风险。
 
-> **安全提示**：务必锁定包版本。此工具管理私钥——未锁定的`npx`安装会引入供应链风险。
+### 选项 A：agentwallet-sdk（Base / 多链）
 
 ```json
 {
@@ -53,19 +73,92 @@ x402将HTTP 402（需要付款）扩展为机器可协商的流程。当服务�
 | 工具 | 用途 |
 |------|---------|
 | `get_balance` | 检查代理钱包余额 |
-| `send_payment` | 向地址或ENS发送付款 |
+| `send_payment` | 向地址或 ENS 发送付款 |
 | `check_spending` | 查询剩余预算 |
 | `list_transactions` | 所有付款的审计追踪 |
 
-> **注意**：消费策略由**编排器**在委托给代理之前设置——而非代理本身。这防止代理自行提高消费限额。通过编排层或任务前钩子中的`set_policy`配置策略，切勿将其作为代理可调用工具。
+> **注意**：支出策略由**编排器**在委托给代理之前设置——而非代理本身。这可防止代理自行提高支出限额。通过编排层或任务前钩子中的 `set_policy` 配置策略，切勿将其作为代理可调用工具。
+
+### 选项 B：OKX 代理支付协议（X Layer）
+
+将此路径用于 X Layer x402、多方支付（MPP）、会话支付、收费和 A2A 收费流程。
+
+对于买方代理流程：
+
+1. 安装或引用当前的 `okx/onchainos-skills` 仓库。
+2. 使用 `skills/okx-agent-payments-protocol/SKILL.md` 作为调度器。
+3. 将 `skills/okx-x402-payment/SKILL.md` 视为已弃用的兼容别名，而非规范技能。
+4. 在钱包状态检查或支付操作前要求明确的用户确认。不要将支付执行隐藏在通用工具调用之后。
+
+对于卖方 API 流程，生成代码前先获取最新的语言专用指南：
+
+| 运行时 | 当前指南 |
+|---------|---------------|
+| TypeScript | `https://raw.githubusercontent.com/okx/payments/main/typescript/SELLER.md` |
+| Go | `https://raw.githubusercontent.com/okx/payments/main/go/x402/SELLER.md` |
+| Rust | `https://raw.githubusercontent.com/okx/payments/main/rust/x402/SELLER.md` |
+| Java | `https://raw.githubusercontent.com/okx/payments/main/java/SELLER.md` |
+
+不要在未检查当前 OKX 仓库的情况下复制旧文档中的示例。当前 OKX 指南使用 `okx-agent-payments-protocol` 作为调度器，且 Java 卖家文档现已可用。
+
+### 选项 C：PayAI 结算器（Solana）
+
+当代理为在 Solana 上结算的 402 门控 API 付费时，使用此路径。与选项 A 和 B 不同，Solana 的买方流程不是独立的 MCP 服务器——你用 x402 拦截器包装代理自己的 HTTP 客户端，由它签署 USDC 转账，并让 [PayAI 结算器](https://facilitator.payai.network) 验证并结算。结算器是费用支付方，因此代理只消耗 USDC，无需 SOL 支付 gas。
+
+**买方侧（代理付费）。** 用 exact-SVM 方案和 Solana 签名者包装 `fetch`（通过 `@x402/axios` 的 Axios 和通过 `x402` 包的 Python `httpx` 形式相同）：
+
+```typescript
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { registerExactSvmScheme } from "@x402/svm/exact/client";
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { base58 } from "@scure/base";
+
+// The signer key belongs to the ORCHESTRATOR's env — never hardcoded, never agent-writable.
+const svmKey = process.env.SVM_PRIVATE_KEY;
+if (!svmKey) {
+  throw new Error("SVM_PRIVATE_KEY is not set — refusing to start payment client");
+}
+
+const client = new x402Client();
+registerExactSvmScheme(client, {
+  signer: await createKeyPairSignerFromBytes(base58.decode(svmKey)),
+});
+
+// Gate every paid call fail-closed BEFORE wrapping — enforce per-task / per-session
+// budget and an allowlisted host, exactly like preToolCheck in the Examples section.
+await assertWithinBudget({ cost: 0.01, host: "api.example.com" });
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const res = await fetchWithPayment("https://api.example.com/data", { method: "GET" });
+```
+
+包装后的客户端只会支付满足以下条件的挑战：`network` 是你注册的 Solana CAIP-2 id，`asset` 是预期的 USDC 铸币地址，且 `amount` 在你门控的价格之内。任何不匹配都按故障关闭处理：不签署，不重试。
+
+**发现。** 通过 PayAI 集市发现可付费的 Solana 资源，而不是硬编码端点：
+
+```bash
+curl -s 'https://facilitator.payai.network/discovery/resources' | jq '.'
+```
+
+**卖方侧（API 向代理收费）。** 添加以 `@payai/facilitator` 为后端的 x402 中间件。每个 starter 都会脚手架出一个可用的 Solana 服务器或客户端；生产环境请锁定版本，而不要追踪 `@latest`：
+
+| 运行时 | 脚手架 |
+|---------|----------|
+| Express 服务器 | `npx @payai/x402-express-starter@latest my-server` |
+| Hono 服务器 | `npx @payai/x402-hono-starter@latest my-server` |
+| Next.js 全栈 | `npx @payai/x402-next-starter@latest my-app` |
+| Fetch 客户端 | `npx @payai/x402-fetch-starter@latest my-client` |
+| Axios 客户端 | `npx @payai/x402-axios-starter@latest my-client` |
+
+在将代理指向真实商户之前，先对 [x402.payai.network](https://x402.payai.network) 的 PayAI Echo Merchant 进行免费的端到端测试——它暴露 Solana 开发网和主网路径，退还代币并承担费用。
 
 ## 示例
 
-### MCP客户端中的预算执行
+### MCP 客户端中的预算执行
 
-在构建调用agentpay MCP服务器的编排器时，在分派付费工具调用前强制执行预算。
+在构建调用 agentpay MCP 服务器的编排器时，在分派付费工具调用前强制执行预算。
 
-> **前提条件**：在添加MCP配置前安装包——`npx`不带`-y`会在非交互环境中提示确认，导致服务器挂起：`npm install -g agentwallet-sdk@6.0.0`
+> **前提条件**：在添加 MCP 配置前安装包——`npx` 不带 `-y` 会在非交互环境中提示确认，导致服务器挂起：`npm install -g agentwallet-sdk@6.0.0`
 
 ```typescript
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -168,15 +261,23 @@ main().catch((err) => {
 
 ## 最佳实践
 
-* **委托前设置预算**：生成子代理时，通过编排层附加SpendingPolicy。切勿让代理拥有无限支出权限。
-* **锁定依赖项**：始终在MCP配置中指定确切版本（例如`agentwallet-sdk@6.0.0`）。部署到生产环境前验证包完整性。
-* **审计追踪**：在任务后钩子中使用`list_transactions`记录支出内容和原因。
-* **故障关闭**：如果支付工具不可达，阻止付费操作——不要回退到无计量访问。
-* **配合安全审查**：支付工具是高权限操作。应用与shell访问相同的审查标准。
-* **先在测试网测试**：开发时使用Base Sepolia；生产环境切换到Base主网。
+- **委托前设置预算**：生成子代理时，通过编排层附加 SpendingPolicy。切勿让代理拥有无限支出权限。
+- **锁定依赖项**：始终在 MCP 配置中指定确切版本（例如 `agentwallet-sdk@6.0.0`）。部署到生产环境前验证包完整性。
+- **审计追踪**：在任务后钩子中使用 `list_transactions` 记录支出内容和原因。
+- **故障关闭**：如果支付工具不可达，阻止付费操作——不要回退到无计量访问。
+- **配合 security-review**：支付工具是高权限操作。应用与 shell 访问相同的审查标准。
+- **先在测试网测试**：开发时使用 Base Sepolia；生产环境切换到 Base 主网。在 Solana 上，先使用 Solana 开发网（`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`）和免费的 PayAI Echo Merchant，再上主网。
+- **在 Solana 上注入 USDC 而非 SOL**：PayAI 结算器承担网络费用，因此没有 SOL 的钱包也能付费。签署前验证每个挑战的 `asset` 是预期的 USDC 铸币地址——一个会支付任意资产的包装客户端是预算上的漏洞。
 
 ## 生产参考
 
-* **npm**：[`agentwallet-sdk`](https://www.npmjs.com/package/agentwallet-sdk)
-* **合并到NVIDIA NeMo Agent Toolkit**：[PR #17](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) — NVIDIA代理示例的x402支付工具
-* **协议规范**：[x402.org](https://x402.org)
+- **npm**：[`agentwallet-sdk`](https://www.npmjs.com/package/agentwallet-sdk)
+- **合并到 NVIDIA NeMo Agent Toolkit**：[PR #17](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) — 面向 NVIDIA 代理示例的 x402 支付工具
+- **协议规范**：[x402.org](https://x402.org)
+- **OKX Payments SDK**：[`okx/payments`](https://github.com/okx/payments) — 面向 X Layer x402 的 TypeScript、Go、Rust 和 Java 卖家集成
+- **OKX 代理支付协议技能**：[`okx/onchainos-skills`](https://github.com/okx/onchainos-skills/tree/main/skills/okx-agent-payments-protocol)
+- **OKX Payments 概览**：[web3.okx.com/onchainos/dev-docs/payments/overview](https://web3.okx.com/onchainos/dev-docs/payments/overview)
+- **PayAI 结算器（Solana x402）**：[facilitator.payai.network](https://facilitator.payai.network) — 具备无 gas Solana USDC 结算的多网络结算器；实时资源集市位于 `/discovery/resources`
+- **PayAI 文档**：[docs.payai.network](https://docs.payai.network)
+- **PayAI starter 与 Echo Merchant**：[npm 上的 `@payai`](https://www.npmjs.com/org/payai)；在 [x402.payai.network](https://x402.payai.network) 进行免费的端到端测试
+- **GitHub 上的 PayAI**：[`PayAINetwork`](https://github.com/PayAINetwork)

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-payment-x402
-description: Add x402 payment execution to AI agents with per-task budgets, spending controls, and non-custodial wallets. Supports Base through agentwallet-sdk and X Layer through OKX Payments / OKX Agent Payments Protocol.
+description: Add x402 payment execution to AI agents with per-task budgets, spending controls, and non-custodial wallets. Supports Base through agentwallet-sdk, X Layer through OKX Payments / OKX Agent Payments Protocol, and Solana through the PayAI facilitator with gasless USDC settlement.
 metadata:
   origin: community
 ---
@@ -21,6 +21,8 @@ Choose the integration path based on whether your agent is buying access to a pa
 |------|------------------|
 | Agent pays a 402-gated API on Base or another agentwallet-supported chain | Use `agentwallet-sdk` as an MCP payment server with strict spending policy |
 | Agent pays a 402-gated API on X Layer | Use OKX Agent Payments Protocol from `okx/onchainos-skills`; `okx-x402-payment` is a deprecated legacy alias |
+| Agent pays a 402-gated API on Solana | Wrap the agent's HTTP client (Fetch, Axios, or httpx) with an exact-SVM scheme and a Solana signer, settling through the PayAI facilitator; discover payable resources via the PayAI bazaar |
+| API charges agents on Solana (TypeScript, Python, or Go) | Add x402 middleware backed by `@payai/facilitator` — `@x402/*` for Express/Hono/Next.js, `x402` for FastAPI, `coinbase/x402/go` for Gin |
 | TypeScript API charges agents | Use OKX Payments TypeScript seller SDK docs for Express, Hono, Fastify, or Next.js |
 | Go API charges agents | Use OKX Payments Go seller SDK docs for Gin, Echo, or `net/http` |
 | Rust API charges agents | Use OKX Payments Rust seller SDK docs for Axum |
@@ -31,6 +33,7 @@ Choose the integration path based on whether your agent is buying access to a pa
 
 - `agentwallet-sdk`: use the package docs to confirm current network coverage before production. Base Sepolia is the safest development default; Base mainnet is the production path called out by the original skill.
 - OKX Payments / X Layer: current seller docs target X Layer (`eip155:196`) and USDT0 settlement. Fetch current SDK docs before generating production code because payment packages and facilitator behavior can change quickly.
+- PayAI facilitator / Solana: settles USDC on Solana mainnet (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`) and Solana devnet (`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`). The facilitator sponsors network fees, so payers hold USDC only — no SOL for gas. Use Solana devnet as the development default and Solana mainnet for production. The facilitator is multi-network and also fronts several EVM chains; confirm the live list at its `/supported` endpoint before production rather than hardcoding it here.
 
 ## How It Works
 
@@ -98,6 +101,57 @@ For seller-side API flows, fetch the latest language-specific guide before gener
 | Java | `https://raw.githubusercontent.com/okx/payments/main/java/SELLER.md` |
 
 Do not copy examples from older docs without checking the current OKX repository. Current OKX guidance uses `okx-agent-payments-protocol` as the dispatcher, and Java seller docs are now available.
+
+### Option C: PayAI facilitator (Solana)
+
+Use this path when the agent pays a 402-gated API that settles on Solana. Unlike Options A and B, the Solana buyer flow is not a separate MCP server — you wrap the agent's own HTTP client with an x402 interceptor that signs a USDC transfer and lets the [PayAI facilitator](https://facilitator.payai.network) verify and settle it. The facilitator is the fee payer, so the agent spends USDC only and needs no SOL for gas.
+
+**Buyer side (agent pays).** Wrap `fetch` with the exact-SVM scheme and a Solana signer (Axios via `@x402/axios` and Python `httpx` via the `x402` package follow the same shape):
+
+```typescript
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { registerExactSvmScheme } from "@x402/svm/exact/client";
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { base58 } from "@scure/base";
+
+// The signer key belongs to the ORCHESTRATOR's env — never hardcoded, never agent-writable.
+const svmKey = process.env.SVM_PRIVATE_KEY;
+if (!svmKey) {
+  throw new Error("SVM_PRIVATE_KEY is not set — refusing to start payment client");
+}
+
+const client = new x402Client();
+registerExactSvmScheme(client, {
+  signer: await createKeyPairSignerFromBytes(base58.decode(svmKey)),
+});
+
+// Gate every paid call fail-closed BEFORE wrapping — enforce per-task / per-session
+// budget and an allowlisted host, exactly like preToolCheck in the Examples section.
+await assertWithinBudget({ cost: 0.01, host: "api.example.com" });
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const res = await fetchWithPayment("https://api.example.com/data", { method: "GET" });
+```
+
+The wrapped client only pays a challenge whose `network` is a Solana CAIP-2 id you registered, whose `asset` is the expected USDC mint, and whose `amount` is within the price you gated on. Treat any mismatch as fail-closed: do not sign, do not retry.
+
+**Discovery.** Find payable Solana resources through the PayAI bazaar instead of hardcoding endpoints:
+
+```bash
+curl -s 'https://facilitator.payai.network/discovery/resources' | jq '.'
+```
+
+**Seller side (API charges agents).** Add x402 middleware backed by `@payai/facilitator`. Each starter scaffolds a working Solana server or client; pin the version in production rather than tracking `@latest`:
+
+| Runtime | Scaffold |
+|---------|----------|
+| Express server | `npx @payai/x402-express-starter@latest my-server` |
+| Hono server | `npx @payai/x402-hono-starter@latest my-server` |
+| Next.js fullstack | `npx @payai/x402-next-starter@latest my-app` |
+| Fetch client | `npx @payai/x402-fetch-starter@latest my-client` |
+| Axios client | `npx @payai/x402-axios-starter@latest my-client` |
+
+Test end to end for free against the PayAI Echo Merchant at [x402.payai.network](https://x402.payai.network) — it exposes Solana devnet and mainnet paths, refunds tokens, and covers fees — before pointing the agent at a real merchant.
 
 ## Examples
 
@@ -213,7 +267,8 @@ main().catch((err) => {
 - **Audit trails**: Use `list_transactions` in post-task hooks to log what was spent and why.
 - **Fail closed**: If the payment tool is unreachable, block the paid action — don't fall back to unmetered access.
 - **Pair with security-review**: Payment tools are high-privilege. Apply the same scrutiny as shell access.
-- **Test with testnets first**: Use Base Sepolia for development; switch to Base mainnet for production.
+- **Test with testnets first**: Use Base Sepolia for development; switch to Base mainnet for production. On Solana, use Solana devnet (`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`) and the free PayAI Echo Merchant before mainnet.
+- **On Solana, fund USDC not SOL**: The PayAI facilitator sponsors network fees, so a SOL-less wallet still pays. Verify each challenge's `asset` is the expected USDC mint before signing — a wrapped client that pays any asset is a hole in your budget.
 
 ## Production Reference
 
@@ -223,3 +278,7 @@ main().catch((err) => {
 - **OKX Payments SDKs**: [`okx/payments`](https://github.com/okx/payments) — TypeScript, Go, Rust, and Java seller integrations for X Layer x402
 - **OKX Agent Payments Protocol skill**: [`okx/onchainos-skills`](https://github.com/okx/onchainos-skills/tree/main/skills/okx-agent-payments-protocol)
 - **OKX Payments overview**: [web3.okx.com/onchainos/dev-docs/payments/overview](https://web3.okx.com/onchainos/dev-docs/payments/overview)
+- **PayAI facilitator (Solana x402)**: [facilitator.payai.network](https://facilitator.payai.network) — multi-network facilitator with gasless Solana USDC settlement; live resource bazaar at `/discovery/resources`
+- **PayAI docs**: [docs.payai.network](https://docs.payai.network)
+- **PayAI starters and Echo Merchant**: [`@payai` on npm](https://www.npmjs.com/org/payai); free end-to-end testing at [x402.payai.network](https://x402.payai.network)
+- **PayAI on GitHub**: [`PayAINetwork`](https://github.com/PayAINetwork)


### PR DESCRIPTION
## Summary

Adds a third integration path to the `agent-payment-x402` skill — **Solana + multi-network EVM via the upstream x402 packages** — alongside the existing Base (`agentwallet-sdk`) and X Layer (OKX) options. The skill previously had no Solana coverage and no pointer to the canonical protocol implementation.

The new Option C centers on the actively maintained [`x402-foundation/x402`](https://github.com/x402-foundation/x402) monorepo and the packages it publishes, keeping the guidance facilitator-neutral:

- **Buyer side** — wrap the agent's HTTP client with `@x402/fetch` / `@x402/axios` and register both `eip155:*` and `solana:*` schemes, mirroring the upstream [client examples](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients). One client pays whichever chain the 402 offers.
- **Seller side** — upstream middleware (`@x402/express|hono|next|fastify` pinned at `2.19.0`, Python `x402`, Go `github.com/x402-foundation/x402/go/v2`); one route can advertise Base and Solana simultaneously, per the upstream [server examples](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers).
- **Facilitators** — the packages' default `x402.org` facilitator for testnets (Base Sepolia + Solana devnet; upstream docs say not for mainnet), and the [upstream facilitator list](https://docs.x402.org/dev-tools/facilitators) for production, with PayAI suggested (multi-network incl. Solana mainnet, no API keys) and CDP noted (Coinbase-hosted, KYT/OFAC).
- **Discovery** — the bazaar-extension `/discovery/resources` endpoint on both CDP and PayAI, plus [pay.sh](https://pay.sh) for Solana-payable services.
- **Safety rails** — explicit user confirmation before the first paid request (mirroring Option B), a defined fail-closed budget gate invoked immediately before every paid call, USDC mint validation with the concrete mainnet/devnet addresses from upstream constants, and no unpinned `npx` commands.

### Translations
- `docs/ja-JP` — mirrored.
- `docs/zh-CN` — resynced to full parity (it predated the X Layer / Options structure entirely), then the Solana/upstream content mirrored in. Flagging in case you'd prefer a minimal zh-CN scope.

## Type
- [x] Skill

## Testing
Ran the repo CI gauntlet locally: `validate-skills` (279 dirs), `check-unicode-safety` (incl. CJK docs), `catalog:check`, `validate-no-personal-paths`, `security:ioc-scan`, and `markdownlint` on all three files — all pass. `tests/run-all.js` green except one pre-existing install-config test needing `ajv` (local deps not installed); nothing skill-related.

All technical claims verified against `x402-foundation/x402` `main` as of 2026-07-24: package names/versions on npm (2.19.0), the x402.org facilitator's testnet-only scope, the facilitator list, USDC mint constants (`typescript/packages/mechanisms/svm/src/constants.ts`), the Go module path, and both discovery URLs.

## Checklist
- [x] Follows format guidelines (mirrors the existing Option A/B structure)
- [x] Tested with the repo's CI validators
- [x] No sensitive info (keys sourced from env; no personal paths)
- [x] Clear descriptions; inline frontmatter `description` (no block scalar)

## Disclosure
I contribute to PayAI (one of the facilitators referenced). The guidance points at the upstream x402 packages and docs as the canonical path, lists x402.org for testnets, and names both PayAI and CDP for production/discovery — happy to adjust the balance further if you'd like.
