### PR TITLE
fix(hooks): correct stale model rates in the cost tracker

### DIFF
--- a/commands/cost-report.md
+++ b/commands/cost-report.md
@@ -16,7 +16,13 @@ session**, so the report takes the **latest row per `session_id`** and sums
 across sessions (summing every row would multiply-count).
 
 Row schema:
-`{ timestamp, session_id, transcript_path, model, input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, estimated_cost_usd }`
+`{ timestamp, session_id, transcript_path, model, rate_bucket, input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, estimated_cost_usd }`
+
+`rate_bucket` names what produced `estimated_cost_usd`: a rate-table row
+(`haiku`, `haiku-legacy`, `sonnet`, `opus`, `opus-legacy`, `fable`), or
+`harness` when the statusline's authoritative `cost.total_cost_usd` supplied
+it. `sonnet-fallback` means the model ID matched no row and sonnet rates were
+assumed, so that row's cost is a guess worth flagging.
 
 ## What this command does
 
@@ -66,8 +72,8 @@ const fs=require("fs"),os=require("os"),path=require("path");
 const f=path.join(os.homedir(),".claude","metrics","costs.jsonl");
 if(!fs.existsSync(f)){console.error("no data");process.exit(0);}
 const rows=fs.readFileSync(f,"utf8").split(/\r?\n/).filter(Boolean).map(l=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean).slice(-100);
-console.log("timestamp,session_id,model,input_tokens,output_tokens,cache_write_tokens,cache_read_tokens,estimated_cost_usd");
-for(const r of rows)console.log([r.timestamp,r.session_id,r.model,r.input_tokens,r.output_tokens,r.cache_write_tokens,r.cache_read_tokens,r.estimated_cost_usd].join(","));
+console.log("timestamp,session_id,model,rate_bucket,input_tokens,output_tokens,cache_write_tokens,cache_read_tokens,estimated_cost_usd");
+for(const r of rows)console.log([r.timestamp,r.session_id,r.model,r.rate_bucket,r.input_tokens,r.output_tokens,r.cache_write_tokens,r.cache_read_tokens,r.estimated_cost_usd].join(","));
 '
 ```
 

--- a/commands/cost-report.md
+++ b/commands/cost-report.md
@@ -73,7 +73,8 @@ const f=path.join(os.homedir(),".claude","metrics","costs.jsonl");
 if(!fs.existsSync(f)){console.error("no data");process.exit(0);}
 const rows=fs.readFileSync(f,"utf8").split(/\r?\n/).filter(Boolean).map(l=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean).slice(-100);
 console.log("timestamp,session_id,model,rate_bucket,input_tokens,output_tokens,cache_write_tokens,cache_read_tokens,estimated_cost_usd");
-for(const r of rows)console.log([r.timestamp,r.session_id,r.model,r.rate_bucket,r.input_tokens,r.output_tokens,r.cache_write_tokens,r.cache_read_tokens,r.estimated_cost_usd].join(","));
+const q=v=>{const t=v==null?"":String(v);return /[",\r\n]/.test(t)?'"'+t.replace(/"/g,'""')+'"':t;};
+for(const r of rows)console.log([r.timestamp,r.session_id,r.model,r.rate_bucket,r.input_tokens,r.output_tokens,r.cache_write_tokens,r.cache_read_tokens,r.estimated_cost_usd].map(q).join(","));
 '
 ```
 

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -68,19 +68,94 @@ function readHarnessCost(sessionId, maxAgeSeconds) {
   }
 }
 
-// Approximate per-1M-token billing rates (USD).
-// Cache creation: 1.25x input rate. Cache read: 0.1x input rate.
+// Per-1M-token billing rates (USD). Cache write is 1.25x input and cache read
+// is 0.1x input in every row, for the default 5-minute cache TTL. The 1-hour
+// TTL bills writes at 2x input and is still not modelled here, as the header
+// notes.
+//
+// The previous table priced every `opus` model at $15/$75, which are Claude 3
+// Opus era rates. Opus 4.5 and later bill at $5/$25, so every current-
+// generation Opus session was reported at exactly 3x real spend (measured: a
+// session summing to 100,000,000 cache-read plus 500,000 output tokens on
+// `claude-opus-5` costs $62.50 and was reported as $187.50). Fable and Mythos
+// had no bucket at all, so they fell through to `sonnet` and were understated
+// 3.3x. The rate constants were the whole defect; the arithmetic that
+// consumes them is unchanged.
+//
+// The legacy rows exist so that correcting the current generation does not
+// reprice the old one. `haikuLegacy` is Claude 3.5 Haiku, for which the
+// previous $0.80/$4.00 was exactly right. Claude 3 Haiku ($0.25/$1.25) is
+// deliberately not modelled: Claude Code never ran it.
 const RATE_TABLE = {
-  haiku:  { in: 0.80,  out: 4.0,  cacheWrite: 1.00,  cacheRead: 0.08 },
-  sonnet: { in: 3.00,  out: 15.0, cacheWrite: 3.75,  cacheRead: 0.30 },
-  opus:   { in: 15.00, out: 75.0, cacheWrite: 18.75, cacheRead: 1.50 }
+  haiku:       { in: 1.00,  out: 5.0,  cacheWrite: 1.25,  cacheRead: 0.10 },
+  haikuLegacy: { in: 0.80,  out: 4.0,  cacheWrite: 1.00,  cacheRead: 0.08 },
+  sonnet:      { in: 3.00,  out: 15.0, cacheWrite: 3.75,  cacheRead: 0.30 },
+  opus:        { in: 5.00,  out: 25.0, cacheWrite: 6.25,  cacheRead: 0.50 },
+  opusLegacy:  { in: 15.00, out: 75.0, cacheWrite: 18.75, cacheRead: 1.50 },
+  fable:       { in: 10.00, out: 50.0, cacheWrite: 12.50, cacheRead: 1.00 }
 };
 
