### PR TITLE
fix(deps): bump fast-uri to 3.1.5 and brace-expansion to 5.0.9 (npm audit)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1123,9 +1123,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -475,12 +475,12 @@
     "node": ">=18"
   },
   "overrides": {
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "markdown-it": "14.3.0",
     "js-yaml": "4.3.0"
   },
   "resolutions": {
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "markdown-it": "14.3.0",
     "js-yaml": "4.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,11 +395,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -802,10 +802,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.4":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
+"fast-uri@npm:3.1.5":
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`npm audit --audit-level=high` in the **Security Scan** job currently fails on every PR (and on `main`, e.g. run 30877829542) due to two freshly published high-severity advisories:

| Package | Advisory | Vulnerable | Patched | Fix applied |
|---|---|---|---|---|
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer | >=3.0.0 <3.1.5 | 3.1.5 | bump the existing `overrides`/`resolutions` pin 3.1.4 → 3.1.5 (still satisfies ajv's `^3.0.1`) |
| `brace-expansion` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays | >=4.0.0 <5.0.9 | 5.0.9 | in-range lockfile bump 5.0.8 → 5.0.9 (under `eslint` → `minimatch`) |

After this change `npm audit --audit-level=high` reports **0 vulnerabilities**.

## Details

- `fast-uri` was pinned at 3.1.4 in both `overrides` (npm/pnpm/bun) and `resolutions` (yarn); both pins bumped to 3.1.5.
- `yarn.lock` regenerated with Yarn 4.9.2 (`yarn install` + `yarn up -R brace-expansion`) so the yarn matrix cells stay in sync — the diff is 7 lines each way.
- No source changes; `node tests/run-all.js` passes locally (3407/3408 — the single failure is a pre-existing spawnSync `maxBuffer` artifact of my long local worktree path, unrelated to this change; it passes from a normal-length path).

## Why a separate PR

Unblocks Security Scan for all open PRs (it is currently red on `main` itself), kept as a focused deps-only diff.