### PR TITLE
fix(hooks): count subagent transcripts in the cost tracker

### DIFF
--- a/commands/cost-report.md
+++ b/commands/cost-report.md
@@ -16,7 +16,23 @@ session**, so the report takes the **latest row per `session_id`** and sums
 across sessions (summing every row would multiply-count).
 
 Row schema:
-`{ timestamp, session_id, transcript_path, model, input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, estimated_cost_usd }`
+`{ timestamp, session_id, transcript_path, model, input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, estimated_cost_usd, subagent_transcripts, models }`
+
+Token totals and `estimated_cost_usd` cover the session's subagent turns as
+well as its main transcript; `subagent_transcripts` counts the subagent files
+that were folded in, and is `0` for a session that never fanned out.
+
+`models` breaks the session down by the model and speed tier that actually
+served each turn: `[{ model, speed, input_tokens, output_tokens,
+cache_write_tokens, cache_read_tokens, estimated_cost_usd }]`, most expensive
+first. It is the more precise basis for a per-model breakdown than `model`,
+which names only the main session's model while a fan-out session commonly
+bills across several. Its token counts always reconcile with the row totals.
+The `By model` grouping below still keys on `model`, which attributes each
+session to one model; read `models` when you need the split. Its costs sum
+to `estimated_cost_usd` except when the harness supplied that number directly,
+in which case `models` remains the transcript-derived estimate and the two need
+not agree.
 
 ## What this command does
 

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -21,6 +21,18 @@
  * To get per-session cost, take the last row per session_id. To get per-day
  * spend, aggregate.
  *
+ * Subagent transcripts: a session that fans out writes each subagent to its own
+ * JSONL beside the main one, at
+ *   <transcript_path minus .jsonl>/subagents/agent-*.jsonl
+ * That spend is the parent session's (the subagent lines carry the parent's
+ * `sessionId`) but it lived in files this hook never opened, so every fan-out
+ * session was under-reported. Measured over 116 local sessions that fanned out:
+ * $1,837 of $13,493 real spend was invisible, 13.6% of the total, and on the
+ * worst session the hidden half was nearly as large as the visible one. The
+ * subagent files share no `message.id` with the parent transcript (0 collisions
+ * across those 116 sessions), so folding them into the same dedupe map is
+ * purely additive and cannot double-count.
+ *
  * Harness-cost contract (optional, opt-in by the statusline):
  *   If the user's statusline (which receives `cost.total_cost_usd` directly
  *   from Claude Code) writes `{ts, cost_usd}` to
@@ -29,7 +41,9 @@
  *   the cache is fresh (≤ 300s). The transcript-sum is kept as a safe
  *   fallback because:
  *     - the hard-coded rate table cannot represent Opus 4.7's >200K-token
- *       2x tier or the 1h-cache 2x tier (under-counts on long sessions);
+ *       2x tier or the 1h-cache 2x tier (under-counts on long sessions).
+ *       Fast mode is no longer in that list: `message.usage.speed` is present
+ *       in the transcript and is now priced (see FAST_SPEED below);
  *     - summing the full transcript double-counts work done across
  *       `--resume` boundaries while `cost.total_cost_usd` is per-process.
  *   Absent a writer, behavior is unchanged.
@@ -83,15 +97,82 @@ function getRates(model) {
   return RATE_TABLE.sonnet;
 }
 
+// Fast mode is a real billing tier, not a latency hint: a fast-mode response
+// bills at 2x the model's standard rate. `message.usage.speed` reports which
+// tier actually served the request, so the transcript carries the fact and no
+// guessing is required. Measured over 1,500 local transcripts: `speed` is
+// present on 123,155 of 151,286 assistant usage blocks (81.4%).
+//
+// The multiplier is applied on whatever `speed` says rather than on a list of
+// models known to offer the tier, because a model that has no fast tier never
+// emits `speed: "fast"`, so the list would add staleness without adding
+// accuracy. Every fast tier published so far is exactly 2x standard; a tier
+// that is not 2x would be a new rate row, the same as any repricing.
+const FAST_SPEED = 'fast';
+const FAST_MULTIPLIER = 2;
+
+// Recorded on the row when `speed` was absent, which is how every transcript
+// written before the field existed reads. Absent means standard rates, which
+// is also the pre-change behavior, so old transcripts reprice identically.
+const STANDARD_SPEED = 'standard';
+
+const SUBAGENT_DIR_NAME = 'subagents';
+const JSONL_EXT = '.jsonl';
+
+/**
+ * Rates for one usage block, accounting for the speed tier it was served at.
+ * @param {string} model
+ * @param {string} speed - normalized speed tier
+ * @returns {object} rate row; a fresh scaled copy on the fast tier
+ */
+function getRatesForSpeed(model, speed) {
+  const rates = getRates(model);
+  if (speed !== FAST_SPEED) return rates;
+  return {
+    in:         rates.in * FAST_MULTIPLIER,
+    out:        rates.out * FAST_MULTIPLIER,
+    cacheWrite: rates.cacheWrite * FAST_MULTIPLIER,
+    cacheRead:  rates.cacheRead * FAST_MULTIPLIER
+  };
+}
+
+/**
+ * Subagent transcripts belonging to a session, given the main transcript path.
+ *
+ * Claude Code lays a fan-out session out as:
+ *   <dir>/<session_id>.jsonl                        <- the main transcript
+ *   <dir>/<session_id>/subagents/agent-*.jsonl      <- one file per subagent
+ *
+ * @param {string} transcriptPath
+ * @returns {string[]} absolute paths, sorted; empty when the session never
+ *   fanned out. A missing directory is the normal case for most sessions, so
+ *   it resolves to "no subagents" without warning or throwing: this is a
+ *   non-blocking Stop hook and must stay fail-open.
+ */
+function subagentTranscriptPaths(transcriptPath) {
+  if (typeof transcriptPath !== 'string' || !transcriptPath.endsWith(JSONL_EXT)) return [];
+  const sessionDir = transcriptPath.slice(0, -JSONL_EXT.length);
+  const dir = path.join(sessionDir, SUBAGENT_DIR_NAME);
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  // `.meta.json` sidecars live in the same directory and carry no usage.
+  return names
+    .filter(name => name.endsWith(JSONL_EXT))
+    .sort()
+    .map(name => path.join(dir, name));
+}
+
 function toNumber(v) {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
 }
 
 /**
- * Scan the session JSONL and sum token usage across all assistant turns.
- * Returns { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model }
- * or null on read failure.
+ * Read one transcript JSONL and fold its assistant usage into `usageById`.
  *
  * Claude Code writes one JSONL line per content block, so a single API
  * response (one message.id) spans multiple assistant lines that each repeat
@@ -99,23 +180,34 @@ function toNumber(v) {
  * (verified: a session with 704 assistant lines had only 286 unique
  * message.ids — $867 line-summed vs $333 deduped). Usage is therefore
  * counted once per message.id, keeping the last line seen for each id.
+ *
+ * @param {string} filePath
+ * @param {Map} usageById - accumulator, shared across the main transcript and
+ *   every subagent transcript so one dedupe map covers the whole session.
+ * @param {string} keyspace - disambiguates the synthetic keys below between
+ *   files, which would otherwise collide and drop real usage.
+ * @returns {{ok: boolean, model: string|null}} `model` is the last model this
+ *   file named, or null if it named none.
  */