-function getRates(model) {
+// The only Opus models that really billed at $15/$75: Claude 3 Opus, Opus 4.0
+// and Opus 4.1. Every spelling of each has to match, alias and dated snapshot
+// alike, which is why the bare `opus-4-<date>` form is listed on its own:
+// Opus 4.0's snapshot is `claude-opus-4-20250514`, with no minor segment, so
+// an `opus-4-0` substring alone misses it and reprices a legacy session at a
+// third of its real cost. The `[-@]` covers Vertex AI, which joins the date
+// with `@` (`claude-opus-4@20250514`); Bedrock's
+// `anthropic.claude-3-opus-20240229-v1:0` is caught by the first alternative.
+//
+// Opus 4.5 through Opus 5 are $5/$25 and take the default bucket, which also
+// means a future Opus is assumed to be $5/$25. That assumption is the same
+// shape of silent staleness this change fixes, so if Opus is ever repriced
+// again, a new row belongs here rather than a rediscovery of this comment.
+const LEGACY_OPUS_RE = /claude-3-opus|opus-4-0(?!\d)|opus-4-1(?!\d)|opus-4[-@]\d{8}/;
+
+// Claude 3.5 Haiku, whose $0.80/$4.00 this table used to apply to all Haiku.
+const LEGACY_HAIKU_RE = /3-5-haiku|haiku-3-5/;
+
+// Recorded on the row, and warned about, when the model ID matched no bucket.
+// Returning sonnet rates anyway keeps this Stop hook fail-open, but an
+// unpriceable model used to yield a plausible number with no signal at all,
+// which is how the stale Opus rate survived unnoticed.
+const FALLBACK_BUCKET = 'sonnet-fallback';
+
+// Recorded instead when the harness's own `cost.total_cost_usd` supplied the
+// number, in which case no rate-table row was consulted at all.
+const HARNESS_BUCKET = 'harness';
+
+// `message.model` values that name no model. `<synthetic>` is what Claude Code
+// writes for interrupts, API errors and "no response requested"; it carries a
+// fully populated but all-zero `usage` block, so it clears the usage guard
+// below and, under last-model-wins, would overwrite the real model for the
+// whole session. Measured over 1,628 local transcripts: 60 `<synthetic>`
+// entries, and 10 transcripts END on one. That last case is the damaging one,
+// because the final row is exactly the cumulative row `/cost-report` reads
+// per session.
+const NON_MODEL_SENTINELS = new Set(['unknown', '<synthetic>']);
+
+/**
+ * Resolve billing rates for a model ID.
+ * @param {string} model
+ * @returns {{bucket: string, rates: object}} `bucket` is FALLBACK_BUCKET when
+ *   nothing matched and sonnet rates were assumed.
+ */
+function resolveRates(model) {
   const m = String(model || '').toLowerCase();
-  if (m.includes('haiku')) return RATE_TABLE.haiku;
-  if (m.includes('opus'))  return RATE_TABLE.opus;
-  return RATE_TABLE.sonnet;
+  if (m.includes('haiku')) {
+    return LEGACY_HAIKU_RE.test(m)
+      ? { bucket: 'haiku-legacy', rates: RATE_TABLE.haikuLegacy }
+      : { bucket: 'haiku',        rates: RATE_TABLE.haiku };
+  }
+  if (m.includes('fable') || m.includes('mythos')) {
+    return { bucket: 'fable', rates: RATE_TABLE.fable };
+  }
+  if (m.includes('opus')) {
+    return LEGACY_OPUS_RE.test(m)
+      ? { bucket: 'opus-legacy', rates: RATE_TABLE.opusLegacy }
+      : { bucket: 'opus',        rates: RATE_TABLE.opus };
+  }
+  if (m.includes('sonnet')) return { bucket: 'sonnet', rates: RATE_TABLE.sonnet };
+  return { bucket: FALLBACK_BUCKET, rates: RATE_TABLE.sonnet };
 }
 
 function toNumber(v) {
@@ -128,7 +203,7 @@ function sumUsageFromTranscript(transcriptPath) {
       : `__line_${++syntheticKey}`;
     usageById.set(key, msg.usage);
 
-    if (msg.model && msg.model !== 'unknown') model = msg.model;
+    if (msg.model && !NON_MODEL_SENTINELS.has(msg.model)) model = msg.model;
   }
 
   let inputTokens = 0;
@@ -191,7 +266,7 @@ process.stdin.on('end', () => {
       model = 'unknown'
     } = usageTotals || {};
 
-    const rates = getRates(model);
+    const { bucket: modelBucket, rates } = resolveRates(model);
     const transcriptCostUsd = Math.round((
       (inputTokens      / 1e6) * rates.in +
       (outputTokens     / 1e6) * rates.out +
@@ -209,6 +284,28 @@ process.stdin.on('end', () => {
       ? Math.round(harnessCost * 1e6) / 1e6
       : transcriptCostUsd;
 
+    // `rate_bucket` names what produced `estimated_cost_usd`, so it has to
+    // follow that choice: on the harness path no rate-table row was consulted,
+    // and reporting the model's bucket there would vouch for a number the
+    // table did not produce (or, worse, flag an authoritative number as a
+    // guess).
+    const rateBucket = harnessCost !== null ? HARNESS_BUCKET : modelBucket;
+
+    // Speak up when a guessed rate is what actually produced the recorded
+    // cost. Silent on the harness path by construction, and gated on a
+    // non-zero cost so a Stop that priced nothing stays quiet. `model` is
+    // skipped when it is the `unknown` sentinel: that means no assistant turn
+    // recorded a model, so naming it in the warning tells the reader nothing
+    // actionable, and the `sonnet-fallback` value on the row already carries
+    // the signal. Note this fires per Stop, and Stop fires per assistant
+    // response, so an unrecognized model warns once per turn by design: the
+    // row is the durable record, the line is the nudge.
+    if (rateBucket === FALLBACK_BUCKET && transcriptCostUsd > 0 && model !== 'unknown') {
+      process.stderr.write(
+        `[Hook] cost-tracker: unrecognized model "${model}"; priced at sonnet rates, cost may be wrong\n`
+      );
+    }
+
     const metricsDir = path.join(getClaudeDir(), 'metrics');
     ensureDir(metricsDir);
 
@@ -217,6 +314,7 @@ process.stdin.on('end', () => {
       session_id:         sessionId,
       transcript_path:    transcriptPath || '',
       model,
+      rate_bucket:        rateBucket,
       input_tokens:       inputTokens,
       output_tokens:      outputTokens,
       cache_write_tokens: cacheWriteTokens,

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -25,6 +25,7 @@ Row schema:
 | `session_id` | Claude Code session identifier |
 | `transcript_path` | Path to the session transcript |
 | `model` | Model used |
+| `rate_bucket` | What produced the cost: a rate-table row (`haiku`, `haiku-legacy`, `sonnet`, `opus`, `opus-legacy`, `fable`, which Fable and Mythos share), `harness` when the harness's own total supplied it, or `sonnet-fallback` when the model ID matched nothing and sonnet rates were assumed |
 | `input_tokens` / `output_tokens` | Token counts |
 | `cache_write_tokens` / `cache_read_tokens` | Prompt-cache token counts |
 | `estimated_cost_usd` | Precomputed cumulative cost in USD for the session |

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -338,6 +338,303 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
+  // --- Rate table ---------------------------------------------------------
+  // These run the hook end to end and assert the dollar figure, not merely
+  // that one is present. A stale rate constant is invisible to a "cost > 0"
+  // assertion, which is how every Opus session came to be reported at 3x.
+
+  function priceSession(model, usage, tag) {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      { type: 'assistant', message: { id: 'msg_01RATE', model, usage } },
+    ]);
+    try {
+      const result = runScript(
+        { session_id: `${tag}-${Date.now()}`, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      return { row, stderr: result.stderr };
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }
+
+  // 1M in + 1M out makes each expected cost read as "input rate plus output
+  // rate", with no arithmetic for a reviewer to check by hand.
+  const ONE_M_EACH = { input_tokens: 1000000, output_tokens: 1000000 };
+
+  // 10. Opus 4.5 and later bill at $5/$25, not Claude 3 Opus's $15/$75.
+  (test('prices current Opus models at $5/$25 per Mtok', () => {
+    for (const model of [
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-opus-4-6',
+      'claude-opus-4-5-20251101',
+      // The `[1m]` context suffix Claude Code appends, and the Vertex form of
+      // a current model, must not be dragged into the legacy bucket.
+      'claude-opus-4-8[1m]',
+      'claude-opus-4-5@20251101',
+    ]) {
+      const { row } = priceSession(model, ONE_M_EACH, 'opus-current');
+      assert.strictEqual(row.rate_bucket, 'opus', `${model} should use the current opus bucket`);
+      assert.strictEqual(
+        row.estimated_cost_usd, 30,
+        `${model}: expected $5 in + $25 out = $30, got ${row.estimated_cost_usd}`
+      );
+    }
+  }) ? passed++ : failed++);
+
+  // 11. The three Opus generations that genuinely billed at $15/$75 keep it.
+  //     `claude-opus-4-20250514` is the subtle one: it is Opus 4.0 with no
+  //     minor segment, so a plain `opus-4-0` substring test misses it.
+  (test('keeps $15/$75 for legacy Opus IDs (3 Opus, 4.0, 4.1)', () => {
+    for (const model of [
+      'claude-3-opus-20240229',
+      'claude-opus-4-0',
+      'claude-opus-4-20250514',
+      'claude-opus-4-1-20250805',
+      // Bedrock and Vertex rewrite the same models. Vertex joins the date with
+      // `@`, which is the spelling a `-` only pattern silently mispriced.
+      'us.anthropic.claude-3-opus-20240229-v1:0',
+      'claude-opus-4@20250514',
+      'claude-opus-4-1@20250805',
+    ]) {
+      const { row } = priceSession(model, ONE_M_EACH, 'opus-legacy');
+      assert.strictEqual(row.rate_bucket, 'opus-legacy', `${model} should use the legacy opus bucket`);
+      assert.strictEqual(
+        row.estimated_cost_usd, 90,
+        `${model}: expected $15 in + $75 out = $90, got ${row.estimated_cost_usd}`
+      );
+    }
+  }) ? passed++ : failed++);
+
+  // 12. Haiku 4.5 is $1/$5. The old table carried Haiku 3.5's $0.80/$4.00.
+  (test('prices Haiku 4.5 at $1/$5 per Mtok', () => {
+    const { row } = priceSession('claude-haiku-4-5-20251001', ONE_M_EACH, 'haiku');
+    assert.strictEqual(row.rate_bucket, 'haiku', 'Expected the haiku bucket');
+    assert.strictEqual(
+      row.estimated_cost_usd, 6,
+      `Expected $1 in + $5 out = $6, got ${row.estimated_cost_usd}`
+    );
+  }) ? passed++ : failed++);
+
+  // 13. Fable and Mythos are $10/$50. They had no bucket at all and fell
+  //     through to sonnet, understating them by 3.3x.
+  (test('prices Fable and Mythos at $10/$50 per Mtok', () => {
+    for (const model of ['claude-fable-5', 'claude-mythos-5']) {
+      const { row } = priceSession(model, ONE_M_EACH, 'fable');
+      assert.strictEqual(row.rate_bucket, 'fable', `${model} should use the fable bucket`);
+      assert.strictEqual(
+        row.estimated_cost_usd, 60,
+        `${model}: expected $10 in + $50 out = $60, got ${row.estimated_cost_usd}`
+      );
+    }
+  }) ? passed++ : failed++);
+
+  // 14. Cache multipliers ride the corrected input rate. This is the measured
+  //     regression: a session summing to 100M cache-read + 500K output on
+  //     claude-opus-5 was reported as $187.50 under the old table.
+  (test('prices a cache-heavy Opus 5 session at $62.50, not the old $187.50', () => {
+    const { row } = priceSession('claude-opus-5', {
+      input_tokens: 0,
+      output_tokens: 500000,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 100000000,
+    }, 'opus5-cache');
+    // 100M cache-read at $0.50/Mtok (0.1x the $5 input rate) = $50.00,
+    // plus 0.5M output at $25/Mtok = $12.50.
+    assert.strictEqual(
+      row.estimated_cost_usd, 62.5,
+      `Expected $62.50, got ${row.estimated_cost_usd}`
+    );
+  }) ? passed++ : failed++);
+
+  // 15. An unrecognized model still gets a usable number, because this is a
+  //     Stop hook and must stay fail-open, but it must not be silent.
+  (test('flags an unrecognized model instead of silently using sonnet rates', () => {
+    const { row, stderr } = priceSession('claude-quokka-9-20270101', ONE_M_EACH, 'unknown-model');
+    assert.strictEqual(row.rate_bucket, 'sonnet-fallback', 'Expected the fallback bucket on the row');
+    assert.strictEqual(row.estimated_cost_usd, 18, 'Expected sonnet rates as the fail-open default');
+    assert.ok(
+      stderr.includes('claude-quokka-9-20270101'),
+      `Expected a stderr warning naming the model, got: ${JSON.stringify(stderr)}`
+    );
+    assert.strictEqual(
+      stderr.split('\n').filter(l => l.includes('unrecognized model')).length, 1,
+      'Expected a single warning line from this invocation'
+    );
+  }) ? passed++ : failed++);
+
+  // 16. Negative case for that warning. A transcript whose assistant turns
+  //     record no model leaves the `unknown` sentinel, which names nothing the
+  //     reader could act on, so the hook stays quiet and lets the row carry it.
+  (test('stays quiet when no assistant turn recorded a model', () => {
+    const { row, stderr } = priceSession('', { input_tokens: 0, output_tokens: 0 }, 'no-model');
+    assert.strictEqual(row.model, 'unknown', 'Expected the unknown-model sentinel');
+    assert.strictEqual(row.rate_bucket, 'sonnet-fallback', 'Expected the fallback bucket');
+    assert.strictEqual(row.estimated_cost_usd, 0, 'Expected a zero estimate');
+    assert.ok(!stderr.includes('unrecognized model'), `Expected no warning, got: ${JSON.stringify(stderr)}`);
+  }) ? passed++ : failed++);
+
+  // 16b. Same sentinel, but with real tokens: the row must still be marked as
+  //      a guess even though nothing is printed.
+  (test('marks an unattributed session as a fallback without warning', () => {
+    const { row, stderr } = priceSession('', ONE_M_EACH, 'no-model-priced');
+    assert.strictEqual(row.model, 'unknown', 'Expected the unknown-model sentinel');
+    assert.strictEqual(row.rate_bucket, 'sonnet-fallback', 'Expected the row to record the guess');
+    assert.strictEqual(row.estimated_cost_usd, 18, 'Expected sonnet rates as the fail-open default');
+    assert.ok(!stderr.includes('unrecognized model'), 'A nameless model has nothing actionable to warn about');
+  }) ? passed++ : failed++);
+
+  // 17. Sonnet keeps its rates and stays distinguishable from the fallback.
+  (test('prices Sonnet at $3/$15 and marks it as a real match', () => {
+    const { row, stderr } = priceSession('claude-sonnet-4-6-20260115', ONE_M_EACH, 'sonnet');
+    assert.strictEqual(row.rate_bucket, 'sonnet', 'Expected a real sonnet match, not the fallback');
+    assert.strictEqual(row.estimated_cost_usd, 18, `Expected $3 in + $15 out = $18, got ${row.estimated_cost_usd}`);
+    assert.ok(!stderr.includes('unrecognized model'), 'A known model must not warn');
+  }) ? passed++ : failed++);
+
+  // 18. Claude 3.5 Haiku really was $0.80/$4.00. Correcting Haiku 4.5 must not
+  //     reprice it, which is why there is a legacy Haiku row at all.
+  (test('keeps $0.80/$4.00 for Claude 3.5 Haiku', () => {
+    for (const model of ['claude-3-5-haiku-20241022', 'claude-3-5-haiku-latest', 'claude-3-5-haiku@20241022']) {
+      const { row } = priceSession(model, ONE_M_EACH, 'haiku-legacy');
+      assert.strictEqual(row.rate_bucket, 'haiku-legacy', `${model} should use the legacy haiku bucket`);
+      assert.strictEqual(
+        row.estimated_cost_usd, 4.8,
+        `${model}: expected $0.80 in + $4.00 out = $4.80, got ${row.estimated_cost_usd}`
+      );
+    }
+  }) ? passed++ : failed++);
+
+  // 19. The cache columns are hand-typed constants and only Opus is pinned by
+  //     the cases above. Every row must stay at 1.25x input for a write and
+  //     0.1x input for a read, or cache-heavy sessions drift silently.
+  (test('keeps cache write at 1.25x and cache read at 0.1x input in every bucket', () => {
+    const inputRateByModel = [
+      ['claude-haiku-4-5-20251001', 1.0],
+      ['claude-3-5-haiku-20241022', 0.8],
+      ['claude-sonnet-5', 3.0],
+      ['claude-opus-5', 5.0],
+      ['claude-3-opus-20240229', 15.0],
+      ['claude-fable-5', 10.0],
+    ];
+    for (const [model, inputRate] of inputRateByModel) {
+      const { row } = priceSession(model, {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 1000000,
+        cache_read_input_tokens: 1000000,
+      }, 'cache-multipliers');
+      const expected = Math.round((inputRate * 1.25 + inputRate * 0.1) * 1e6) / 1e6;
+      assert.strictEqual(
+        row.estimated_cost_usd, expected,
+        `${model}: expected 1M cache-write + 1M cache-read = $${expected}, got ${row.estimated_cost_usd}`
+      );
+    }
+  }) ? passed++ : failed++);
+
+  // 20. `<synthetic>` is what Claude Code writes for interrupts and API
+  //     errors. It carries an all-zero but fully populated `usage` block, so
+  //     it clears the usage guard, and under last-model-wins it would rename
+  //     the whole session and drag it into the fallback bucket. Measured over
+  //     1,628 local transcripts, 10 end on one, and the final row is the one
+  //     /cost-report reads per session.
+  (test('ignores the <synthetic> sentinel when attributing the session model', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: { id: 'msg_01REAL', model: 'claude-opus-5', usage: { input_tokens: 1000000, output_tokens: 1000000 } },
+      },
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_01SYNTH',
+          model: '<synthetic>',
+          usage: { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        },
+      },
+    ]);
+    try {
+      const result = runScript(
+        { session_id: `synthetic-${Date.now()}`, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.model, 'claude-opus-5', 'Expected the real model, not the synthetic sentinel');
+      assert.strictEqual(row.rate_bucket, 'opus', 'Expected opus rates, not the fallback');
+      assert.strictEqual(row.estimated_cost_usd, 30, `Expected $30 at Opus rates, got ${row.estimated_cost_usd}`);
+      assert.ok(!result.stderr.includes('unrecognized model'), 'The sentinel must not trigger the warning');
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
+  // 21. When the harness supplied the cost, no rate-table row was consulted,
+  //     so `rate_bucket` must say `harness` rather than vouch for a table row
+  //     that did not produce the number.
+  (test('records rate_bucket as harness when the harness cost wins', () => {
+    const tmpHome = makeTempDir();
+    const sessionId = `bucket-harness-${Date.now()}`;
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      { type: 'assistant', message: { id: 'msg_01H', model: 'claude-opus-5', usage: { input_tokens: 1000000, output_tokens: 1000000 } } },
+    ]);
+    const harnessCachePath = path.join(os.tmpdir(), `harness-cost-${sessionId}.json`);
+    fs.writeFileSync(
+      harnessCachePath,
+      JSON.stringify({ ts: Math.floor(Date.now() / 1000), cost_usd: 7.77 }),
+      'utf8'
+    );
+    try {
+      runScript({ session_id: sessionId, transcript_path: transcriptPath }, withTempHome(tmpHome));
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 7.77, 'Expected the harness cost to win');
+      assert.strictEqual(row.rate_bucket, 'harness', 'Expected rate_bucket to follow the cost source');
+    } finally {
+      try { fs.unlinkSync(harnessCachePath); } catch { /* best-effort */ }
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
+  // 22. The mirror of 21: an unrecognized model must not be flagged as a guess
+  //     when the recorded cost came from the harness and is authoritative.
+  (test('does not flag an unrecognized model when the harness supplied the cost', () => {
+    const tmpHome = makeTempDir();
+    const sessionId = `harness-unknown-${Date.now()}`;
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      { type: 'assistant', message: { id: 'msg_01U', model: 'claude-quokka-9-20270101', usage: { input_tokens: 1000000, output_tokens: 1000000 } } },
+    ]);
+    const harnessCachePath = path.join(os.tmpdir(), `harness-cost-${sessionId}.json`);
+    fs.writeFileSync(
+      harnessCachePath,
+      JSON.stringify({ ts: Math.floor(Date.now() / 1000), cost_usd: 7.77 }),
+      'utf8'
+    );
+    try {
+      const result = runScript({ session_id: sessionId, transcript_path: transcriptPath }, withTempHome(tmpHome));
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.rate_bucket, 'harness', 'Expected the harness bucket, not the fallback');
+      assert.ok(
+        !result.stderr.includes('unrecognized model'),
+        `An authoritative cost must not be called a guess, got: ${JSON.stringify(result.stderr)}`
+      );
+    } finally {
+      try { fs.unlinkSync(harnessCachePath); } catch { /* best-effort */ }
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What Changed

`scripts/hooks/cost-tracker.js` priced every `opus` model at **$15/$75** per Mtok. Those are Claude 3 Opus era rates. Opus 4.5 and later bill at **$5/$25**, so every current-generation Opus session has been reported at exactly **3x real spend**.

**The arithmetic in the hook was always correct. Only the rate constants were wrong.**

Concrete, measured: a session whose transcript summed to **100,000,000 cache-read + 500,000 output tokens** on `claude-opus-5`.

| | Reported |
|---|---|
| Stale table | **$187.50** |
| Corrected table | **$62.50** |

That case is now test 14, so the number in this table is machine-checked rather than asserted.

**This affects every user running any Opus model.** Opus is ECC's default for the heavier agents, so for many users it is most of the bill.

### The rate table

| Bucket | Was | Now |
|---|---|---|
| `opus` (4.5, 4.6, 4.7, 4.8, Opus 5) | $15.00 / $75.00 | **$5.00 / $25.00** |
| `opusLegacy` (Claude 3 Opus, Opus 4.0, Opus 4.1) | (same bucket as above) | **$15.00 / $75.00** (new row) |
| `fable` (Fable 5, Mythos 5) | no bucket, fell through to `sonnet` | **$10.00 / $50.00** (new row) |
| `haiku` (Haiku 4.5) | $0.80 / $4.00 | **$1.00 / $5.00** |
| `haikuLegacy` (Claude 3.5 Haiku) | (same bucket as above) | **$0.80 / $4.00** (new row) |
| `sonnet` (Sonnet 5, Sonnet 4.6) | $3.00 / $15.00 | unchanged |

Cache write is 1.25x input and cache read is 0.1x input in every row, pinned by a test so the hand-typed cache columns cannot drift.

The two legacy rows exist so that correcting the current generation does not reprice the old one. Claude 3.5 Haiku's $0.80/$4.00 was *exactly right*; collapsing all Haiku to $1/$5 would have traded one error for another. Claude 3 Haiku ($0.25/$1.25) is deliberately not modelled, and the comment says so.

A bare `includes('opus')` cannot separate the two Opus eras, so legacy IDs are matched explicitly. Every spelling had to be covered:

- aliases: `claude-opus-4-0`, `claude-opus-4-1`
- dated snapshots: `claude-opus-4-20250514` (Opus 4.0 has **no minor segment**, so an `opus-4-0` substring alone misses it), `claude-opus-4-1-20250805`
- Bedrock: `us.anthropic.claude-3-opus-20240229-v1:0`
- Vertex: `claude-opus-4@20250514` (joins the date with `@`)

and the negative side is tested too: `claude-opus-4-5-20251101`, `claude-opus-4-8[1m]` and `claude-opus-4-5@20251101` must **not** land in the legacy bucket.

### Unknown models: the root cause

The table had no way to say "I do not know". Any unrecognized model got a plausible sonnet-priced number with **no signal at all**, which is precisely how the stale Opus rate survived unnoticed. Two changes, both non-blocking:

1. Rows carry a new **`rate_bucket`** field naming what produced the cost. `sonnet-fallback` means the model ID matched nothing.
2. An unrecognized model that actually priced tokens writes **one line to stderr** naming it.

`rate_bucket` follows the *cost source*, not the model, so it reads `harness` when the statusline's authoritative `cost.total_cost_usd` supplied the number and no rate-table row was consulted. Without that, the field would vouch for harness rows as table-priced and, worse, flag an authoritative number as a guess.

The hook stays **fail-open throughout**: an unknown model still gets a usable default, nothing throws, and stdout pass-through is untouched. Per the file's own contract, this hook never fails the Stop event.

### One adjacent fix the new bucket exposed

Claude Code writes `{"type":"assistant","message":{"model":"<synthetic>","usage":{...}}}` for interrupts, API errors, and "no response requested". It carries a **fully populated but all-zero** `usage` block, so it cleared the existing usage guard and then, under last-model-wins, renamed the whole session.

Measured over **1,628 local transcripts**: 60 such entries, and **10 transcripts end on one**. That last case is the damaging one, because the final row is exactly the cumulative row `/cost-report` reads per session. An Opus session ending on an interrupt was reported at $18 instead of $30 in the reproduction, and it also produced a useless `unrecognized model "<synthetic>"` warning from the new code. `<synthetic>` now joins `unknown` as a sentinel that does not claim the session.

I would happily split this out if you would rather keep the PR to rates alone, but it is what makes the new fallback signal mean anything in practice.

## Why This Change

Cost tracking that is confidently wrong is worse than no cost tracking. A 3x overstatement on the most expensive model pushes users toward exactly the wrong optimization, and `skills/cost-tracking/SKILL.md` tells readers to trust `estimated_cost_usd` over hand-calculating.

The deeper problem was that a hard-coded table with a silent default has no failure mode. Every future model repricing produces a plausible-but-wrong number and nothing ever surfaces it. `rate_bucket` plus the warning is the smallest change that gives it one.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

**14 new cases** in `tests/hooks/cost-tracker.test.js`, matching the file's existing spawn-the-hook-and-read-the-row style and its runner. Each asserts the **dollar figure**, not merely that one is present: a "cost > 0" assertion is exactly what let the stale rate survive.

```
$ node tests/hooks/cost-tracker.test.js

=== Testing cost-tracker.js ===

  PASS passes through input on stdout
  PASS creates metrics file when given transcript usage data
  PASS counts usage once per message.id across multi-line responses
  PASS handles empty input gracefully
  PASS handles invalid JSON gracefully
  PASS handles missing usage fields gracefully
  PASS prefers ECC_SESSION_ID over CLAUDE_SESSION_ID when both are present
  PASS uses input session_id for session correlation when env vars are absent
  PASS prefers fresh harness-cost cache over transcript estimate
  PASS ignores stale harness-cost cache (>300s) and uses transcript estimate
  PASS prices current Opus models at $5/$25 per Mtok
  PASS keeps $15/$75 for legacy Opus IDs (3 Opus, 4.0, 4.1)
  PASS prices Haiku 4.5 at $1/$5 per Mtok
  PASS prices Fable and Mythos at $10/$50 per Mtok
  PASS prices a cache-heavy Opus 5 session at $62.50, not the old $187.50
  PASS flags an unrecognized model instead of silently using sonnet rates
  PASS stays quiet when no assistant turn recorded a model
  PASS marks an unattributed session as a fallback without warning
  PASS prices Sonnet at $3/$15 and marks it as a real match
  PASS keeps $0.80/$4.00 for Claude 3.5 Haiku
  PASS keeps cache write at 1.25x and cache read at 0.1x input in every bucket
  PASS ignores the <synthetic> sentinel when attributing the session model
  PASS records rate_bucket as harness when the harness cost wins
  PASS does not flag an unrecognized model when the harness supplied the cost

Results: Passed: 24, Failed: 0
```

**Verified red before green.** With the new tests in place and only `scripts/hooks/cost-tracker.js` reverted to `main`, 14 of the 24 fail, and the headline case fails with the exact regression:

```
  FAIL prices a cache-heavy Opus 5 session at $62.50, not the old $187.50
    Error: Expected $62.50, got 187.5
    187.5 !== 62.5
```

Full gauntlet, `npm test`: **3456 tests, 3445 passed, 11 failed.** Those 11 all live in `hooks/gateguard*` and `hooks/suggest-compact` and are **pre-existing on a clean `main`**, which I confirmed by stashing this change and re-running (clean `main`: 3442 tests, 3431 passed, **the same 11 failed**). Nothing here touches those paths.

`eslint`, `markdownlint` and `node scripts/ci/check-unicode-safety.js` all clean on the changed files.

The change was also put through an adversarial review pass before opening. Findings on the Vertex `@date` spelling, the `rate_bucket` harness path, the Haiku 3.5 regression, the `<synthetic>` sentinel, and several overstated code comments are all incorporated above.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (no JSON files changed)
- [x] Shell scripts pass shellcheck (if applicable) (no shell scripts changed)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output. The new stderr line prints only the model ID from the transcript.
- [x] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
- [x] Not applicable. No dependency, `package.json` or `yarn.lock` change.

## If you added a skill, command, agent, hook, or CLI tool
- [x] Not applicable. This modifies an existing hook. No new surface, so no manifest, catalog, command-registry or publish-allowlist change is needed. `npm run catalog:check` and `npm run command-registry:check` pass as part of the `npm test` run above.

## Documentation
- [x] Updated relevant documentation. The row schema is documented in two places and both now list `rate_bucket`: `commands/cost-report.md` (schema line, plus the CSV export columns so the field is actually reachable) and `skills/cost-tracking/SKILL.md` (schema table).
- [x] Added comments for complex logic. The regex alternatives and the fallback gating each carry a *why*, including the Opus 4.0 snapshot case and the reason the warning is silent on the harness path.
- [ ] README updated (if needed). Not needed, the README does not document this row schema.

## Noticed but deliberately left out of scope

Two places carry the same stale numbers. Both are separable and neither is in this hook's path, so I left them rather than sprawl the diff. Happy to send either as a follow-up, or to fold them in here if you would prefer one PR.

1. **`scripts/lib/cost-estimate.js`** has an independent `RATE_TABLE` with the identical `opus: { in: 15.0, out: 75.0 }` and `haiku: { in: 0.8, out: 4.0 }`. Nothing currently requires it except its own test (`tests/lib/cost-estimate.test.js`), which pins the values, so fixing it means changing that test too.
2. **`skills/cost-aware-llm-pipeline/SKILL.md`** (and the `docs/zh-CN` and `docs/ja-JP` translations of it) has a pricing table listing "Opus 4.5 | $15.00 | $75.00", which is the same error in prose. That is a docs change across three locales.
