### PR TITLE
fix(skill-stocktake): discover symlinked SKILL.md files

### DIFF
--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -74,7 +74,7 @@ process_dir() {
       '{path:$path,mtime:$mtime,is_new:$is_new}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -118,7 +118,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/tests/scripts/skill-stocktake-discovery.test.js
+++ b/tests/scripts/skill-stocktake-discovery.test.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scannerPaths = [
+  path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'scan.sh'),
+  path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'quick-diff.sh'),
+];
+const bashPath = process.platform === 'win32'
+  ? path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Git', 'bin', 'bash.exe')
+  : 'bash';
+
+let passed = 0;
+let failed = 0;
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${description}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${description}: ${error.message}`);
+    failed++;
+  }
+}
+
+function extractDiscoveryCommand(scannerPath) {
+  const source = fs.readFileSync(scannerPath, 'utf8');
+  const match = source.match(/done < <\((find [^\r\n]+)\)/);
+  assert.ok(match, `Could not find the discovery command in ${scannerPath}`);
+  return match[1];
+}
+
+function runDiscovery(scannerPath, skillsDir) {
+  const discoveryCommand = extractDiscoveryCommand(scannerPath);
+  const command = process.platform === 'win32'
+    ? `dir=$(cygpath -u "$dir"); ${discoveryCommand}`
+    : discoveryCommand;
+  const result = spawnSync(bashPath, ['-c', command], {
+    encoding: 'utf8',
+    env: { ...process.env, dir: skillsDir },
+  });
+
+  assert.strictEqual(result.status, 0, result.stderr || 'skill discovery failed');
+  return result.stdout
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(filePath => filePath.replace(/\\/g, '/'));
+}
+
+function writeSkill(skillDir, name) {
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: test fixture\n---\n# ${name}\n`,
+  );
+}
+
+console.log('\nSkill stocktake discovery tests:');
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-skill-stocktake-'));
+
+try {
+  for (const scannerPath of scannerPaths) {
+    const scannerName = path.basename(scannerPath);
+
+    if (process.platform === 'win32') {
+      console.log(`  ↷ ${scannerName} symlink case skipped on Windows`);
+    } else {
+      test(`${scannerName} follows symlinked skill directories`, () => {
+        const fixtureRoot = path.join(tempRoot, `${scannerName}-symlink`);
+        const skillsDir = path.join(fixtureRoot, 'skills');
+        const targetDir = path.join(fixtureRoot, 'shared', 'linked-skill');
+        const linkedDir = path.join(skillsDir, 'linked-skill');
+        writeSkill(targetDir, 'linked-skill');
+        fs.mkdirSync(skillsDir, { recursive: true });
+        fs.symlinkSync(targetDir, linkedDir, 'dir');
+
+        const discovered = runDiscovery(scannerPath, skillsDir);
+
+        assert.strictEqual(discovered.length, 1);
+        assert.ok(
+          discovered[0].endsWith('/linked-skill/SKILL.md'),
+          `Expected linked SKILL.md, got ${discovered[0]}`,
+        );
+      });
+    }
+
+    test(`${scannerName} ignores Markdown assets inside a skill`, () => {
+      const skillsDir = path.join(tempRoot, `${scannerName}-assets`, 'skills');
+      const skillDir = path.join(skillsDir, 'direct-skill');
+      const referencePath = path.join(skillDir, 'references', 'notes.md');
+      writeSkill(skillDir, 'direct-skill');
+      fs.mkdirSync(path.dirname(referencePath), { recursive: true });
+      fs.writeFileSync(referencePath, '# Supporting notes\n');
+
+      const discovered = runDiscovery(scannerPath, skillsDir);
+
+      assert.strictEqual(discovered.length, 1);
+      assert.ok(
+        discovered[0].endsWith('/direct-skill/SKILL.md'),
+        `Expected direct SKILL.md, got ${discovered[0]}`,
+      );
+    });
+  }
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## What Changed

- update `scan.sh` and `quick-diff.sh` to follow symlinked skill directories
- restrict skill discovery to canonical `SKILL.md` files instead of every Markdown asset
- add focused regression coverage for symlinked skills and nested Markdown files

## Why This Change

Both skill-stocktake scanners currently use `find` without `-L`, so skill directories installed through symlinks are omitted on POSIX systems.

The scanners also match every `*.md` file, causing nested references and context documents to be counted as independent skills.

This change aligns both scanners with the canonical `SKILL.md` layout while keeping the rest of their inventory and comparison behavior unchanged.

Fixes #2598.

Related to #2492, which also touches these scripts for Windows compatibility. This PR is intentionally limited to skill discovery behavior and does not include its path-normalization or documentation changes.

## Testing Done

- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Targeted checks completed:

- `node tests/scripts/skill-stocktake-discovery.test.js`
- `npx eslint tests/scripts/skill-stocktake-discovery.test.js`
- `bash -n skills/skill-stocktake/scripts/scan.sh`
- `bash -n skills/skill-stocktake/scripts/quick-diff.sh`
- POSIX symlink reproduction through both production discovery commands

The repository validation stage of `npm test` passed. The full run on Windows with Node 24 finished with 3272 passed and 20 failed; the new regression test passed. Node 24 is outside the repository's Node 18/20/22 CI matrix, so the full-suite checkbox is intentionally left unchecked.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (not available locally)
- [ ] Pre-commit hooks pass locally (not configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Dependencies and Package Metadata

Not applicable. No dependencies, `package.json`, or lockfiles were changed.

## New Publish Surfaces

Not applicable. This PR does not add a new skill, command, agent, hook, CLI tool, or published script path.

## Documentation

No documentation update is needed because this fixes existing scanner behavior and adds regression coverage without changing the user-facing interface.