### PR TITLE
fix(hooks): correct Opus rate and stop guessing Sonnet for unknown models

### DIFF
--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -73,14 +73,20 @@ function readHarnessCost(sessionId, maxAgeSeconds) {
 const RATE_TABLE = {
   haiku:  { in: 0.80,  out: 4.0,  cacheWrite: 1.00,  cacheRead: 0.08 },
   sonnet: { in: 3.00,  out: 15.0, cacheWrite: 3.75,  cacheRead: 0.30 },
-  opus:   { in: 15.00, out: 75.0, cacheWrite: 18.75, cacheRead: 1.50 }
+  opus:   { in: 5.00,  out: 25.0, cacheWrite: 6.25,  cacheRead: 0.50 },
+  fable:  { in: 10.00, out: 50.0, cacheWrite: 12.50, cacheRead: 1.00 }
 };
 
+// Returns null for a model name matching none of the table above, rather
+// than guessing: a silent Sonnet default previously mispriced every new
+// model (most recently Fable) until someone noticed (#2574).
 function getRates(model) {
   const m = String(model || '').toLowerCase();
-  if (m.includes('haiku')) return RATE_TABLE.haiku;
-  if (m.includes('opus'))  return RATE_TABLE.opus;
-  return RATE_TABLE.sonnet;
+  if (m.includes('haiku'))  return RATE_TABLE.haiku;
+  if (m.includes('fable'))  return RATE_TABLE.fable;
+  if (m.includes('opus'))   return RATE_TABLE.opus;
+  if (m.includes('sonnet')) return RATE_TABLE.sonnet;
+  return null;
 }
 
 function toNumber(v) {
@@ -174,12 +180,15 @@ process.stdin.on('end', () => {
     } = usageTotals || {};
 
     const rates = getRates(model);
-    const transcriptCostUsd = Math.round((
-      (inputTokens      / 1e6) * rates.in +
-      (outputTokens     / 1e6) * rates.out +
-      (cacheWriteTokens / 1e6) * rates.cacheWrite +
-      (cacheReadTokens  / 1e6) * rates.cacheRead
-    ) * 1e6) / 1e6;
+    const rateKnown = rates !== null;
+    const transcriptCostUsd = rateKnown
+      ? Math.round((
+          (inputTokens      / 1e6) * rates.in +
+          (outputTokens     / 1e6) * rates.out +
+          (cacheWriteTokens / 1e6) * rates.cacheWrite +
+          (cacheReadTokens  / 1e6) * rates.cacheRead
+        ) * 1e6) / 1e6
+      : 0;
 
     // Prefer the harness's authoritative `cost.total_cost_usd` when the
     // statusline has written it to the per-session cache (see contract in
@@ -190,6 +199,7 @@ process.stdin.on('end', () => {
     const estimatedCostUsd = harnessCost !== null
       ? Math.round(harnessCost * 1e6) / 1e6
       : transcriptCostUsd;
+    const costEstimated = harnessCost !== null || rateKnown;
 
     const metricsDir = path.join(getClaudeDir(), 'metrics');
     ensureDir(metricsDir);
@@ -203,7 +213,8 @@ process.stdin.on('end', () => {
       output_tokens:      outputTokens,
       cache_write_tokens: cacheWriteTokens,
       cache_read_tokens:  cacheReadTokens,
-      estimated_cost_usd: estimatedCostUsd
+      estimated_cost_usd: estimatedCostUsd,
+      cost_estimated:     costEstimated
     };
 
     appendFile(path.join(metricsDir, 'costs.jsonl'), `${JSON.stringify(row)}\n`);

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -302,6 +302,79 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
+  // 10. Prices Opus at the current rate, not the stale 3x-too-high figure
+  (test('prices opus at $5/$25 per 1M tokens, not the stale $15/$75', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-opus-4-6',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+    const result = runScript({ transcript_path: transcriptPath }, withTempHome(tmpHome));
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 30, 'Expected 1M in + 1M out at $5/$25, not $15/$75');
+    assert.strictEqual(row.cost_estimated, true, 'Opus is a known model, cost should be marked estimated');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // 11. Fable gets its own rate instead of silently falling through to Sonnet
+  (test('prices fable at its own rate instead of the Sonnet fallback', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-fable-5',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+    const result = runScript({ transcript_path: transcriptPath }, withTempHome(tmpHome));
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 60, 'Expected 1M in + 1M out at fable rate $10/$50, not Sonnet $3/$15');
+    assert.strictEqual(row.cost_estimated, true, 'Fable is a known model, cost should be marked estimated');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // 12. An unrecognized model name is priced as unknown, never guessed at Sonnet rates
+  (test('marks an unrecognized model unestimated instead of guessing Sonnet rates', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-nova-9',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+    const result = runScript({ transcript_path: transcriptPath }, withTempHome(tmpHome));
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 0, 'Expected no guessed cost for an unrecognized model');
+    assert.strictEqual(row.cost_estimated, false, 'Expected the row to flag the cost as not estimated');
+    assert.strictEqual(row.input_tokens, 1_000_000, 'Token totals should still be recorded');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary

`RATE_TABLE.opus` in `scripts/hooks/cost-tracker.js` still carries the old $15/$75 per 1M token rate, 3x the current $5/$25. `getRates()` also fell through to Sonnet rates for any model matching neither `haiku` nor `opus`, so a newer model like `claude-fable-5` was silently priced as Sonnet instead of at its own (higher) rate.

## Fix

- Updated the Opus entry to $5/$25 (in/out) and $6.25/$0.50 (cache write/read), and added a Fable entry at $10/$50 / $12.50/$1.00.
- `getRates()` now returns `null` for a model it doesn't recognize instead of guessing. The caller records `estimated_cost_usd: 0` and a new `cost_estimated: false` flag on that row, so a reader of `costs.jsonl` can distinguish an unpriced model from a genuinely free one.

## Testing

- `tests/hooks/cost-tracker.test.js`: added 3 cases (Opus at the corrected rate, Fable at its own rate, an unrecognized model marked unestimated). All 3 fail on unmodified `main` (Opus priced at $90 instead of $30, Fable at $18 instead of $60, an unknown model guessed at $18 instead of $0) and pass with this fix.
- Full existing suite for this hook (`node tests/hooks/cost-tracker.test.js`, 12 cases) and the repo-wide suite (`node tests/run-all.js`, 3300 cases) both green; `npm run lint` and `npm run coverage` clean.
- Did not check the `>200K-token` or `1h-cache` billing tiers mentioned in this file's own header; this hook's rate table is documented there as an approximation for exactly that reason, and this fix only corrects the flat per-model rates and the fallback behavior.
