### PR TITLE
Claude/ecc end to end jiegyg

### DIFF
--- a/examples/energy-industry-tracker/README.md
+++ b/examples/energy-industry-tracker/README.md
@@ -1,0 +1,106 @@
+# Energy Industry Tracker
+
+A small Node.js CLI that maintains a personal watchlist of companies and
+vendors in the energy management industry — demand response, DERMS, VPP,
+building energy management, EV fleet charging, and similar segments.
+
+This example was built end to end using ECC's own workflow:
+[`skills/tdd-workflow`](../../skills/tdd-workflow/SKILL.md) (user journeys ->
+RED -> GREEN -> refactor -> coverage -> evidence report), following the same
+loop `/plan` and `/tdd` codify for this repo. See
+[`TDD-EVIDENCE.md`](TDD-EVIDENCE.md) for the full RED/GREEN trail and
+commit checkpoints.
+
+Data is a manual, structured watchlist — you add entries as you research
+them. It intentionally does not fetch live data from the web, which keeps
+the whole tool deterministic and unit-testable offline.
+
+## Requirements
+
+Node.js >= 18 (uses only Node built-ins: `node:fs`, `node:path`,
+`node:child_process`, `node:test`). No dependencies to install.
+
+## Usage
+
+All commands operate on a JSON watchlist file, `.energy-tracker.json` in the
+current directory by default. Override the location with `--file <path>`
+(placed anywhere in the argument list).
+
+```bash
+# Track a company
+node bin/energy-tracker.js add "Voltus" --segment "Demand Response" \
+  --stage "Series C" --source "https://voltus.co" \
+  --notes "Piloting demand flexibility with two utilities"
+
+# List everything you're currently watching
+node bin/energy-tracker.js list
+
+# Filter by segment
+node bin/energy-tracker.js list --segment "Demand Response"
+
+# Full detail, including notes history
+node bin/energy-tracker.js show 1
+
+# Append a research note (notes accumulate, they never overwrite)
+node bin/energy-tracker.js note 1 "Closed $60M Series C"
+
+# Stop actively tracking a company without deleting its history
+node bin/energy-tracker.js archive 1
+
+# Include archived companies in a listing
+node bin/energy-tracker.js list --all
+
+# Permanently delete an entry
+node bin/energy-tracker.js rm 1
+
+# Industry-shape overview: watching companies per segment
+node bin/energy-tracker.js segments
+```
+
+Every write command exits `0` on success and `1` with a message on
+`stderr` for usage errors or an unknown id.
+
+## Data model
+
+Each tracked company is:
+
+```json
+{
+  "id": 1,
+  "name": "Voltus",
+  "segment": "Demand Response",
+  "stage": "Series C",
+  "source": "https://voltus.co",
+  "status": "watching",
+  "notes": [{ "text": "Piloting demand flexibility with two utilities", "at": "2026-07-25T00:00:00.000Z" }],
+  "createdAt": "2026-07-25T00:00:00.000Z",
+  "updatedAt": "2026-07-25T00:00:00.000Z"
+}
+```
+
+`status` is `"watching"` or `"archived"`. `list` and `segments` only
+consider `"watching"` companies unless `--all` is passed.
+
+## Project layout
+
+```text
+bin/energy-tracker.js   # CLI entrypoint (thin process.exit wrapper)
+src/cli.js               # argument parsing, command dispatch, I/O
+src/watchlist-store.js   # pure, immutable company CRUD + segment summary
+tests/watchlist-store.test.js  # unit tests (node:test)
+tests/cli.test.js              # integration tests (spawns the CLI)
+```
+
+## Testing
+
+```bash
+node --test tests/*.test.js
+
+# with coverage
+node --experimental-test-coverage --test-coverage-include='src/**' \
+  --test tests/cli.test.js tests/watchlist-store.test.js
+```
+
+28 tests, 100% line / 96%+ branch / 100% function coverage on `src/`. See
+[`TDD-EVIDENCE.md`](TDD-EVIDENCE.md) for the guarantee-by-guarantee
+breakdown and the RED/GREEN evidence.

