### PR TITLE
fix(suggest-compact): percent-of-window thresholds and honest unknown-window handling

### DIFF
--- a/.agents/skills/strategic-compact/SKILL.md
+++ b/.agents/skills/strategic-compact/SKILL.md
@@ -31,7 +31,7 @@ Strategic compaction at logical boundaries:
 
 The `suggest-compact.js` script runs on PreToolUse (Edit/Write) and combines two signals:
 
-1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at a window-scaled threshold — 160k tokens on a 200k window, 250k on a 1M window (detected from a `[1m]` model marker, or inferred when observed tokens already exceed 200k) — and re-reminds after every additional 60k tokens of context growth
+1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at 70% of the detected context window — 140k tokens on a 200k window, 280k on 400k, 700k on 1M (the window is detected from a `[1m]` model marker, the known-model table, or model-family patterns) — and re-reminds after every additional 60k tokens of context growth. When the model's window cannot be determined, the suggestion reports the raw token count past 300k and says the window is unknown instead of printing a percentage of a guessed window
 2. **Tool-call count (secondary)** — Counts tool invocations in session; suggests at a configurable threshold (default: 50 calls), then every 25 calls after
 
 ## Hook Setup
@@ -59,7 +59,7 @@ Add to your `~/.claude/settings.json`:
 
 Environment variables:
 - `COMPACT_THRESHOLD` — Tool calls before first suggestion (default: 50)