-function sumUsageFromTranscript(transcriptPath) {
+function readUsageInto(filePath, usageById, keyspace) {
   let content;
   try {
-    content = fs.readFileSync(transcriptPath, 'utf8');
+    content = fs.readFileSync(filePath, 'utf8');
   } catch {
-    return null;
+    return { ok: false, model: null };
   }
 
-  const usageById = new Map();
   let syntheticKey = 0;
-  let model = 'unknown';
+  let model = null;
 
   for (const line of content.split('\n')) {
     if (!line.trim()) continue;
     let entry;
-    try { entry = JSON.parse(line); } catch { continue; }
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
 
     if (entry.type !== 'assistant') continue;
     const msg = entry.message;
@@ -123,12 +215,47 @@ function sumUsageFromTranscript(transcriptPath) {
 
     // Lines without a message.id (older transcript shapes) keep the previous
     // per-line behavior via a synthetic key.
-    const key = (typeof msg.id === 'string' && msg.id)
-      ? msg.id
-      : `__line_${++syntheticKey}`;
-    usageById.set(key, msg.usage);
+    const key = typeof msg.id === 'string' && msg.id ? msg.id : `__line_${keyspace}_${++syntheticKey}`;
+    usageById.set(key, { usage: msg.usage, model: msg.model });
 
     if (msg.model && msg.model !== 'unknown') model = msg.model;
+  }
+
+  return { ok: true, model };
+}
+
+/**
+ * Sum a session's token usage across its main transcript and every subagent
+ * transcript, grouped by the model and speed tier that actually served each
+ * response.
+ *
+ * Grouping is what makes folding subagents in safe. The previous code priced
+ * a whole session at one model's rate, which was tolerable while the only
+ * turns counted were the main session's. Subagents routinely run a different
+ * model than the parent (measured: 48 of 116 local fan-out sessions, 41.4%,
+ * most often an Opus parent delegating to Sonnet or Haiku), so charging their
+ * tokens at the parent's rate would trade one error for another. Each bucket
+ * is therefore priced at its own rate and the costs are added.
+ *
+ * @param {string} transcriptPath
+ * @returns {object|null} null when the main transcript could not be read.
+ */
+function sumUsageFromTranscript(transcriptPath) {
+  const usageById = new Map();
+
+  const main = readUsageInto(transcriptPath, usageById, 'main');
+  if (!main.ok) return null;
+
+  // The subagents' own models deliberately do not participate in the row's
+  // `model` field: it names the session's model, which `/cost-report` groups
+  // by, and letting a Haiku subagent win last-model-wins would relabel an
+  // Opus session as a Haiku one. Their spend still lands in the totals and in
+  // the per-model breakdown.
+  const model = main.model || 'unknown';
+
+  const subagentPaths = subagentTranscriptPaths(transcriptPath);
+  for (const subagentPath of subagentPaths) {
+    readUsageInto(subagentPath, usageById, subagentPath);
   }
 
   let inputTokens = 0;
@@ -136,14 +263,65 @@ function sumUsageFromTranscript(transcriptPath) {
   let cacheWriteTokens = 0;
   let cacheReadTokens = 0;
 
-  for (const u of usageById.values()) {
-    inputTokens      += toNumber(u.input_tokens);
-    outputTokens     += toNumber(u.output_tokens);
-    cacheWriteTokens += toNumber(u.cache_creation_input_tokens);
-    cacheReadTokens  += toNumber(u.cache_read_input_tokens);
+  const buckets = new Map();
+
+  for (const { usage, model: usageModel } of usageById.values()) {
+    const input = toNumber(usage.input_tokens);
+    const output = toNumber(usage.output_tokens);
+    const cacheWrite = toNumber(usage.cache_creation_input_tokens);
+    const cacheRead = toNumber(usage.cache_read_input_tokens);
+
+    inputTokens += input;
+    outputTokens += output;
+    cacheWriteTokens += cacheWrite;
+    cacheReadTokens += cacheRead;
+
+    const bucketModel = usageModel && usageModel !== 'unknown' ? usageModel : model;
+    const speed = usage.speed === FAST_SPEED ? FAST_SPEED : STANDARD_SPEED;
+    // A model ID cannot contain a NUL, so this cannot collide.
+    const key = `${bucketModel}\u0000${speed}`;
+
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        model: bucketModel,
+        speed,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheWriteTokens: 0,
+        cacheReadTokens: 0
+      };
+      buckets.set(key, bucket);
+    }
+    bucket.inputTokens += input;
+    bucket.outputTokens += output;
+    bucket.cacheWriteTokens += cacheWrite;
+    bucket.cacheReadTokens += cacheRead;
   }
 
-  return { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model };
+  return {
+    inputTokens,
+    outputTokens,
+    cacheWriteTokens,
+    cacheReadTokens,
+    model,
+    buckets: [...buckets.values()],
+    subagentTranscripts: subagentPaths.length
+  };
+}
+
+/**
+ * Price one per-model, per-speed bucket.
+ * @param {object} bucket
+ * @returns {number} USD, rounded to 6 decimal places
+ */
+function priceBucket(bucket) {
+  const rates = getRatesForSpeed(bucket.model, bucket.speed);
+  return (
+    Math.round(
+      ((bucket.inputTokens / 1e6) * rates.in + (bucket.outputTokens / 1e6) * rates.out + (bucket.cacheWriteTokens / 1e6) * rates.cacheWrite + (bucket.cacheReadTokens / 1e6) * rates.cacheRead) * 1e6
+    ) / 1e6
+  );
 }
 
 // 1MB, matching the other Stop hooks. The Stop payload carries
@@ -168,36 +346,35 @@ process.stdin.on('end', () => {
   try {
     const input = raw.trim() ? JSON.parse(raw) : {};
 
-    const transcriptPath = (typeof input.transcript_path === 'string' && input.transcript_path)
-      ? input.transcript_path
-      : process.env.CLAUDE_TRANSCRIPT_PATH || null;
+    const transcriptPath = typeof input.transcript_path === 'string' && input.transcript_path ? input.transcript_path : process.env.CLAUDE_TRANSCRIPT_PATH || null;
 
-    const sessionId =
-      sanitizeSessionId(input.session_id) ||
-      sanitizeSessionId(process.env.ECC_SESSION_ID) ||
-      sanitizeSessionId(process.env.CLAUDE_SESSION_ID) ||
-      'default';
+    const sessionId = sanitizeSessionId(input.session_id) || sanitizeSessionId(process.env.ECC_SESSION_ID) || sanitizeSessionId(process.env.CLAUDE_SESSION_ID) || 'default';
 
     let usageTotals = null;
     if (transcriptPath && fs.existsSync(transcriptPath)) {
       usageTotals = sumUsageFromTranscript(transcriptPath);
     }
 
-    const {
-      inputTokens = 0,
-      outputTokens = 0,
-      cacheWriteTokens = 0,
-      cacheReadTokens = 0,
-      model = 'unknown'
-    } = usageTotals || {};
+    const { inputTokens = 0, outputTokens = 0, cacheWriteTokens = 0, cacheReadTokens = 0, model = 'unknown', buckets = [], subagentTranscripts = 0 } = usageTotals || {};
 
-    const rates = getRates(model);
-    const transcriptCostUsd = Math.round((
-      (inputTokens      / 1e6) * rates.in +
-      (outputTokens     / 1e6) * rates.out +
-      (cacheWriteTokens / 1e6) * rates.cacheWrite +
-      (cacheReadTokens  / 1e6) * rates.cacheRead
-    ) * 1e6) / 1e6;
+    // Each model and speed tier is priced at its own rate and the results are
+    // summed, rather than pricing every token in the session at one model's
+    // rate. Rounding is per bucket and again on the total, which can differ
+    // from a single rounding by at most a millionth of a dollar per bucket.
+    const pricedBuckets = buckets.map(bucket => ({
+      model: bucket.model,
+      speed: bucket.speed,
+      input_tokens: bucket.inputTokens,
+      output_tokens: bucket.outputTokens,
+      cache_write_tokens: bucket.cacheWriteTokens,
+      cache_read_tokens: bucket.cacheReadTokens,
+      estimated_cost_usd: priceBucket(bucket)
+    }));
+    // Most expensive first, so the breakdown reads as an attribution and the
+    // row is byte-for-byte deterministic for a given transcript.
+    pricedBuckets.sort((a, b) => b.estimated_cost_usd - a.estimated_cost_usd || a.model.localeCompare(b.model));
+
+    const transcriptCostUsd = Math.round(pricedBuckets.reduce((sum, b) => sum + b.estimated_cost_usd, 0) * 1e6) / 1e6;
 
     // Prefer the harness's authoritative `cost.total_cost_usd` when the
     // statusline has written it to the per-session cache (see contract in
@@ -205,23 +382,28 @@ process.stdin.on('end', () => {
     // (correct rates, 1h-cache 2x, >200K tier 2x) and is per-process so it
     // does not drift across `--resume`. Cache miss → transcript-sum.
     const harnessCost = readHarnessCost(sessionId, HARNESS_COST_MAX_AGE_SECONDS);
-    const estimatedCostUsd = harnessCost !== null
-      ? Math.round(harnessCost * 1e6) / 1e6
-      : transcriptCostUsd;
+    const estimatedCostUsd = harnessCost !== null ? Math.round(harnessCost * 1e6) / 1e6 : transcriptCostUsd;
 
     const metricsDir = path.join(getClaudeDir(), 'metrics');
     ensureDir(metricsDir);
 
+    // Every pre-existing field keeps its name, type and meaning, so readers of
+    // costs.jsonl need no change: `model` still names the session's model and
+    // the token counts are still session totals, they simply now include the
+    // subagent turns that were being dropped. `models` and
+    // `subagent_transcripts` are additive.
     const row = {
-      timestamp:          new Date().toISOString(),
-      session_id:         sessionId,
-      transcript_path:    transcriptPath || '',
+      timestamp: new Date().toISOString(),
+      session_id: sessionId,
+      transcript_path: transcriptPath || '',
       model,
-      input_tokens:       inputTokens,
-      output_tokens:      outputTokens,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
       cache_write_tokens: cacheWriteTokens,
-      cache_read_tokens:  cacheReadTokens,
-      estimated_cost_usd: estimatedCostUsd
+      cache_read_tokens: cacheReadTokens,
+      estimated_cost_usd: estimatedCostUsd,
+      subagent_transcripts: subagentTranscripts,
+      models: pricedBuckets
     };
 
     appendFile(path.join(metricsDir, 'costs.jsonl'), `${JSON.stringify(row)}\n`);

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -186,18 +186,23 @@ function toNumber(v) {
  *   every subagent transcript so one dedupe map covers the whole session.
  * @param {string} keyspace - disambiguates the synthetic keys below between
  *   files, which would otherwise collide and drop real usage.
- * @returns {{ok: boolean, model: string|null}} `model` is the last model this
- *   file named, or null if it named none.
+ * @returns {{ok: boolean, usageEntries: number, model: string|null}} `ok` is
+ *   false only when the file could not be read at all. `usageEntries` counts
+ *   the usage-bearing lines actually parsed out of it, which is what "folded
+ *   in" means: a readable file whose every line fails `JSON.parse` — or a
+ *   directory named `*.jsonl` — is `ok` but contributes nothing. `model` is
+ *   the last model this file named, or null if it named none.
  */
 function readUsageInto(filePath, usageById, keyspace) {
   let content;
   try {
     content = fs.readFileSync(filePath, 'utf8');
   } catch {
-    return { ok: false, model: null };
+    return { ok: false, usageEntries: 0, model: null };
   }
 
   let syntheticKey = 0;
+  let usageEntries = 0;
   let model = null;
 
   for (const line of content.split('\n')) {
@@ -217,11 +222,12 @@ function readUsageInto(filePath, usageById, keyspace) {
     // per-line behavior via a synthetic key.
     const key = typeof msg.id === 'string' && msg.id ? msg.id : `__line_${keyspace}_${++syntheticKey}`;
     usageById.set(key, { usage: msg.usage, model: msg.model });
+    usageEntries += 1;
 
     if (msg.model && msg.model !== 'unknown') model = msg.model;
   }
 
-  return { ok: true, model };
+  return { ok: true, usageEntries, model };
 }
 
 /**
@@ -253,9 +259,17 @@ function sumUsageFromTranscript(transcriptPath) {
   // the per-model breakdown.
   const model = main.model || 'unknown';
 
+  // Count the subagent files whose usage was actually read, not the ones that
+  // were merely discovered. `subagent_transcripts` is documented as the files
+  // that were folded in, and an unreadable file, a directory named `*.jsonl`,
+  // or a file whose every line fails JSON.parse folds in nothing. Token totals
+  // were always correct here; only this audit field over-reported.
   const subagentPaths = subagentTranscriptPaths(transcriptPath);
+  let subagentTranscripts = 0;
   for (const subagentPath of subagentPaths) {
-    readUsageInto(subagentPath, usageById, subagentPath);
+    if (readUsageInto(subagentPath, usageById, subagentPath).usageEntries > 0) {
+      subagentTranscripts += 1;
+    }
   }
 
   let inputTokens = 0;
@@ -306,7 +320,7 @@ function sumUsageFromTranscript(transcriptPath) {
     cacheReadTokens,
     model,
     buckets: [...buckets.values()],
-    subagentTranscripts: subagentPaths.length
+    subagentTranscripts
   };
 }
 
@@ -371,8 +385,17 @@ process.stdin.on('end', () => {
       estimated_cost_usd: priceBucket(bucket)
     }));
     // Most expensive first, so the breakdown reads as an attribution and the
-    // row is byte-for-byte deterministic for a given transcript.
-    pricedBuckets.sort((a, b) => b.estimated_cost_usd - a.estimated_cost_usd || a.model.localeCompare(b.model));
+    // row is byte-for-byte deterministic for a given transcript. The model
+    // comparison is a plain codepoint one rather than `localeCompare`, which
+    // reads the active ICU locale and would let two hosts order equal-cost
+    // buckets differently. `speed` breaks the remaining tie, so two buckets of
+    // one model at equal cost cannot fall back to Map insertion order.
+    pricedBuckets.sort(
+      (a, b) =>
+        b.estimated_cost_usd - a.estimated_cost_usd ||
+        (a.model < b.model ? -1 : a.model > b.model ? 1 : 0) ||
+        (a.speed < b.speed ? -1 : a.speed > b.speed ? 1 : 0)
+    );
 
     const transcriptCostUsd = Math.round(pricedBuckets.reduce((sum, b) => sum + b.estimated_cost_usd, 0) * 1e6) / 1e6;
 

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -29,7 +29,7 @@ Row schema:
 | `cache_write_tokens` / `cache_read_tokens` | Prompt-cache token counts, including subagent turns |
 | `estimated_cost_usd` | Precomputed cumulative cost in USD for the session |
 | `subagent_transcripts` | Number of subagent transcripts folded in; `0` when the session never fanned out |
-| `models` | Per-model, per-speed-tier breakdown, most expensive first |
+| `models` | Per-model, per-speed-tier breakdown, most expensive first. Token counts always reconcile with the row totals. Costs sum to `estimated_cost_usd` unless the harness supplied that number directly, in which case `models` stays the transcript-derived estimate and the two need not agree |
 
 Prefer `estimated_cost_usd` over hand-calculating pricing — model and cache
 prices change, and the tracker is the source of truth.

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -24,10 +24,12 @@ Row schema:
 | `timestamp` | ISO timestamp of the snapshot |
 | `session_id` | Claude Code session identifier |
 | `transcript_path` | Path to the session transcript |
-| `model` | Model used |
-| `input_tokens` / `output_tokens` | Token counts |
-| `cache_write_tokens` / `cache_read_tokens` | Prompt-cache token counts |
+| `model` | Model used by the main session |
+| `input_tokens` / `output_tokens` | Token counts, including subagent turns |
+| `cache_write_tokens` / `cache_read_tokens` | Prompt-cache token counts, including subagent turns |
 | `estimated_cost_usd` | Precomputed cumulative cost in USD for the session |
+| `subagent_transcripts` | Number of subagent transcripts folded in; `0` when the session never fanned out |
+| `models` | Per-model, per-speed-tier breakdown, most expensive first |
 
 Prefer `estimated_cost_usd` over hand-calculating pricing — model and cache
 prices change, and the tracker is the source of truth.

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -338,6 +338,261 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
+
+  // --- Subagent transcripts ------------------------------------------------
+  // A session that fans out writes each subagent to its own JSONL under
+  //   <transcript minus .jsonl>/subagents/agent-*.jsonl
+  // and that spend is the parent session's. It was never read, so every
+  // fan-out session under-reported. Measured over 116 local fan-out sessions:
+  // $1,837 of $13,493 was invisible (13.6%).
+
+  // Writes a main transcript plus a subagents/ directory, and returns the row.
+  function priceFanOut({ mainEntries, subagentFiles = {}, extraFiles = {} }) {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, mainEntries);
+
+    const subagentDir = path.join(tmpHome, 'session', 'subagents');
+    const names = Object.keys(subagentFiles).concat(Object.keys(extraFiles));
+    if (names.length > 0) fs.mkdirSync(subagentDir, { recursive: true });
+    for (const [name, entries] of Object.entries(subagentFiles)) {
+      writeTranscript(path.join(subagentDir, name), entries);
+    }
+    for (const [name, body] of Object.entries(extraFiles)) {
+      fs.writeFileSync(path.join(subagentDir, name), body, 'utf8');
+    }
+
+    try {
+      const result = runScript(
+        { session_id: `fanout-${Date.now()}-${Math.random()}`, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      return { row, stderr: result.stderr };
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }
+
+  const assistant = (id, model, usage) => ({ type: 'assistant', message: { id, model, usage } });
+
+  // 20. The defect itself: subagent tokens must reach the row.
+  (test('counts subagent transcripts in the session total', () => {
+    const { row } = priceFanOut({
+      mainEntries: [
+        assistant('msg_main', 'claude-sonnet-4-6', { input_tokens: 1000, output_tokens: 100 }),
+      ],
+      subagentFiles: {
+        'agent-aaa.jsonl': [
+          assistant('msg_sub_a', 'claude-sonnet-4-6', { input_tokens: 2000, output_tokens: 200 }),
+        ],
+        'agent-bbb.jsonl': [
+          assistant('msg_sub_b', 'claude-sonnet-4-6', { input_tokens: 4000, output_tokens: 400 }),
+        ],
+      },
+    });
+    assert.strictEqual(row.subagent_transcripts, 2, 'Expected both subagent files to be folded in');
+    assert.strictEqual(row.input_tokens, 7000, 'Expected 1000 main + 2000 + 4000 subagent input tokens');
+    assert.strictEqual(row.output_tokens, 700, 'Expected 100 main + 200 + 400 subagent output tokens');
+    // Sonnet: 7000/1e6*3 + 700/1e6*15 = 0.021 + 0.0105
+    assert.strictEqual(row.estimated_cost_usd, 0.0315, `Expected $0.0315, got ${row.estimated_cost_usd}`);
+  }) ? passed++ : failed++);
+
+  // 21. Negative case for the whole feature. Most sessions never fan out, so
+  //     the missing directory is the common path: it must be silent, must not
+  //     throw, and must leave the numbers exactly as before.
+  (test('a session with no subagents directory is unchanged and silent', () => {
+    const { row, stderr } = priceFanOut({
+      mainEntries: [
+        assistant('msg_main', 'claude-sonnet-4-6', { input_tokens: 1000, output_tokens: 100 }),
+      ],
+    });
+    assert.strictEqual(row.subagent_transcripts, 0, 'Expected no subagent transcripts');
+    assert.strictEqual(row.input_tokens, 1000, 'Expected the main transcript total, unchanged');
+    assert.strictEqual(row.estimated_cost_usd, 0.0045, 'Expected 1000/1e6*3 + 100/1e6*15');
+    assert.strictEqual(stderr, '', `Expected no stderr for the ordinary no-subagent case, got: ${JSON.stringify(stderr)}`);
+  }) ? passed++ : failed++);
+
+  // 22. Folding must not double-count. Real subagent files share no message.id
+  //     with the parent (0 collisions over 116 local sessions), but the dedupe
+  //     map is what guarantees it, so pin the guarantee rather than the data.
+  (test('dedupes a message.id that appears in both parent and subagent', () => {
+    const usage = { input_tokens: 1000, output_tokens: 100 };
+    const { row } = priceFanOut({
+      mainEntries: [assistant('msg_shared', 'claude-sonnet-4-6', usage)],
+      subagentFiles: { 'agent-aaa.jsonl': [assistant('msg_shared', 'claude-sonnet-4-6', usage)] },
+    });
+    assert.strictEqual(row.subagent_transcripts, 1, 'Expected the subagent file to have been read at all');
+    assert.strictEqual(row.input_tokens, 1000, 'A repeated message.id must be counted once, not twice');
+    assert.strictEqual(row.output_tokens, 100, 'A repeated message.id must be counted once, not twice');
+  }) ? passed++ : failed++);
+
+  // 23. Subagents routinely run a different model than the parent (48 of 116
+  //     local fan-out sessions, 41.4%). Pricing the whole session at the
+  //     parent's rate would trade the under-count for an over-count, so each
+  //     model is priced at its own rate.
+  (test('prices each model at its own rate rather than the parent model rate', () => {
+    const { row } = priceFanOut({
+      mainEntries: [
+        assistant('msg_main', 'claude-opus-4-5', { input_tokens: 1000000, output_tokens: 0 }),
+      ],
+      subagentFiles: {
+        'agent-aaa.jsonl': [
+          assistant('msg_sub', 'claude-haiku-4-5', { input_tokens: 1000000, output_tokens: 0 }),
+        ],
+      },
+    });
+    const opus = row.models.find(m => m.model === 'claude-opus-4-5');
+    const haiku = row.models.find(m => m.model === 'claude-haiku-4-5');
+    assert.ok(opus && haiku, `Expected a bucket per model, got ${JSON.stringify(row.models)}`);
+    assert.strictEqual(opus.input_tokens, 1000000, 'Expected the opus tokens in the opus bucket');
+    assert.strictEqual(haiku.input_tokens, 1000000, 'Expected the haiku tokens in the haiku bucket');
+    // The haiku million must NOT be billed at the opus input rate.
+    assert.ok(
+      haiku.estimated_cost_usd < opus.estimated_cost_usd,
+      `Haiku tokens billed at opus rates: haiku $${haiku.estimated_cost_usd} vs opus $${opus.estimated_cost_usd}`
+    );
+    assert.strictEqual(
+      row.estimated_cost_usd,
+      Math.round((opus.estimated_cost_usd + haiku.estimated_cost_usd) * 1e6) / 1e6,
+      'Expected the row total to be the sum of the per-model buckets'
+    );
+  }) ? passed++ : failed++);
+
+  // 24. The breakdown must reconcile with the headline number, or it is
+  //     decoration rather than an audit trail.
+  (test('models breakdown sums to estimated_cost_usd and to the token totals', () => {
+    const { row } = priceFanOut({
+      mainEntries: [
+        assistant('msg_main', 'claude-opus-4-5', {
+          input_tokens: 1000, output_tokens: 100,
+          cache_creation_input_tokens: 50, cache_read_input_tokens: 900,
+        }),
+      ],
+      subagentFiles: {
+        'agent-aaa.jsonl': [
+          assistant('msg_sub', 'claude-sonnet-4-6', {
+            input_tokens: 3000, output_tokens: 300,
+            cache_creation_input_tokens: 20, cache_read_input_tokens: 40,
+          }),
+        ],
+      },
+    });
+    assert.strictEqual(row.models.length, 2, `Expected two model buckets, got ${JSON.stringify(row.models)}`);
+    const sum = k => row.models.reduce((n, m) => n + m[k], 0);
+    assert.strictEqual(sum('input_tokens'), row.input_tokens, 'input_tokens must reconcile');
+    assert.strictEqual(sum('output_tokens'), row.output_tokens, 'output_tokens must reconcile');
+    assert.strictEqual(sum('cache_write_tokens'), row.cache_write_tokens, 'cache_write_tokens must reconcile');
+    assert.strictEqual(sum('cache_read_tokens'), row.cache_read_tokens, 'cache_read_tokens must reconcile');
+    assert.strictEqual(
+      Math.round(sum('estimated_cost_usd') * 1e6) / 1e6,
+      row.estimated_cost_usd,
+      'The per-model costs must sum to the row total'
+    );
+    // Most expensive bucket first, so the row is deterministic.
+    assert.ok(
+      row.models[0].estimated_cost_usd >= row.models[1].estimated_cost_usd,
+      'Expected the breakdown sorted by cost, most expensive first'
+    );
+  }) ? passed++ : failed++);
+
+  // 25. Fail-open: a Stop hook must never break the session. An unreadable or
+  //     malformed subagent file degrades to skipping that file.
+  (test('stays fail-open on a malformed subagent transcript', () => {
+    const { row } = priceFanOut({
+      mainEntries: [
+        assistant('msg_main', 'claude-sonnet-4-6', { input_tokens: 1000, output_tokens: 100 }),
+      ],
+      subagentFiles: {
+        'agent-good.jsonl': [
+          assistant('msg_sub', 'claude-sonnet-4-6', { input_tokens: 2000, output_tokens: 200 }),
+        ],
+      },
+      extraFiles: { 'agent-bad.jsonl': '{ this is not json\nneither is this\n' },
+    });
+    assert.strictEqual(row.input_tokens, 3000, 'Expected the readable files to still be counted');
+    assert.strictEqual(row.output_tokens, 300, 'Expected the readable files to still be counted');
+  }) ? passed++ : failed++);
+
+  // 26. `.meta.json` sidecars sit in the same directory and carry no usage.
+  (test('ignores non-jsonl sidecars in the subagents directory', () => {
+    const { row } = priceFanOut({
+      mainEntries: [
+        assistant('msg_main', 'claude-sonnet-4-6', { input_tokens: 1000, output_tokens: 100 }),
+      ],
+      subagentFiles: {
+        'agent-aaa.jsonl': [
+          assistant('msg_sub', 'claude-sonnet-4-6', { input_tokens: 2000, output_tokens: 200 }),
+        ],
+      },
+      extraFiles: { 'agent-aaa.meta.json': JSON.stringify({ agent: 'explorer' }) },
+    });
+    assert.strictEqual(row.subagent_transcripts, 1, 'Expected only the .jsonl file to count as a transcript');
+    assert.strictEqual(row.input_tokens, 3000, 'Expected the sidecar to contribute nothing');
+  }) ? passed++ : failed++);
+
+  // --- Fast mode -----------------------------------------------------------
+  // Fast mode is a 2x billing tier, and `message.usage.speed` records which
+  // tier served the request (present on 123,155 of 151,286 assistant usage
+  // blocks across 1,500 local transcripts). The expectations below are pinned
+  // as a RATIO to the standard tier rather than as dollars, so they hold
+  // whatever the underlying rate table says.
+
+  // 27. A fast-mode turn bills at exactly twice the standard tier.
+  (test('bills a fast-mode turn at 2x the standard tier', () => {
+    const usage = { input_tokens: 1000000, output_tokens: 1000000 };
+    const { row: standard } = priceFanOut({
+      mainEntries: [assistant('msg_std', 'claude-opus-5', { ...usage, speed: 'standard' })],
+    });
+    const { row: fast } = priceFanOut({
+      mainEntries: [assistant('msg_fast', 'claude-opus-5', { ...usage, speed: 'fast' })],
+    });
+    assert.ok(standard.estimated_cost_usd > 0, 'Expected a priceable standard-tier session');
+    assert.strictEqual(
+      fast.estimated_cost_usd,
+      standard.estimated_cost_usd * 2,
+      `Expected fast mode at 2x $${standard.estimated_cost_usd}, got $${fast.estimated_cost_usd}`
+    );
+    assert.strictEqual(fast.models[0].speed, 'fast', 'Expected the row to record the fast tier');
+  }) ? passed++ : failed++);
+
+  // 28. Negative case. `speed` is absent on older transcripts and reads as
+  //     standard, so those must price exactly as they did before this change.
+  (test('prices an absent speed field at standard rates', () => {
+    const usage = { input_tokens: 1000000, output_tokens: 1000000 };
+    const { row: absent } = priceFanOut({
+      mainEntries: [assistant('msg_absent', 'claude-opus-5', usage)],
+    });
+    const { row: explicit } = priceFanOut({
+      mainEntries: [assistant('msg_std', 'claude-opus-5', { ...usage, speed: 'standard' })],
+    });
+    assert.strictEqual(
+      absent.estimated_cost_usd,
+      explicit.estimated_cost_usd,
+      'A missing speed field must not change the price'
+    );
+    assert.strictEqual(absent.models[0].speed, 'standard', 'Expected an absent speed recorded as standard');
+  }) ? passed++ : failed++);
+
+  // 29. Mixed tiers inside one session are separate buckets, which is the only
+  //     way a session that switched speed mid-flight prices correctly.
+  (test('splits one model into separate buckets per speed tier', () => {
+    const usage = { input_tokens: 1000000, output_tokens: 0 };
+    const { row } = priceFanOut({
+      mainEntries: [
+        assistant('msg_std', 'claude-opus-5', { ...usage, speed: 'standard' }),
+        assistant('msg_fast', 'claude-opus-5', { ...usage, speed: 'fast' }),
+      ],
+    });
+    assert.strictEqual(row.models.length, 2, `Expected a bucket per speed tier, got ${JSON.stringify(row.models)}`);
+    const std = row.models.find(m => m.speed === 'standard');
+    const fast = row.models.find(m => m.speed === 'fast');
+    assert.ok(std && fast, 'Expected both a standard and a fast bucket');
+    assert.strictEqual(fast.estimated_cost_usd, std.estimated_cost_usd * 2, 'Expected the fast bucket at 2x');
+  }) ? passed++ : failed++);
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -429,6 +429,24 @@ function runTests() {
     assert.strictEqual(row.output_tokens, 100, 'A repeated message.id must be counted once, not twice');
   }) ? passed++ : failed++);
 
+  // 22b. Entries without a message.id fall back to a synthetic key, and that
+  //      key is scoped per file because the same ordinal line in two files
+  //      would otherwise collide and drop real usage. A regression to a shared
+  //      counter would silently under-count rather than fail, so pin it.
+  (test('keeps id-less entries from different files separate', () => {
+    const usage = { input_tokens: 1000, output_tokens: 100 };
+    const { row } = priceFanOut({
+      mainEntries: [assistant('msg_main', 'claude-sonnet-4-6', usage)],
+      subagentFiles: {
+        'agent-aaa.jsonl': [assistant(undefined, 'claude-sonnet-4-6', usage)],
+        'agent-bbb.jsonl': [assistant(undefined, 'claude-sonnet-4-6', usage)],
+      },
+    });
+    assert.strictEqual(row.subagent_transcripts, 2, 'Expected both subagent files to be folded in');
+    assert.strictEqual(row.input_tokens, 3000, 'Id-less entries in different files must each count');
+    assert.strictEqual(row.output_tokens, 300, 'Id-less entries in different files must each count');
+  }) ? passed++ : failed++);
+
   // 23. Subagents routinely run a different model than the parent (48 of 116
   //     local fan-out sessions, 41.4%). Pricing the whole session at the
   //     parent's rate would trade the under-count for an over-count, so each
@@ -514,6 +532,11 @@ function runTests() {
     });
     assert.strictEqual(row.input_tokens, 3000, 'Expected the readable files to still be counted');
     assert.strictEqual(row.output_tokens, 300, 'Expected the readable files to still be counted');
+    assert.strictEqual(
+      row.subagent_transcripts,
+      1,
+      'Expected only the parseable transcript to be reported as folded in'
+    );
   }) ? passed++ : failed++);
 
   // 26. `.meta.json` sidecars sit in the same directory and carry no usage.


### PR DESCRIPTION
## What Changed

`scripts/hooks/cost-tracker.js` now folds a session's **subagent transcripts** into the same usage total as its main transcript, and prices each turn at the model and speed tier that actually served it.

- Derives `<transcript_path minus .jsonl>/subagents/` from the transcript path, globs `*.jsonl`, and folds those usages into the existing dedupe-by-`message.id` map.
- Accumulates per model **and** per speed tier, pricing each bucket separately instead of pricing the whole session at one model's rate.
- Prices **fast mode** at its real 2x tier, read from `message.usage.speed`.
- Adds two additive row fields, `subagent_transcripts` and `models`, documented in `/cost-report` and the `cost-tracking` skill.

## Why This Change

**Subagent spend was invisible.** The hook read only `input.transcript_path`. A session that fans out writes each subagent to its own JSONL, and that spend is genuinely the parent's (the subagent lines carry the parent's `sessionId`), but those files were never opened.

Measured over **116 local sessions that fanned out**: **$1,837 of $13,493 of real spend was invisible, 13.6% of the total.** On the worst session the hidden half was nearly as large as the visible one.

Folding them in is safe because subagent files share **no `message.id`** with the parent transcript (0 collisions across those 116 sessions), so the existing dedupe map absorbs them additively. A test pins that guarantee rather than the observation, by feeding the same `message.id` through both a parent and a subagent file and asserting it counts once.

**Per-model pricing is required by the fix, not separate polish.** The old code priced every token at the last model the session named. Subagents routinely run a different model than the parent: **48 of 116 local fan-out sessions, 41.4%**, most often an Opus parent delegating to Sonnet or Haiku. Folding subagent tokens into a single-model total would have traded the under-count for an over-count.

**Fast mode is recoverable from the transcript.** Fast mode is a real 2x billing tier. `message.usage.speed` records which tier served each request, so no heuristic is needed: it is present on **123,155 of 151,286 assistant usage blocks across 1,500 local transcripts (81.4%)**, with the value `standard` on every non-absent case in that sample. The multiplier keys off `speed` rather than off a list of models known to offer the tier, because a model without a fast tier never emits `speed: "fast"`, so a list would add staleness without adding accuracy. An absent `speed` reads as standard, so transcripts written before the field existed reprice identically.

## Backward compatibility

Every pre-existing field keeps its name, type and meaning, so readers of `costs.jsonl` need no change. In particular `model` still names the **main session's** model: letting a Haiku subagent win last-model-wins would relabel an Opus session, which is what `/cost-report` groups by. Subagent spend still lands in the totals and in the new `models` breakdown.

The token counts and `estimated_cost_usd` do go **up** for fan-out sessions. That is the defect being fixed, not a regression.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Every new test was verified **RED before GREEN**. With the new tests in place and `scripts/hooks/cost-tracker.js` reverted to this branch's base:

```
Results: Passed: 10, Failed: 10
```

With the implementation applied, same command, same environment:

```
=== Testing cost-tracker.js ===

  ✓ passes through input on stdout
  ✓ creates metrics file when given transcript usage data
  ✓ counts usage once per message.id across multi-line responses
  ✓ handles empty input gracefully
  ✓ handles invalid JSON gracefully
  ✓ handles missing usage fields gracefully
  ✓ prefers ECC_SESSION_ID over CLAUDE_SESSION_ID when both are present
  ✓ uses input session_id for session correlation when env vars are absent
  ✓ prefers fresh harness-cost cache over transcript estimate
  ✓ ignores stale harness-cost cache (>300s) and uses transcript estimate
  ✓ counts subagent transcripts in the session total
  ✓ a session with no subagents directory is unchanged and silent
  ✓ dedupes a message.id that appears in both parent and subagent
  ✓ prices each model at its own rate rather than the parent model rate
  ✓ models breakdown sums to estimated_cost_usd and to the token totals
  ✓ stays fail-open on a malformed subagent transcript
  ✓ ignores non-jsonl sidecars in the subagents directory
  ✓ bills a fast-mode turn at 2x the standard tier
  ✓ prices an absent speed field at standard rates
  ✓ splits one model into separate buckets per speed tier

Results: Passed: 20, Failed: 0
```

Full suite, this branch:

```
  Total Tests: 3452
  Passed:      3441  ✓
  Failed:        11  ✗
```

Baseline on this branch's merge base, with the changes stashed:

```
  Total Tests: 3442
  Passed:      3431  ✓
  Failed:        11  ✗
```

The same **11 failures are pre-existing**, in the same 5 suites (`detect-project-worktree`, `gateguard-fact-force`, `observe-subdirectory-detection`, `suggest-compact`, `dry-run`), none touched here. The delta is exactly the 10 tests added.

`eslint`, `markdownlint`, `check-unicode-safety`, `validate-skills`, `validate-commands`, `validate-hooks` and `catalog:check` all pass.

The fail-open contract has explicit coverage: a missing subagents directory (the normal case for a session that never fanned out) is silent and leaves the numbers unchanged, and a malformed subagent file is skipped rather than thrown.

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable) - no shell scripts touched
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (`commands/cost-report.md`, `skills/cost-tracking/SKILL.md`)
- [x] Added comments for complex logic
- [ ] README updated (if needed) - not needed, no surface change

## Notes for the reviewer

- **Relationship to #2691.** That PR corrects the rate constants in this same file; this one does not touch them, so the two are independent but will conflict textually in the `getRates` region. Whichever lands second needs a small adaptation: #2691 renames `getRates` to `resolveRates` returning `{bucket, rates}`, and this PR adds a `getRatesForSpeed(model, speed)` wrapper around `getRates`. Once both are in, `rate_bucket` becomes a single scalar over a session that can now span several buckets, which is worth a follow-up.
- Fast-mode tests are pinned as a **ratio** to the standard tier, not as absolute dollars, precisely so they stay correct across #2691's repricing.
- `/cost-report`'s `By model` grouping still keys on `model`, attributing each session to one model. Switching it to consume `models` is a natural follow-up, deliberately left out to keep this diff to the defect.
- `models` is always the transcript-derived attribution. When the harness's authoritative `cost.total_cost_usd` supplies `estimated_cost_usd`, the two need not agree, and the docs say so.
