### PR TITLE
fix(mcp): accept reserved _meta field in tools/call params

### DIFF
--- a/scripts/memory-mcp.mjs
+++ b/scripts/memory-mcp.mjs
@@ -437,7 +437,8 @@ function createMemoryMcpService(options = {}) {
           !isRecord(params)
           || typeof name !== 'string'
           || !TOOL_BY_NAME.has(name)
-          || Object.keys(params).some(key => !['name', 'arguments'].includes(key))
+          // `_meta` is reserved by MCP for request metadata (e.g. progressToken) and must be accepted.
+          || Object.keys(params).some(key => !['name', 'arguments', '_meta'].includes(key))
         ) {
           return jsonRpcError(message.id, -32602, 'Unknown or missing memory tool.');
         }

--- a/scripts/memory-mcp.mjs
+++ b/scripts/memory-mcp.mjs
@@ -437,7 +437,9 @@ function createMemoryMcpService(options = {}) {
           !isRecord(params)
           || typeof name !== 'string'
           || !TOOL_BY_NAME.has(name)
-          // `_meta` is reserved by MCP for request metadata (e.g. progressToken) and must be accepted.
+          // `_meta` is reserved by MCP for request metadata (e.g. progressToken); accept it,
+          // but when present it must be a metadata object — reject null, arrays, and scalars.
+          || (Object.prototype.hasOwnProperty.call(params, '_meta') && !isRecord(params._meta))
           || Object.keys(params).some(key => !['name', 'arguments', '_meta'].includes(key))
         ) {
           return jsonRpcError(message.id, -32602, 'Unknown or missing memory tool.');

--- a/tests/scripts/memory-mcp.test.js
+++ b/tests/scripts/memory-mcp.test.js
@@ -136,6 +136,7 @@ async function withClient(fn, options = {}) {
       'tools/call',
       { name, arguments: toolArguments }
     ),
+    callToolRaw: params => request('tools/call', params),
   };
 
   try {
@@ -177,6 +178,40 @@ async function main() {
       assert.ok(!JSON.stringify(save.inputSchema).includes('sourceHarness'));
       assert.ok(!JSON.stringify(search.inputSchema).includes('targetHarness'));
       assert.strictEqual(save.inputSchema.properties.body.minLength, 1);
+    });
+  });
+
+  await test('accepts the reserved _meta param on tools/call and rejects malformed values', async () => {
+    await withClient(async client => {
+      // A valid `_meta` object (e.g. progressToken) must not block the tool call.
+      const withMeta = await client.callToolRaw({
+        name: 'memory_doctor',
+        arguments: {},
+        _meta: { progressToken: 'progress-123' },
+      });
+      assert.ok(Array.isArray(withMeta.content));
+
+      // Baseline: no `_meta` still works.
+      const withoutMeta = await client.callToolRaw({
+        name: 'memory_doctor',
+        arguments: {},
+      });
+      assert.ok(Array.isArray(withoutMeta.content));
+
+      // A malformed `_meta` (null, array, or scalar) must be rejected.
+      for (const badMeta of [null, ['not', 'an', 'object'], 'string', 42, true]) {
+        await assert.rejects(
+          client.callToolRaw({ name: 'memory_doctor', arguments: {}, _meta: badMeta }),
+          /-32602/,
+          `expected _meta=${JSON.stringify(badMeta)} to be rejected`
+        );
+      }
+
+      // Unrelated top-level params must still be rejected.
+      await assert.rejects(
+        client.callToolRaw({ name: 'memory_doctor', arguments: {}, unexpected: true }),
+        /-32602/
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

The memory MCP server rejects any `tools/call` whose `params` contains a key
other than `name`/`arguments`, returning `-32602 "Unknown or missing memory tool."`
— even for tools that are correctly registered.

MCP clients (e.g. Claude Code) attach the spec-reserved `_meta` field
(such as `progressToken`) to request params. As a result **every** tool call
from a compliant client fails and the entire memory MCP surface becomes
unreachable, while `initialize` / `tools/list` and the `ecc memory` CLI keep
working (they don't hit this check). This makes the failure look like a broken
connection when the server is actually connected.

## Root cause

`scripts/memory-mcp.mjs`, the `tools/call` params allowlist:

```js
|| Object.keys(params).some(key => !['name', 'arguments'].includes(key))
```

`_meta` is not in the allowlist, so its presence trips the guard before the
tool ever runs.

## Fix

Add `_meta` to the allowlist. Per the MCP base protocol, `_meta` is reserved
for request metadata and must be accepted by servers.

## Reproduction (against pristine `main`)

Calling `createMemoryMcpService().handle(...)` directly:

| `params` | result |
|----------|--------|
| `{ name, arguments }` | ✅ OK |
| `{ name, arguments, _meta: { progressToken } }` | ❌ `-32602` |

After this change, both return OK.

## Spec reference

MCP 2025-06-18 basic protocol, General fields → `_meta`:
> "The `_meta` property/parameter is reserved by MCP to allow clients and
> servers to attach additional metadata to their interactions."