-- `COMPACT_CONTEXT_THRESHOLD` — Context tokens before the context-size suggestion (default: 160000 on a 200k window, 250000 on a 1M window; `0` disables the context signal)
+- `COMPACT_CONTEXT_THRESHOLD` — Absolute context tokens before the context-size suggestion, overriding the percentage default (default: 70% of the detected window — 140000 on 200k, 280000 on 400k, 700000 on 1M; 300000 when the window is unknown; `0` disables the context signal)
 - `COMPACT_CONTEXT_INTERVAL` — Additional context tokens before the suggestion repeats (default: 60000)
 - `ECC_CONTEXT_WINDOW_TOKENS` — Explicit context-window size, in tokens, overriding auto-detection. Set this for large-window models whose reported id lacks a `[1m]` marker (e.g. 400k Opus 4.x, or a new 1M-window model family) so the threshold scales to the real window instead of defaulting to 200k and overstating context usage.
 - `CLAUDE_CODE_AUTO_COMPACT_WINDOW` — Claude Code's native window-size override, in tokens; honored as a fallback when `ECC_CONTEXT_WINDOW_TOKENS` is unset.

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -15,12 +15,16 @@
  * Two signals (#2155):
  * - Tool-call count: first at COMPACT_THRESHOLD (default 50), then every 25.
  * - Context size (primary): the latest assistant `usage` record from the
- *   session transcript, compared against a window-scaled token threshold
- *   (COMPACT_CONTEXT_THRESHOLD; default 160k on a 200k window, 250k on 1M),
- *   re-reminding after every COMPACT_CONTEXT_INTERVAL tokens of growth
- *   (default 60k). Tool count is a weak proxy for window pressure — a few
- *   large reads can fill the window in very few calls, and many tiny calls
- *   can cross 50 while the window is barely used.
+ *   session transcript, compared against a percent-of-window token threshold
+ *   (COMPACT_CONTEXT_THRESHOLD overrides it absolutely; the default is 70% of
+ *   the detected window — 140k on 200k, 280k on 400k, 700k on 1M), re-reminding
+ *   after every COMPACT_CONTEXT_INTERVAL tokens of growth (default 60k). Tool
+ *   count is a weak proxy for window pressure — a few large reads can fill the
+ *   window in very few calls, and many tiny calls can cross 50 while the window
+ *   is barely used.
+ *
+ * When the model's window cannot be determined, the suggestion reports the raw
+ * token count and says so instead of printing a percentage of a guessed window.
  */
 
 const fs = require('fs');
@@ -175,7 +179,7 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     const threshold = resolveContextThreshold(env, windowTokens);
     if (threshold <= 0) return null; // COMPACT_CONTEXT_THRESHOLD=0 disables
 
-    const interval = resolveContextInterval(env);
+    const interval = resolveContextInterval(env, windowTokens);
     const bucket = computeContextBucket(usage.tokens, threshold, interval);
     if (bucket < 0) return null;
 
@@ -185,6 +189,12 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     writeFile(bucketFile, String(bucket));
 
     const approxTokens = `${Math.round(usage.tokens / 1000)}k`;
+    if (!Number.isFinite(windowTokens) || windowTokens <= 0) {
+      // Unknown window: report what is measured, never a percentage of a guess.
+      const modelLabel = usage.model || 'unknown model';
+      return `[StrategicCompact] Context ~${approxTokens} tokens (window unknown for ${modelLabel}; set ECC_CONTEXT_WINDOW_TOKENS or extend KNOWN_MODEL_WINDOW_TOKENS) - consider /compact at the next logical boundary`;
+    }
+
     const percent = Math.round((usage.tokens / windowTokens) * 100);
     return `[StrategicCompact] Context ~${approxTokens} tokens (${percent}% of ${formatWindowLabel(windowTokens)} window) - consider /compact at the next logical boundary`;
   } catch (err) {

--- a/scripts/lib/llm-summary.js
+++ b/scripts/lib/llm-summary.js
@@ -99,6 +99,8 @@ function getContextRemainingPct(transcriptPath) {
     const usage = readLatestContextTokens(transcriptPath);
     if (!usage) return null;
     const windowTokens = resolveContextWindowTokens(usage.tokens, usage.model);
+    // Unknown window (unrecognized model id): no honest percentage exists.
+    if (!Number.isFinite(windowTokens) || windowTokens <= 0) return null;
     return Math.round((1 - usage.tokens / windowTokens) * 100);
   } catch {
     return null;

--- a/scripts/lib/transcript-context.js
+++ b/scripts/lib/transcript-context.js
@@ -6,12 +6,13 @@
  *
  * - `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
  *   partition the prompt, so their sum is the true context size of the turn.
- * - The context window is detected from the model id (`[1m]` marker) or from
- *   the observed token count (anything above 200k implies a 1M window even
- *   when logs drop the suffix).
- * - Thresholds are window-scaled and env-overridable; re-reminders fire in
- *   fixed token "buckets" above the threshold so the suggestion only repeats
- *   after real context growth.
+ * - The context window is detected from the model id: the `[1m]` marker, the
+ *   known-family table, then family patterns (`opus-4` is 400k, `sonnet-4` /
+ *   `haiku` / `claude-3` are 200k). An id that matches nothing yields `null`
+ *   (unknown) rather than a guess, so no percentage is ever fabricated.
+ * - Thresholds are a percentage of the detected window (70%) and
+ *   env-overridable; re-reminders fire in token "buckets" above the threshold
+ *   so the suggestion only repeats after real context growth.
  *
  * Only the tail of the transcript is read (latest records live at the end),
  * keeping the PreToolUse hook fast even for very large sessions.
@@ -20,10 +21,21 @@
 const fs = require('fs');
 
 const STANDARD_CONTEXT_WINDOW_TOKENS = 200000;
+const EXTENDED_CONTEXT_WINDOW_TOKENS = 400000;
 const LARGE_CONTEXT_WINDOW_TOKENS = 1000000;
+// Legacy absolute defaults, kept exported for compatibility with anything that
+// imported them; the live default is now a percentage of the detected window.
 const DEFAULT_CONTEXT_THRESHOLD_STANDARD = 160000;
 const DEFAULT_CONTEXT_THRESHOLD_LARGE = 250000;
+// One rule that holds at every window size: 140k on 200k, 280k on 400k, 700k on
+// 1M. The old absolute 250k default meant a 1M-window session was nagged from
+// 25% usage onward, re-firing every interval for the rest of a long session.
+const DEFAULT_CONTEXT_THRESHOLD_PCT = 0.7;
+// Used when the window is unknown: past every standard window, so the nudge is
+// still truthful without inventing a percentage.
+const UNKNOWN_WINDOW_THRESHOLD_TOKENS = 300000;
 const DEFAULT_CONTEXT_INTERVAL_TOKENS = 60000;
+const CONTEXT_INTERVAL_PCT = 0.05;
 const DEFAULT_TRANSCRIPT_TAIL_BYTES = 256 * 1024;
 const MAX_TOKEN_SETTING = 10000000;
 const LARGE_WINDOW_MODEL_MARKER = '[1m]';
@@ -37,6 +49,15 @@ const LARGE_WINDOW_MODEL_MARKER = '[1m]';
 const KNOWN_MODEL_WINDOW_TOKENS = [
   ['claude-fable-5', LARGE_CONTEXT_WINDOW_TOKENS],
   ['claude-mythos-5', LARGE_CONTEXT_WINDOW_TOKENS]
+];
+
+// Family patterns applied after the exact table above. These cover whole model
+// generations rather than single ids, so `opus-4` no longer needs the
+// env-only workaround from #2290 (Opus 4.x is a 400k window, which matches
+// neither the 200k default nor the `[1m]` marker). Checked in order.
+const MODEL_WINDOW_PATTERNS = [
+  [/opus-4/i, EXTENDED_CONTEXT_WINDOW_TOKENS],
+  [/sonnet-4|haiku|claude-3|opus-3/i, STANDARD_CONTEXT_WINDOW_TOKENS]
 ];
 
 /**
@@ -157,11 +178,18 @@ function readLatestContextTokens(transcriptPath, options = {}) {
 }
 
 /**
- * Detect the context window size for a turn.
- * 1M when the model id carries the `[1m]` marker, matches a known large-window
- * model family, or when the observed token count already exceeds the standard
- * 200k window (covers logs that drop the suffix); otherwise the standard 200k
- * window.
+ * Detect the context window size for a turn, in resolution order:
+ *   1. `ECC_CONTEXT_WINDOW_TOKENS` / `CLAUDE_CODE_AUTO_COMPACT_WINDOW` override;
+ *   2. the `[1m]` marker on the model id;
+ *   3. the known large-window family table (#2461);
+ *   4. family patterns (`opus-4` 400k, `sonnet-4`/`haiku`/`claude-3` 200k);
+ *   5. no model id at all: 200k, unless the observed token count already
+ *      exceeds it — then the window is provably larger but its size is unknown.
+ *
+ * @returns {number|null} Window size in tokens, or null when the window cannot
+ *   be determined. Callers must treat null as "unknown" and must not derive a
+ *   percentage from it — a wrong window is worse than no number, because it is
+ *   indistinguishable from a real one.
  */
 function resolveContextWindowTokens(tokens, model) {
   // Explicit window override wins: 400k models (e.g. Opus 4.x) match neither the
@@ -179,15 +207,26 @@ function resolveContextWindowTokens(tokens, model) {
 
   // Large-window model families without a [1m] marker fall through the checks
   // above and would be misreported against the 200k default (#2461).
-  if (typeof model === 'string') {
+  if (typeof model === 'string' && model) {
     const known = KNOWN_MODEL_WINDOW_TOKENS.find(([familyId]) => isKnownModelFamilyMatch(model, familyId));
     if (known) {
       return known[1];
     }
+
+    const pattern = MODEL_WINDOW_PATTERNS.find(([regex]) => regex.test(model));
+    if (pattern) {
+      return pattern[1];
+    }
+
+    // A model id we do not recognize. Guessing "over 200k therefore 1M" was
+    // wrong for every 400k model and invented percentages for the rest.
+    return null;
   }
 
+  // No model id in the transcript. Above the standard window the context is
+  // provably larger than 200k, but nothing says how much larger.
   if (Number.isFinite(tokens) && tokens > STANDARD_CONTEXT_WINDOW_TOKENS) {
-    return LARGE_CONTEXT_WINDOW_TOKENS;
+    return null;
   }
 
   return STANDARD_CONTEXT_WINDOW_TOKENS;
@@ -195,8 +234,14 @@ function resolveContextWindowTokens(tokens, model) {
 
 /**
  * Resolve the context-size suggestion threshold (tokens).
- * `COMPACT_CONTEXT_THRESHOLD=0` disables the context signal entirely;
- * other invalid values fall back to the window-scaled default.
+ * Defaults to `DEFAULT_CONTEXT_THRESHOLD_PCT` of the detected window (140k on
+ * 200k, 280k on 400k, 700k on 1M), so the signal means the same thing on every
+ * model. `COMPACT_CONTEXT_THRESHOLD` still sets an absolute token count and
+ * `COMPACT_CONTEXT_THRESHOLD=0` still disables the context signal entirely;
+ * other invalid values fall back to the percentage default.
+ *
+ * @param {object} env - Environment map.
+ * @param {number|null} windowTokens - Detected window, or null when unknown.
  */
 function resolveContextThreshold(env, windowTokens) {
   const raw = env && env.COMPACT_CONTEXT_THRESHOLD;
@@ -210,17 +255,35 @@ function resolveContextThreshold(env, windowTokens) {
     }
   }
 
-  return windowTokens >= LARGE_CONTEXT_WINDOW_TOKENS ? DEFAULT_CONTEXT_THRESHOLD_LARGE : DEFAULT_CONTEXT_THRESHOLD_STANDARD;
+  if (!Number.isFinite(windowTokens) || windowTokens <= 0) {
+    return UNKNOWN_WINDOW_THRESHOLD_TOKENS;
+  }
+
+  return Math.round(windowTokens * DEFAULT_CONTEXT_THRESHOLD_PCT);
 }
 
 /**
- * Resolve the re-reminder step (tokens of additional context growth before
- * the suggestion repeats). Invalid values fall back to the default.
+ * Resolve the re-reminder step (tokens of additional context growth before the
+ * suggestion repeats). Scales with the window when one is known
+ * (`CONTEXT_INTERVAL_PCT`, floored at the 60k default) so a bigger window does
+ * not mean proportionally more reminders. Invalid values fall back to the
+ * default.
+ *
+ * @param {object} env - Environment map.
+ * @param {number|null} [windowTokens] - Detected window, or null when unknown.
  */
-function resolveContextInterval(env) {
+function resolveContextInterval(env, windowTokens) {
   const raw = env && env.COMPACT_CONTEXT_INTERVAL;
   const parsed = Number.parseInt(raw, 10);
-  return Number.isInteger(parsed) && parsed > 0 && parsed <= MAX_TOKEN_SETTING ? parsed : DEFAULT_CONTEXT_INTERVAL_TOKENS;
+  if (Number.isInteger(parsed) && parsed > 0 && parsed <= MAX_TOKEN_SETTING) {
+    return parsed;
+  }
+
+  if (Number.isFinite(windowTokens) && windowTokens > 0) {
+    return Math.max(DEFAULT_CONTEXT_INTERVAL_TOKENS, Math.round(windowTokens * CONTEXT_INTERVAL_PCT));
+  }
+
+  return DEFAULT_CONTEXT_INTERVAL_TOKENS;
 }
 
 /**
@@ -239,17 +302,30 @@ function computeContextBucket(tokens, threshold, interval) {
 }
 
 /**
- * Human-readable label for a context window size (e.g. "200k", "1M").
+ * Human-readable label for a context window size (e.g. "200k", "400k", "1M",
+ * "1.5M"). Returns "unknown" when the window could not be determined.
  */
 function formatWindowLabel(windowTokens) {
-  return windowTokens >= LARGE_CONTEXT_WINDOW_TOKENS ? '1M' : `${Math.round(windowTokens / 1000)}k`;
+  if (!Number.isFinite(windowTokens) || windowTokens <= 0) {
+    return 'unknown';
+  }
+
+  if (windowTokens >= LARGE_CONTEXT_WINDOW_TOKENS) {
+    const millions = windowTokens / LARGE_CONTEXT_WINDOW_TOKENS;
+    return `${Number.isInteger(millions) ? millions : Number(millions.toFixed(1))}M`;
+  }
+
+  return `${Math.round(windowTokens / 1000)}k`;
 }
 
 module.exports = {
   STANDARD_CONTEXT_WINDOW_TOKENS,
+  EXTENDED_CONTEXT_WINDOW_TOKENS,
   LARGE_CONTEXT_WINDOW_TOKENS,
   DEFAULT_CONTEXT_THRESHOLD_STANDARD,
   DEFAULT_CONTEXT_THRESHOLD_LARGE,
+  DEFAULT_CONTEXT_THRESHOLD_PCT,
+  UNKNOWN_WINDOW_THRESHOLD_TOKENS,
   DEFAULT_CONTEXT_INTERVAL_TOKENS,
   DEFAULT_TRANSCRIPT_TAIL_BYTES,
   readLatestContextTokens,

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -33,7 +33,7 @@ Strategic compaction at logical boundaries:
 
 The `suggest-compact.js` script runs on PreToolUse (Edit/Write) and combines two signals:
 
-1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at a window-scaled threshold — 160k tokens on a 200k window, 250k on a 1M window (detected from a `[1m]` model marker, or inferred when observed tokens already exceed 200k) — and re-reminds after every additional 60k tokens of context growth
+1. **Context size (primary)** — Reads the latest `usage` record from the session transcript (`transcript_path` in the hook payload) and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (the true context size of the turn). Suggests `/compact` at 70% of the detected context window — 140k tokens on a 200k window, 280k on 400k, 700k on 1M (the window is detected from a `[1m]` model marker, the known-model table, or model-family patterns) — and re-reminds after every additional 60k tokens of context growth. When the model's window cannot be determined, the suggestion reports the raw token count past 300k and says the window is unknown instead of printing a percentage of a guessed window
 2. **Tool-call count (secondary)** — Counts tool invocations in session; suggests at a configurable threshold (default: 50 calls), then every 25 calls after
 
 Tool count alone is a weak proxy for window pressure: a few large file reads or MCP responses can fill the window in very few calls, while many tiny calls can cross 50 with a near-empty window. The context-size signal fires when it actually matters.
@@ -65,7 +65,7 @@ Tool count alone is a weak proxy for window pressure: a few large file reads or 
 
 Environment variables:
 - `COMPACT_THRESHOLD` — Tool calls before first suggestion (default: 50)
-- `COMPACT_CONTEXT_THRESHOLD` — Context tokens before the context-size suggestion (default: 160000 on a 200k window, 250000 on a 1M window; `0` disables the context signal)
+- `COMPACT_CONTEXT_THRESHOLD` — Absolute context tokens before the context-size suggestion, overriding the percentage default (default: 70% of the detected window — 140000 on 200k, 280000 on 400k, 700000 on 1M; 300000 when the window is unknown; `0` disables the context signal)
 - `COMPACT_CONTEXT_INTERVAL` — Additional context tokens before the suggestion repeats (default: 60000)
 - `COMPACT_STATE_TTL_DAYS` — Days before stale per-session state files in the temp dir are swept (default: 14)
 - `ECC_CONTEXT_WINDOW_TOKENS` — Explicit context-window size, in tokens, overriding auto-detection. Set this for large-window models whose reported id lacks a `[1m]` marker (e.g. 400k Opus 4.x, or a new 1M-window model family) so the threshold scales to the real window instead of defaulting to 200k and overstating context usage.

--- a/tests/hooks/suggest-compact.test.js
+++ b/tests/hooks/suggest-compact.test.js
@@ -778,15 +778,19 @@ function runTests() {
   })) passed++;
   else failed++;
 
-  if (test('uses the 250k default threshold for [1m] models', () => {
+  if (test('uses the 70%-of-window default threshold for [1m] models', () => {
     const ctx = createContextContext();
     const transcript = writeTranscriptFixture(230000, 'claude-opus-4-5[1m]');
     try {
       const silent = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
       assert.strictEqual(silent.stdout.trim(), '', `230k on a 1M window must stay silent. Got: "${silent.stdout}"`);
-      writeTranscriptTokens(transcript, 260000, 'claude-opus-4-5[1m]');
+      // The old absolute 250k default nagged from 25% of a 1M window onward.
+      writeTranscriptTokens(transcript, 690000, 'claude-opus-4-5[1m]');
+      const stillSilent = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
+      assert.strictEqual(stillSilent.stdout.trim(), '', `690k on a 1M window must stay silent. Got: "${stillSilent.stdout}"`);
+      writeTranscriptTokens(transcript, 700000, 'claude-opus-4-5[1m]');
       const fired = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
-      assert.ok(fired.stdout.includes('26% of 1M window'), `260k on a 1M window should fire. Got: "${fired.stdout}"`);
+      assert.ok(fired.stdout.includes('70% of 1M window'), `700k on a 1M window should fire. Got: "${fired.stdout}"`);
     } finally {
       try { fs.unlinkSync(transcript); } catch (_err) { /* ignore */ }
       ctx.cleanup();
@@ -794,14 +798,45 @@ function runTests() {
   })) passed++;
   else failed++;
 
-  if (test('treats >200k observed tokens as a 1M window even without the [1m] marker', () => {
+  if (test('recognizes opus-4 as a 400k window without an env override (#2290)', () => {
     const ctx = createContextContext();
     const transcript = writeTranscriptFixture(230000, 'claude-opus-4-5');
     try {
+      // 230k exceeds the 200k-window threshold but not 70% of 400k (280k).
+      const silent = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
+      assert.strictEqual(silent.stdout.trim(), '', `Expected 400k-window detection to keep the run silent. Got: "${silent.stdout}"`);
+      writeTranscriptTokens(transcript, 300000, 'claude-opus-4-5');
+      const fired = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
+      assert.ok(fired.stdout.includes('75% of 400k window'), `300k on a 400k window should fire. Got: "${fired.stdout}"`);
+    } finally {
+      try { fs.unlinkSync(transcript); } catch (_err) { /* ignore */ }
+      ctx.cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('reports an unknown window without inventing a percentage', () => {
+    const ctx = createContextContext();
+    const transcript = writeTranscriptFixture(310000, 'some-future-model-9');
+    try {
       const result = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
-      // 230k would exceed the 160k standard threshold, but the observed size
-      // implies a 1M window whose 250k default threshold is not reached yet.
-      assert.strictEqual(result.stdout.trim(), '', `Expected 1M-window inference to keep run silent. Got: "${result.stdout}"`);
+      assert.ok(result.stdout.includes('Context ~310k tokens'), `Expected the raw token estimate. Got: "${result.stdout}"`);
+      assert.ok(result.stdout.includes('window unknown for some-future-model-9'), `Expected an unknown-window notice. Got: "${result.stdout}"`);
+      assert.ok(result.stdout.includes('ECC_CONTEXT_WINDOW_TOKENS'), `Expected the override hint. Got: "${result.stdout}"`);
+      assert.ok(!/\d+% of/.test(result.stdout), `Must not fabricate a percentage. Got: "${result.stdout}"`);
+    } finally {
+      try { fs.unlinkSync(transcript); } catch (_err) { /* ignore */ }
+      ctx.cleanup();
+    }
+  })) passed++;
+  else failed++;
+
+  if (test('stays silent below the unknown-window threshold', () => {
+    const ctx = createContextContext();
+    const transcript = writeTranscriptFixture(290000, 'some-future-model-9');
+    try {
+      const result = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
+      assert.strictEqual(result.stdout.trim(), '', `290k with an unknown window must stay silent. Got: "${result.stdout}"`);
     } finally {
       try { fs.unlinkSync(transcript); } catch (_err) { /* ignore */ }
       ctx.cleanup();

--- a/tests/lib/llm-summary.test.js
+++ b/tests/lib/llm-summary.test.js
@@ -173,6 +173,19 @@ test('returns numeric percentage for transcript with usage data', () => {
   assert.ok(pct >= 0 && pct <= 100);
 });
 
+test('returns null when the model window is unknown (no fabricated percentage)', () => {
+  const p = writeTranscript([JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'some-future-model-9',
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 250000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    }
+  })]);
+  assert.strictEqual(getContextRemainingPct(p), null);
+});
+
 // --- generateSessionSummary ---
 console.log('\ngenerateSessionSummary:');
 

--- a/tests/lib/transcript-context.test.js
+++ b/tests/lib/transcript-context.test.js
@@ -14,9 +14,10 @@ const os = require('os');
 const path = require('path');
 const {
   STANDARD_CONTEXT_WINDOW_TOKENS,
+  EXTENDED_CONTEXT_WINDOW_TOKENS,
   LARGE_CONTEXT_WINDOW_TOKENS,
-  DEFAULT_CONTEXT_THRESHOLD_STANDARD,
-  DEFAULT_CONTEXT_THRESHOLD_LARGE,
+  DEFAULT_CONTEXT_THRESHOLD_PCT,
+  UNKNOWN_WINDOW_THRESHOLD_TOKENS,
   DEFAULT_CONTEXT_INTERVAL_TOKENS,
   readLatestContextTokens,
   resolveContextWindowTokens,
@@ -176,8 +177,26 @@ test('detects a 1M window from the [1m] model marker', () => {
   assert.strictEqual(resolveContextWindowTokens(50000, 'claude-opus-4-5[1m]'), LARGE_CONTEXT_WINDOW_TOKENS);
 });
 
-test('detects a 1M window when observed tokens exceed 200k (marker dropped)', () => {
-  assert.strictEqual(resolveContextWindowTokens(220000, 'claude-opus-4-5'), LARGE_CONTEXT_WINDOW_TOKENS);
+test('recognizes opus-4 as a 400k window without an env override (#2290)', () => {
+  assert.strictEqual(resolveContextWindowTokens(220000, 'claude-opus-4-5'), EXTENDED_CONTEXT_WINDOW_TOKENS);
+  assert.strictEqual(resolveContextWindowTokens(50000, 'claude-opus-4-1-20250805'), EXTENDED_CONTEXT_WINDOW_TOKENS);
+});
+
+test('recognizes 200k families by pattern (sonnet-4 / haiku / claude-3 / opus-3)', () => {
+  for (const model of ['claude-sonnet-4-6', 'claude-haiku-4-5', 'claude-3-5-sonnet-20241022', 'claude-opus-3']) {
+    assert.strictEqual(resolveContextWindowTokens(50000, model), STANDARD_CONTEXT_WINDOW_TOKENS, `Expected 200k for ${model}`);
+  }
+});
+
+test('returns null for an unrecognized model id instead of guessing a window', () => {
+  assert.strictEqual(resolveContextWindowTokens(220000, 'some-future-model-9'), null);
+  assert.strictEqual(resolveContextWindowTokens(50000, 'gpt-nextgen'), null);
+});
+
+test('returns null without a model id once tokens exceed the standard window', () => {
+  // Provably larger than 200k, but nothing says how much larger - so no guess.
+  assert.strictEqual(resolveContextWindowTokens(220000, ''), null);
+  assert.strictEqual(resolveContextWindowTokens(220000, undefined), null);
 });
 
 test('recognizes claude-fable-5 as a 1M window without a [1m] marker or 200k+ tokens (#2461)', () => {
@@ -202,8 +221,10 @@ test('env window override still wins over the known-model table (#2461)', () => 
 });
 
 test('does not match hypothetical smaller tiers sharing a known-family prefix (#2461)', () => {
-  assert.strictEqual(resolveContextWindowTokens(50000, 'claude-fable-5-mini'), STANDARD_CONTEXT_WINDOW_TOKENS);
+  // Neither id may inherit the 1M window of its family. `-haiku` is a known
+  // 200k pattern; `-mini` matches nothing at all, so its window is unknown.
   assert.strictEqual(resolveContextWindowTokens(50000, 'claude-mythos-5-haiku-20260201'), STANDARD_CONTEXT_WINDOW_TOKENS);
+  assert.strictEqual(resolveContextWindowTokens(50000, 'claude-fable-5-mini'), null);
 });
 
 test('keeps the 200k default for unknown model ids at low token counts (no false positives, #2461)', () => {
@@ -217,25 +238,47 @@ test('treats an empty model id as standard window', () => {
 // ── resolveContextThreshold ──
 console.log('\nresolveContextThreshold:');
 
-test('defaults to 160k for the 200k window', () => {
-  assert.strictEqual(resolveContextThreshold({}, STANDARD_CONTEXT_WINDOW_TOKENS), DEFAULT_CONTEXT_THRESHOLD_STANDARD);
+test('defaults to 70% of the window at every size', () => {
+  assert.strictEqual(resolveContextThreshold({}, STANDARD_CONTEXT_WINDOW_TOKENS), 140000);
+  assert.strictEqual(resolveContextThreshold({}, EXTENDED_CONTEXT_WINDOW_TOKENS), 280000);
+  assert.strictEqual(resolveContextThreshold({}, LARGE_CONTEXT_WINDOW_TOKENS), 700000);
 });
 
-test('defaults to 250k for the 1M window', () => {
-  assert.strictEqual(resolveContextThreshold({}, LARGE_CONTEXT_WINDOW_TOKENS), DEFAULT_CONTEXT_THRESHOLD_LARGE);
+test('derives the default from DEFAULT_CONTEXT_THRESHOLD_PCT for any window size', () => {
+  for (const windowTokens of [200000, 400000, 1000000, 2000000]) {
+    assert.strictEqual(
+      resolveContextThreshold({}, windowTokens),
+      Math.round(windowTokens * DEFAULT_CONTEXT_THRESHOLD_PCT),
+      `Expected the percentage default for a ${windowTokens}-token window`
+    );
+  }
+});
+
+test('falls back to a fixed threshold when the window is unknown', () => {
+  // No percentage exists without a window; 300k is past every standard window,
+  // so the nudge is still truthful.
+  assert.strictEqual(resolveContextThreshold({}, null), UNKNOWN_WINDOW_THRESHOLD_TOKENS);
+  assert.strictEqual(resolveContextThreshold({}, undefined), UNKNOWN_WINDOW_THRESHOLD_TOKENS);
+  assert.strictEqual(resolveContextThreshold({}, 0), UNKNOWN_WINDOW_THRESHOLD_TOKENS);
 });
 
 test('honours COMPACT_CONTEXT_THRESHOLD override', () => {
   assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: '1234' }, STANDARD_CONTEXT_WINDOW_TOKENS), 1234);
 });
 
+test('an absolute COMPACT_CONTEXT_THRESHOLD still wins over the percentage default', () => {
+  assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: '250000' }, LARGE_CONTEXT_WINDOW_TOKENS), 250000);
+  assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: '160000' }, null), 160000);
+});
+
 test('COMPACT_CONTEXT_THRESHOLD=0 disables the signal', () => {
   assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: '0' }, STANDARD_CONTEXT_WINDOW_TOKENS), 0);
+  assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: '0' }, null), 0);
 });
 
 test('invalid COMPACT_CONTEXT_THRESHOLD falls back to the default', () => {
   for (const bad of ['-5', 'abc', '99999999999']) {
-    assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: bad }, STANDARD_CONTEXT_WINDOW_TOKENS), DEFAULT_CONTEXT_THRESHOLD_STANDARD, `Expected fallback for ${bad}`);
+    assert.strictEqual(resolveContextThreshold({ COMPACT_CONTEXT_THRESHOLD: bad }, STANDARD_CONTEXT_WINDOW_TOKENS), 140000, `Expected fallback for ${bad}`);
   }
 });
 
@@ -254,6 +297,24 @@ test('invalid COMPACT_CONTEXT_INTERVAL falls back to the default', () => {
   for (const bad of ['0', '-1', 'abc']) {
     assert.strictEqual(resolveContextInterval({ COMPACT_CONTEXT_INTERVAL: bad }), DEFAULT_CONTEXT_INTERVAL_TOKENS, `Expected fallback for ${bad}`);
   }
+});
+
+test('keeps the 60k floor for known windows up to 1M', () => {
+  assert.strictEqual(resolveContextInterval({}, STANDARD_CONTEXT_WINDOW_TOKENS), DEFAULT_CONTEXT_INTERVAL_TOKENS);
+  assert.strictEqual(resolveContextInterval({}, EXTENDED_CONTEXT_WINDOW_TOKENS), DEFAULT_CONTEXT_INTERVAL_TOKENS);
+  assert.strictEqual(resolveContextInterval({}, LARGE_CONTEXT_WINDOW_TOKENS), DEFAULT_CONTEXT_INTERVAL_TOKENS);
+});
+
+test('scales the interval with very large windows (5% of window)', () => {
+  assert.strictEqual(resolveContextInterval({}, 2000000), 100000);
+});
+
+test('an explicit COMPACT_CONTEXT_INTERVAL still wins over window scaling', () => {
+  assert.strictEqual(resolveContextInterval({ COMPACT_CONTEXT_INTERVAL: '5000' }, 2000000), 5000);
+});
+
+test('unknown window keeps the default interval', () => {
+  assert.strictEqual(resolveContextInterval({}, null), DEFAULT_CONTEXT_INTERVAL_TOKENS);
 });
 
 // ── computeContextBucket ──
@@ -287,6 +348,19 @@ console.log('\nformatWindowLabel:');
 test('labels the standard and large windows', () => {
   assert.strictEqual(formatWindowLabel(STANDARD_CONTEXT_WINDOW_TOKENS), '200k');
   assert.strictEqual(formatWindowLabel(LARGE_CONTEXT_WINDOW_TOKENS), '1M');
+});
+
+test('labels the extended and multi-million windows', () => {
+  assert.strictEqual(formatWindowLabel(EXTENDED_CONTEXT_WINDOW_TOKENS), '400k');
+  assert.strictEqual(formatWindowLabel(1500000), '1.5M');
+  assert.strictEqual(formatWindowLabel(2000000), '2M');
+});
+
+test('labels an undetermined window as unknown', () => {
+  assert.strictEqual(formatWindowLabel(null), 'unknown');
+  assert.strictEqual(formatWindowLabel(undefined), 'unknown');
+  assert.strictEqual(formatWindowLabel(0), 'unknown');
+  assert.strictEqual(formatWindowLabel(NaN), 'unknown');
 });
 
 // Cleanup


### PR DESCRIPTION
## Problem

The strategic-compact context signal uses **absolute** token thresholds:

- `DEFAULT_CONTEXT_THRESHOLD_STANDARD = 160000` — 80% of a 200k window, sensible.
- `DEFAULT_CONTEXT_THRESHOLD_LARGE = 250000` — only **25%** of a 1M window.

So on a 1M-window model every long session starts getting "consider /compact" at 250k tokens and
re-fires every 60k for the rest of the session: dozens of premature nudges while three quarters of
the window is still free.

`resolveContextWindowTokens` also guesses. `tokens > 200k ⇒ 1M window` is:

- wrong for 400k models — #2290 notes Opus 4.x is 400k and today needs `ECC_CONTEXT_WINDOW_TOKENS`;
- a fabrication for models whose window is genuinely unknown, since the guessed window is then
  printed as a confident percentage.

#2468 fixed *recognition* for the fable/mythos families, but the threshold scaling and the guess
above it were untouched.

## Fix

1. **Percent-of-window threshold.** `DEFAULT_CONTEXT_THRESHOLD_PCT = 0.7`; the default threshold is
   `round(window * 0.7)`. One rule that holds at every size, including future ones.
2. **Family patterns after the known-model table.** `opus-4 → 400k`,
   `sonnet-4 | haiku | claude-3 | opus-3 → 200k`. Opus 4.x no longer needs the env workaround.
3. **Honest unknowns.** An unrecognized model id returns `null` instead of a guess, as does a
   missing model id whose token count already exceeds 200k (provably larger, size unknown).
   `null` → threshold `UNKNOWN_WINDOW_THRESHOLD_TOKENS = 300000` (past every standard window, so
   the nudge is still truthful) and a percentless message:

   ```
   [StrategicCompact] Context ~310k tokens (window unknown for <model>; set ECC_CONTEXT_WINDOW_TOKENS
   or extend KNOWN_MODEL_WINDOW_TOKENS) - consider /compact at the next logical boundary
   ```
4. **Interval scales with the window** — `max(60k, 5% of window)` when the window is known.
5. **`formatWindowLabel`** handles `400k`, `1.5M`, and `unknown`.
6. **`getContextRemainingPct`** returns `null` instead of dividing by a window it does not have.

### Before / after

| Window | Threshold before | Threshold after | Note |
| --- | --- | --- | --- |
| 200k | 160k (80%) | 140k (70%) | unchanged in spirit |
| 400k (Opus 4.x) | 250k, window mis-detected as 1M | 280k (70%) | window now detected without env |
| 1M | 250k (25%) | 700k (70%) | ends the premature-nag loop |
| unknown | fabricated % of a guessed window | percentless nudge past 300k | no invented numbers |

## Tests

`node tests/lib/transcript-context.test.js` — 36 → **47 passed, 0 failed**
`node tests/hooks/suggest-compact.test.js` — 44 → **46 passed, 0 failed**
`node tests/lib/llm-summary.test.js` — 18 → **19 passed, 0 failed**
`node tests/hooks/hooks.test.js` — 248 passed, `node tests/integration/hooks.test.js` — 27 passed
(unchanged, re-run as regression guards).

Cases that encoded the old behavior were updated rather than deleted; the #2461/#2468 family cases
stay green. New coverage: percentage thresholds at 200k/400k/1M and for arbitrary sizes, absolute
env override still winning, unknown model → `null` window + 300k threshold, `formatWindowLabel`
unknown/400k/1.5M/2M, interval floor and scaling, the hook's unknown-window message (and its silence
below 300k), and the `getContextRemainingPct` null guard.

## Compatibility

- `COMPACT_CONTEXT_THRESHOLD`, `COMPACT_CONTEXT_INTERVAL`, `ECC_CONTEXT_WINDOW_TOKENS` and
  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` behave exactly as before; `COMPACT_CONTEXT_THRESHOLD=0` still
  disables the signal.
- `DEFAULT_CONTEXT_THRESHOLD_STANDARD` / `DEFAULT_CONTEXT_THRESHOLD_LARGE` remain exported for
  anything importing them.
- `resolveContextInterval(env)` keeps its old one-argument behavior; the window argument is optional.
- Callers of `resolveContextWindowTokens` must now treat `null` as "unknown" — both in-repo callers
  are updated in this PR.
- Both copies of the strategic-compact skill doc (`skills/` and `.agents/skills/`) are updated to
  match, per CONTRIBUTING.

Builds on #2468. Refs #2290.