--- a/examples/energy-industry-tracker/TDD-EVIDENCE.md
+++ b/examples/energy-industry-tracker/TDD-EVIDENCE.md
@@ -1,0 +1,122 @@
+# TDD Evidence Report: energy-industry-tracker
+
+Built by following ECC's [`tdd-workflow`](../../skills/tdd-workflow/SKILL.md)
+skill directly, as a live demonstration of the ECC harness end to end.
+
+## Source plan
+
+No `*.plan.md` file was used. Requirements were gathered interactively
+(clarifying questions on scope: manual watchlist vs. live web lookups;
+companies/vendors vs. deals vs. news as the tracked entity) and the user
+journeys below were written from that conversation, in the style `/plan`
+would produce.
+
+## User journeys
+
+1. As an analyst, I want to add a company to my watchlist with its segment,
+   so I can group it with similar vendors later.
+2. As an analyst, I want to record optional funding stage, a source link,
+   and an initial note when I add a company, so first-pass research isn't
+   lost.
+3. As an analyst, I want to list the companies I'm actively watching, and
+   filter that list by segment, so I can review one part of the market at
+   a time.
+4. As an analyst, I want to append research notes to a company over time
+   without losing earlier notes, so the history of what I learned and when
+   is preserved.
+5. As an analyst, I want to archive a company instead of deleting it, so
+   companies that fall out of relevance stay in the record but out of my
+   active list.
+6. As an analyst, I want a segment-level summary (count of watched
+   companies per segment), so I can see how the industry map is shaped at
+   a glance.
+7. As an analyst, I want invalid input (missing name, missing segment,
+   unknown id, unknown command) to fail clearly with a non-zero exit code,
+   so scripts and shells around this CLI can detect errors.
+
+## Task report
+
+| Task | Validation command | Result |
+|---|---|---|
+| RED: write failing suites for `watchlist-store.js` and the CLI | `node --test tests/*.test.js` | 25 failing on `MODULE_NOT_FOUND` (implementation absent) — commit `5888358` |
+| GREEN: implement `src/watchlist-store.js`, `src/cli.js`, `bin/energy-tracker.js` | `node --test tests/*.test.js` | 25/25 passing — commit `010f907`. One real bug found and fixed during this stage: `--file` was only recognized when it appeared after the subcommand; `main()` assumed `argv[0]` was always the command. Fixed by parsing options across the full argv before splitting out the command. |
+| Refactor: lint-clean unused handler params, close coverage gaps | `node --experimental-test-coverage --test-coverage-include='src/**' --test tests/cli.test.js tests/watchlist-store.test.js` | 28/28 passing, 100% line / 96.25% branch / 100% function coverage on `src/` — commit `8e22b30` |
+
+## Test specification
+
+| # | What is guaranteed | Test | Type | Result |
+|---|---|---|---|---|
+| 1 | Adding a company assigns a sequential id and defaults to `watching` with no notes | `tests/watchlist-store.test.js:createCompany adds a watching company with a sequential id` | unit | PASS |
+| 2 | Ids increase monotonically based on existing companies | `tests/watchlist-store.test.js:createCompany assigns increasing ids...` | unit | PASS |
+| 3 | `createCompany` never mutates the array passed in | `tests/watchlist-store.test.js:createCompany does not mutate...` | unit | PASS |
+| 4 | Blank/missing name is rejected | `tests/watchlist-store.test.js:createCompany rejects a missing or blank name` | unit | PASS |
+| 5 | Blank/missing segment is rejected | `tests/watchlist-store.test.js:createCompany rejects a missing or blank segment` | unit | PASS |
+| 6 | Optional stage, source, and an initial note are stored correctly | `tests/watchlist-store.test.js:createCompany stores optional stage, source and an initial note` | unit | PASS |
+| 7 | `listCompanies` defaults to watching-only | `tests/watchlist-store.test.js:listCompanies returns only watching companies by default` | unit | PASS |
+| 8 | `--all` includes archived companies | `tests/watchlist-store.test.js:listCompanies returns archived companies too when all is set` | unit | PASS |
+| 9 | Segment filter is case-insensitive | `tests/watchlist-store.test.js:listCompanies filters by segment case-insensitively` | unit | PASS |
+| 10 | Notes append with a timestamp, other companies untouched | `tests/watchlist-store.test.js:addNote appends a timestamped note...` | unit | PASS |
+| 11 | Blank note text rejected | `tests/watchlist-store.test.js:addNote rejects blank note text` | unit | PASS |
+| 12 | Unknown id on note throws | `tests/watchlist-store.test.js:addNote throws for an unknown id` | unit | PASS |
+| 13 | Archive is idempotent, sets status correctly | `tests/watchlist-store.test.js:archiveCompany marks a company archived and is idempotent` | unit | PASS |
+| 14 | Unknown id on archive throws | `tests/watchlist-store.test.js:archiveCompany throws for an unknown id` | unit | PASS |
+| 15 | `removeCompany` deletes only the target | `tests/watchlist-store.test.js:removeCompany removes only the matching company` | unit | PASS |
+| 16 | Unknown id on remove throws | `tests/watchlist-store.test.js:removeCompany throws for an unknown id` | unit | PASS |
+| 17 | Segment summary counts watching companies only, sorted by count then name | `tests/watchlist-store.test.js:segmentSummary counts watching companies...` | unit | PASS |
+| 18 | `add` + `list` round-trips through the real CLI and file storage | `tests/cli.test.js:add then list shows the new company as watching` | integration | PASS |
+| 19 | `add` without `--segment` fails with a usage error | `tests/cli.test.js:add without --segment exits non-zero...` | integration | PASS |
+| 20 | `--segment` and `--all` filters work through the CLI | `tests/cli.test.js:list --segment filters, list --all includes archived companies` | integration | PASS |
+| 21 | `--stage`/`--source`/`--notes` flags are parsed and surfaced in `show` | `tests/cli.test.js:add accepts --stage, --source and --notes...` | integration | PASS |
+| 22 | `show` reports "No notes." when there are none yet | `tests/cli.test.js:show reports no notes for a freshly added company` | integration | PASS |
+| 23 | `segments` reports "No segments tracked." on an empty watchlist | `tests/cli.test.js:segments reports nothing tracked...` | integration | PASS |
+| 24 | `note` persists and is visible via `show` | `tests/cli.test.js:note appends research notes visible in show` | integration | PASS |
+| 25 | `segments` aggregates counts correctly through the CLI | `tests/cli.test.js:segments summarizes watching companies by segment` | integration | PASS |
+| 26 | `rm` permanently removes a company | `tests/cli.test.js:rm permanently removes a company` | integration | PASS |
+| 27 | `show` on an unknown id fails clearly | `tests/cli.test.js:show with an unknown id exits non-zero...` | integration | PASS |
+| 28 | Unknown subcommands fail clearly and list available commands | `tests/cli.test.js:unknown command exits non-zero...` | integration | PASS |
+
+Evidence command for the full table:
+
+```bash
+node --test tests/cli.test.js tests/watchlist-store.test.js
+# 1..28 / pass 28 / fail 0
+```
+
+## Coverage and known gaps
+
+```bash
+node --experimental-test-coverage --test-coverage-include='src/**' \
+  --test tests/cli.test.js tests/watchlist-store.test.js
+```
+
+```text
+file                | line % | branch % | funcs % | uncovered lines
+src
+ cli.js             | 100.00 |    93.94 |  100.00 |
+ watchlist-store.js | 100.00 |    97.87 |  100.00 |
+all files           | 100.00 |    96.25 |  100.00 |
+```
+
+No known gaps: every exported function and every CLI subcommand has at
+least one direct test, and all error paths (missing name, missing segment,
+blank note, unknown id, unknown command) are exercised.
+
+Two things are intentionally out of scope for this example, not gaps in
+what was promised:
+
+- No live web/network lookups (by design — see README).
+- No monorepo-wide `npm run lint` / `npm test` run against this example,
+  because the repository's `node_modules` is not installed in this
+  sandbox. The code was hand-checked against `eslint.config.js`'s rules
+  (`no-unused-vars` with the `^_` ignore pattern, `eqeqeq`) instead.
+
+## Merge evidence
+
+Checkpoint commits on `claude/ecc-end-to-end-jiegyg`:
+
+1. `5888358` — `test: add RED reproducer for energy-industry-tracker` (RED)
+2. `010f907` — `fix: implement energy-industry-tracker to GREEN` (GREEN, includes the argv-ordering bug fix)
+3. `8e22b30` — `refactor: lint-clean unused params, close coverage gaps` (refactor + coverage)
+
+These are kept as separate commits; if this branch is ever squash-merged,
+this file preserves the RED -> GREEN -> refactor trail.

