### PR TITLE
fix(hooks): stop block-no-verify from firing on flags it does not own

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -150,18 +150,103 @@ function detectGitCommand(input) {
 }
 
 /**
- * Check if the input contains a --no-verify flag for a specific git command.
+ * Flags whose FOLLOWING token git consumes as a value rather than a flag.
+ *
+ * Only options whose value is mandatory belong here. An optional-value option
+ * such as -S or -u does not swallow the next token, so listing one would let
+ * `git commit -S -n` slip through.
+ */
+const VALUE_TAKING_FLAGS = new Set([
+  '-m', '--message',
+  '-F', '--file',
+  '-c', '--reedit-message',
+  '-C', '--reuse-message',
+  '-t', '--template',
+  '--author',
+  '--date',
+  '--cleanup',
+  '--trailer',
+  '--fixup',
+  '--squash',
+  '--pathspec-from-file',
+]);
+
+/**
+ * Split a command string into shell-like tokens.
+ *
+ * Quote-aware by design: without it, text inside a quoted argument cannot be
+ * told apart from a real flag, so `git commit -m "head -n 5"` — a message that
+ * merely mentions a flag — was blocked as if the flag had been passed. Quoted
+ * spans collapse into one token, exactly as the shell hands them to git.
+ *
+ * Each token carries a `segment` index that increments at every unquoted shell
+ * operator, letting callers tell git's own arguments (segment 0) from a later
+ * command's in a pipe or chain.
+ */
+function tokenizeCommand(input) {
+  const tokens = [];
+  let current = '';
+  let started = false;
+  let quote = null;
+  let segment = 0;
+
+  const flush = () => {
+    if (started) {
+      tokens.push({ value: current, segment });
+      current = '';
+      started = false;
+    }
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (quote) {
+      if (quote === '"' && ch === '\\' && i + 1 < input.length) { current += input[++i]; continue; }
+      if (ch === quote) { quote = null; continue; }
+      current += ch;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") { quote = ch; started = true; continue; }
+    if (ch === '\\' && i + 1 < input.length) { current += input[++i]; started = true; continue; }
+    if (/\s/.test(ch)) { flush(); continue; }
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '>' || ch === '<') { flush(); segment++; continue; }
+
+    current += ch;
+    started = true;
+  }
+
+  flush();
+  return tokens;
+}
+
+/**
+ * Check if a bypass flag is passed to a specific git command.
  * Only inspects the portion of the input starting at `offset` (the position
  * right after the detected subcommand keyword) so that flags belonging to
  * earlier commands in a chain are not falsely matched.
  */
 function hasNoVerifyFlag(input, command, offset) {
-  const region = input.slice(offset);
-  if (/--no-verify\b/.test(region)) return true;
+  const tokens = tokenizeCommand(input.slice(offset));
+  let expectValue = false;
 
-  // For commit, -n is shorthand for --no-verify
-  if (command === 'commit') {
-    if (/\s-n(?:\s|$)/.test(region) || /\s-n[a-zA-Z]/.test(region)) return true;
+  for (const { value, segment } of tokens) {
+    // A value token is data, never a flag — `-m "--no-verify"` is a message.
+    if (expectValue) { expectValue = false; continue; }
+    if (VALUE_TAKING_FLAGS.has(value)) { expectValue = true; continue; }
+
+    // Long form is unambiguous wherever it lands, including later in a chain
+    // (`git commit -m x && git push --no-verify`), so it is not scoped. Quoting
+    // does not exempt it: `git commit "--no-verify"` still reaches git as a flag.
+    if (value === '--no-verify') return true;
+
+    // For commit, -n is shorthand for --no-verify. Unlike the long form, -n is a
+    // common flag on other tools, so it only counts inside git's own argument
+    // list. Without that scope an innocent `git commit -m x | head -n 5` reads
+    // head's -n as git's; `tail -n`, `grep -n` and `sort -n` hit the same trap.
+    // Short flags cluster, so -an carries -n too.
+    if (command === 'commit' && segment === 0 && /^-[a-zA-Z]*n[a-zA-Z]*$/.test(value)) return true;
   }
 
   return false;
@@ -169,9 +254,23 @@ function hasNoVerifyFlag(input, command, offset) {
 
 /**
  * Check if the input contains a -c core.hooksPath= override.
+ * Token-based for the same reason as above: a commit message that quotes the
+ * setting is not an attempt to override it.
  */
 function hasHooksPathOverride(input) {
-  return /-c\s+["']?core\.hooksPath\s*=/.test(input);
+  const tokens = tokenizeCommand(input);
+
+  for (let i = 0; i < tokens.length; i++) {
+    const { value } = tokens[i];
+    if (/^core\.hooksPath\s*=/.test(value)) {
+      if (i > 0 && tokens[i - 1].value === '-c') return true;
+      continue;
+    }
+    // Attached form: -ccore.hooksPath=...
+    if (/^-c["']?core\.hooksPath\s*=/.test(value)) return true;
+  }
+
+  return false;
 }
 
 /**

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -89,6 +89,61 @@ if (test('still blocks --no-verify on the git commit part of a chain', () => {
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
+// --- Downstream -n belongs to another tool, not to git commit ---
+
+if (test('does not false-positive on head -n after a piped git commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "msg" | head -n 5' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('does not false-positive on tail -n later in a chain', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "msg" && git log --oneline -1 | tail -n 4' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('does not false-positive on grep -n after git commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "msg" && grep -n TODO src/app.js' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still blocks a genuine -n on git commit before a pipe', () => {
+  const r = runHook({ tool_input: { command: 'git commit -n -m "msg" | head -n 5' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+// --- Quoted text is data, not flags ---
+
+if (test('allows a commit message that merely mentions a short flag', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "example: head -n 5"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows a commit message that merely mentions the long flag', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "never pass --no-verify"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows a commit message that mentions core.hooksPath', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "do not use -c core.hooksPath=/dev/null"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks a quoted long flag, since git still receives it', () => {
+  const r = runHook({ tool_input: { command: 'git commit "--no-verify" -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks a clustered short flag carrying n', () => {
+  const r = runHook({ tool_input: { command: 'git commit -an -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('does not let an optional-value flag swallow the bypass', () => {
+  // -S takes an OPTIONAL value, so git does not consume -n as its argument
+  const r = runHook({ tool_input: { command: 'git commit -S -n -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
 // --- Subcommand detection (Comment 4) ---
 
 if (test('does not misclassify "commit" as subcommand when it is an argument to push', () => {


### PR DESCRIPTION
## Problem

`block-no-verify` scans the raw command string after the `commit` keyword, so it
blocks flags that do not belong to git. Two ways this bites in normal use:

**1. A downstream tool's `-n`.** Everything after `commit` is inspected,
including whatever follows a pipe:

```sh
git commit -m "msg" | head -n 5      # BLOCKED — head's -n read as git's
git commit -m "msg" && … | tail -n 4 # BLOCKED
git commit -m "msg" && grep -n TODO  # BLOCKED
```

In practice this means the more output an agent asks for, the likelier a
spurious block — the opposite of what you want from a guardrail.

**2. Quoted text.** Quoting is invisible to a regex, so a commit message that
merely *mentions* a flag trips the hook on its own documentation:

```sh
git commit -m "example: head -n 5"                     # BLOCKED
git commit -m "never pass --no-verify"                 # BLOCKED
git commit -m "do not use -c core.hooksPath=/dev/null" # BLOCKED
```

I hit the second one while committing the fix for the first.

## Fix

Replace the regex scan with a quote-aware tokenizer.

Quoted spans collapse into a single token — exactly what the shell hands to git
— and each token records which pipe/chain `segment` it came from, so git's own
arguments can be told apart from a later command's. A token consumed as the
value of a mandatory-value flag is data, never a flag.

`hasHooksPathOverride` is token-based for the same reason.

## Detection is unchanged where it matters

| Case | Behaviour |
|---|---|
| `git commit --no-verify` | blocked |
| `git commit -n` | blocked |
| `git commit -an` (clustered) | blocked |
| `git commit "--no-verify"` (quoted flag) | blocked — git receives it either way |
| `git commit -m x && git push --no-verify` | blocked — long form is not scoped |
| `git -c core.hooksPath=/dev/null commit` | blocked |

The long form deliberately stays unscoped: it is unambiguous, so a bypass
anywhere downstream in a chain should still trip.

## One subtlety worth reviewing

`VALUE_TAKING_FLAGS` lists **only** options whose value is mandatory.

An optional-value option such as `-S` or `-u` does not swallow the next token,
so listing one would let `git commit -S -n` through — a real bypass introduced
by a false-positive fix. There is a test pinning that.

## Tests

Suite goes 12 → 22. The 10 new cases cover both false-positive classes and the
bypasses that must keep tripping.

I verified the new tests fail against the previous implementation and pass
after, so they pin real behaviour rather than describing the new code back to
itself.

```
Passed: 22  Failed: 0
```
