### PR TITLE
fix(memory-vault): compare dev only when both stats report one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Default MCP connector set reduced to a single connector (`chrome-devtools`) per the new connector policy (`docs/MCP-CONNECTOR-POLICY.md`). The six previous defaults (`github`, `context7`, `exa`, `memory`, `playwright`, `sequential-thinking`) were retired after the June 2026 audit: their jobs are covered by skills wrapping CLIs/REST APIs (`github-ops`, `documentation-lookup`, `exa-search`, e2e skills) or by harness-native features (memory, extended thinking, web search). All six remain opt-in via `mcp-configs/mcp-servers.json`.
 
+### Fixed
+
+- `ecc memory` writes and `--body-file` reads failed on Windows under Node 22.12-22.16 and 24.0-24.1. libuv resolved path-based `stat()`/`lstat()` through `GetFileInformationByName` without setting the volume serial, while `fstat()` reported it, so the memory vault's TOCTOU guard rejected every operation. Fixed upstream in libuv 1.51.0; the guard no longer depends on the runtime's patch level. The guard's stat calls now request `BigInt` values, so Windows file IDs past `Number.MAX_SAFE_INTEGER` can no longer collapse two distinct files into one identity.
+
 ## 2.0.0 - 2026-06-09
 
 ### Added

--- a/scripts/lib/memory-vault.js
+++ b/scripts/lib/memory-vault.js
@@ -122,7 +122,21 @@ function assertMemoryDirectorySafe(directory, root) {
 }
 
 function sameFileIdentity(left, right) {
-  return left.dev === right.dev && left.ino === right.ino;
+  // The inode is the primary identity signal and must always match.
+  if (left.ino !== right.ino) {
+    return false;
+  }
+  // libuv 1.49.0 through 1.50.x resolve path-based stat() and lstat() on Windows
+  // through GetFileInformationByName, which leaves the volume serial unset, while
+  // fstat() on an open handle reports it. Comparing the two then never matches and
+  // every vault read and write is rejected. libuv 82cdfb75f fixed this in 1.51.0,
+  // so only Node 22.12-22.16 and 24.0-24.1 are affected, but the guard should not
+  // depend on the runtime's patch level. Compare dev only when both sides report
+  // one; POSIX always does, so the original strict behaviour is preserved there.
+  if (!left.dev || !right.dev) {
+    return true;
+  }
+  return left.dev === right.dev;
 }
 
 function readRegularTextFile(filePath, options = {}) {
@@ -137,11 +151,11 @@ function readRegularTextFile(filePath, options = {}) {
     | (fs.constants.O_NONBLOCK || 0);
   const descriptor = fs.openSync(filePath, flags);
   try {
-    const opened = fs.fstatSync(descriptor);
+    const opened = fs.fstatSync(descriptor, { bigint: true });
     if (!opened.isFile()) {
       throw new Error(`${label} must be a regular, non-symlink file.`);
     }
-    const after = fs.lstatSync(filePath);
+    const after = fs.lstatSync(filePath, { bigint: true });
     if (
       after.isSymbolicLink()
       || !after.isFile()
@@ -152,7 +166,7 @@ function readRegularTextFile(filePath, options = {}) {
     if (options.trustedRoot) {
       assertWithinTrustedRoot(filePath, options.trustedRoot, `read ${label}`);
     }
-    if (opened.size > maxBytes) {
+    if (opened.size > BigInt(maxBytes)) {
       throw new Error(`${label} is too large (${opened.size} bytes).`);
     }
 
@@ -189,8 +203,8 @@ function writeCreateOnlyTextFile(filePath, content, trustedRoot) {
   let cleanupError;
   try {
     descriptor = fs.openSync(temporaryPath, flags, 0o600);
-    const opened = fs.fstatSync(descriptor);
-    const after = fs.lstatSync(temporaryPath);
+    const opened = fs.fstatSync(descriptor, { bigint: true });
+    const after = fs.lstatSync(temporaryPath, { bigint: true });
     assertWithinTrustedRoot(temporaryPath, trustedRoot, 'write memory');
     if (
       !opened.isFile()
@@ -770,6 +784,7 @@ module.exports = {
   readMemoryById,
   readMemoryFiles,
   resolveVaultRoots,
+  sameFileIdentity,
   saveMemory,
   scoreMemory,
   searchMemories,

--- a/tests/lib/memory-vault.test.js
+++ b/tests/lib/memory-vault.test.js
@@ -19,6 +19,7 @@ const {
   readMemoryById,
   readRegularTextFile,
   resolveVaultRoots,
+  sameFileIdentity,
   saveMemory,
   searchMemories,
   serializeMemoryDocument,
@@ -516,6 +517,47 @@ test('quarantines imported secrets and metadata that disagrees with its vault lo
   }
 });
 
+// Windows reports dev = 0 from path-based stat()/lstat() while fstat() on an open
+// handle reports the real volume serial number, so a strict dev comparison can never
+// match and every vault read/write is rejected. The stat pairs below are the values
+// measured on Node v22.15.0 / Windows 11 10.0.26200 reported in issue #2626.
+test('matches a Windows path-vs-handle stat pair where only dev differs', () => {
+  const openedByHandle = { dev: 1644385068, ino: 21110623254304612 };
+  const openedByPath = { dev: 0, ino: 21110623254304612 };
+  assert.strictEqual(sameFileIdentity(openedByPath, openedByHandle), true);
+});
+
+test('matches a Windows stat pair on a non-system volume', () => {
+  const openedByHandle = { dev: 3054669153, ino: 562949953451607 };
+  const openedByPath = { dev: 0, ino: 562949953451607 };
+  assert.strictEqual(sameFileIdentity(openedByPath, openedByHandle), true);
+});
+
+test('separates files that share an inode across two reported devices', () => {
+  const left = { dev: 16777232, ino: 42 };
+  const right = { dev: 16777233, ino: 42 };
+  assert.strictEqual(sameFileIdentity(left, right), false);
+});
+
+test('separates distinct inodes reported from the same device', () => {
+  const left = { dev: 16777232, ino: 42 };
+  const right = { dev: 16777232, ino: 43 };
+  assert.strictEqual(sameFileIdentity(left, right), false);
+});
+
+// Runs on every platform, but only the windows-latest CI leg exercises the
+// path-vs-handle dev divergence that issue #2626 reports.
+test('reads a regular file whose handle and path stats are compared', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-memory-identity-'));
+  const target = path.join(root, 'target.md');
+  try {
+    fs.writeFileSync(target, 'durable');
+    assert.strictEqual(readRegularTextFile(target, { maxBytes: 16 }), 'durable');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('opens regular text files without following a stable symlink', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-memory-file-'));
   const target = path.join(root, 'target.md');
@@ -572,6 +614,45 @@ test('opens a file descriptor before inspecting path metadata', () => {
     assert.strictEqual(readRegularTextFile(target, { maxBytes: 16 }), 'safe');
   } finally {
     fs.openSync = originalOpenSync;
+    fs.lstatSync = originalLstatSync;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Windows file IDs run past Number.MAX_SAFE_INTEGER, so two distinct files can
+// collapse to the same value in a number-valued Stats. On the libuv versions that
+// report dev = 0 the inode is the only identity signal left, so the stats have to
+// be requested as BigInt for the guard to hold. The stubs below mimic fs: BigInt
+// when { bigint: true } is requested, lossy numbers otherwise.
+test('detects a swapped file whose inode differs beyond Number precision', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-memory-bigint-ino-'));
+  const target = path.join(root, 'target.md');
+  const originalFstatSync = fs.fstatSync;
+  const originalLstatSync = fs.lstatSync;
+
+  const stat = (base, fileId, options) => Object.assign(
+    Object.create(Object.getPrototypeOf(base)),
+    base,
+    {
+      dev: options && options.bigint ? 0n : 0,
+      ino: options && options.bigint ? fileId : Number(fileId),
+      size: options && options.bigint ? BigInt(base.size) : base.size,
+    }
+  );
+
+  try {
+    fs.writeFileSync(target, 'safe');
+    fs.fstatSync = (descriptor, options) =>
+      stat(originalFstatSync(descriptor), 21110623254304612n, options);
+    fs.lstatSync = (filePath, options) =>
+      stat(originalLstatSync(filePath), 21110623254304613n, options);
+
+    assert.throws(
+      () => readRegularTextFile(target, { maxBytes: 16 }),
+      /must remain a regular, non-symlink file/
+    );
+  } finally {
+    fs.fstatSync = originalFstatSync;
     fs.lstatSync = originalLstatSync;
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #2626.

`sameFileIdentity()` compares the `dev` field of a path-based stat against a handle-based `fstat`. On Windows those two come from different code paths in libuv, and only one of them fills in the volume serial, so the comparison never matches and the TOCTOU guard rejects every `ecc memory` write and every `--body-file` read.

## Root cause

This is an upstream libuv bug, not an ECC bug, but ECC is exposed to it.

libuv 1.49.0 added a fast path for path-based stat that calls `GetFileInformationByName` (`src/win/fs.c`, `fs__stat_path`). That API does not populate `VolumeSerialNumber`, and libuv assigns it straight through to `st_dev`. The handle-based path, `fs__stat_handle`, queries `NtQueryVolumeInformationFile` explicitly and gets a real serial. So `fstat` returns the volume serial and `lstat` returns 0 for the same file.

libuv fixed this in commit `82cdfb75f`, "win: fix the inconsistency in volume serial number". I checked the ancestry: it is not in 1.50.0 and is in 1.51.0.

## Affected versions

| Node | libuv | Affected |
| --- | --- | --- |
| 18.x, 20.x | 1.44.2, 1.46.0 | No, predates the fast path |
| 22.11.0 and earlier | 1.48.0 | No |
| 22.12.0 to 22.16.x | 1.49.1, 1.49.2 | Yes |
| 22.17.0 and later | 1.51.0 | No |
| 24.0.0 to 24.1.x | 1.50.0 | Yes |
| 24.2.0 and later | 1.51.0 | No |

The reporter was on 22.15.0, which is inside the window. `package.json` declares `engines: {"node": ">=18"}`, so affected versions are supported.

## Verification, including what did not reproduce

I want to be clear about this rather than claim more than I checked.

I ran a probe on a GitHub Actions `windows-latest` runner that compares `fstat` against `lstat` on two volumes and then exercises `readRegularTextFile`. **It did not reproduce the bug.** The runner is on Node 22.23.1, which bundles libuv 1.51.0 and therefore already has the upstream fix:

```
node v22.23.1 / win32 10.0.26100
C:\...\ecc-probe.txt   fstat dev=1115898621  lstat dev=1115898621   dev diverges: false
D:\ecc-probe.txt       fstat dev=2130175210  lstat dev=2130175210   dev diverges: false
READ_REGULAR_TEXT_FILE: ok
```

That is consistent with the diagnosis rather than against it, but it does mean I have not personally observed the failure. The evidence for it is the libuv source above plus the measurements in the issue.

It also means CI cannot guard this. The matrix pins `22.x`, which always resolves to a patched Node, so no end-to-end test in this repo can ever fail on this. That is why the tests here assert against the stat values directly.

The probe workflow was temporary and is not part of this PR. I am happy to share it if you want to run it yourself.

## Changes

- `sameFileIdentity()` keeps the inode strict and compares `dev` only when both sides report one. POSIX always reports a non-zero `dev`, so behaviour there is unchanged.
- The helper is exported so it can be tested directly.
- The guard's stat calls request `BigInt` values. On the affected libuv versions `dev` is 0, which leaves the inode as the only identity signal, and Windows file IDs run past `Number.MAX_SAFE_INTEGER`, where two distinct files collapse to the same number-valued inode and defeat the guard.
- Six tests in `tests/lib/memory-vault.test.js`. Two use the stat pairs measured in the issue and fail on `main`. Two assert that differing non-zero devices and differing inodes are still treated as different files, so a broader fix that dropped the `dev` check would fail them. One reads a real file end to end on whatever platform is running. One stubs `fstat`/`lstat` with adjacent file IDs above `Number.MAX_SAFE_INTEGER` and fails without the `BigInt` change.
- A CHANGELOG entry under Unreleased.

`node tests/lib/memory-vault.test.js` passes 35 of 35 locally on macOS. I could not run the full `npm test` to completion because it exceeds ten minutes on my machine, so CI is the real check on the rest of the suite.
