### PR TITLE
feat(commands): add Antigravity CLI (agy) as santa-loop Reviewer B option

### DIFF
--- a/commands/santa-loop.md
+++ b/commands/santa-loop.md
@@ -76,6 +76,7 @@ First, detect which CLIs are available:
 ```bash
 command -v codex >/dev/null 2>&1 && echo "codex" || true
 command -v gemini >/dev/null 2>&1 && echo "gemini" || true
+command -v agy >/dev/null 2>&1 && echo "agy" || true
 ```
 
 Build the reviewer prompt (identical rubric + instructions as Reviewer A) and write it to a unique temp file:
@@ -86,7 +87,7 @@ cat > "$PROMPT_FILE" << 'EOF'
 EOF
 ```
 
-Use the first available CLI:
+Use the first available CLI, in this order:
 
 **Codex CLI** (if installed)
 ```bash
@@ -100,7 +101,14 @@ gemini -p "$(cat "$PROMPT_FILE")" -m gemini-2.5-pro
 rm -f "$PROMPT_FILE"
 ```
 
-**Claude Agent fallback** (only if neither `codex` nor `gemini` is installed)
+**Antigravity CLI** (if installed and neither codex nor gemini is)
+```bash
+agy -p "$(cat "$PROMPT_FILE")" --model gemini-3.6-flash-high --sandbox
+rm -f "$PROMPT_FILE"
+```
+Despite the "flash" name, this outranks `gemini-3.1-pro-high` on every published coding/agentic benchmark (SWE-Bench Pro, Terminal-Bench, MLE-Bench) — Pro only leads on PhD-level reasoning benchmarks (GPQA, HLE), which aren't relevant to code review. Don't "correct" this back to a `-pro-` model by name alone; check current benchmarks first, since generation-over-tier ordering shifts release to release. Run `agy models` to see the current catalog before assuming this is stale.
+
+**Claude Agent fallback** (only if none of `codex`, `gemini`, or `agy` is installed)
 Launch a second Claude Agent (subagent_type: `code-reviewer`, model: `opus`). Log a warning that both reviewers share the same model family — true model diversity was not achieved but context isolation is still enforced.
 
 In all cases, the reviewer must return the same structured JSON verdict as Reviewer A.
@@ -166,9 +174,10 @@ Result:     [PUSHED / ESCALATED TO USER]
 ## Notes
 
 - Reviewer A (Claude Opus) always runs — guarantees at least one strong reviewer regardless of tooling.
-- Model diversity is the goal for Reviewer B. GPT-5.4 or Gemini 2.5 Pro gives true independence — different training data, different biases, different blind spots. The Claude-only fallback still provides value via context isolation but loses model diversity.
-- Strongest available models are used: Opus for Reviewer A, GPT-5.4 or Gemini 2.5 Pro for Reviewer B.
-- External reviewers run with `--sandbox read-only` (Codex) to prevent repo mutation during review.
+- Model diversity is the goal for Reviewer B. GPT-5.4, Gemini 2.5 Pro, or Antigravity's Gemini 3.6 Flash (via `agy`) all give true independence — different training data, different biases, different blind spots. The Claude-only fallback still provides value via context isolation but loses model diversity.
+- Strongest available models are used: Opus for Reviewer A, GPT-5.4, Gemini 2.5 Pro, or Gemini 3.6 Flash High (`agy`) for Reviewer B, in that priority order.
+- Never point `agy` at a Claude model (`claude-sonnet-4-6`, `claude-opus-4-6-thinking`) — Reviewer A is already Claude Opus, so that would eliminate model diversity entirely.
+- External reviewers run with `--sandbox read-only` (Codex) or `--sandbox` (`agy`) to prevent repo mutation during review.
 - Fresh reviewers each round prevents anchoring bias from prior findings.
 - The rubric is the most important input. Tighten it if reviewers rubber-stamp or flag subjective style issues.
 - Commits happen on NAUGHTY rounds so fixes are preserved even if the loop is interrupted.


### PR DESCRIPTION
## Summary
Adds the Antigravity CLI (`agy`) as a third detectable external model for `/santa-loop`'s Reviewer B, tried after `codex` and `gemini` and before falling back to a same-family Claude reviewer (which loses model diversity). Uses `gemini-3.6-flash-high` — despite the "flash" tier name, it currently outranks `gemini-3.1-pro-high` on every published coding/agentic benchmark (SWE-Bench Pro, Terminal-Bench, MLE-Bench); Pro only leads on PhD-level reasoning benchmarks (GPQA, HLE) that don't apply to code review. Also documents never pointing `agy` at a Claude model (`claude-sonnet-4-6`, `claude-opus-4-6-thinking`), which would eliminate Reviewer A/B model diversity entirely.

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [x] Command

## Testing
- Verified `agy` CLI flags (`-p`, `--model`, `--sandbox`) and confirmed the model catalog via `agy models` (v1.1.9).
- Confirmed benchmark ordering (gemini-3.6-flash-high > gemini-3.1-pro-high on coding/agentic tasks) via public model-comparison sources before picking the model id.
- `npm test` (full suite: unicode safety, agents/commands/rules/skills/hooks validation, install-manifest validation, no-personal-paths, catalog:check, command-registry:check, and `tests/run-all.js`) — 3385/3385 passing, 0 failures.
- Doc-only change to an existing command; no new command/agent/skill/hook surface, so no manifest/catalog/registry entries needed updating.

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
