### PR TITLE
chore(ci): add AgentShield review workflow

### DIFF
--- a/.github/workflows/agentshield-security.yml
+++ b/.github/workflows/agentshield-security.yml
@@ -1,0 +1,22 @@
+name: AgentShield Security Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  agentshield:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: AgentShield Security Scan
+        uses: affaan-m/agentshield@v1.4.0
+        with:
+          path: "."
+          min-severity: "medium"
+          fail-on-findings: "true"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for AgentShield review scanning
- pin the action to affaan-m/agentshield@v1.4.0
- scan the repository on push and pull_request with min-severity medium