### PR TITLE
fix: add claude-opus-5 to KNOWN_MODEL_WINDOW_TOKENS

### DIFF
--- a/scripts/lib/transcript-context.js
+++ b/scripts/lib/transcript-context.js
@@ -35,6 +35,7 @@ const LARGE_WINDOW_MODEL_MARKER = '[1m]';
 // Checked in order, first match wins. Best-effort and expected to lag new
 // releases; the env override remains the escape hatch for unlisted models.
 const KNOWN_MODEL_WINDOW_TOKENS = [
+  ['claude-opus-5', LARGE_CONTEXT_WINDOW_TOKENS],
   ['claude-fable-5', LARGE_CONTEXT_WINDOW_TOKENS],
   ['claude-mythos-5', LARGE_CONTEXT_WINDOW_TOKENS]
 ];

--- a/tests/lib/transcript-context.test.js
+++ b/tests/lib/transcript-context.test.js
@@ -188,6 +188,10 @@ test('recognizes claude-mythos-5 as a 1M window from the known-model table (#246
   assert.strictEqual(resolveContextWindowTokens(50000, 'claude-mythos-5'), LARGE_CONTEXT_WINDOW_TOKENS);
 });
 
+test('recognizes claude-opus-5 as a 1M window from the known-model table', () => {
+  assert.strictEqual(resolveContextWindowTokens(50000, 'claude-opus-5'), LARGE_CONTEXT_WINDOW_TOKENS);
+});
+
 test('recognizes dated/prefixed variants of known large-window model ids (#2461)', () => {
   assert.strictEqual(resolveContextWindowTokens(50000, 'us.anthropic.claude-fable-5-20260115-v1:0'), LARGE_CONTEXT_WINDOW_TOKENS);
 });


### PR DESCRIPTION
## Problem

`claude-opus-5` is missing from `KNOWN_MODEL_WINDOW_TOKENS` in `scripts/lib/transcript-context.js`. When `resolveContextWindowTokens()` is called with `model = "claude-opus-5"` and `tokens < 200000`, none of the detection paths match:

1. No env override set
2. No `[1m]` marker in the model id
3. Token count below 200k threshold

It falls back to `STANDARD_CONTEXT_WINDOW_TOKENS` (200k), incorrectly triggering compact warnings. The `tokens > 200000` heuristic on line 186 catches it later, but only after the session has already used 200k+ tokens — exactly when compact is most wasteful.

**Verified**: 250156 tokens at 25% usage = ~1M context window.

## Bad behavior shape

This bug only manifests in the first 20% of a 1M session. Past 200k tokens, it self-heals via the heuristic branch. This makes it particularly misleading: the compact warning appears precisely when compacting would waste the most tokens.

## Fix

Add `['claude-opus-5', LARGE_CONTEXT_WINDOW_TOKENS]` to the table. Same pattern as #2461 (fable-5/mythos-5) and #2290 (Opus 4.x).

`claude-sonnet-5` is not included — no empirical window-size data available yet. Guessing would be the same class of error.

## Workaround

Set `ECC_CONTEXT_WINDOW_TOKENS=1000000` in `~/.claude/settings.json` env. This is model-agnostic and survives plugin upgrades.

Refs: #2290, #2461, #2468