--- a/examples/energy-industry-tracker/bin/energy-tracker.js
+++ b/examples/energy-industry-tracker/bin/energy-tracker.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+
+const { main } = require('../src/cli');
+
+process.exitCode = main(process.argv.slice(2));

--- a/examples/energy-industry-tracker/src/cli.js
+++ b/examples/energy-industry-tracker/src/cli.js
@@ -79,7 +79,7 @@ function cmdAdd(positional, options, companies, streams) {
   return 0;
 }
 
-function cmdList(positional, options, companies, streams) {
+function cmdList(_positional, options, companies, streams) {
   const result = listCompanies(companies, { all: options.all, segment: options.segment });
   if (result.length === 0) {
     streams.stdout.write('No companies tracked.\n');
@@ -91,7 +91,7 @@ function cmdList(positional, options, companies, streams) {
   return 0;
 }
 
-function cmdShow(positional, options, companies, streams) {
+function cmdShow(positional, _options, companies, streams) {
   const id = Number(positional[0]);
   const company = findCompanyOrThrow(companies, id);
   streams.stdout.write(`${formatCompanyLine(company)}\n`);
@@ -134,7 +134,7 @@ function cmdRm(positional, options, companies, streams) {
   return 0;
 }
 
-function cmdSegments(positional, options, companies, streams) {
+function cmdSegments(_positional, _options, companies, streams) {
   const summary = segmentSummary(companies);
   if (summary.length === 0) {
     streams.stdout.write('No segments tracked.\n');

--- a/examples/energy-industry-tracker/src/cli.js
+++ b/examples/energy-industry-tracker/src/cli.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  createCompany,
+  listCompanies,
+  addNote,
+  archiveCompany,
+  removeCompany,
+  segmentSummary,
+  findCompanyOrThrow
+} = require('./watchlist-store');
+
+const DEFAULT_FILE = '.energy-tracker.json';
+
+function loadCompanies(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+  const raw = fs.readFileSync(filePath, 'utf8').trim();
+  return raw.length === 0 ? [] : JSON.parse(raw);
+}
+
+function saveCompanies(filePath, companies) {
+  fs.mkdirSync(path.dirname(path.resolve(filePath)), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(companies, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const positional = [];
+  const options = { file: DEFAULT_FILE, all: false };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--file') {
+      options.file = argv[++i];
+    } else if (arg === '--segment') {
+      options.segment = argv[++i];
+    } else if (arg === '--stage') {
+      options.stage = argv[++i];
+    } else if (arg === '--source') {
+      options.source = argv[++i];
+    } else if (arg === '--notes') {
+      options.notes = argv[++i];
+    } else if (arg === '--all') {
+      options.all = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { positional, options };
+}
+
+function formatCompanyLine(company) {
+  const flag = company.status === 'archived' ? '[archived]' : '[watching]';
+  const stage = company.stage ? ` (${company.stage})` : '';
+  return `${flag} #${company.id} ${company.name} — ${company.segment}${stage}`;
+}
+
+function cmdAdd(positional, options, companies, streams) {
+  const name = positional[0];
+  if (!options.segment) {
+    streams.stderr.write('Error: --segment is required\n');
+    return 1;
+  }
+
+  const { companies: updated, company } = createCompany(companies, {
+    name,
+    segment: options.segment,
+    stage: options.stage,
+    source: options.source,
+    notes: options.notes
+  });
+
+  saveCompanies(options.file, updated);
+  streams.stdout.write(`Added #${company.id} ${company.name}\n`);
+  return 0;
+}
+
+function cmdList(positional, options, companies, streams) {
+  const result = listCompanies(companies, { all: options.all, segment: options.segment });
+  if (result.length === 0) {
+    streams.stdout.write('No companies tracked.\n');
+    return 0;
+  }
+  for (const company of result) {
+    streams.stdout.write(`${formatCompanyLine(company)}\n`);
+  }
+  return 0;
+}
+
+function cmdShow(positional, options, companies, streams) {
+  const id = Number(positional[0]);
+  const company = findCompanyOrThrow(companies, id);
+  streams.stdout.write(`${formatCompanyLine(company)}\n`);
+  if (company.source) {
+    streams.stdout.write(`Source: ${company.source}\n`);
+  }
+  if (company.notes.length === 0) {
+    streams.stdout.write('No notes.\n');
+  } else {
+    streams.stdout.write('Notes:\n');
+    for (const note of company.notes) {
+      streams.stdout.write(`  - [${note.at}] ${note.text}\n`);
+    }
+  }
+  return 0;
+}
+
+function cmdNote(positional, options, companies, streams) {
+  const id = Number(positional[0]);
+  const text = positional.slice(1).join(' ');
+  const updated = addNote(companies, id, text);
+  saveCompanies(options.file, updated);
+  streams.stdout.write(`Noted on #${id}\n`);
+  return 0;
+}
+
+function cmdArchive(positional, options, companies, streams) {
+  const id = Number(positional[0]);
+  const updated = archiveCompany(companies, id);
+  saveCompanies(options.file, updated);
+  streams.stdout.write(`Archived #${id}\n`);
+  return 0;
+}
+
+function cmdRm(positional, options, companies, streams) {
+  const id = Number(positional[0]);
+  const updated = removeCompany(companies, id);
+  saveCompanies(options.file, updated);
+  streams.stdout.write(`Removed #${id}\n`);
+  return 0;
+}
+
+function cmdSegments(positional, options, companies, streams) {
+  const summary = segmentSummary(companies);
+  if (summary.length === 0) {
+    streams.stdout.write('No segments tracked.\n');
+    return 0;
+  }
+  for (const { segment, count } of summary) {
+    streams.stdout.write(`${segment}\t${count}\n`);
+  }
+  return 0;
+}
+
+const COMMANDS = {
+  add: cmdAdd,
+  list: cmdList,
+  show: cmdShow,
+  note: cmdNote,
+  archive: cmdArchive,
+  rm: cmdRm,
+  segments: cmdSegments
+};
+
+function main(argv, streams = { stdout: process.stdout, stderr: process.stderr }) {
+  const { positional, options } = parseArgs(argv);
+  const [command, ...commandArgs] = positional;
+  const handler = COMMANDS[command];
+
+  if (!handler) {
+    streams.stderr.write(`Error: unknown command "${command || ''}"\n`);
+    streams.stderr.write(`Available commands: ${Object.keys(COMMANDS).join(', ')}\n`);
+    return 1;
+  }
+
+  try {
+    const companies = loadCompanies(options.file);
+    return handler(commandArgs, options, companies, streams);
+  } catch (error) {
+    streams.stderr.write(`Error: ${error.message}\n`);
+    return 1;
+  }
+}
+
+module.exports = { main };

--- a/examples/energy-industry-tracker/src/watchlist-store.js
+++ b/examples/energy-industry-tracker/src/watchlist-store.js
@@ -1,0 +1,95 @@
+'use strict';
+
+function nextId(companies) {
+  return companies.reduce((max, company) => Math.max(max, company.id), 0) + 1;
+}
+
+function findCompanyOrThrow(companies, id) {
+  const company = companies.find(item => item.id === id);
+  if (!company) {
+    throw new Error(`Company not found: ${id}`);
+  }
+  return company;
+}
+
+function createCompany(companies, { name, segment, stage = null, source = null, notes = null } = {}) {
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new TypeError('Company name must be a non-empty string');
+  }
+  if (typeof segment !== 'string' || segment.trim().length === 0) {
+    throw new TypeError('Company segment must be a non-empty string');
+  }
+
+  const now = new Date().toISOString();
+  const company = {
+    id: nextId(companies),
+    name: name.trim(),
+    segment: segment.trim(),
+    stage: stage && stage.trim().length > 0 ? stage.trim() : null,
+    source: source && source.trim().length > 0 ? source.trim() : null,
+    status: 'watching',
+    notes: notes && notes.trim().length > 0 ? [{ text: notes.trim(), at: now }] : [],
+    createdAt: now,
+    updatedAt: now
+  };
+
+  return { companies: [...companies, company], company };
+}
+
+function listCompanies(companies, { all = false, segment = null } = {}) {
+  let result = all ? companies.slice() : companies.filter(company => company.status !== 'archived');
+  if (segment) {
+    const target = segment.trim().toLowerCase();
+    result = result.filter(company => company.segment.toLowerCase() === target);
+  }
+  return result;
+}
+
+function addNote(companies, id, text) {
+  findCompanyOrThrow(companies, id);
+  if (typeof text !== 'string' || text.trim().length === 0) {
+    throw new TypeError('Note text must be a non-empty string');
+  }
+
+  const now = new Date().toISOString();
+  return companies.map(company =>
+    company.id === id
+      ? { ...company, notes: [...company.notes, { text: text.trim(), at: now }], updatedAt: now }
+      : company
+  );
+}
+
+function archiveCompany(companies, id) {
+  findCompanyOrThrow(companies, id);
+  const now = new Date().toISOString();
+  return companies.map(company =>
+    company.id === id ? { ...company, status: 'archived', updatedAt: now } : company
+  );
+}
+
+function removeCompany(companies, id) {
+  findCompanyOrThrow(companies, id);
+  return companies.filter(company => company.id !== id);
+}
+
+function segmentSummary(companies) {
+  const counts = new Map();
+  for (const company of companies) {
+    if (company.status !== 'watching') continue;
+    counts.set(company.segment, (counts.get(company.segment) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([segment, count]) => ({ segment, count }))
+    .sort((a, b) => b.count - a.count || a.segment.localeCompare(b.segment));
+}
+
+module.exports = {
+  createCompany,
+  listCompanies,
+  addNote,
+  archiveCompany,
+  removeCompany,
+  segmentSummary,
+  findCompanyOrThrow
+};

--- a/examples/energy-industry-tracker/tests/cli.test.js
+++ b/examples/energy-industry-tracker/tests/cli.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const binPath = path.join(__dirname, '..', 'bin', 'energy-tracker.js');
+
+function run(args, filePath) {
+  return spawnSync(process.execPath, [binPath, '--file', filePath, ...args], {
+    encoding: 'utf8'
+  });
+}
+
+function withTempFile(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'energy-tracker-test-'));
+  const filePath = path.join(dir, 'watchlist.json');
+  try {
+    fn(filePath);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('add then list shows the new company as watching', () => {
+  withTempFile(filePath => {
+    const add = run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);
+    assert.equal(add.status, 0);
+    assert.match(add.stdout, /#1/);
+
+    const list = run(['list'], filePath);
+    assert.equal(list.status, 0);
+    assert.match(list.stdout, /Voltus/);
+    assert.match(list.stdout, /Demand Response/);
+  });
+});
+
+test('add without --segment exits non-zero with a usage error', () => {
+  withTempFile(filePath => {
+    const add = run(['add', 'Voltus'], filePath);
+    assert.notEqual(add.status, 0);
+    assert.match(add.stderr, /segment/i);
+  });
+});
+
+test('list --segment filters, list --all includes archived companies', () => {
+  withTempFile(filePath => {
+    run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);
+    run(['add', 'GridBeyond', '--segment', 'VPP'], filePath);
+    run(['archive', '2'], filePath);
+
+    const derOnly = run(['list', '--segment', 'Demand Response'], filePath);
+    assert.match(derOnly.stdout, /Voltus/);
+    assert.doesNotMatch(derOnly.stdout, /GridBeyond/);
+
+    const active = run(['list'], filePath);
+    assert.doesNotMatch(active.stdout, /GridBeyond/);
+
+    const all = run(['list', '--all'], filePath);
+    assert.match(all.stdout, /GridBeyond/);
+  });
+});
+
+test('note appends research notes visible in show', () => {
+  withTempFile(filePath => {
+    run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);
+    const note = run(['note', '1', 'Closed $60M Series C'], filePath);
+    assert.equal(note.status, 0);
+
+    const show = run(['show', '1'], filePath);
+    assert.equal(show.status, 0);
+    assert.match(show.stdout, /Closed \$60M Series C/);
+  });
+});
+
+test('segments summarizes watching companies by segment', () => {
+  withTempFile(filePath => {
+    run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);
+    run(['add', 'CPower', '--segment', 'Demand Response'], filePath);
+    run(['add', 'GridBeyond', '--segment', 'VPP'], filePath);
+
+    const segments = run(['segments'], filePath);
+    assert.equal(segments.status, 0);
+    assert.match(segments.stdout, /Demand Response\s+2/);
+    assert.match(segments.stdout, /VPP\s+1/);
+  });
+});
+
+test('rm permanently removes a company', () => {
+  withTempFile(filePath => {
+    run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);
+    const rm = run(['rm', '1'], filePath);
+    assert.equal(rm.status, 0);
+
+    const all = run(['list', '--all'], filePath);
+    assert.doesNotMatch(all.stdout, /Voltus/);
+  });
+});
+
+test('show with an unknown id exits non-zero with a clear error', () => {
+  withTempFile(filePath => {
+    const show = run(['show', '42'], filePath);
+    assert.notEqual(show.status, 0);
+    assert.match(show.stderr, /not found/i);
+  });
+});
+
+test('unknown command exits non-zero and prints an error', () => {
+  withTempFile(filePath => {
+    const result = run(['bogus'], filePath);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown command/i);
+  });
+});

--- a/examples/energy-industry-tracker/tests/cli.test.js
+++ b/examples/energy-industry-tracker/tests/cli.test.js
@@ -64,6 +64,36 @@ test('list --segment filters, list --all includes archived companies', () => {
   });
 });
 
+test('add accepts --stage, --source and --notes, all visible in show', () => {
+  withTempFile(filePath => {
+    run(
+      ['add', 'Voltus', '--segment', 'Demand Response', '--stage', 'Series C', '--source', 'https://voltus.co', '--notes', 'Initial research'],
+      filePath
+    );
+
+    const show = run(['show', '1'], filePath);
+    assert.match(show.stdout, /Series C/);
+    assert.match(show.stdout, /https:\/\/voltus\.co/);
+    assert.match(show.stdout, /Initial research/);
+  });
+});
+
+test('show reports no notes for a freshly added company', () => {
+  withTempFile(filePath => {
+    run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);
+    const show = run(['show', '1'], filePath);
+    assert.match(show.stdout, /No notes\./);
+  });
+});
+
+test('segments reports nothing tracked when the watchlist is empty', () => {
+  withTempFile(filePath => {
+    const segments = run(['segments'], filePath);
+    assert.equal(segments.status, 0);
+    assert.match(segments.stdout, /No segments tracked\./);
+  });
+});
+
 test('note appends research notes visible in show', () => {
   withTempFile(filePath => {
     run(['add', 'Voltus', '--segment', 'Demand Response'], filePath);

--- a/examples/energy-industry-tracker/tests/watchlist-store.test.js
+++ b/examples/energy-industry-tracker/tests/watchlist-store.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createCompany,
+  listCompanies,
+  addNote,
+  archiveCompany,
+  removeCompany,
+  segmentSummary
+} = require('../src/watchlist-store');
+
+test('createCompany adds a watching company with a sequential id', () => {
+  const { companies, company } = createCompany([], { name: 'Voltus', segment: 'Demand Response' });
+  assert.equal(companies.length, 1);
+  assert.equal(company.id, 1);
+  assert.equal(company.name, 'Voltus');
+  assert.equal(company.segment, 'Demand Response');
+  assert.equal(company.status, 'watching');
+  assert.deepEqual(company.notes, []);
+});
+
+test('createCompany assigns increasing ids based on existing companies', () => {
+  const existing = [{ id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' }];
+  const { company } = createCompany(existing, { name: 'b', segment: 's' });
+  assert.equal(company.id, 2);
+});
+
+test('createCompany does not mutate the original companies array', () => {
+  const original = [];
+  createCompany(original, { name: 'a', segment: 's' });
+  assert.equal(original.length, 0);
+});
+
+test('createCompany rejects a missing or blank name', () => {
+  assert.throws(() => createCompany([], { name: '', segment: 's' }), /name/i);
+  assert.throws(() => createCompany([], { name: '   ', segment: 's' }), /name/i);
+});
+
+test('createCompany rejects a missing or blank segment', () => {
+  assert.throws(() => createCompany([], { name: 'Voltus', segment: '' }), /segment/i);
+});
+
+test('createCompany stores optional stage, source and an initial note', () => {
+  const { company } = createCompany([], {
+    name: 'Voltus',
+    segment: 'Demand Response',
+    stage: 'Series C',
+    source: 'https://example.com/voltus',
+    notes: 'Piloting with two utilities'
+  });
+  assert.equal(company.stage, 'Series C');
+  assert.equal(company.source, 'https://example.com/voltus');
+  assert.equal(company.notes.length, 1);
+  assert.equal(company.notes[0].text, 'Piloting with two utilities');
+});
+
+test('listCompanies returns only watching companies by default', () => {
+  const companies = [
+    { id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 2, name: 'b', segment: 's', status: 'archived', notes: [], createdAt: 'x', updatedAt: 'x' }
+  ];
+  const result = listCompanies(companies);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 1);
+});
+
+test('listCompanies returns archived companies too when all is set', () => {
+  const companies = [
+    { id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 2, name: 'b', segment: 's', status: 'archived', notes: [], createdAt: 'x', updatedAt: 'x' }
+  ];
+  const result = listCompanies(companies, { all: true });
+  assert.equal(result.length, 2);
+});
+
+test('listCompanies filters by segment case-insensitively', () => {
+  const companies = [
+    { id: 1, name: 'a', segment: 'DERMS', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 2, name: 'b', segment: 'VPP', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' }
+  ];
+  const result = listCompanies(companies, { segment: 'derms' });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].name, 'a');
+});
+
+test('addNote appends a timestamped note without touching other companies', () => {
+  const companies = [
+    { id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 2, name: 'b', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' }
+  ];
+  const result = addNote(companies, 1, 'Raised Series B');
+  const updated = result.find(item => item.id === 1);
+  assert.equal(updated.notes.length, 1);
+  assert.equal(updated.notes[0].text, 'Raised Series B');
+  assert.ok(updated.notes[0].at);
+  assert.equal(result.find(item => item.id === 2).notes.length, 0);
+});
+
+test('addNote rejects blank note text', () => {
+  const companies = [{ id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' }];
+  assert.throws(() => addNote(companies, 1, '  '), /note/i);
+});
+
+test('addNote throws for an unknown id', () => {
+  assert.throws(() => addNote([], 99, 'text'), /not found/i);
+});
+
+test('archiveCompany marks a company archived and is idempotent', () => {
+  const companies = [{ id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' }];
+  const once = archiveCompany(companies, 1);
+  assert.equal(once.find(item => item.id === 1).status, 'archived');
+  const twice = archiveCompany(once, 1);
+  assert.equal(twice.find(item => item.id === 1).status, 'archived');
+});
+
+test('archiveCompany throws for an unknown id', () => {
+  assert.throws(() => archiveCompany([], 99), /not found/i);
+});
+
+test('removeCompany deletes only the matching company', () => {
+  const companies = [
+    { id: 1, name: 'a', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 2, name: 'b', segment: 's', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' }
+  ];
+  const result = removeCompany(companies, 1);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 2);
+});
+
+test('removeCompany throws for an unknown id', () => {
+  assert.throws(() => removeCompany([], 99), /not found/i);
+});
+
+test('segmentSummary counts watching companies per segment, sorted by count then name', () => {
+  const companies = [
+    { id: 1, name: 'a', segment: 'DERMS', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 2, name: 'b', segment: 'VPP', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 3, name: 'c', segment: 'DERMS', status: 'watching', notes: [], createdAt: 'x', updatedAt: 'x' },
+    { id: 4, name: 'd', segment: 'VPP', status: 'archived', notes: [], createdAt: 'x', updatedAt: 'x' }
+  ];
+  const summary = segmentSummary(companies);
+  assert.deepEqual(summary, [
+    { segment: 'DERMS', count: 2 },
+    { segment: 'VPP', count: 1 }
+  ]);
+});


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

## Why This Change
<!-- Explain the motivation and context for this change -->

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [ ] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [ ] No sensitive data exposed in logs or output
- [ ] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
- [ ] Ran `yarn install --mode=update-lockfile` and committed the `yarn.lock` change. CI runs Yarn in hardened mode on public PRs and fails if the lockfile would be modified, so an out of date `yarn.lock` breaks the build even when nothing else is wrong.

## If you added a skill, command, agent, hook, or CLI tool
- [ ] Registered in `package.json` (`bin` and `files`), `manifests/install-components.json`, `manifests/install-modules.json`, and `agent.yaml`
- [ ] Regenerated the catalog (`npm run catalog:sync`) and command registry (`npm run command-registry:write`)
- [ ] Updated the docs tables it belongs in (`README.md`, `COMMANDS-QUICK-REF.md`, `docs/COMMAND-AGENT-MAP.md`)
- [ ] If it ships a new script path, added it to the publish surface allowlist (`tests/scripts/npm-publish-surface.test.js`)
- [ ] Cross-harness surfaces updated if applicable (for Codex, `.agents/skills/<name>/` plus `agents/openai.yaml`; the Codex frontmatter validator allows only `name`, `description`, `metadata`, `license`, `allowed-tools`, so drop keys like `version` from that copy)
- [ ] Full gauntlet passes locally (`npm test`)

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)
