### PR TITLE
chore(ci): pin AgentShield action and fix ECC skills mapping

### DIFF
--- a/.github/workflows/agentshield-security.yml
+++ b/.github/workflows/agentshield-security.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: AgentShield Security Scan
-        uses: affaan-m/agentshield@v1
+        uses: affaan-m/agentshield@v1.4.0
         with:
           path: "."
           min-severity: "medium"

--- a/.github/workflows/agentshield-security.yml
+++ b/.github/workflows/agentshield-security.yml
@@ -1,0 +1,22 @@
+name: AgentShield Security Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  agentshield:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: AgentShield Security Scan
+        uses: affaan-m/agentshield@v1
+        with:
+          path: "."
+          min-severity: "medium"
+          fail-on-findings: "true"

--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -7,7 +7,7 @@ const {
   normalizeRelativePath,
 } = require('./helpers');
 
-const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', 'skills', '.agents', 'AGENTS.md'];
+const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', '.agents', 'AGENTS.md'];
 
 function supportsAntigravitySourcePath(sourceRelativePath) {
   const normalizedPath = normalizeRelativePath(sourceRelativePath);


### PR DESCRIPTION
Improvements to AgentShield workflow and fixes for ECC skills exclusion from antigravity install target.

Ready for review.