### PR TITLE
fix(lib): correct stale opus rate and stop guessing sonnet in cost-estimate

### DIFF
--- a/scripts/lib/cost-estimate.js
+++ b/scripts/lib/cost-estimate.js
@@ -9,21 +9,26 @@
 const RATE_TABLE = {
   haiku: { in: 0.8, out: 4.0 },
   sonnet: { in: 3.0, out: 15.0 },
-  opus: { in: 15.0, out: 75.0 }
+  opus: { in: 5.0, out: 25.0 },
+  fable: { in: 10.0, out: 50.0 }
 };
 
 /**
  * Estimate USD cost from token counts.
- * @param {string} model - Model name (may contain "haiku", "sonnet", or "opus")
+ * @param {string} model - Model name (may contain "haiku", "sonnet", "opus", or "fable")
  * @param {number} inputTokens
  * @param {number} outputTokens
- * @returns {number} Estimated cost in USD (rounded to 6 decimal places)
+ * @returns {number|null} Estimated cost in USD (rounded to 6 decimal places), or null if the model is not recognized
  */
 function estimateCost(model, inputTokens, outputTokens) {
   const normalized = String(model || '').toLowerCase();
-  let rates = RATE_TABLE.sonnet;
+  let rates = null;
   if (normalized.includes('haiku')) rates = RATE_TABLE.haiku;
-  if (normalized.includes('opus')) rates = RATE_TABLE.opus;
+  else if (normalized.includes('sonnet')) rates = RATE_TABLE.sonnet;
+  else if (normalized.includes('opus')) rates = RATE_TABLE.opus;
+  else if (normalized.includes('fable')) rates = RATE_TABLE.fable;
+
+  if (!rates) return null;
 
   const cost = (inputTokens / 1_000_000) * rates.in + (outputTokens / 1_000_000) * rates.out;
   return Math.round(cost * 1e6) / 1e6;

--- a/tests/lib/cost-estimate.test.js
+++ b/tests/lib/cost-estimate.test.js
@@ -31,16 +31,19 @@ function runTests() {
   console.log('RATE_TABLE:');
 
   if (
-    test('RATE_TABLE has haiku, sonnet, opus keys', () => {
+    test('RATE_TABLE has haiku, sonnet, opus, fable keys', () => {
       assert.ok(RATE_TABLE.haiku, 'Missing haiku');
       assert.ok(RATE_TABLE.sonnet, 'Missing sonnet');
       assert.ok(RATE_TABLE.opus, 'Missing opus');
+      assert.ok(RATE_TABLE.fable, 'Missing fable');
       assert.strictEqual(typeof RATE_TABLE.haiku.in, 'number');
       assert.strictEqual(typeof RATE_TABLE.haiku.out, 'number');
       assert.strictEqual(typeof RATE_TABLE.sonnet.in, 'number');
       assert.strictEqual(typeof RATE_TABLE.sonnet.out, 'number');
       assert.strictEqual(typeof RATE_TABLE.opus.in, 'number');
       assert.strictEqual(typeof RATE_TABLE.opus.out, 'number');
+      assert.strictEqual(typeof RATE_TABLE.fable.in, 'number');
+      assert.strictEqual(typeof RATE_TABLE.fable.out, 'number');
     })
   )
     passed++;
@@ -50,9 +53,18 @@ function runTests() {
   console.log('\nestimateCost:');
 
   if (
-    test('opus 1M/1M tokens returns 90', () => {
+    test('opus 1M/1M tokens returns 30', () => {
       const cost = estimateCost('opus', 1_000_000, 1_000_000);
-      assert.strictEqual(cost, 90);
+      assert.strictEqual(cost, 30);
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('fable 1M/1M tokens returns 60', () => {
+      const cost = estimateCost('fable', 1_000_000, 1_000_000);
+      assert.strictEqual(cost, 60);
     })
   )
     passed++;
@@ -77,9 +89,9 @@ function runTests() {
   else failed++;
 
   if (
-    test('null model with 0 tokens returns 0', () => {
+    test('null model returns null', () => {
       const cost = estimateCost(null, 0, 0);
-      assert.strictEqual(cost, 0);
+      assert.strictEqual(cost, null);
     })
   )
     passed++;
@@ -88,8 +100,8 @@ function runTests() {
   if (
     test('full model name claude-opus-4-6 uses opus rates', () => {
       const cost = estimateCost('claude-opus-4-6', 500, 200);
-      // (500 / 1_000_000) * 15 + (200 / 1_000_000) * 75 = 0.0075 + 0.015 = 0.0225
-      const expected = Math.round(0.0225 * 1e6) / 1e6;
+      // (500 / 1_000_000) * 5 + (200 / 1_000_000) * 25 = 0.0025 + 0.005 = 0.0075
+      const expected = Math.round(0.0075 * 1e6) / 1e6;
       assert.strictEqual(cost, expected);
     })
   )
@@ -97,9 +109,9 @@ function runTests() {
   else failed++;
 
   if (
-    test('unknown model falls back to sonnet rates', () => {
+    test('unknown model returns null', () => {
       const cost = estimateCost('unknown-model', 1_000_000, 1_000_000);
-      assert.strictEqual(cost, 18);
+      assert.strictEqual(cost, null);
     })
   )
     passed++;


### PR DESCRIPTION
## Summary
While looking at #2596 (fix for #2574 in `scripts/hooks/cost-tracker.js`), found the identical bug shape in `scripts/lib/cost-estimate.js`: `RATE_TABLE.opus` still carried the old $15/$75 per 1M token rate (3x the current $5/$25), and `estimateCost()` silently fell back to sonnet rates for any model it didn't recognize (e.g. `claude-fable-5`), mispricing it without any signal.

## Type
- [ ] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command
- [x] Library fix (`scripts/lib/`)

## Changes
- `RATE_TABLE.opus` corrected to `{ in: 5, out: 25 }`
- Added `RATE_TABLE.fable: { in: 10, out: 50 }`
- `estimateCost()` now returns `null` for an unrecognized model instead of guessing sonnet, mirroring the `getRates() -> null` behavior change in #2596
- Updated `tests/lib/cost-estimate.test.js` accordingly (opus/fable rates, null-on-unknown)

Note: this module has no callers outside its own test today (confirmed via `git log --follow` and repo-wide grep), so there's no live behavioral impact — this just corrects the module before anything gets wired up to it.

## Testing
- `node tests/lib/cost-estimate.test.js` — 8/8 passing
- `node tests/run-all.js` — 3385/3385 passing, no regressions
- Manual repro:
  ```
  opus 1M/1M -> 30
  claude-fable-5 1M/1M -> 60
  unknown 1M/1M -> null
  ```

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions