### PR TITLE
Center README entry cards and correct sponsor tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ ECC v2.0.0 adds the public Hermes operator story on top of that reusable layer: 
 
 ---
 
-<table aria-label="ECC primary links" width="100%">
+<div align="center">
+
+<table aria-label="ECC primary links">
 <tr>
 <td width="33%" align="center">
   <a href="https://ecc.tools/pricing">
@@ -64,7 +66,7 @@ ECC v2.0.0 adds the public Hermes operator story on top of that reusable layer: 
     <img src="assets/images/community/heart.svg" height="42" alt="" /><br />
     <strong>Sponsor ECC</strong>
   </a><br />
-  <sub>Fund the OSS · From $5/mo</sub>
+  <sub>Fund the open-source project</sub>
 </td>
 <td width="33%" align="center">
   <a href="https://discord.gg/36yGMHGFbR">
@@ -75,6 +77,8 @@ ECC v2.0.0 adds the public Hermes operator story on top of that reusable layer: 
 </td>
 </tr>
 </table>
+
+</div>
 
 <sub>**OSS stays free.** This repo is MIT-licensed forever. ECC Pro is the hosted GitHub App for private repos. <a href="https://github.com/sponsors/affaan-m">Sponsors</a> and <a href="https://ecc.tools/pricing">Pro subscribers</a> fund the work. That's why a single maintainer ships weekly across 7 harnesses.</sub>
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -2,7 +2,7 @@
 
 Thank you to everyone funding ECC's open-source work. Your sponsorship is what lets the OSS layer stay free while the GitHub App, hosted security scans, and continuous improvements ship every week.
 
-## Strategic Sponsors — $2,500/mo
+## Strategic Sponsors — $3,700/mo
 
 *Become a [Strategic sponsor](https://github.com/sponsors/affaan-m) to be featured here.*
 
@@ -41,7 +41,7 @@ Run or self-host any open-source model. Itô partners with ECC on compute, while
 
 *[Become a Builder sponsor](https://github.com/sponsors/affaan-m) to support the project and get your name in this list.*
 
-## Supporters — $5/mo
+## Supporters — $10/mo
 
 *[Become a Supporter](https://github.com/sponsors/affaan-m) to back the project with a profile badge and a thank-you in release notes.*
 
@@ -51,12 +51,12 @@ Run or self-host any open-source model. Itô partners with ECC on compute, while
 
 | Tier | Monthly | Perks |
 |------|--------:|-------|
-| Supporter | $5 | Sponsor badge on profile, thank-you in release notes |
+| Supporter | $10 | Sponsor badge on profile, thank-you in release notes |
 | Builder | $25 | Above + name in SPONSORS.md |
 | Pro Sponsor | $50 | Above + listed in SPONSORS.md |
 | Team Sponsor | $200 | SPONSORS.md listing |
-| Business Sponsor | $500 | README sponsor placement + SPONSORS.md listing |
-| Strategic Sponsor | $2,500 | Premium sponsor placement + sponsor placement call |
+| Business Sponsor | $800 | README sponsor placement + SPONSORS.md listing |
+| Strategic Sponsor | $3,700 | Premium sponsor placement + sponsor placement call |
 
 [**Become a Sponsor →**](https://github.com/sponsors/affaan-m)
 
@@ -79,4 +79,4 @@ If you sponsored before May 2026, you keep your original perks at your original 
 
 ---
 
-*Updated by Hermes. Last sync: 2026-06-16*
+*Last verified against the public GitHub Sponsor tiers: 2026-07-24*

--- a/tests/scripts/ito-compute-sponsor.test.js
+++ b/tests/scripts/ito-compute-sponsor.test.js
@@ -176,13 +176,19 @@ function main() {
       const readme = read('README.md');
       const primaryLinks = extractNamedTable(readme, 'ECC primary links');
       const guides = extractNamedTable(readme, 'ECC guides');
+      const centeredPrimaryLinks = readme.match(
+        /<div align="center">\s*<table[^>]*aria-label="ECC primary links"[^>]*>[\s\S]*?<\/table>\s*<\/div>/
+      );
 
+      assert.ok(centeredPrimaryLinks, 'The three primary-link cards should be centered as one group');
       assert.strictEqual((primaryLinks.match(/<td\b/g) || []).length, 3);
       assert.ok(primaryLinks.includes('assets/images/community/ecc-tools-mark.svg'));
       assertExactHref(primaryLinks, 'https://github.com/apps/ecc-tools');
       assertExactHref(primaryLinks, 'https://ecc.tools/pricing');
       assertExactHref(primaryLinks, 'https://github.com/sponsors/affaan-m');
       assert.ok(primaryLinks.includes('assets/images/community/heart.svg'));
+      assert.match(primaryLinks, /Fund the open-source project/);
+      assert.doesNotMatch(primaryLinks, /From \$5\/mo/);
       assertExactHref(primaryLinks, 'https://discord.gg/36yGMHGFbR');
       assert.ok(primaryLinks.includes('assets/images/community/discord.svg'));
 
@@ -226,6 +232,15 @@ function main() {
         eccToolsMark,
         /<script|<foreignObject|\son[a-z]+=|(?:href|xlink:href)=/i
       );
+    }],
+    ['sponsor docs match the current public tiers', () => {
+      const sponsors = read('SPONSORS.md');
+
+      assert.match(sponsors, /## Supporters — \$10\/mo/);
+      assert.match(sponsors, /\| Supporter \| \$10 \|/);
+      assert.match(sponsors, /\| Business Sponsor \| \$800 \|/);
+      assert.match(sponsors, /\| Strategic Sponsor \| \$3,700 \|/);
+      assert.doesNotMatch(sponsors, /Supporters — \$5\/mo|\| Supporter \| \$5 \|/);
     }],
     ['README shows the verified local Kimi via Ito path without claiming managed serving', () => {
       const readme = read('README.md');


### PR DESCRIPTION
## What changed

- center the three primary ECC entry cards as a single group in GitHub's README renderer
- remove the stale `From $5/mo` sponsor claim
- align `SPONSORS.md` with the current public $10 / $25 / $50 / $200 / $800 / $3,700 tiers
- add regression coverage for card centering and sponsor-tier drift

## Root cause

After the fourth card was removed, GitHub rendered the remaining HTML table at its intrinsic width and left-aligned it within the wider README column. The $5 copy came from stale sponsor documentation even though the currently selectable public Supporter tier starts at $10.

## Validation

- `node tests/scripts/ito-compute-sponsor.test.js` — 13/13
- `npm test` — 3172/3172
- targeted ESLint and Markdownlint — pass
- `git diff --check` — pass

The canonical Itō Drive SVG artwork is unchanged; the repository retains only the previously reviewed canvas trim that removes its dead horizontal space for correct visual centering.