### PR TITLE
feat(skills): add repo-mastery — learn any open-source repo like a course

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -349,7 +349,8 @@
         "skills/repo-scan",
         "skills/rules-distill",
         "skills/santa-method",
-        "skills/git-workflow"
+        "skills/git-workflow",
+        "skills/repo-mastery"
       ],
       "targets": [
         "claude",

--- a/skills/repo-mastery/AGENTS.md
+++ b/skills/repo-mastery/AGENTS.md
@@ -1,0 +1,97 @@
+# Repo-Mastery — Agent Instructions (AGENTS.md)
+
+> This file makes Repo-Mastery usable from any agent that reads `AGENTS.md`
+> (OpenAI Codex, opencode, Cursor, and compatible CLIs). Claude Code loads the
+> skill natively via `SKILL.md`; Gemini CLI via `GEMINI.md`. The skill itself
+> follows the open Agent Skills standard, so it can also be installed as a
+> native skill on any tool that supports `SKILL.md`.
+
+## What this is
+
+Repo-Mastery turns any open-source repository into a **developer-focused
+mastery course**: a confirmed course map, then interactive mastery learning
+(diagnostic → explain → Feynman check → practice → error diagnosis → spaced
+review) so the user fully masters a project's **usage → architecture → key
+implementations**.
+
+## When to act as the Repo-Mastery tutor
+
+Activate this behavior when the user says any of:
+
+- "learn / master / fully understand / deep-dive into" a repository or codebase
+- "turn X repo into a course", "master this codebase", "learn X from source"
+- They point at a local repo path or `github:owner/repo`
+
+## The deterministic engine — always call it, never re-derive it
+
+The **gate** (does the learner advance?) is computed by the engine script, not
+interpreted from prose. Before/after any judgment, call:
+
+```bash
+python3 <skill_root>/scripts/learning_engine.py <subcommand> ...
+```
+
+| Decision | Command |
+|---|---|
+| Mastery after attempts | `compute-mastery '[true,false,true]'` |
+| Spaced-review state | `schedule procedure false '<state-json>'` |
+| Record an attempt (updates progress.json) | `record-attempt <path>/.learning/progress.json --kp k1 --type procedure --correct --write` |
+| What to teach next | `next-objective <path>/.learning/progress.json` |
+| Validate a course map | `validate-map <path>/.learning/course-map.json` |
+| Create `.learning/` scaffolding | `init <repo_path> [--force]` |
+
+The engine is pure stdlib Python, JSON in/out. If Python isn't available, fall
+back to the arithmetic in `references/mastery-policy.md` — but prefer the script.
+
+## The workflow (follow this order)
+
+1. **Phase 0 — assess complexity.** Small/medium repo → read source directly.
+   Large (≥100k lines / ≥20 top modules) → run `scripts/index_repo.py` to build
+   `code-map.json`, locate source on demand.
+2. **Phase 1 — objective pre-scan** (explore_context style: map the repo, don't
+   conclude), then propose a **course map** (modules + knowledge points, each
+   backed by source evidence) per `references/curriculum-design.md`.
+3. **Phase 2 — Mission + confirmation (mandatory).** Ask "why do you want to
+   master this repo?" → write `.learning/MISSION.md`. Present the map; the user
+   approves/customizes before any learning. Never skip this.
+4. **Phase 3 — interactive mastery learning** per `references/session-flow.md`.
+   Each turn: diagnose (test-out) → explain from source → Feynman check →
+   practice (quiz / hands-on) → error diagnosis → spaced review. **Every gate
+   decision goes through the engine script.**
+5. **Phase 4 — output.** Synthesize `COVERAGE.md` (Markdown) and optionally a
+   shareable HTML course using `references/html-shell/` (copy verbatim).
+
+## Hard rules
+
+- **Never** replace the gate with "do you feel you've got it?" — call the engine.
+- **Never** put the expected answer in question text; store it in
+  `progress.json.pending_question` server-side.
+- **Course-map approval is mandatory** (opposite of docs-to-course).
+- Read-only commands may run; **mutating commands need explicit user approval**.
+- Teaching language follows the user's input language; code stays original.
+
+## Where the details live
+
+Read the relevant reference only when you reach that phase (keep context lean):
+
+- Course map design: `references/curriculum-design.md`
+- Mastery/gates/spaced review/error diagnosis: `references/mastery-policy.md`
+- Session protocol: `references/session-flow.md`
+- Quiz design: `references/quiz-design.md`
+- Notes / learning records: `references/note-template.md`,
+  `references/learning-records-template.md`
+- Failure checklist: `references/gotchas.md`
+
+## Install hints per tool
+
+One-command installs (published package):
+
+```bash
+npx @dieselzhang/repo-mastery install            # all tools
+curl -fsSL https://raw.githubusercontent.com/DieselZhang/repo-mastery/main/scripts/install.sh | bash
+```
+
+- **Claude Code**: `~/.claude/skills/repo-mastery/` — or `/plugin marketplace add DieselZhang/repo-mastery` + `/plugin install repo-mastery@repo-mastery`
+- **Codex / Agent-Skills**: `~/.codex/skills/repo-mastery/` or `~/.agents/skills/repo-mastery/`
+- **Gemini CLI**: its skills directory; project instructions via `GEMINI.md`
+- Or run `scripts/install.sh` to install everywhere at once.

--- a/skills/repo-mastery/GEMINI.md
+++ b/skills/repo-mastery/GEMINI.md
@@ -1,0 +1,101 @@
+# Repo-Mastery — Agent Instructions (GEMINI.md)
+
+> This file makes Repo-Mastery usable from **Gemini CLI**. Gemini loads
+> `GEMINI.md` as always-on project instructions and can also activate the skill
+> natively via `activate_skill` (the skill follows the open Agent Skills
+> standard). Claude Code loads `SKILL.md`; AGENTS.md-compatible tools load
+> `AGENTS.md`.
+
+## What this is
+
+Repo-Mastery turns any open-source repository into a **developer-focused
+mastery course**: a confirmed course map, then interactive mastery learning
+(diagnostic → explain → Feynman check → practice → error diagnosis → spaced
+review) so the user fully masters a project's **usage → architecture → key
+implementations**.
+
+## When to act as the Repo-Mastery tutor
+
+Activate when the user says any of: "learn / master / fully understand /
+deep-dive into" a repo or codebase; "turn X repo into a course"; "master this
+codebase"; "learn X from source". They point at a local path or
+`github:owner/repo`.
+
+## The deterministic engine — always call it, never re-derive it
+
+The **gate** (does the learner advance?) is computed by the engine script, not
+interpreted from prose. Call it via your shell tool:
+
+```bash
+python3 <skill_root>/scripts/learning_engine.py <subcommand> ...
+```
+
+| Decision | Command |
+|---|---|
+| Mastery after attempts | `compute-mastery '[true,false,true]'` |
+| Spaced-review state | `schedule procedure false '<state-json>'` |
+| Record an attempt | `record-attempt <path>/.learning/progress.json --kp k1 --type procedure --correct --write` |
+| What to teach next | `next-objective <path>/.learning/progress.json` |
+| Validate a course map | `validate-map <path>/.learning/course-map.json` |
+| Create `.learning/` scaffolding | `init <repo_path> [--force]` |
+
+Pure stdlib Python, JSON in/out. Prefer the script; only fall back to the
+arithmetic in `references/mastery-policy.md` if Python is unavailable.
+
+## The workflow (follow this order)
+
+1. **Phase 0 — assess complexity.** Small/medium → read source directly. Large
+   (≥100k lines / ≥20 top modules) → run `scripts/index_repo.py` → `code-map.json`.
+2. **Phase 1 — objective pre-scan** → propose a **course map** (modules +
+   knowledge points, each backed by source evidence) per
+   `references/curriculum-design.md`.
+3. **Phase 2 — Mission + confirmation (mandatory).** Ask "why do you want to
+   master this repo?" → write `.learning/MISSION.md`. User approves/customizes
+   the map before any learning. Never skip.
+4. **Phase 3 — interactive mastery learning** per `references/session-flow.md`:
+   diagnose (test-out) → explain from source → Feynman check → practice (quiz /
+   hands-on) → error diagnosis → spaced review. **Every gate decision goes
+   through the engine script.**
+5. **Phase 4 — output.** Synthesize `COVERAGE.md` (+ optional HTML course using
+   `references/html-shell/`, copy verbatim).
+
+## Hard rules
+
+- **Never** replace the gate with "do you feel you've got it?" — call the engine.
+- **Never** put the expected answer in question text; store it in
+  `progress.json.pending_question` server-side.
+- **Course-map approval is mandatory**.
+- Read-only commands may run; **mutating commands need explicit user approval**.
+- Teaching language follows the user's input language; code stays original.
+
+## Where the details live
+
+Read the relevant reference only when you reach that phase:
+
+- Course map: `references/curriculum-design.md`
+- Mastery/gates/spaced review/error diagnosis: `references/mastery-policy.md`
+- Session protocol: `references/session-flow.md`
+- Quiz design: `references/quiz-design.md`
+- Notes / learning records: `references/note-template.md`,
+  `references/learning-records-template.md`
+- Failure checklist: `references/gotchas.md`
+
+## Install
+
+One-command install (published package):
+
+```bash
+npx @dieselzhang/repo-mastery install --only gemini     # Gemini only
+curl -fsSL https://raw.githubusercontent.com/DieselZhang/repo-mastery/main/scripts/install.sh | bash
+# set GEMINI_SKILLS_DIR if your Gemini skills dir differs
+```
+
+Or manually:
+
+```bash
+git clone https://github.com/DieselZhang/repo-mastery.git \
+  ~/.gemini/skills/repo-mastery
+```
+
+You can also copy this file to a project as `GEMINI.md` (or append the
+"Workflow" section) to enable repo-mastery tutoring in that project.

--- a/skills/repo-mastery/LICENSE
+++ b/skills/repo-mastery/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DieselZhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/repo-mastery/SKILL.md
+++ b/skills/repo-mastery/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: repo-mastery
+description: "Turn any open-source repository into a developer-focused mastery course. Given a local repo path or GitHub URL, it builds a confirmed course map and drives interactive mastery learning (diagnostic, explanation, Feynman check, practice, spaced review) with hands-on tasks, note-taking, and dual-format (Markdown + HTML) course output — so you fully master a project's usage, architecture, and key implementations like a real course. Triggers: 'learn this repo', 'master this codebase', 'turn X into a course', 'deep-dive into X project'."
+origin: ECC
+version: 2.2.1
+tags: [learning, education, codebase, mastery, spaced-repetition]
+---
+
+# Repo-Mastery — Master an Open-Source Project from Source
+
+> Turn any open-source repository into a **developer-focused mastery course**. Instead of "browsing code", you progressively master its **usage → architecture → key implementations**, with per-knowledge-point mastery gates, spaced review, and persistent notes.
+
+## When to Activate
+
+Use this skill whenever any of these applies:
+
+- The user wants to "learn / master / fully understand / deep-dive into" an open-source repo or codebase.
+- The user just got a new project's source and wants systematic learning instead of random browsing.
+- The user wants to understand a project's **architecture and key implementations from source** (not just how to use it).
+- The user wants learning progress to **persist across sessions** (memory + spaced review).
+- The user says "turn X repo into a course", "learn X from source", "deep-dive into X project".
+
+Do **not** activate when: the user just wants a doc/README summary, a one-off code Q&A, or an end-user tutorial for a tool (that is `docs-to-course`'s job).
+
+## Prerequisites
+
+- **Claude Code** (the skill runtime) — the same skill also runs on OpenAI Codex and Gemini CLI (Agent Skills standard).
+- **Target repository**: a local path, or a reachable `github:owner/repo` (the skill auto-runs `git clone --depth 1`).
+- **Python 3** — needed by the deterministic engine (`scripts/learning_engine.py`) and the large-repo index (`scripts/index_repo.py`), both pure stdlib.
+- **Write permission**: creates `.learning/` inside the target repo (auto-gitignored) and a global `~/.repo-mastery/`.
+
+## Language
+
+Teaching language **follows the user's input language by default** (Chinese input → Chinese teaching; English input → English teaching). You can also pass an explicit language flag:
+
+```bash
+/repo-mastery start <path|github:owner/repo> --language zh    # force Chinese
+/repo-mastery start <path|github:owner/repo> --language en    # force English
+```
+
+Code, file paths, and identifiers always stay in their original form regardless of language.
+
+## Core Design Axiom (always hold)
+
+> **Intelligence at the exit, advancement at the gate.** You (the tutor) decide what to teach, how to question, how to explain — but whether the learner *may advance* is always a **deterministic engine decision**, never the LLM patting itself on the back.
+
+- Quantitative gate (memory / procedure types): `compute_mastery()` recency-weighted accuracy ≥ 0.9, capped by a confidence ceiling — **one lucky answer is not mastery**.
+- Qualitative gate (concept / design types): a Feynman-style explanation judged by the tutor (`mastery_assess`).
+- Advancement is computed **from what is already mastered** (`next_objective`), never from a stage counter. Knowledge points already proven are skipped (test-out path).
+
+**The gate is code, not prose** — run `scripts/learning_engine.py` for `compute-mastery`, `schedule`, `record-attempt`, `next-objective`, `validate-map`, and `init`. Every platform calls the same script, so mastery math never drifts.
+
+---
+
+## Commands
+
+```bash
+/repo-mastery start <local-path | github:owner/repo> [--language zh|en]  # Main flow: map → confirm → learn → output
+/repo-mastery continue                                                  # Resume progress (back to next_objective)
+/repo-mastery review                                                    # Run spaced-review session (due items)
+/repo-mastery note "<text>"                                             # Manually append to the current module notes
+/repo-mastery status                                                    # Show progress (map_summary style)
+/repo-mastery report                                                    # Generate mastery report MASTERY.md
+/repo-mastery export [--html]                                           # Synthesize complete course doc (COVERAGE.md; --html adds HTML)
+```
+
+---
+
+## Main Flow (`/repo-mastery start`)
+
+### Phase 0 — Complexity Assessment (decide how to ingest)
+
+Make a quick scale judgment first, **then** choose how to digest the source:
+
+| Metric | Small / Medium | Large |
+|---|---|---|
+| Source lines (`src/` + non-test) | < 100k | ≥ 100k |
+| Top-level modules / packages | < 20 | ≥ 20 |
+| Dependency complexity / multi-language | simple | complex |
+
+- **Small / medium** → pure skill reads the source directly (Grep/Glob/Read + explore_context-style pre-scan), no Python dependency.
+- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand instead of cramming the whole repo into context.
+- When unsure, measure with `find` + `wc -l`; do not guess.
+
+### Phase 1 — Pre-scan → Course Map Candidates
+
+Start with an **explore_context-style objective pre-scan**: calmly map the repo first (README, entry files, directory structure, build config, core modules) **without jumping to conclusions**. Then generate course-map candidates per `references/curriculum-design.md`:
+
+```jsonc
+{
+  "repo": "owner/name",
+  "summary": "an objective overview of the repo",
+  "modules": [
+    {
+      "id": "m01",
+      "name": "Build & environment",
+      "order": 1,
+      "pass_threshold": 0.7,
+      "knowledge_points": [
+        {"id": "kp01-01", "name": "Build and run from scratch", "type": "procedure"},
+        {"id": "kp01-02", "name": "Mental model of the directory structure", "type": "concept"}
+      ]
+    }
+  ]
+}
+```
+
+**Module arc** (absorbed from docs-to-course's "reference → route", adapted for source learning):
+
+> **First win (build) → overall architecture mental model → core workflows/modules → key implementations → hands-on labs → troubleshooting → deep references**
+
+This is a menu, not a checklist — pick 4–8 modules that fit the repo; fewer, deeper beats more, thinner. The knowledge point's `type` decides its gate (see `mastery-policy.md`).
+
+### Phase 2 — Course Map Confirmation & Customization (user decision, never skipped)
+
+First establish the **Mission** (absorbed from the teach skill's MISSION.md): ask the user one key question — **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …). Write the answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
+
+Then **present the candidate map** to the user, explain each module, and:
+
+- ✅ User removes irrelevant modules / adds interesting ones / adjusts knowledge-point granularity.
+- ✅ User confirms each module's `pass_threshold` (default 0.7).
+- ✅ **Learning starts only after user approval.** This is mandatory — the opposite of docs-to-course's "don't get outline approval".
+
+After confirmation, write `<repo>/.learning/course-map.json` and initialize the `.learning/` structure (below).
+
+### Phase 3 — Interactive Mastery Learning
+
+Drive per `references/session-flow.md`. Core loop (per knowledge point):
+
+> **diagnostic (probe how much is known; test-out skip) → explain → Feynman check → practice (quiz / hands-on) → error diagnosis → spaced-review scheduling**
+
+- The next station is always decided by the **engine script** — run `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json` (priority: pending question → due review → first unmastered point → complete).
+- Quantitative gate (memory/procedure): pose a question, then record the attempt and recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`; advance only when the script reports `passed_gate: true` (≥ 0.9).
+- Qualitative gate (concept/design): have the user do a Feynman recital; you judge `passed`; retry if not. (Qualitative results are stored in `progress.json.qualitative_mastery` and read by the engine's `next-objective`.)
+- **Hands-on on demand**: for procedure points, guide the user to actually run things (build/test/write a small demo). Read-only commands (`build`, `test`, `--help`) may run directly; **mutating operations (writing files, installing deps) require explicit user approval first**. The hands-on result is recorded as mastery evidence.
+- **Auto notes**: after each explanation/judgment, automatically append to `<repo>/.learning/notes/<module>.md` (format: `note-template.md`); the user can `/repo-mastery note "..."` at any time.
+- **Command convention**: only run read-only/no-side-effect commands by default; show any command that modifies the user's filesystem or installs dependencies and request approval.
+
+### Phase 4 — Synthesize the Complete Course Document (dual format)
+
+When learning completes (or the user runs `/repo-mastery export`), synthesize **course map + explanation notes + user practice records + mastery & blockers** into a complete course document:
+
+1. **Markdown full version** `COVERAGE.md`: complete content with source references, module explanations, mastery, blockers, and review schedule. This is the primary artifact.
+2. **HTML share version** (`/repo-mastery export --html`): **reuse the finished shell in `references/html-shell/`** (styles.css / main.js / _base.html / _footer.html / build.sh — copy verbatim, never regenerate), convert COVERAGE.md module content into `modules/0N-slug.html`, and assemble `index.html` with `build.sh`. Interactive elements (flow animations, group chat, glossary tooltips, scenario quizzes) follow the patterns in `references/html-shell/interactive-elements.md`.
+
+> Note: the HTML version's visuals serve "source understanding" — **architecture diagrams, dependency graphs, call chains are the core content**, the opposite of docs-to-course's "UI step-strips bias".
+
+---
+
+## Data Structures
+
+```text
+<target-repo>/.learning/                  ← travels with the repo; auto-gitignored
+  ├── MISSION.md           learning mission (why you want to master it; grounds teaching)
+  ├── course-map.json      course map (confirmed version)
+  ├── progress.json        LearningProgress (mastery / spaced review / blockers; see mastery-policy.md)
+  ├── records/NNNN-slug.md ADR-style learning records (understanding evolution)
+  ├── notes/<module>.md    structured notes (auto + /note append)
+  ├── briefs/<module>.md   module briefs (large repos, token-saving)
+  ├── code-map.json        large-repo index (optional)
+  └── .gitignore           contains ".learning/"
+~/.repo-mastery/                     ← global lightweight memory (no L1/L2/L3 layering)
+  ├── profile.md           cross-repo preferences / level / blocker summary
+  └── index.json           repos studied + state (last learned where)
+```
+
+Progress is stored in JSON, one record per knowledge point; the **expected answer of a pending question lives server-side (`progress.json`) and never round-trips to the user** — grading never drifts (absorbed from DeepTutor's `PendingQuestion`).
+
+---
+
+## Reference Files (read per phase to keep context lean)
+
+- `references/curriculum-design.md` — **Phase 1**: designing the course map from source
+- `references/mastery-policy.md` — **Phase 3**: mastery, gates, spaced review, error diagnosis, fluency vs storage
+- `references/session-flow.md` — **Phase 3**: interactive learning session protocol (incl. Mission + ZPD)
+- `references/quiz-design.md` — **Phase 3**: quiz design (test application, not memory)
+- `references/module-brief-template.md` — **Phase 3, large repos**: pre-extract source snippets, save tokens
+- `references/note-template.md` — **Phase 3**: note format
+- `references/learning-records-template.md` — **All phases**: ADR-style learning record format
+- `references/gotchas.md` — **All phases**: failure-point checklist
+- `references/index-script-spec.md` — **Phase 0, large repos**: Python indexing script docs
+- `references/html-shell/` — **Phase 4**: HTML course shell (copy verbatim)
+
+## Scripts
+
+- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery / schedule / record-attempt / next-objective / validate-map / init. Mandatory; never re-derive the math from prose.
+- `scripts/index_repo.py` — large-repo code index (`code-map.json`), pure stdlib.
+
+## Anti-Patterns
+
+> The full failure checklist is in `references/gotchas.md`. These anti-patterns destroy learning quality outright — stop when you see one:
+
+- ❌ **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of the engine script.
+- ❌ **Skipping course-map confirmation** — the user must approve/customize the map (with Mission); this is an explicit requirement.
+- ❌ **Leaking the expected answer** — the question text/options must never contain it; only `progress.json.pending_question` does.
+- ❌ **Confusing "worked once" with "mastered"** — one lucky answer / one successful run ≠ mastery; the confidence ceiling + spaced review are the real goal (fluency ≠ storage).
+- ❌ **Cramming the whole repo into context** — read only the files relevant to the current knowledge point; use `code-map.json` to locate on demand in large repos.
+
+## Related Skills
+
+- `docs-to-course` (codebase-to-course) — docs → end-user usage course (source of this skill's methodology & HTML shell).
+- `understand-anything` — builds a knowledge graph of a codebase (pair well for architecture deep dives).
+- `codebase-onboarding` — quick ramp on unfamiliar codebases (complements this skill's Phase 1 pre-scan).
+- `find-docs` — locate project docs; useful for enriching a module's "primary sources".
+
+## Verification (completion checks)
+
+When starting / ending a learning session, self-check with `references/gotchas.md` and confirm:
+
+- [ ] `.learning/` is gitignored; the target repo is not polluted.
+- [ ] `course-map.json` is the user-confirmed version.
+- [ ] `progress.json` written atomically, uncorrupted.
+- [ ] Notes appended and `~/.repo-mastery/index.json` updated each turn.
+- [ ] No expected-answer leakage; no unapproved mutating commands.

--- a/skills/repo-mastery/SKILL.md
+++ b/skills/repo-mastery/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: repo-mastery
 description: "Turn any open-source repository into a developer-focused mastery course. Given a local repo path or GitHub URL, it builds a confirmed course map and drives interactive mastery learning (diagnostic, explanation, Feynman check, practice, spaced review) with hands-on tasks, note-taking, and dual-format (Markdown + HTML) course output — so you fully master a project's usage, architecture, and key implementations like a real course. Triggers: 'learn this repo', 'master this codebase', 'turn X into a course', 'deep-dive into X project'."
-origin: ECC
-version: 2.2.1
+origin: personal
+version: 2.4.0
 tags: [learning, education, codebase, mastery, spaced-repetition]
 ---
 
@@ -24,9 +24,9 @@ Do **not** activate when: the user just wants a doc/README summary, a one-off co
 
 ## Prerequisites
 
-- **Claude Code** (the skill runtime) — the same skill also runs on OpenAI Codex and Gemini CLI (Agent Skills standard).
+- **Claude Code** (the skill runtime).
 - **Target repository**: a local path, or a reachable `github:owner/repo` (the skill auto-runs `git clone --depth 1`).
-- **Python 3** — needed by the deterministic engine (`scripts/learning_engine.py`) and the large-repo index (`scripts/index_repo.py`), both pure stdlib.
+- **Python 3** — only needed by the large-repo indexing script `scripts/index_repo.py` (pure stdlib).
 - **Write permission**: creates `.learning/` inside the target repo (auto-gitignored) and a global `~/.repo-mastery/`.
 
 ## Language
@@ -40,6 +40,37 @@ Teaching language **follows the user's input language by default** (Chinese inpu
 
 Code, file paths, and identifiers always stay in their original form regardless of language.
 
+## Multi-Tool Support
+
+Repo-Mastery is not Claude Code-only. The skill follows the open **Agent
+Skills** standard (agentskills.io), so the same `SKILL.md` runs natively on
+**Claude Code**, **OpenAI Codex**, **Gemini CLI**, and any tool that loads
+`SKILL.md` skills.
+
+| Tool | Entry point | Install |
+|---|---|---|
+| Claude Code | `SKILL.md` (this file) | `~/.claude/skills/repo-mastery/` |
+| OpenAI Codex | `SKILL.md` + `agents/openai.yaml` | `~/.codex/skills/repo-mastery/` |
+| Gemini CLI | `GEMINI.md` + skills via `activate_skill` | its skills dir; or copy `GEMINI.md` into a project |
+| AGENTS.md tools (opencode, Cursor, …) | `AGENTS.md` | clone repo or copy `AGENTS.md` into the project |
+
+**The deterministic engine is real code, not prose** — `scripts/learning_engine.py`
+implements `compute-mastery`, the spaced-repetition scheduler, `record-attempt`,
+and `next-objective`. **Every gate decision MUST go through this script**, so
+mastery math is identical in every tool. See `AGENTS.md` / `GEMINI.md` for the
+per-tool protocol; `scripts/install.sh` installs to all tools at once.
+
+## Difference from docs-to-course
+
+This skill **does not read docs and targets developers**. The learner is you — a developer who wants to understand how an open-source project was built — not an end-user who wants to learn how to use it. Therefore:
+
+- **Input** is source code (local path or GitHub URL), not a docs site.
+- Learning goes **inside the implementation**: architecture, design decisions, core algorithms — that is the point, not "surface operations".
+- Driving mode is **interactive mastery learning**, not one-shot static course generation.
+- Output is **resumable learning state** + a complete course document (Markdown + HTML dual format).
+
+> Methodologically it stands on `docs-to-course`'s shoulders: the course-design arc, quiz philosophy, module-brief pre-extraction, and HTML course shell are absorbed from it; the mastery engine (deterministic gates, spaced repetition, error diagnosis) is adapted from DeepTutor's `learning/` module. See `docs/ARCHITECTURE.md` and `ADOPTION.md`.
+
 ## Core Design Axiom (always hold)
 
 > **Intelligence at the exit, advancement at the gate.** You (the tutor) decide what to teach, how to question, how to explain — but whether the learner *may advance* is always a **deterministic engine decision**, never the LLM patting itself on the back.
@@ -47,8 +78,6 @@ Code, file paths, and identifiers always stay in their original form regardless 
 - Quantitative gate (memory / procedure types): `compute_mastery()` recency-weighted accuracy ≥ 0.9, capped by a confidence ceiling — **one lucky answer is not mastery**.
 - Qualitative gate (concept / design types): a Feynman-style explanation judged by the tutor (`mastery_assess`).
 - Advancement is computed **from what is already mastered** (`next_objective`), never from a stage counter. Knowledge points already proven are skipped (test-out path).
-
-**The gate is code, not prose** — run `scripts/learning_engine.py` for `compute-mastery`, `schedule`, `record-attempt`, `next-objective`, `validate-map`, and `init`. Every platform calls the same script, so mastery math never drifts.
 
 ---
 
@@ -79,7 +108,7 @@ Make a quick scale judgment first, **then** choose how to digest the source:
 | Dependency complexity / multi-language | simple | complex |
 
 - **Small / medium** → pure skill reads the source directly (Grep/Glob/Read + explore_context-style pre-scan), no Python dependency.
-- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand instead of cramming the whole repo into context.
+- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand during learning instead of cramming the whole repo into context.
 - When unsure, measure with `find` + `wc -l`; do not guess.
 
 ### Phase 1 — Pre-scan → Course Map Candidates
@@ -113,13 +142,15 @@ This is a menu, not a checklist — pick 4–8 modules that fit the repo; fewer,
 
 ### Phase 2 — Course Map Confirmation & Customization (user decision, never skipped)
 
-First establish the **Mission** (absorbed from the teach skill's MISSION.md): ask the user one key question — **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …). Write the answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
+First establish the **Mission** (absorbed from the teach skill's MISSION.md): clarify **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …) as a **decision-tree interview** — see `references/clarification-interview.md`. Ask one question at a time, carry an evidence-based recommended answer with each, and look up any fact the repo can settle instead of asking. Write the settled answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
 
-Then **present the candidate map** to the user, explain each module, and:
+Then **present the candidate map** to the user, explain each module, and walk each one as a decision (keep / adjust / drop) with your recommended answer:
 
 - ✅ User removes irrelevant modules / adds interesting ones / adjusts knowledge-point granularity.
 - ✅ User confirms each module's `pass_threshold` (default 0.7).
 - ✅ **Learning starts only after user approval.** This is mandatory — the opposite of docs-to-course's "don't get outline approval".
+
+> Confirmation questions are asked **one at a time** — never batched. Recommended answers belong to **decision questions only**; Phase 3 assessment (quiz / Feynman) never leaks the answer.
 
 After confirmation, write `<repo>/.learning/course-map.json` and initialize the `.learning/` structure (below).
 
@@ -129,8 +160,12 @@ Drive per `references/session-flow.md`. Core loop (per knowledge point):
 
 > **diagnostic (probe how much is known; test-out skip) → explain → Feynman check → practice (quiz / hands-on) → error diagnosis → spaced-review scheduling**
 
-- The next station is always decided by the **engine script** — run `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json` (priority: pending question → due review → first unmastered point → complete).
-- Quantitative gate (memory/procedure): pose a question, then record the attempt and recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`; advance only when the script reports `passed_gate: true` (≥ 0.9).
+- The next station is always decided by the **engine script** — run
+  `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json`
+  (priority: pending question → due review → first unmastered point → complete).
+- Quantitative gate (memory/procedure): pose a question, then record the attempt and
+  recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`;
+  advance only when the script reports `passed_gate: true` (≥ 0.9).
 - Qualitative gate (concept/design): have the user do a Feynman recital; you judge `passed`; retry if not. (Qualitative results are stored in `progress.json.qualitative_mastery` and read by the engine's `next-objective`.)
 - **Hands-on on demand**: for procedure points, guide the user to actually run things (build/test/write a small demo). Read-only commands (`build`, `test`, `--help`) may run directly; **mutating operations (writing files, installing deps) require explicit user approval first**. The hands-on result is recorded as mastery evidence.
 - **Auto notes**: after each explanation/judgment, automatically append to `<repo>/.learning/notes/<module>.md` (format: `note-template.md`); the user can `/repo-mastery note "..."` at any time.
@@ -183,14 +218,24 @@ Progress is stored in JSON, one record per knowledge point; the **expected answe
 
 ## Scripts
 
-- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery / schedule / record-attempt / next-objective / validate-map / init. Mandatory; never re-derive the math from prose.
+- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery /
+  schedule / record-attempt / next-objective / validate-map / init. Mandatory in
+  every tool; never re-derive the math from prose.
 - `scripts/index_repo.py` — large-repo code index (`code-map.json`), pure stdlib.
+- `scripts/install.sh` — install the skill to Claude Code, Codex, and Gemini CLI
+  at once (`--only <tool>` / `--skip <tool>` / `--dry-run`).
+
+## Multi-tool entry points
+
+- `AGENTS.md` — portable protocol for AGENTS.md-compatible tools (Codex, opencode, Cursor).
+- `GEMINI.md` — protocol for Gemini CLI.
+- `agents/openai.yaml` — Codex/Agent-Skills UI metadata.
 
 ## Anti-Patterns
 
 > The full failure checklist is in `references/gotchas.md`. These anti-patterns destroy learning quality outright — stop when you see one:
 
-- ❌ **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of the engine script.
+- ❌ **Letting the LLM replace the gate** — never use "do you feel you've mastered it?" instead of `compute_mastery` / `mastery_assess`.
 - ❌ **Skipping course-map confirmation** — the user must approve/customize the map (with Mission); this is an explicit requirement.
 - ❌ **Leaking the expected answer** — the question text/options must never contain it; only `progress.json.pending_question` does.
 - ❌ **Confusing "worked once" with "mastered"** — one lucky answer / one successful run ≠ mastery; the confidence ceiling + spaced review are the real goal (fluency ≠ storage).

--- a/skills/repo-mastery/agents/openai.yaml
+++ b/skills/repo-mastery/agents/openai.yaml
@@ -1,0 +1,16 @@
+# Codex (Agent Skills standard) UI metadata for repo-mastery.
+# See the Agent Skills standard (agentskills.io) for the schema.
+
+display_name: Repo-Mastery
+brand_color: "#0d9488"
+
+# The prompt shown when the user picks the skill in the Codex app.
+default_prompt: >-
+  Turn an open-source repository into a developer-focused mastery course
+  (usage → architecture → key implementations). Which repo do you want to
+  master? Give a local path or github:owner/repo.
+
+# Allow the skill to trigger from its description when a task matches,
+# not only when the user names it explicitly.
+policy:
+  allow_implicit_invocation: true

--- a/skills/repo-mastery/references/clarification-interview.md
+++ b/skills/repo-mastery/references/clarification-interview.md
@@ -1,0 +1,39 @@
+# Clarification Interview — Decision-Clarifying Confirmation (absorbed from the grilling skill)
+
+> **Read in**: Phase 2. This protocol turns the open confirmation steps (Mission + course-map sign-off) into a decision-tree clarification: every implicit assumption made explicit, until you and the learner share the same understanding. Absorbed from mattpocock's `grilling` skill (user entry `grill-me`); see `ADOPTION.md` §5.
+
+## 1. Purpose
+
+Phase 2 confirmation is a decision, not a formality. The goal is not to reach agreement quickly; it is to surface every implicit choice and make it explicit, so nothing important is silently assumed. The output is a confirmed `MISSION.md` + `course-map.json` the learner actually owns.
+
+## 2. Decision-tree walk
+
+Treat the confirmation as a tree of decisions, resolving dependencies one by one — a parent decision settled before the choices that hang off it:
+
+- Root (parent): **Mission** — why does the learner want to master this repo? (use it / modify it / explain it in interviews / borrow its design / …)
+- Branch: **module-level decisions** — keep / adjust / drop each candidate module; adjust granularity.
+- Leaf: **parameter decisions** — each module's `pass_threshold` (default 0.7), optional hands-on labs.
+
+An early answer reshapes which questions come next. Do not fire questions in parallel; descend in dependency order.
+
+## 3. One question at a time
+
+Ask one question, wait for the answer, then continue. Asking multiple questions at once is bewildering — the learner cannot converge on a decision tree if every branch is presented simultaneously.
+
+## 4. Facts vs decisions (information retrieval)
+
+If a *fact* can be found by exploring the environment (source code, README, call chains, `course-map.json` evidence paths), look it up rather than asking. The *decisions* are the learner's — put each one to them and wait.
+
+## 5. Recommended answers (decision questions only)
+
+Every decision question comes with the tutor's own recommended answer, grounded in repo evidence — so the learner reacts to a proposal, not a blank prompt.
+
+**Boundary — never for assessment questions.** The recommended-answer habit applies only to decision questions (Mission, module choices, thresholds, "what next"). It must **never** leak into Phase 3 assessment (quiz / Feynman recital): `progress.json.pending_question.expected_answer` is the only place the answer lives, and it never round-trips to the learner (see `mastery-policy.md` §7 and `gotchas.md`).
+
+## 6. Shared-understanding gate
+
+When the confirmation is complete, summarize the settled decisions back and confirm before proceeding — then write them to `MISSION.md` and `course-map.json`. Learning starts only after the learner approves. If the Mission changes mid-course, update `MISSION.md` and write a learning record.
+
+## Difference from grilling
+
+`grilling` is stateless — it writes nothing and leaves no artifact. Repo-Mastery's clarification is stateful by design: the settled decisions land in `.learning/MISSION.md` and `course-map.json`, because they ground every later teaching decision.

--- a/skills/repo-mastery/references/curriculum-design.md
+++ b/skills/repo-mastery/references/curriculum-design.md
@@ -1,0 +1,65 @@
+# Curriculum Design — Designing the Course Map from Source
+
+> **Read in**: Phase 1. Your job is to turn a source repo's *structure tree* into a learning *route*. The learner is you (a developer), and the goal is to fully understand the project: **usage → architecture → key implementations**.
+
+## The core move: reference → route (absorbed from docs-to-course)
+
+Source repos are organized for *lookup* (by module, by directory, by language convention). A course is organized for *learning* — each step earns the next. **Do not mirror the directory tree; re-sequence it.**
+
+The spine of a code-learning course:
+
+> **First win (build) → overall architecture mental model → core workflows/modules → key implementations → hands-on labs → troubleshooting → deep references**
+
+## The module menu (a menu, not a checklist)
+
+Each candidate module comes from real repo evidence — files, directories, build config, README, issues. Pick 4–8; fewer, deeper is better.
+
+| # | Module | Where it comes from | Why a developer cares |
+|---|---|---|---|
+| 1 | **Build & environment** | README quickstart, Dockerfile, Makefile, pyproject/package.json | Trust. Seeing it run gives every later code discussion a vehicle. **Almost always keep.** |
+| 2 | **Overall architecture mental model** | top-level dirs, entry files (main/app/__init__), dependency graph, README architecture section | Lets you predict behavior instead of memorizing code line by line. |
+| 3 | **Core workflows** | high-frequency entry APIs, CLI commands, main request-response paths | The "how to use it" body. |
+| 4 | **Key implementations (internals)** | core algorithms, data structures, async/concurrency mechanisms, plugin/extension points | **This skill's signature module** — docs-to-course explicitly avoids it; we specialize in it. |
+| 5 | **Hands-on labs** | test suites, examples dir, modifiable demos | Turns "understood" into "can do". |
+| 6 | **Troubleshooting & boundaries** | common issues, error paths, exception handling, config traps | Lets you stand on your own when things break. |
+| 7 | **Deep references** | API docs, contributing guide, internal design docs | Your self-service entry after the course. |
+
+**How to choose**:
+- Small CLI/lib: modules 1, 2, 3, 5, 6. ~5 modules.
+- Medium app: 1, 2, 3, 4, 5, 6. ~6 modules.
+- Large platform (multi-language/multi-entry/plugin ecosystem): all of 1–7; split "key implementations" into several modules if needed. Use the parallel build path.
+
+## Knowledge points: granularity and type
+
+Break each module into **3–8 knowledge points**. Granularity rule of thumb: *each knowledge point should be a unit you can answer "do I know it or not" in one word*. One point = one judgeable interaction; never vague.
+
+Every knowledge point must have a `type` (it decides the gate; see `mastery-policy.md`):
+
+| type | Meaning (for code learning) | Gate | Example |
+|---|---|---|---|
+| `memory` | remembered APIs/commands/key constants | quantitative (quiz) | "syntax of `deeptutor kb create`" |
+| `procedure` | can operate: build/run/call | quantitative + hands-on | "build and launch the project from scratch" |
+| `concept` | understand core concepts/data structures | qualitative (Feynman recital) | "understand the RAG retrieval flow" |
+| `design` | can explain why it's designed this way / extend it | qualitative + design tradeoff follow-ups | "why message queue instead of RPC" |
+
+> A common mistake is over-coarse points ("understand the system architecture"). Split to judgeable units: "dependency direction between modules", "the complete call chain of a request", "config load precedence".
+
+## Generate from evidence, not invention
+
+Every module/knowledge point must point to **concrete evidence in the repo**:
+
+- Module → top-level dir or core file path.
+- Knowledge point → specific file/function/doc section.
+- Key-implementation module → the file and entry function where that code lives.
+
+If you have no evidence for a module while designing the map, either go read it or leave it out. **Better one fewer module than one that's hollow.**
+
+## Pre-scan order (explore_context style)
+
+1. README / top-level docs — how the repo wants to be understood.
+2. Build config (pyproject.toml / package.json / Cargo.toml / Makefile / Dockerfile) — how it runs.
+3. Directory structure & entry files (`find` top-level + read `main`/`app`/`__init__.py`).
+4. Core modules — read the 3–5 heaviest at interface level.
+5. Tests & examples — see the real usage.
+
+**Stay objective**: this phase only *maps*; conclusions come in the explanation phase.

--- a/skills/repo-mastery/references/gotchas.md
+++ b/skills/repo-mastery/references/gotchas.md
@@ -1,0 +1,47 @@
+# Gotchas — Failure-Point Checklist
+
+> **Read in**: all phases. Self-check with this list at the start of the main flow, on exceptions, and before Phase 4 output. Absorbed from docs-to-course's `gotchas.md`, with repo-mastery-specific traps added.
+
+## Course-map phase
+
+- [ ] **Over-coarse knowledge points** — "understand the system architecture" is not a judgeable unit. Split to "dependency direction between modules / complete request call chain / config load precedence".
+- [ ] **Modules without evidence** — every module in the map points to a real file/dir. No evidence → cut it; better fewer than hollow.
+- [ ] **Skipping Phase 2 confirmation** — the user must approve/customize the map (with Mission). This is an explicit requirement; don't skip.
+- [ ] **Concluding too early in the pre-scan** — Phase 1 only maps; conclusions belong to the explanation phase.
+
+## Learning-session phase
+
+- [ ] **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of `compute_mastery` / `mastery_assess`.
+- [ ] **Expected-answer leakage** — the question text/options must never contain the expected answer; it lives only in `progress.json.pending_question`.
+- [ ] **Dumping multiple concepts at once** — one knowledge point, one layer.
+- [ ] **Re-posing the same question** — when below 0.9, pose a different question to avoid memorizing the answer.
+- [ ] **Skipping error diagnosis** — answering the question directly without user self-attribution and an `error_records` entry corrupts review priority.
+- [ ] **Feynman that only asks "got it?"** — the qualitative gate must make the user actually recital; design type must probe tradeoffs.
+- [ ] **Cramming the whole repo into context** — read only the relevant files for the current point (locate via `code-map.json` in large repos).
+
+## Hands-on phase
+
+- [ ] **Running mutating commands without approval** — read-only commands may run directly; writing files / installing deps must be shown and approved first.
+- [ ] **Treating the user's demo as evidence without qualifying it** — a procedure point's hands-on pass = mastery evidence, but record the result; don't just say "nice".
+- [ ] **Non-verbatim commands** — commands/config the user will copy must be exact; don't invent flags.
+
+## Mission & learning-records phase
+
+- [ ] **Starting without the Mission** — Phase 2 must first ask "why do you want to master this repo" and write MISSION.md; skipping makes module choices groundless.
+- [ ] **Not updating a changed Mission** — when the learning goal shifts, update MISSION.md and write a learning record.
+- [ ] **Not writing a learning record when due** — when the user shows real understanding / states prior knowledge / a misconception gets corrected, write `records/NNNN-slug.md`; otherwise the ZPD baseline drifts.
+- [ ] **Not marking supersession after a correction** — mark the old record `Status: superseded by LR-NNNN` instead of deleting (the evolution history is useful).
+
+## Notes & data phase
+
+- [ ] **Rewriting whole notes** — notes append incrementally, never full rewrites (token economy).
+- [ ] **Rewriting user note text** — `/note` content is kept verbatim; the tutor only registers blockers.
+- [ ] **Non-atomic `progress.json` writes** — temp file + rename, or the learning state can corrupt.
+- [ ] **Forgetting to update global memory** — update `~/.repo-mastery/index.json` (where you left off) each turn, or `continue` breaks.
+
+## Phase 4 output phase
+
+- [ ] **Regenerating the HTML shell** — `styles.css` / `main.js` / `_footer.html` / `build.sh` are only copied verbatim from `references/html-shell/`, never rewritten.
+- [ ] **HTML biased to UI step-strips** — this skill's HTML course centers on architecture diagrams / dependency graphs / call chains, not UI screenshots.
+- [ ] **COVERAGE.md missing source references** — the complete course doc must carry `file:line` references, or it loses its "traceable back to source" value.
+- [ ] **Interactive elements using ad-hoc classes** — follow `html-shell/interactive-elements.md`'s class/data-* conventions; the CSS/JS won't cover invented classes.

--- a/skills/repo-mastery/references/gotchas.md
+++ b/skills/repo-mastery/references/gotchas.md
@@ -8,6 +8,8 @@
 - [ ] **Modules without evidence** — every module in the map points to a real file/dir. No evidence → cut it; better fewer than hollow.
 - [ ] **Skipping Phase 2 confirmation** — the user must approve/customize the map (with Mission). This is an explicit requirement; don't skip.
 - [ ] **Concluding too early in the pre-scan** — Phase 1 only maps; conclusions belong to the explanation phase.
+- [ ] **Batching confirmation questions** — ask one at a time (see `clarification-interview.md`); dumping the whole tree at once is bewildering.
+- [ ] **Blank-prompt decisions** — every decision question carries the tutor's evidence-based recommendation; assessment questions (Phase 3) never do.
 
 ## Learning-session phase
 
@@ -18,6 +20,8 @@
 - [ ] **Skipping error diagnosis** — answering the question directly without user self-attribution and an `error_records` entry corrupts review priority.
 - [ ] **Feynman that only asks "got it?"** — the qualitative gate must make the user actually recital; design type must probe tradeoffs.
 - [ ] **Cramming the whole repo into context** — read only the relevant files for the current point (locate via `code-map.json` in large repos).
+- [ ] **Substituting re-reading for retrieval** — rereading/summarizing creates an "illusion of learning" (recognition ≠ recall). Review must force recall (see `quiz-design.md`), never re-read.
+- [ ] **Consecutive same-type reviews** — interleave knowledge types in a review session; grinding one type trains discrimination poorly (`next_objective` prefers a different type from `last_review_type`).
 
 ## Hands-on phase
 

--- a/skills/repo-mastery/references/html-shell/_base.html
+++ b/skills/repo-mastery/references/html-shell/_base.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>COURSE_TITLE</title>
+
+  <!-- Fonts: Sora (display) · DM Sans (body) · JetBrains Mono (code) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!-- Per-course accent. Pick one palette; only these four lines change.
+         ember    #D9542E / #BF4322 / #FCEDE7 / #E68A6F   (default)
+         teal     #2C7C9C / #225F77 / #E6F1F5 / #5F9DB8
+         plum     #7C6BB0 / #5F5193 / #EEEAF6 / #A89AD0
+         pine     #2E8B57 / #226B41 / #E7F4EC / #6BB089
+         amber    #C9912F / #A8761F / #FBF1DC / #DFBE74     -->
+  <style>
+    :root {
+      --color-accent:       ACCENT_COLOR;
+      --color-accent-hover: ACCENT_HOVER;
+      --color-accent-light: ACCENT_LIGHT;
+      --color-accent-muted: ACCENT_MUTED;
+    }
+  </style>
+
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <nav class="nav">
+    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="nav-inner">
+      <span class="nav-title">COURSE_TITLE</span>
+      <div class="nav-dots" id="nav-dots" role="tablist">
+        NAV_DOTS
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">

--- a/skills/repo-mastery/references/html-shell/_footer.html
+++ b/skills/repo-mastery/references/html-shell/_footer.html
@@ -1,0 +1,3 @@
+  </main>
+</body>
+</html>

--- a/skills/repo-mastery/references/html-shell/build.sh
+++ b/skills/repo-mastery/references/html-shell/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Assemble the course into a single index.html.
+# Usage: run from the course directory →  bash build.sh
+set -euo pipefail
+cat _base.html modules/*.html _footer.html > index.html
+echo "Built index.html ($(wc -c < index.html) bytes) — open it in a browser."

--- a/skills/repo-mastery/references/html-shell/design-system.md
+++ b/skills/repo-mastery/references/html-shell/design-system.md
@@ -1,0 +1,53 @@
+# Design System
+
+> **When to read this:** Phase 3, when writing module HTML. All tokens below are defined in `styles.css` (`:root`). Use the CSS variables — never hard-code colors, sizes, or spacing.
+
+The visual identity is a **warm field notebook**: aged-paper backgrounds, one confident accent, a geometric display face with personality, and generous whitespace. It should feel friendly and made-by-a-human, not like a generic AI gradient deck.
+
+## Color tokens
+
+Surfaces and ink (fixed):
+- `--color-bg` `#FBF8F3`, `--color-bg-warm` `#F4EEE4` (alternating module backgrounds), `--color-bg-code` `#21222C`
+- `--color-surface` `#FFFFFF`, `--color-surface-warm` `#FDFAF4`
+- `--color-border` `#E6DFD3`, `--color-border-light` `#EFEAE1`
+- `--color-text` `#2B2925`, `--color-text-secondary` `#6A645B`, `--color-text-muted`
+
+Semantic:
+- `--color-success` / `--color-success-light` — used by the recap card and correct quiz states.
+
+Accent (set per course in `_base.html`, five palettes provided): `--color-accent`, `--color-accent-hover`, `--color-accent-light`, `--color-accent-muted`. Pick the palette that fits the product's character.
+
+Category accents for actors and cards: `--color-actor-1..5` (ember, teal, plum, amber, pine). Use them to give chat avatars, flow actors, pattern cards, and icon circles distinct identities — assign by category, never as a rainbow.
+
+## Typography
+
+- Display (headings): `--font-display` = Sora.
+- Body: `--font-body` = DM Sans.
+- Code/commands: `--font-mono` = JetBrains Mono.
+- Scale: `--text-xs … --text-6xl`. Module title = `--text-4xl`, screen heading = `--text-2xl`, body = `--text-base`.
+
+## Layout
+
+- `--content-width` 760px, centered. `--nav-height` 56px (fixed top bar with progress + dots).
+- Spacing scale `--space-1 … --space-24`; radii `--radius-sm/md/lg/full`; shadows `--shadow-sm/md/lg`.
+- Modules are full-height (`100dvh` with `100vh` fallback) and alternate background tone via `:nth-child(even)`.
+- Motion: `--duration-fast/normal/slow`, `--ease-out`. All motion collapses under `prefers-reduced-motion`.
+
+## Module skeleton
+
+```html
+<section class="module" id="module-N">
+  <div class="module-content">
+    <div class="module-header">
+      <span class="module-number">0N</span>
+      <h2 class="module-title">…</h2>
+      <p class="module-subtitle">…</p>
+    </div>
+    <!-- objectives card here -->
+    <div class="screen"><h3 class="screen-heading">…</h3> … </div>
+    <!-- more screens; recap card screen; quiz screen -->
+  </div>
+</section>
+```
+
+Module files contain **only** the `<section>` — no `<html>`, `<head>`, `<style>`, or `<script>`. CSS and JS come from the copied `styles.css` / `main.js`.

--- a/skills/repo-mastery/references/html-shell/interactive-elements.md
+++ b/skills/repo-mastery/references/html-shell/interactive-elements.md
@@ -1,0 +1,125 @@
+# Interactive Elements
+
+> **When to read this:** Phase 3, when writing module HTML. Use only the HTML patterns below — all CSS lives in `styles.css` and all behavior in `main.js`, which auto-initialize by scanning class names and `data-*` attributes. Never inline `<style>`/`<script>` for these.
+
+Every course must include, somewhere: a **flow animation**, a **group chat**, **glossary tooltips**, a **quiz per module**, and a **command↔plain-English** block per module that has commands. Objectives + recap cards are required per module too.
+
+## Learning objectives (after the header, once per module)
+```html
+<div class="objectives animate-in">
+  <span class="objectives-eyebrow">🎯 学完本模块，你将能够</span>
+  <ul class="objectives-list">
+    <li>用动词开头、可检验的能力一</li>
+    <li>能力二</li>
+    <li>能力三</li>
+  </ul>
+</div>
+```
+3–4 items, each a concrete capability. Mirror the quiz.
+
+## Recap (its own screen, right before the quiz)
+```html
+<div class="screen">
+  <div class="recap animate-in">
+    <span class="recap-eyebrow">✅ 本模块小结</span>
+    <ul class="recap-list">
+      <li>要点一</li><li>要点二</li><li>要点三</li>
+    </ul>
+  </div>
+</div>
+```
+Each takeaway maps back to an objective. The card is green to signal "you've arrived".
+
+## Command ↔ plain-English translation
+Left = exact command/config from the docs; right = line-by-line plain English (the "why", not just the "what").
+```html
+<div class="translation-block animate-in">
+  <div class="translation-code"><span class="translation-label">命令</span>
+    <pre><code><span class="code-line">codex -m gpt-5.5</span></code></pre>
+  </div>
+  <div class="translation-english"><span class="translation-label">大白话</span>
+    <div class="translation-lines"><p class="tl">…</p></div>
+  </div>
+</div>
+```
+Use `white-space` wrapping (built in) — never horizontal scroll. Use commands verbatim.
+
+## Quiz (one per module, at the end)
+`main.js` exposes `selectOption(btn)`, `checkQuiz(id)`, `resetQuiz(id)`. Per-question answer + explanations live on `.quiz-question-block` via `data-correct`, `data-explanation-right`, `data-explanation-wrong`.
+```html
+<div class="quiz-container" id="quiz-mN">
+  <div class="scenario-block">
+    <div class="scenario-context"><span class="scenario-label">场景</span><p>…situation…</p></div>
+    <div class="quiz-question-block" data-correct="b"
+         data-explanation-right="对，因为…" data-explanation-wrong="再想想：…">
+      <div class="quiz-options">
+        <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>选项 A</span></button>
+        <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>选项 B</span></button>
+      </div>
+      <div class="quiz-feedback"></div>
+    </div>
+  </div>
+  <button class="quiz-check-btn" onclick="checkQuiz('quiz-mN')">提交答案</button>
+  <button class="quiz-reset-btn" onclick="resetQuiz('quiz-mN')">再试一次</button>
+</div>
+```
+Drop the `.scenario-block` wrapper for a plain multiple-choice question. Quiz application, not memory: scenarios, "which surface/command", troubleshooting — never definitions.
+
+## Group chat (≥1 per course)
+`main.js` auto-inits each `.chat-window`. Messages start hidden; buttons reveal them with a typing indicator.
+```html
+<div class="chat-window animate-in" id="chat-mN">
+  <div class="chat-messages">
+    <div class="chat-message" data-msg="0" data-sender="you" style="display:none">
+      <div class="chat-avatar" style="background: var(--color-actor-1)">你</div>
+      <div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">你</span><p>…</p></div>
+    </div>
+    <!-- more .chat-message, incrementing data-msg -->
+  </div>
+  <div class="chat-typing" id="chat-mN-typing" style="display:none">
+    <div class="chat-avatar">C</div>
+    <div class="chat-typing-dots"><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div>
+  </div>
+  <div class="chat-controls"><button class="btn chat-next-btn">下一条</button><button class="btn chat-all-btn">全部播放</button><button class="btn chat-reset-btn">重播</button><span class="chat-progress"></span></div>
+</div>
+```
+
+## Flow / data animation (≥1 per course)
+`main.js` auto-inits each `.flow-animation`. Steps are JSON in `data-steps`; actor element ids are `flow-actor-1`, `2`, … and `from`/`to` reference the numeric suffix.
+```html
+<div class="flow-animation" data-steps='[
+  {"highlight":"flow-actor-1","label":"第一步"},
+  {"highlight":"flow-actor-2","label":"传给下一个","packet":true,"from":"1","to":"2"}
+]'>
+  <div class="flow-actors">
+    <div class="flow-actor" id="flow-actor-1"><div class="flow-actor-icon">🧑</div><span>你</span></div>
+    <div class="flow-actor" id="flow-actor-2"><div class="flow-actor-icon">🧠</div><span>模型</span></div>
+  </div>
+  <div class="flow-packet" id="flow-packet"></div>
+  <div class="flow-step-label" id="flow-label">点“下一步”开始</div>
+  <div class="flow-controls"><button class="btn flow-next-btn">下一步</button><button class="btn flow-reset-btn">重来</button><span class="flow-progress"></span></div>
+</div>
+```
+⚠️ No apostrophes inside labels — the attribute is single-quote delimited and they break `JSON.parse`.
+
+## Glossary tooltips (every term, first use per module)
+```html
+<span class="term" data-definition="一句话、可带比喻的大白话定义。">沙箱</span>
+```
+`main.js` builds a fixed-position tooltip appended to `<body>` (never clipped). Be aggressive: acronyms and tool-specific nouns all get one.
+
+## Callouts (1–2 per module)
+```html
+<div class="callout callout-accent">
+  <div class="callout-icon">💡</div>
+  <div class="callout-content"><strong class="callout-title">标题</strong><p>…</p></div>
+</div>
+```
+Variants: `callout-accent` (insight), `callout-info` (good to know), `callout-warning` (common mistake).
+
+## Cards & lists (replace prose lists)
+- **Pattern cards** — `.pattern-cards > .pattern-card` with `.pattern-icon`, `.pattern-title`, `.pattern-desc`. For comparisons / "如果…就用…".
+- **Icon rows** — `.icon-rows > .icon-row` with `.icon-circle` + `<strong>` + `<p>`. For labeled lists.
+- **Step cards** — `.step-cards > .step-card` with `.step-num` + `.step-body`. For sequences and try-it checklists (put the expected result in the `<p>`).
+- **Badge list** — `.badge-list > .badge-item` with `.badge-code` + `.badge-desc`. For annotating config keys / modes.
+- **File tree** — `.file-tree` with `.ft-folder`/`.ft-file` (`.ft-name` + `.ft-desc`). For showing where files live.

--- a/skills/repo-mastery/references/html-shell/main.js
+++ b/skills/repo-mastery/references/html-shell/main.js
@@ -1,0 +1,270 @@
+/* ============================================================
+   docs-to-course — interactive engine (original)
+   Author: CZ. Powers quizzes, group chat, flow animation,
+   glossary tooltips, scroll progress and reveal. No dependencies.
+   ============================================================ */
+(function () {
+  "use strict";
+  var ready = function (fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  };
+
+  /* ---------- Quizzes ---------- */
+  window.selectOption = function (btn) {
+    var block = btn.closest(".quiz-question-block");
+    if (!block || block.dataset.locked === "1") return;
+    block.querySelectorAll(".quiz-option").forEach(function (o) { o.classList.remove("selected"); });
+    btn.classList.add("selected");
+  };
+
+  window.checkQuiz = function (containerId) {
+    var c = document.getElementById(containerId);
+    if (!c) return;
+    c.querySelectorAll(".quiz-question-block").forEach(function (block) {
+      var picked = block.querySelector(".quiz-option.selected");
+      var fb = block.querySelector(".quiz-feedback");
+      if (!picked) {
+        if (fb) { fb.textContent = "先选一个答案 👆"; fb.className = "quiz-feedback show error"; }
+        return;
+      }
+      block.dataset.locked = "1";
+      var ok = picked.dataset.value === block.dataset.correct;
+      picked.classList.add(ok ? "correct" : "incorrect");
+      if (!ok) {
+        var right = block.querySelector('.quiz-option[data-value="' + block.dataset.correct + '"]');
+        if (right) right.classList.add("correct");
+      }
+      if (fb) {
+        fb.textContent = ok
+          ? (block.dataset.explanationRight || "答对了！")
+          : (block.dataset.explanationWrong || "再想想。");
+        fb.className = "quiz-feedback show " + (ok ? "success" : "error");
+      }
+    });
+    var reset = c.querySelector(".quiz-reset-btn");
+    if (reset) reset.classList.add("show");
+  };
+
+  window.resetQuiz = function (containerId) {
+    var c = document.getElementById(containerId);
+    if (!c) return;
+    c.querySelectorAll(".quiz-question-block").forEach(function (block) {
+      block.dataset.locked = "";
+      block.querySelectorAll(".quiz-option").forEach(function (o) {
+        o.classList.remove("selected", "correct", "incorrect");
+      });
+      var fb = block.querySelector(".quiz-feedback");
+      if (fb) fb.className = "quiz-feedback";
+    });
+    var reset = c.querySelector(".quiz-reset-btn");
+    if (reset) reset.classList.remove("show");
+  };
+
+  /* ---------- Group chat ---------- */
+  function initChat(win) {
+    var msgs = Array.prototype.slice.call(win.querySelectorAll(".chat-message"));
+    var typing = win.querySelector(".chat-typing");
+    var prog = win.querySelector(".chat-progress");
+    var nextBtn = win.querySelector(".chat-next-btn");
+    var allBtn = win.querySelector(".chat-all-btn");
+    var resetBtn = win.querySelector(".chat-reset-btn");
+    var i = 0, busy = false;
+    if (typing) typing.style.display = "none";
+
+    function updateProgress() { if (prog) prog.textContent = i + " / " + msgs.length; }
+    function done() { return i >= msgs.length; }
+
+    function reveal() {
+      if (busy || done()) return;
+      busy = true;
+      var m = msgs[i];
+      var sender = m.getAttribute("data-sender");
+      // show typing bubble briefly, mirroring the next sender's avatar colour
+      if (typing) {
+        var av = typing.querySelector(".chat-avatar");
+        var srcAv = m.querySelector(".chat-avatar");
+        if (av && srcAv) { av.textContent = srcAv.textContent; av.style.background = srcAv.style.background; }
+        typing.style.display = "flex";
+      }
+      setTimeout(function () {
+        if (typing) typing.style.display = "none";
+        m.style.display = "flex";
+        i++; updateProgress(); busy = false;
+        if (done() && nextBtn) nextBtn.disabled = true;
+      }, 520);
+    }
+
+    function playAll() {
+      if (done()) return;
+      reveal();
+      var t = setInterval(function () {
+        if (done()) { clearInterval(t); return; }
+        if (!busy) reveal();
+      }, 760);
+    }
+
+    function reset() {
+      msgs.forEach(function (m) { m.style.display = "none"; });
+      i = 0; busy = false; if (nextBtn) nextBtn.disabled = false; updateProgress();
+    }
+
+    msgs.forEach(function (m) { m.style.display = "none"; });
+    updateProgress();
+    if (nextBtn) nextBtn.addEventListener("click", reveal);
+    if (allBtn) allBtn.addEventListener("click", playAll);
+    if (resetBtn) resetBtn.addEventListener("click", reset);
+  }
+
+  /* ---------- Flow / data animation ---------- */
+  function initFlow(flow) {
+    var steps;
+    try { steps = JSON.parse(flow.getAttribute("data-steps") || "[]"); }
+    catch (e) { steps = []; }
+    var label = flow.querySelector(".flow-step-label");
+    var packet = flow.querySelector(".flow-packet");
+    var prog = flow.querySelector(".flow-progress");
+    var nextBtn = flow.querySelector(".flow-next-btn");
+    var resetBtn = flow.querySelector(".flow-reset-btn");
+    var i = 0;
+
+    function actor(idSuffix) { return flow.querySelector("#flow-actor-" + idSuffix.replace(/^actor-/, "").replace(/^flow-actor-/, "")); }
+    function clearActive() { flow.querySelectorAll(".flow-actor").forEach(function (a) { a.classList.remove("active"); }); }
+
+    function center(el) {
+      var cr = flow.getBoundingClientRect();
+      var r = el.getBoundingClientRect();
+      return { x: r.left - cr.left + r.width / 2, y: r.top - cr.top + r.height / 2 };
+    }
+
+    function movePacket(from, to) {
+      if (!packet || !from || !to) return;
+      var a = center(from.querySelector(".flow-actor-icon") || from);
+      var b = center(to.querySelector(".flow-actor-icon") || to);
+      packet.style.transition = "none";
+      packet.style.transform = "translate(" + (a.x - 7) + "px," + (a.y - 7) + "px)";
+      packet.classList.add("moving");
+      requestAnimationFrame(function () {
+        requestAnimationFrame(function () {
+          packet.style.transition = "";
+          packet.style.transform = "translate(" + (b.x - 7) + "px," + (b.y - 7) + "px)";
+        });
+      });
+      setTimeout(function () { packet.classList.remove("moving"); }, 650);
+    }
+
+    function render(step) {
+      clearActive();
+      if (step.highlight) { var h = flow.querySelector("#" + step.highlight); if (h) h.classList.add("active"); }
+      if (label) label.textContent = step.label || "";
+      if (step.packet && step.from && step.to) movePacket(actor(step.from), actor(step.to));
+    }
+
+    function next() {
+      if (i >= steps.length) return;
+      render(steps[i]); i++;
+      if (prog) prog.textContent = i + " / " + steps.length;
+      if (nextBtn && i >= steps.length) nextBtn.disabled = true;
+    }
+    function reset() {
+      i = 0; clearActive();
+      if (packet) packet.classList.remove("moving");
+      if (label) label.textContent = "点“下一步”开始 / Click Next to begin";
+      if (prog) prog.textContent = "0 / " + steps.length;
+      if (nextBtn) nextBtn.disabled = false;
+    }
+
+    if (prog) prog.textContent = "0 / " + steps.length;
+    if (nextBtn) nextBtn.addEventListener("click", next);
+    if (resetBtn) resetBtn.addEventListener("click", reset);
+  }
+
+  /* ---------- Glossary tooltips ---------- */
+  function initTooltips() {
+    var active = null;
+    function place(term, tip) {
+      document.body.appendChild(tip);
+      var r = term.getBoundingClientRect();
+      var w = tip.offsetWidth, h = tip.offsetHeight;
+      var left = Math.max(8, Math.min(r.left + r.width / 2 - w / 2, window.innerWidth - w - 8));
+      var top = r.top - h - 8;
+      if (top < 8) top = r.bottom + 8;
+      tip.style.left = left + "px";
+      tip.style.top = top + "px";
+    }
+    function hide() { if (active) { active.tip.classList.remove("visible"); active.tip.remove(); active.term.classList.remove("active"); active = null; } }
+    function show(term) {
+      hide();
+      var tip = document.createElement("span");
+      tip.className = "term-tip";
+      tip.textContent = term.getAttribute("data-definition");
+      term.classList.add("active");
+      place(term, tip);
+      requestAnimationFrame(function () { tip.classList.add("visible"); });
+      active = { term: term, tip: tip };
+    }
+    document.querySelectorAll(".term").forEach(function (term) {
+      term.addEventListener("mouseenter", function () { show(term); });
+      term.addEventListener("mouseleave", hide);
+      term.addEventListener("click", function (e) {
+        e.stopPropagation();
+        if (active && active.term === term) hide(); else show(term);
+      });
+    });
+    document.addEventListener("click", hide);
+    window.addEventListener("scroll", hide, { passive: true });
+  }
+
+  /* ---------- Nav: progress bar, dots, scroll reveal ---------- */
+  function initNav() {
+    var bar = document.getElementById("progress-bar");
+    var dots = Array.prototype.slice.call(document.querySelectorAll(".nav-dot"));
+    var modules = Array.prototype.slice.call(document.querySelectorAll(".module"));
+
+    function onScroll() {
+      var st = document.documentElement.scrollTop || document.body.scrollTop;
+      var h = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      if (bar) bar.style.width = (h > 0 ? (st / h) * 100 : 0) + "%";
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+
+    dots.forEach(function (dot) {
+      dot.addEventListener("click", function () {
+        var t = document.getElementById(dot.getAttribute("data-target"));
+        if (t) window.scrollTo({ top: t.offsetTop - 40, behavior: "smooth" });
+      });
+    });
+
+    if ("IntersectionObserver" in window && modules.length) {
+      var obs = new IntersectionObserver(function (entries) {
+        entries.forEach(function (en) {
+          if (en.isIntersecting) {
+            var id = en.target.id;
+            dots.forEach(function (d) { d.classList.toggle("active", d.getAttribute("data-target") === id); });
+          }
+        });
+      }, { rootMargin: "-45% 0px -45% 0px" });
+      modules.forEach(function (m) { obs.observe(m); });
+    }
+  }
+
+  function initReveal() {
+    var els = Array.prototype.slice.call(document.querySelectorAll(".animate-in"));
+    if (!("IntersectionObserver" in window)) { els.forEach(function (e) { e.classList.add("visible"); }); return; }
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) { en.target.classList.add("visible"); obs.unobserve(en.target); }
+      });
+    }, { rootMargin: "0px 0px -8% 0px", threshold: 0.05 });
+    els.forEach(function (e) { obs.observe(e); });
+  }
+
+  ready(function () {
+    document.querySelectorAll(".chat-window").forEach(initChat);
+    document.querySelectorAll(".flow-animation").forEach(initFlow);
+    initTooltips();
+    initNav();
+    initReveal();
+  });
+})();

--- a/skills/repo-mastery/references/html-shell/styles.css
+++ b/skills/repo-mastery/references/html-shell/styles.css
@@ -1,0 +1,314 @@
+/* ============================================================
+   docs-to-course — course stylesheet (original)
+   Author: CZ. Warm "field-notebook" aesthetic for learning courses.
+   Accent variables (--color-accent*) are injected per-course in _base.html.
+   ============================================================ */
+
+:root {
+  /* surfaces & ink */
+  --color-bg:            #FBF8F3;
+  --color-bg-warm:       #F4EEE4;
+  --color-bg-code:       #21222C;
+  --color-surface:       #FFFFFF;
+  --color-surface-warm:  #FDFAF4;
+  --color-border:        #E6DFD3;
+  --color-border-light:  #EFEAE1;
+  --color-text:          #2B2925;
+  --color-text-secondary:#6A645B;
+  --color-text-muted:    #9A938860;
+
+  /* semantic */
+  --color-success:       #2F8C57;
+  --color-success-light: #E7F4EC;
+
+  /* category accents for actors/cards */
+  --color-actor-1: #D9542E;
+  --color-actor-2: #2C7C9C;
+  --color-actor-3: #7C6BB0;
+  --color-actor-4: #D2A23C;
+  --color-actor-5: #2E8B57;
+
+  /* type */
+  --font-display: "Sora", system-ui, sans-serif;
+  --font-body:    "DM Sans", system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, monospace;
+
+  --text-xs:  0.75rem;
+  --text-sm:  0.875rem;
+  --text-base:1rem;
+  --text-lg:  1.125rem;
+  --text-xl:  1.375rem;
+  --text-2xl: 1.75rem;
+  --text-4xl: 2.5rem;
+  --text-6xl: 4.5rem;
+
+  /* spacing scale */
+  --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem;
+  --space-5:1.25rem; --space-6:1.5rem; --space-8:2rem; --space-10:2.5rem;
+  --space-12:3rem; --space-16:4rem; --space-20:5rem; --space-24:6rem;
+
+  --radius-sm:8px; --radius-md:12px; --radius-lg:18px; --radius-full:9999px;
+
+  --shadow-sm: 0 1px 2px rgba(43,41,37,.06);
+  --shadow-md: 0 6px 18px rgba(43,41,37,.09);
+  --shadow-lg: 0 14px 34px rgba(43,41,37,.12);
+
+  --leading-tight:1.12; --leading-snug:1.35; --leading-normal:1.65;
+
+  --nav-height: 56px;
+  --content-width: 760px;
+  --duration-fast:140ms; --duration-normal:300ms; --duration-slow:620ms;
+  --ease-out: cubic-bezier(.22,.8,.32,1);
+  --stagger-delay: 70ms;
+
+  /* fallback accents (overridden per-course in _base.html) */
+  --color-accent:#D9542E; --color-accent-hover:#BF4322;
+  --color-accent-light:#FCEDE7; --color-accent-muted:#E68A6F;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+}
+h1,h2,h3,h4 { font-family: var(--font-display); font-weight: 700; }
+p { margin: 0 0 var(--space-4); }
+p:last-child { margin-bottom: 0; }
+code { font-family: var(--font-mono); font-size: .9em; }
+:not(pre) > code {
+  background: var(--color-bg-warm);
+  color: var(--color-accent-hover);
+  padding: .1em .4em; border-radius: 6px;
+  font-size: .85em;
+}
+
+/* ── top nav + progress ─────────────────────────────────── */
+.nav {
+  position: fixed; top: 0; left: 0; right: 0; height: var(--nav-height);
+  z-index: 100; background: color-mix(in srgb, var(--color-bg) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--color-border-light);
+}
+.progress-bar {
+  position: absolute; top: 0; left: 0; height: 3px; width: 0%;
+  background: var(--color-accent); transition: width var(--duration-fast) linear;
+}
+.nav-inner {
+  max-width: var(--content-width); height: 100%; margin: 0 auto;
+  padding: 0 var(--space-6);
+  display: flex; align-items: center; justify-content: space-between; gap: var(--space-4);
+}
+.nav-title {
+  font-family: var(--font-display); font-weight: 700; font-size: var(--text-base);
+  color: var(--color-text); white-space: nowrap;
+}
+.nav-dots { display: flex; gap: var(--space-3); align-items: center; }
+.nav-dot {
+  position: relative; width: 11px; height: 11px; padding: 0;
+  border: 2px solid var(--color-accent-muted); border-radius: 50%;
+  background: transparent; cursor: pointer; transition: all var(--duration-fast);
+}
+.nav-dot:hover { border-color: var(--color-accent); transform: scale(1.15); }
+.nav-dot.active { background: var(--color-accent); border-color: var(--color-accent); }
+.nav-dot::after {
+  content: attr(data-tooltip);
+  position: absolute; top: 150%; right: 0; white-space: nowrap;
+  background: var(--color-bg-code); color: #F2EEE6;
+  font-family: var(--font-body); font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3); border-radius: 6px;
+  opacity: 0; pointer-events: none; transform: translateY(-4px);
+  transition: opacity var(--duration-fast), transform var(--duration-fast);
+}
+.nav-dot:hover::after { opacity: 1; transform: translateY(0); }
+@media (max-width: 600px){ .nav-dots{ display:none; } }
+
+/* ── module + screen layout ─────────────────────────────── */
+.module {
+  min-height: 100vh; min-height: 100dvh;
+  padding: var(--space-16) var(--space-6) var(--space-20);
+  padding-top: calc(var(--nav-height) + var(--space-12));
+}
+.module:nth-child(even){ background: var(--color-bg-warm); }
+.module-content { max-width: var(--content-width); margin: 0 auto; }
+.module-header { margin-bottom: var(--space-10); }
+.module-number {
+  display: block; font-family: var(--font-display); font-weight: 700;
+  font-size: var(--text-6xl); line-height: 1; color: var(--color-accent); opacity: .14;
+}
+.module-title { font-size: var(--text-4xl); line-height: var(--leading-tight); margin: var(--space-2) 0 0; }
+.module-subtitle { margin-top: var(--space-3); font-size: var(--text-lg); color: var(--color-text-secondary); line-height: var(--leading-snug); }
+.screen { margin-bottom: var(--space-16); }
+.screen-heading { font-size: var(--text-2xl); margin: 0 0 var(--space-6); line-height: var(--leading-snug); }
+
+/* ── scroll reveal ──────────────────────────────────────── */
+.animate-in { opacity: 0; transform: translateY(18px); transition: opacity var(--duration-slow) var(--ease-out), transform var(--duration-slow) var(--ease-out); }
+.animate-in.visible { opacity: 1; transform: none; }
+
+/* ── learning objectives / recap ────────────────────────── */
+.objectives, .recap {
+  position: relative; margin: var(--space-8) 0 var(--space-12);
+  padding: var(--space-6) var(--space-6) var(--space-6) var(--space-8);
+  border: 1px solid var(--color-border-light); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+.recap { margin: var(--space-8) 0; }
+.objectives { background: var(--color-accent-light); }
+.recap { background: var(--color-success-light); }
+.objectives::before, .recap::before {
+  content: ""; position: absolute; left: 0; top: var(--space-4); bottom: var(--space-4);
+  width: 4px; border-radius: var(--radius-full);
+}
+.objectives::before { background: var(--color-accent); }
+.recap::before { background: var(--color-success); }
+.objectives-eyebrow, .recap-eyebrow {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-family: var(--font-display); font-size: var(--text-xs); font-weight: 700;
+  text-transform: uppercase; letter-spacing: .08em; margin-bottom: var(--space-4);
+}
+.objectives-eyebrow { color: var(--color-accent-hover); }
+.recap-eyebrow { color: var(--color-success); }
+.objectives-list, .recap-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-3); }
+.objectives-list li, .recap-list li { display: flex; align-items: flex-start; gap: var(--space-3); font-size: var(--text-base); line-height: var(--leading-snug); }
+.objectives-list li::before {
+  content: "✓"; flex-shrink: 0; width: 22px; height: 22px; margin-top: 1px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--color-accent); color: #fff; border-radius: var(--radius-full);
+  font-size: 13px; font-weight: 700;
+}
+.recap-list li::before { content: "→"; flex-shrink: 0; color: var(--color-success); font-weight: 700; margin-top: 1px; }
+
+/* ── command / plain-english translation ────────────────── */
+.translation-block {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border-radius: var(--radius-md); overflow: hidden; box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.translation-code { position: relative; background: var(--color-bg-code); color: #E7E4DC; padding: var(--space-6); font-family: var(--font-mono); font-size: var(--text-sm); line-height: 1.7; overflow-x: hidden; }
+.translation-code pre, .translation-code code { white-space: pre-wrap; word-break: break-word; margin: 0; }
+.code-line { display: block; }
+.translation-english { background: var(--color-surface-warm); padding: var(--space-6); font-size: var(--text-sm); line-height: 1.7; border-left: 3px solid var(--color-accent); }
+.translation-label { position: absolute; top: var(--space-2); right: var(--space-3); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .1em; opacity: .5; }
+.translation-english .translation-label { position: static; display: block; margin-bottom: var(--space-3); color: var(--color-text-muted); }
+.translation-lines .tl { margin: 0 0 var(--space-3); }
+@media (max-width: 720px){ .translation-block{ grid-template-columns: 1fr; } .translation-english{ border-left: none; border-top: 3px solid var(--color-accent);} }
+
+/* ── quizzes ────────────────────────────────────────────── */
+.quiz-container { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-6); box-shadow: var(--shadow-sm); }
+.scenario-block { margin-bottom: var(--space-6); }
+.scenario-context { background: var(--color-bg-warm); border-radius: var(--radius-md); padding: var(--space-4) var(--space-5); margin-bottom: var(--space-4); }
+.scenario-label { display: inline-block; font-family: var(--font-display); font-size: var(--text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--color-accent-hover); margin-bottom: var(--space-2); }
+.scenario-context p { margin: 0; }
+.quiz-question { font-size: var(--text-lg); margin: 0 0 var(--space-4); }
+.quiz-options { display: flex; flex-direction: column; gap: var(--space-3); }
+.quiz-option { display: flex; align-items: center; gap: var(--space-3); width: 100%; text-align: left; padding: var(--space-3) var(--space-4); border: 2px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface); cursor: pointer; font: inherit; color: inherit; transition: border-color var(--duration-fast), background var(--duration-fast); }
+.quiz-option:hover { border-color: var(--color-accent-muted); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.quiz-option.correct { border-color: var(--color-success); background: var(--color-success-light); }
+.quiz-option.incorrect { border-color: #C0432F; background: #FBEAE6; }
+.quiz-option-radio { width: 18px; height: 18px; border-radius: 50%; border: 2px solid var(--color-border); flex-shrink: 0; transition: all var(--duration-fast); }
+.quiz-option.selected .quiz-option-radio { border-color: var(--color-accent); background: var(--color-accent); box-shadow: inset 0 0 0 3px #fff; }
+.quiz-option.correct .quiz-option-radio { border-color: var(--color-success); background: var(--color-success); box-shadow: inset 0 0 0 3px #fff; }
+.quiz-feedback { max-height: 0; overflow: hidden; opacity: 0; transition: max-height var(--duration-normal), opacity var(--duration-normal); font-size: var(--text-sm); }
+.quiz-feedback.show { max-height: 240px; opacity: 1; padding: var(--space-3) var(--space-4); margin-top: var(--space-3); border-radius: var(--radius-sm); }
+.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.quiz-feedback.error { background: #FBEAE6; color: #B23A28; }
+.quiz-check-btn, .quiz-reset-btn, .btn { font: inherit; font-family: var(--font-display); font-weight: 600; cursor: pointer; border-radius: var(--radius-full); padding: var(--space-2) var(--space-5); border: 1.5px solid var(--color-accent); transition: all var(--duration-fast); }
+.quiz-check-btn { background: var(--color-accent); color: #fff; margin-top: var(--space-5); }
+.quiz-check-btn:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); }
+.quiz-reset-btn { background: transparent; color: var(--color-accent); margin: var(--space-5) 0 0 var(--space-3); display: none; }
+.quiz-reset-btn.show { display: inline-block; }
+
+/* ── callouts ───────────────────────────────────────────── */
+.callout { display: flex; gap: var(--space-4); padding: var(--space-5) var(--space-6); border-radius: var(--radius-md); margin: var(--space-6) 0; border-left: 4px solid var(--color-accent); background: var(--color-accent-light); }
+.callout-info { border-left-color: var(--color-actor-2); background: #E6F1F5; }
+.callout-warning { border-left-color: #C0432F; background: #FBEAE6; }
+.callout-icon { font-size: 1.4rem; line-height: 1; flex-shrink: 0; }
+.callout-title { display: block; font-family: var(--font-display); margin-bottom: var(--space-1); }
+.callout-content p { margin: 0; }
+
+/* ── pattern cards / icon rows / step cards / badges ────── */
+.pattern-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px,1fr)); gap: var(--space-4); margin: var(--space-6) 0; }
+.pattern-card { background: var(--color-surface); border-radius: var(--radius-md); padding: var(--space-6); box-shadow: var(--shadow-sm); transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal); }
+.pattern-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+.pattern-icon { width: 44px; height: 44px; border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 1.3rem; color: #fff; margin-bottom: var(--space-3); }
+.pattern-title { font-size: var(--text-lg); margin: 0 0 var(--space-2); }
+.pattern-desc { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+.icon-rows { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-6) 0; }
+.icon-row { display: flex; align-items: center; gap: var(--space-4); padding: var(--space-4); background: var(--color-surface); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
+.icon-row p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+.icon-circle { width: 48px; height: 48px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.25rem; color: #fff; flex-shrink: 0; }
+
+.step-cards { display: flex; flex-direction: column; gap: var(--space-3); margin: var(--space-6) 0; }
+.step-card { display: flex; align-items: flex-start; gap: var(--space-4); padding: var(--space-4) var(--space-5); background: var(--color-surface); border-radius: var(--radius-md); border-left: 3px solid var(--color-accent); box-shadow: var(--shadow-sm); }
+.step-num { width: 32px; height: 32px; border-radius: 50%; background: var(--color-accent); color: #fff; font-family: var(--font-display); font-weight: 700; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.step-body p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+.badge-list { display: flex; flex-direction: column; gap: var(--space-2); margin: var(--space-6) 0; }
+.badge-item { display: flex; align-items: center; gap: var(--space-4); padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border-light); border-radius: var(--radius-sm); transition: border-color var(--duration-fast); }
+.badge-item:hover { border-color: var(--color-accent-muted); }
+.badge-code { font-family: var(--font-mono); font-size: var(--text-sm); background: var(--color-bg-code); color: #D9C7F2; padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); white-space: nowrap; }
+.badge-desc { color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+/* ── file tree ──────────────────────────────────────────── */
+.file-tree { font-family: var(--font-mono); font-size: var(--text-sm); margin: var(--space-6) 0; }
+.ft-folder, .ft-file { padding: var(--space-2) var(--space-3); border-left: 2px solid var(--color-border-light); margin-left: var(--space-4); }
+.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
+.ft-folder > .ft-name::before { content: "📁 "; }
+.ft-file > .ft-name::before { content: "📄 "; }
+.ft-desc { color: var(--color-text-secondary); font-family: var(--font-body); margin-left: var(--space-2); font-size: var(--text-xs); }
+.ft-children { margin-left: var(--space-4); }
+
+/* ── glossary tooltip terms ─────────────────────────────── */
+.term { border-bottom: 1.5px dashed var(--color-accent-muted); cursor: pointer; }
+.term:hover, .term.active { border-bottom-color: var(--color-accent); color: var(--color-accent-hover); }
+.term-tip {
+  position: fixed; z-index: 10000; max-width: min(320px, 80vw);
+  background: var(--color-bg-code); color: #EFEBE3;
+  padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm);
+  font-family: var(--font-body); font-size: var(--text-sm); line-height: var(--leading-normal);
+  box-shadow: var(--shadow-lg); opacity: 0; pointer-events: none; transition: opacity var(--duration-fast);
+}
+.term-tip.visible { opacity: 1; }
+
+/* ── group chat ─────────────────────────────────────────── */
+.chat-window { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-5); margin: var(--space-6) 0; box-shadow: var(--shadow-sm); }
+.chat-messages { display: flex; flex-direction: column; gap: var(--space-4); min-height: 80px; }
+.chat-message { display: flex; gap: var(--space-3); align-items: flex-start; animation: chatIn var(--duration-normal) var(--ease-out); }
+@keyframes chatIn { from { opacity: 0; transform: translateY(8px);} to { opacity:1; transform:none; } }
+.chat-avatar { width: 36px; height: 36px; border-radius: 50%; flex-shrink: 0; color: #fff; font-family: var(--font-display); font-weight: 700; font-size: var(--text-sm); display: flex; align-items: center; justify-content: center; }
+.chat-bubble { background: var(--color-bg-warm); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); max-width: 80%; }
+.chat-sender { display: block; font-family: var(--font-display); font-weight: 600; font-size: var(--text-xs); margin-bottom: var(--space-1); }
+.chat-bubble p { margin: 0; font-size: var(--text-sm); line-height: var(--leading-snug); }
+.chat-typing { display: flex; gap: var(--space-3); align-items: center; }
+.chat-typing-dots { display: flex; gap: 5px; background: var(--color-bg-warm); padding: var(--space-3) var(--space-4); border-radius: var(--radius-md); }
+.typing-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-text-secondary); animation: typingBounce 1.4s infinite; }
+.typing-dot:nth-child(2){ animation-delay:.2s; } .typing-dot:nth-child(3){ animation-delay:.4s; }
+@keyframes typingBounce { 0%,60%,100%{ transform: translateY(0);} 30%{ transform: translateY(-6px);} }
+.chat-controls, .flow-controls { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-5); flex-wrap: wrap; }
+.btn { background: transparent; color: var(--color-accent); font-size: var(--text-sm); padding: var(--space-2) var(--space-4); }
+.btn:hover { background: var(--color-accent-light); }
+.chat-progress, .flow-progress { font-size: var(--text-xs); color: var(--color-text-muted); margin-left: auto; }
+
+/* ── flow / data animation ──────────────────────────────── */
+.flow-animation { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-6); margin: var(--space-6) 0; box-shadow: var(--shadow-sm); position: relative; }
+.flow-actors { display: flex; justify-content: space-between; gap: var(--space-3); position: relative; }
+.flow-actor { display: flex; flex-direction: column; align-items: center; gap: var(--space-2); flex: 1; text-align: center; font-size: var(--text-sm); color: var(--color-text-secondary); transition: all var(--duration-normal) var(--ease-out); }
+.flow-actor-icon { width: 56px; height: 56px; border-radius: var(--radius-md); background: var(--color-bg-warm); display: flex; align-items: center; justify-content: center; font-size: 1.5rem; transition: all var(--duration-normal) var(--ease-out); }
+.flow-actor.active { color: var(--color-text); }
+.flow-actor.active .flow-actor-icon { background: var(--color-accent-light); box-shadow: 0 0 0 3px var(--color-accent); transform: scale(1.08); }
+.flow-packet { position: absolute; width: 14px; height: 14px; border-radius: 50%; background: var(--color-accent); opacity: 0; top: 0; left: 0; transition: transform var(--duration-slow) var(--ease-out), opacity var(--duration-fast); pointer-events: none; }
+.flow-packet.moving { opacity: 1; }
+.flow-step-label { margin-top: var(--space-5); text-align: center; font-size: var(--text-sm); color: var(--color-text-secondary); min-height: 1.4em; }
+
+/* ── reduced motion ─────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  .animate-in { opacity: 1; transform: none; }
+}

--- a/skills/repo-mastery/references/index-script-spec.md
+++ b/skills/repo-mastery/references/index-script-spec.md
@@ -1,0 +1,52 @@
+# Index Script Spec — `scripts/index_repo.py`
+
+> **Read in**: Phase 0, when the repo is judged large. Run the script and use `code-map.json` to build the course map and learn on demand — instead of cramming the whole repo into context.
+
+## When you need the index
+
+Phase 0 "large" judgment (any hit): ≥ 100k source lines, ≥ 20 top-level modules, or complex/multi-language dependencies. When unsure, actually measure with `find` + `wc -l`; don't guess.
+
+## Run
+
+```bash
+python3 ~/.claude/skills/repo-mastery/scripts/index_repo.py <repo_path> -o <repo_path>/.learning/code-map.json
+```
+
+- Pure stdlib, **no dependencies to install**.
+- Read-only scan; skips blacklisted dirs (`.git`, `node_modules`, `.venv`, `dist`, etc.).
+- Writes to a temp file then atomically renames, so no half-written output.
+
+## `code-map.json` structure
+
+```jsonc
+{
+  "repo": "owner/name",
+  "summary": {
+    "total_source_files": 1234,
+    "total_lines": 182340,
+    "languages": { "python": 800, "typescript": 300 },
+    "top_dirs": [ { "name": "deeptutor", "files": 600 } ]   // top-level dir stats
+  },
+  "entry_points": [ "package.json/main: src/index.js", "main.py" ],
+  "dependency_graph": { "src/pipeline.py": ["deeptutor", "core"] },  // in-project edges only
+  "files": [ { "path": "src/pipeline.py", "lang": "python", "lines": 640 } ],
+  "symbol_lookup": { "python": [ "src/pipeline.py", "..." ] }  // heaviest 30 files per language
+}
+```
+
+## How to use it for the course map (Phase 1)
+
+1. **Module division** ← `summary.top_dirs` + `dependency_graph`: top-level dirs are natural module boundaries; clusters of dependency edges are strong "key implementations" candidates.
+2. **Key-implementation location** ← `symbol_lookup` + `files` sorted by `lines` desc: the heaviest files are often core.
+3. **Usage-module evidence** ← `entry_points`: entry files ground the "build / core workflows" modules.
+4. **Read on demand during learning** ← from the map's knowledge points → the `path` in `files` → Read the relevant `file:line`. No more whole-repo scans.
+
+## Known limitations (honest)
+
+- Dependency extraction is **heuristic regex, not a syntax tree** — dynamic imports and indirect references are missed. It's for "finding candidates", not "exhaustive enumeration".
+- Multi-language repos (e.g. Rust core + Python wrapper) are grouped by extension only; cross-language boundaries still need README/docs.
+- For extreme monorepos (millions of lines), build an index per sub-directory, or index only the subsystem you care about.
+
+## Where to put the index
+
+- Default: `<repo>/.learning/code-map.json` (travels with the repo). For very large repos, `~/.repo-mastery/caches/<repo-id>/code-map.json` keeps the target repo clean — pick one and stay consistent.

--- a/skills/repo-mastery/references/learning-records-template.md
+++ b/skills/repo-mastery/references/learning-records-template.md
@@ -1,0 +1,47 @@
+# Learning Records Template — ADR-style Learning Records
+
+> **Read in**: all phases. Learning records and notes are **two layers**:
+> - `notes/<module>.md` = content notes — what each module covered (knowledge accumulation).
+> - `records/NNNN-slug.md` = decision records — **how the learner's understanding evolved** (non-obvious learnings, stated prior knowledge, corrected misconceptions). These feed ZPD decisions and future sessions.
+>
+> Format absorbed from mattpocock teach skill's `LEARNING-RECORD-FORMAT.md` (the teaching-world ADR).
+
+## Location & numbering
+
+- Location: `<repo>/.learning/records/`, filenames `0001-slug.md`, `0002-slug.md`, … incrementing.
+- Lazy creation: only create the directory when the first record is written.
+
+## Template (minimal)
+
+```md
+# {one-line title: what was learned / established}
+
+{1-3 sentences: what was learned (or what prior knowledge was established), and why it matters for future sessions.}
+
+Status: active | superseded by LR-NNNN   ← only when needed
+Evidence: {how the user demonstrated this: answered a question / ran a demo / cited prior experience}
+Implications: {what this unlocks or rules out for future sessions}
+```
+
+**The whole format is these few lines.** The value of a record is capturing "this is now known" + "it changes what to teach next" — not filling out sections.
+
+## When to write one
+
+1. **The user demonstrated genuine understanding of something non-trivial** — not just exposure, but evidence they can use it correctly (answered, demo ran). This sets a new floor for what to teach next.
+2. **The user disclosed prior knowledge** — "I already know X." Record it, and the claimed depth, so future sessions don't re-teach it.
+3. **A misconception was corrected** — the user believed something wrong and now sees why. High value: predicts future stumbling blocks for related topics.
+4. **The Mission shifted in response to learning** — the user discovered they care about something different. Update `MISSION.md` and cross-link.
+
+### What does *not* qualify
+
+- Material merely covered. Coverage is not learning; wait for evidence.
+- Anything already captured tersely as a glossary term. Don't duplicate.
+- Session-by-session activity logs. Records are not a journal — they're decision-grade insights.
+
+## Supersession
+
+When a later record contradicts an earlier one (understanding deepened or corrected), mark the old record `Status: superseded by LR-NNNN` rather than deleting it — the history of how understanding evolved is itself useful signal (absorbed from teach's supersession).
+
+## Relationship to ZPD
+
+Each record updates the baseline of "what the user already knows". At session start, read `records/` + `progress.json` to judge the **zone of proximal development**: teach what's "just challenging enough" — not re-covering established knowledge, not leaping too far.

--- a/skills/repo-mastery/references/mastery-policy.md
+++ b/skills/repo-mastery/references/mastery-policy.md
@@ -1,0 +1,142 @@
+# Mastery Policy — Mastery, Gates, Spaced Review, Error Diagnosis
+
+> **Read in**: Phase 3. This is the pure decision engine — **no LLM calls, no I/O**. The tutor consults these rules every learning turn. Three core questions: **Is this knowledge point mastered? What should the learner work on next? What does the whole map look like?**
+
+This policy is ported from DeepTutor's `learning/` module (`mastery.py` / `policy.py` / `scheduler.py` / `models.py`), replacing "subject knowledge" with "code knowledge".
+
+> **Every formula in this document is implemented in `scripts/learning_engine.py`.**
+> The tutor (in any tool) MUST call the script for gate decisions
+> (`compute-mastery`, `schedule`, `record-attempt`, `next-objective`,
+> `validate-map`, `init`) rather than re-deriving the math by hand — this keeps
+> mastery judgment identical across Claude Code, Codex, Gemini CLI, etc.
+
+## 0. Design rationale: Fluency vs Storage Strength (absorbed from the teach skill)
+
+Distinguish two kinds of "knowing":
+
+- **Fluency**: retrievable in the moment — the "I get it" right after an explanation. It creates the **illusion of mastery**.
+- **Storage**: long-term retention — still usable after a gap. This is the real goal.
+
+All mechanisms in this policy fight the fluency illusion:
+
+- Confidence ceiling (one lucky answer ≠ mastery) → prevents fluency masquerading as mastery.
+- Feynman recital (not nodding along) → forces retrieval from storage.
+- Spaced review (delayed review) → only what survives forgetting counts as storage.
+
+**ZPD (zone of proximal development)**: what to teach next = challenge "just enough". Its inputs = `records/` (established understanding) + `progress.json` (mastery) + Mission (why the learner is here). Don't re-cover what's mastered; don't leap too far.
+
+## 1. Knowledge types and gates
+
+| type | Gate kind | Pass condition |
+|---|---|---|
+| `memory` | quantitative | recency-weighted accuracy ≥ **0.9** |
+| `procedure` | quantitative | recency-weighted accuracy ≥ **0.9** (with the key hands-on task passing as evidence) |
+| `concept` | qualitative | tutor judges the Feynman recital passed (`mastery_assess`) |
+| `design` | qualitative | tutor judges the recital + design-tradeoff follow-ups passed |
+
+**Design axiom**: quantitative types (memory/procedure) use exact grading because most have a single correct answer; concept/design use qualitative judgment because "why is it designed this way" has no single canonical answer — this is exactly how DeepTutor splits it.
+
+## 2. Quantitative mastery (`compute_mastery`)
+
+```text
+Input: a knowledge point's chronological answer correctness [bool, ...]
+Take the most recent up-to-5 attempts; weights oldest→newest = (0.5, 0.7, 0.85, 0.95, 1.0)
+score = Σ(weight × right/wrong) / Σ(weights)
+Confidence ceiling: only 1 recorded attempt → score capped at 0.5; only 2 → capped at 0.8
+mastery = min(score, ceiling)
+```
+
+Meaning:
+
+- Newer attempts weigh more — recovery after early mistakes is rewarded.
+- **One lucky answer is not mastery** — the confidence ceiling keeps mastery below 0.9 until enough evidence accumulates.
+- The judgment is deterministic, recorded in `progress.json`, independent of tutor memory.
+
+## 3. Spaced-repetition scheduling
+
+One interval sequence per type (days):
+
+| type | interval sequence |
+|---|---|
+| `memory` | `[0, 1, 3, 7, 14, 30]` |
+| `concept` | `[3, 7, 14, 30]` |
+| `procedure` | `[3, 7, 14]` |
+| `design` | `[14, 28]` |
+
+**Scheduling rules** (`schedule_next`):
+
+- Correct: `consecutive_correct += 1`; if `consecutive_correct ≥ 2` → index +2; else +1.
+- Wrong: `consecutive_wrong += 1`; index steps back 1 (floor 0); if `consecutive_wrong ≥ 2` → reset the counter.
+- Index clamped to `[0, max_index]`; `next_review_at = now + interval[index]`.
+
+**Priority**: knowledge points with **error records** (active/retrying status) get priority 1 (highest); otherwise by type `memory:2 / concept:3 / procedure:4 / design:5`. Due review tasks sort by priority.
+
+## 4. What to learn next (`next_objective`)
+
+**Advancement is computed from what is already mastered — never from a stage counter.** Priority, high to low:
+
+1. **A pending question** (`pending_question`) → grade it first (`answer_pending`).
+2. **A due review** → review first, so mastered ground doesn't decay (`review`).
+3. **The first unmastered knowledge point** (by module order, then point order):
+   - Never touched → `probe` (test whether it can be skipped — **test-out path**: already-proven points are skipped, not forced through fixed stages).
+   - Quantitative type below its gate → `practice` (keep working it until it clears).
+   - Qualitative type → `assess` (Feynman check).
+4. **All mastered and nothing due** → `complete`.
+
+`NextStep` actions: `answer_pending / review / probe / practice / assess / complete`.
+
+## 5. Error diagnosis and metacognition
+
+When the learner is wrong/stuck, classify the **error type** (DeepTutor's four categories, mapped to code learning):
+
+| ErrorType | Meaning | Code-learning example |
+|---|---|---|
+| `structural` | missing prerequisite knowledge/context | "can't understand this async framework because I don't know `asyncio`" |
+| `deviation` | a concept is understood wrong | "thought RAG trains the model; it's actually retrieval-augmented" |
+| `application` | concept right but wrong scenario | "knows locks exist but used them where they don't apply" |
+| `metacognitive` | doesn't know what they don't know | "thought I got it, then the recital exposed the gaps" |
+
+Each error record: `error_type` + user's self-attribution + tutor confirmation + retry history. **Status flow**: `active → retrying → review → graduated`. active/retrying errors raise that point's review priority.
+
+## 6. Qualitative judgment (`mastery_assess`)
+
+Pass criteria for the Feynman check on concept/design points:
+
+- **concept**: the user can explain in their own words "what + why + relation to adjacent concepts". Can't → not passed → return to explanation, record the error type.
+- **design**: beyond the recital, add design-tradeoff follow-ups — "why not the alternative? in what scenario would it fail? where is the extension point?" Being able to answer the tradeoffs = mastery.
+
+Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows full value once passed, but the judgment itself is a boolean, not a score.
+
+## 7. Progress data structure (`progress.json`)
+
+```jsonc
+{
+  "repo": "owner/name",
+  "diagnostic": { "module_mastery": {} },
+  "modules": [
+    { "id": "m01", "name": "Build & environment", "order": 1,
+      "pass_threshold": 0.7,
+      "knowledge_points": [ { "id": "kp01-01", "name": "...", "type": "procedure" } ] }
+  ],
+  "mastery_levels": { "kp01-01": 0.42 },       // quantitative mastery 0..1
+  "qualitative_mastery": { "kp01-02": true },  // qualitative judgment
+  "knowledge_types": { "kp01-01": "procedure" },
+  "quiz_attempts": [ { "question_id": "q1", "knowledge_point_id": "kp01-01",
+                       "is_correct": false, "error_type": "deviation",
+                       "mastery_estimate": 0.0, "timestamp": 1754567890 } ],
+  "error_records": [ { "id": "e1", "knowledge_point_id": "kp01-01",
+                       "error_type": "deviation", "status": "active" } ],
+  "repetition_states": { "kp01-01": { "interval_index": 0, "next_review_at": 1754571490 } },
+  "review_queue": [ { "id": "review_kp01-01", "knowledge_point_id": "kp01-01",
+                      "due_at": 1754571490, "priority": 1 } ],
+  "pending_question": { "question_id": "q3", "knowledge_point_id": "kp01-01",
+                        "prompt": "...", "question_type": "short", "expected_answer": "..." },
+  "version": 1
+}
+```
+
+Key points:
+
+- `pending_question.expected_answer` **lives server-side (this file)** and never round-trips to the user — grading never drifts (DeepTutor's `PendingQuestion`).
+- All timestamps are Unix seconds.
+- Once the file exists, **write it back atomically** (temp file + rename) at the end of each turn to avoid corruption.

--- a/skills/repo-mastery/references/mastery-policy.md
+++ b/skills/repo-mastery/references/mastery-policy.md
@@ -52,9 +52,9 @@ Meaning:
 - **One lucky answer is not mastery** — the confidence ceiling keeps mastery below 0.9 until enough evidence accumulates.
 - The judgment is deterministic, recorded in `progress.json`, independent of tutor memory.
 
-## 3. Spaced-repetition scheduling
+## 3. Spaced-repetition scheduling (FSRS-inspired personalization)
 
-One interval sequence per type (days):
+Base interval sequence per type (days), as before:
 
 | type | interval sequence |
 |---|---|
@@ -63,13 +63,41 @@ One interval sequence per type (days):
 | `procedure` | `[3, 7, 14]` |
 | `design` | `[14, 28]` |
 
-**Scheduling rules** (`schedule_next`):
+**Personalization parameters** — each knowledge point carries two learned
+values (FSRS-inspired, simplified to pure deterministic math; see `ADOPTION.md` §6):
 
-- Correct: `consecutive_correct += 1`; if `consecutive_correct ≥ 2` → index +2; else +1.
-- Wrong: `consecutive_wrong += 1`; index steps back 1 (floor 0); if `consecutive_wrong ≥ 2` → reset the counter.
-- Index clamped to `[0, max_index]`; `next_review_at = now + interval[index]`.
+- `difficulty` (0.1–1.0, default 0.5): how hard this point is for the learner.
+- `stability` (1.0–5.0, default 1.0): how durable the memory is.
 
-**Priority**: knowledge points with **error records** (active/retrying status) get priority 1 (highest); otherwise by type `memory:2 / concept:3 / procedure:4 / design:5`. Due review tasks sort by priority.
+**Update rules** (`schedule_next`):
+
+- Correct:
+  - `consecutive_correct += 1`; if `≥ 2` → index +2; else +1.
+  - `difficulty = max(0.1, difficulty − 0.05)`.
+  - `stability = min(5.0, stability × (1 + 0.2 × min(consecutive_correct, 5)))`.
+- Wrong:
+  - `consecutive_wrong += 1`; index steps back 1 (floor 0); if `≥ 2` → reset.
+  - `difficulty = min(1.0, difficulty + 0.15)`.
+  - `stability = max(1.0, stability × 0.5)`.
+
+Index is clamped to `[0, max_index]`.
+
+**Effective interval** (replaces `next_review_at = now + interval[index]`):
+
+```text
+effective_days = base_days[interval_index] × stability × (1 − difficulty × 0.5)
+next_review_at = now + effective_days × 86400
+```
+
+- Higher `difficulty` → shorter interval (review sooner).
+- Higher `stability` → longer interval (defer).
+
+**Priority** (unchanged): error-record points get priority 1; else by type
+`memory:2 / concept:3 / procedure:4 / design:5`.
+
+**Interleaving** (`next_objective`): among due reviews of equal priority, a
+review whose `knowledge_type` differs from `progress.last_review_type` is picked
+first, so consecutive reviews interleave types instead of stacking one type.
 
 ## 4. What to learn next (`next_objective`)
 
@@ -105,6 +133,12 @@ Pass criteria for the Feynman check on concept/design points:
 - **concept**: the user can explain in their own words "what + why + relation to adjacent concepts". Can't → not passed → return to explanation, record the error type.
 - **design**: beyond the recital, add design-tradeoff follow-ups — "why not the alternative? in what scenario would it fail? where is the extension point?" Being able to answer the tradeoffs = mastery.
 
+**Causal questioning** (absorbed from RetainCraft): after the recital, push with
+causal probes to expose whether understanding is causal or merely associative —
+"why this design instead of X?", "if we swapped Y in, what would break and
+where?", "which single change flips this behavior?" Causal answers count as
+mastery evidence; vague recall does not.
+
 Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows full value once passed, but the judgment itself is a boolean, not a score.
 
 ## 7. Progress data structure (`progress.json`)
@@ -126,11 +160,14 @@ Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows 
                        "mastery_estimate": 0.0, "timestamp": 1754567890 } ],
   "error_records": [ { "id": "e1", "knowledge_point_id": "kp01-01",
                        "error_type": "deviation", "status": "active" } ],
-  "repetition_states": { "kp01-01": { "interval_index": 0, "next_review_at": 1754571490 } },
+  "repetition_states": { "kp01-01": { "interval_index": 0, "consecutive_correct": 0,
+                                       "consecutive_wrong": 0, "difficulty": 0.5,
+                                       "stability": 1.0, "next_review_at": 1754571490 } },
   "review_queue": [ { "id": "review_kp01-01", "knowledge_point_id": "kp01-01",
-                      "due_at": 1754571490, "priority": 1 } ],
+                      "knowledge_type": "procedure", "due_at": 1754571490, "priority": 1 } ],
   "pending_question": { "question_id": "q3", "knowledge_point_id": "kp01-01",
                         "prompt": "...", "question_type": "short", "expected_answer": "..." },
+  "last_review_type": "concept",
   "version": 1
 }
 ```
@@ -140,3 +177,6 @@ Key points:
 - `pending_question.expected_answer` **lives server-side (this file)** and never round-trips to the user — grading never drifts (DeepTutor's `PendingQuestion`).
 - All timestamps are Unix seconds.
 - Once the file exists, **write it back atomically** (temp file + rename) at the end of each turn to avoid corruption.
+- `repetition_states[].difficulty` / `stability` are FSRS-inspired personalization
+  parameters (default 0.5 / 1.0; missing → treated as defaults for old data).
+  `last_review_type` is updated on each attempt and used to interleave review types.

--- a/skills/repo-mastery/references/module-brief-template.md
+++ b/skills/repo-mastery/references/module-brief-template.md
@@ -1,0 +1,67 @@
+# Module Brief Template — Pre-extracted Source Snippets
+
+> **Read in**: Phase 3, **for large repos** (or when the user asks to save tokens). Before learning a module, write a brief that pre-extracts the module's **key source snippets + evidence locations**, so later turns don't re-Read the source repeatedly. Absorbed from docs-to-course's `module-brief-template.md` (it pre-extracts commands/config; we pre-extract source).
+
+## Why it saves tokens
+
+To explain a knowledge point well, you usually need 2–4 key source snippets. Re-reading whole files every turn burns tokens repeatedly. **Pre-extraction** condenses "what this code does" into the brief; the tutor quotes the brief and only Reads source when the brief lacks detail.
+
+## When to write a brief
+
+- Large repos (Phase 0 judgment): one brief per module before learning it.
+- Small/medium repos: worth it when a module has lots of source or a long call chain.
+- Keep the brief at `.learning/briefs/`; reuse it in later review sessions.
+
+## Brief template
+
+Write to `<repo>/.learning/briefs/<module>.md`:
+
+```md
+# Module Brief — <module title>（<module_id>）
+
+**Evidence locations**
+- Top-level dir / core file: <path>
+- Entry function: <file>:<line>
+
+## Teaching arc
+- One-line "why care" (practical payoff)
+- The key mental model (one core picture the user should leave with)
+- Key-implementation highlights of this module (if any)
+
+## Knowledge point → evidence map (core)
+| Knowledge point | type | snippet (file:line) | one-line note |
+|---|---|---|---|
+| kp01-01 | procedure | `src/main.py:42-58` | the launch entry, responsible for… |
+| kp01-02 | concept | `src/pipeline.py:120-160` | RAG retrieval main chain |
+
+## Pre-extracted snippets (verbatim, with file:line)
+> Only include snippets needed to teach the points; each ≤ 20 lines. Longer → split or write "see <file>:<range> to expand".
+
+### Snippet A — Launch flow (src/main.py:42-58)
+```python
+<verbatim source>
+```
+**Note**: what this does, why this order, where it's easy to go wrong.
+
+### Snippet B — RAG main chain (src/pipeline.py:120-160)
+```python
+<verbatim source>
+```
+**Note**: …
+
+## Pitfalls / traps
+- Where the user is likely to get stuck (anticipate via error types: structural/deviation/application/metacognitive)
+
+## Neighboring module handoff
+- Previous module covers: …
+- Next module covers: …
+
+## Feynman follow-ups for this module (design type)
+- Why not approach B? → evidence-backed answer: …
+```
+
+## Iron rules
+
+- **Snippets must be verbatim**: copy the source unchanged, with `file:line`. Keep notes separate from source; never mix.
+- **Less is more**: only pre-extract what's needed to teach the points. Snippets over 20 lines get a location (`file:line`) in the brief, not the full text.
+- **The brief is an evidence cache, not the authority**: if learning reveals the brief is unclear, go back to source, verify, and update the brief.

--- a/skills/repo-mastery/references/note-template.md
+++ b/skills/repo-mastery/references/note-template.md
@@ -1,0 +1,75 @@
+# Note Template — Note Format
+
+> **Read in**: Phase 3. After each module's explanations/judgments, the tutor **automatically** accumulates key points into `notes/<module>.md`; the user appends personal thoughts/questions/blockers at any time with `/repo-mastery note "<text>"`. Notes are the context for later review and sessions (absorbed from DeepTutor's notebook idea).
+
+## Note file organization
+
+```text
+<repo>/.learning/notes/
+  ├── m01-run-build.md     # one per module; named <module_id>-<slug>.md
+  ├── m02-architecture.md
+  └── README.md            # note index: module → file + one-line status
+```
+
+## Per-module note structure
+
+```md
+# Module N — <title>
+
+> Status: in-progress / mastered / has-blockers
+> Mastery: <module-level average | qualitative result>
+> Last updated: <ISO date> <UTC time>
+
+## Key points (auto-accumulated)
+> Appended after each explanation. Each = one self-checkable takeaway with a source reference (file:line).
+
+- **Takeaway title** — one-sentence conclusion. `src/pipeline.py:120` `RAG main chain: …`
+- …
+
+## Command / config cheatsheet
+> Verbatim, so the user can copy-and-use.
+
+```bash
+deeptutor kb create physics --doc ch1.pdf
+```
+
+## My notes (/note appended)
+> User-appended content, kept verbatim; the tutor never rewrites the user's words.
+
+- 2026-08-07: I don't get why message queue instead of RPC here —— <user text>
+- …
+
+## Blockers
+> Diagnosed blockers (error type + attribution), mapped to review tasks.
+
+| Knowledge point | Blocker | Error type | Status |
+|---|---|---|---|
+| kp01-01 | don't understand async prerequisite | structural | active |
+
+## Feynman self-check
+> When a qualitative point passes, record the distilled version of the user's recital (one line).
+
+- kp01-02 (concept): user recital = "…"
+
+## Resources / primary sources (absorbed from the teach skill)
+> Recommend 1 high-quality primary source per module for going deeper — official docs / design docs / papers / maintainer talks. This is the "keep going on your own" entry point.
+
+- Official docs: <link>
+- Design doc / ADR: <link>
+- Source file worth reading closely: `file:line`
+
+## Due reviews
+> Synced from `progress.json`'s `review_queue`, for quick entry into review in later sessions.
+```
+
+## Division of labor: auto vs manual
+
+- **Auto-accumulated** (tutor's job): key points, command cheatsheet, blocker table, Feynman self-checks, due reviews. Updated after each explanation and judgment.
+- **Manual append** (user's job): `/repo-mastery note "..."` goes verbatim into the "My notes" section. **The tutor never rewrites the user's words** — but may register it as a blocker/review point in the Blockers section.
+
+## Iron rules
+
+- Source references in notes carry `file:line` for traceability.
+- Commands/config must be verbatim (the user will copy them).
+- Notes update **incrementally**: append new content, don't rewrite the whole file (token economy).
+- Review sessions read notes first rather than re-reading source — notes are your long-term memory.

--- a/skills/repo-mastery/references/quiz-design.md
+++ b/skills/repo-mastery/references/quiz-design.md
@@ -1,0 +1,60 @@
+# Quiz Design — Principles (Test Application, Not Memory)
+
+> **Read in**: Phase 3, when posing quantitative questions. This principle is absorbed from docs-to-course's `content-philosophy.md`, adapted for "code understanding".
+
+## The iron rule: test application, not memory
+
+The value of a question is: **a wrong answer reveals "can't use / don't understand", not "didn't memorize"**. Definitions are the job of a glossary tooltip, not a quiz.
+
+**What to test (best first)**:
+1. **"What would you do" scenarios** — "to add feature X to this project, which extension point/module would you use?" Gold standard.
+2. **Tracing** — "which modules does this request pass through, from entry to storage?" Tests call-chain understanding.
+3. **Troubleshooting scenarios** — "startup fails with `ImportError: xxx` — most likely cause and first thing to check?"
+4. **Tradeoff/decision questions** — "for task Z, would you pick A or B? Why?" Tests design understanding.
+5. **"What is it / why"** — short definition + one why.
+
+**What NOT to test**:
+- ❌ Verbatum definitions (that's memory, and scrollable).
+- ❌ Exact flag/argument spelling (unless the point is explicitly a memory type).
+- ❌ Anything answerable by scrolling up.
+
+## Question formats (for code learning)
+
+| Form | Use for | Example |
+|---|---|---|
+| Multiple choice (with scenario) | fast grading, most memory/procedure | "which is the correct config-load precedence? A) … B) … C) …" |
+| Sequencing | call chains / flows | "arrange build → install → launch in the real order" |
+| Fill-in / short answer | procedure, must write it | "after `deeptutor kb create`, which command searches the KB?" |
+| Small code change | understanding a function's behavior | "change one line here to make it output X — which line?" |
+
+## Tone of grading and feedback
+
+- **Wrong answers get encouraging, teaching explanations**: "not quite — B is right here because A bypasses the config-loading layer…" Never punitive, no score anxiety.
+- Correct answers **reinforce the principle**, not just praise.
+- Quantity: 1–3 questions per point is enough to judge; don't inflate.
+
+## Option formatting: no clues (absorbed from the teach skill)
+
+- In multiple choice, keep **every option roughly equal in length** — don't let "the long one is right" leak the answer.
+- Avoid "all of the above / none of the above" cop-out distractors.
+- Distractors should look real — taken from genuinely confusable configs/modules/calls, not invented.
+
+## Retrieval practice first (absorbed from the teach skill)
+
+Grading should force **retrieval from memory**, not "recognizing the answer feels right":
+
+- Short-answer/fill-in > recognition multiple-choice: being able to write the call chain proves storage better than recognizing the right option.
+- Review turns especially use short-answer: the whole point of spaced review is retrieving after forgetting.
+- Frame multiple-choice as "scenario → what would you do", so the user forms the answer in their head before comparing options.
+
+## How grading drives mastery
+
+- Each attempt appends to that point's `quiz_attempts`.
+- `compute_mastery` recomputes (recency-weighted + confidence ceiling; see `mastery-policy.md`).
+- ≥ 0.9 advances; below → back to explain, then pose a **different question** (never the same one — avoid memorizing the answer).
+
+## When not to quiz
+
+- A point already has 2 correct attempts and mastery ≥ 0.9 → pose a harder "deepening" question or just advance.
+- The user explicitly wants to hear the explanation first → respect the pace, explain first.
+- A hands-on verification (procedure) already passed → it counts as evidence; no need to pile on a pointless question.

--- a/skills/repo-mastery/references/quiz-design.md
+++ b/skills/repo-mastery/references/quiz-design.md
@@ -58,3 +58,30 @@ Grading should force **retrieval from memory**, not "recognizing the answer feel
 - A point already has 2 correct attempts and mastery ≥ 0.9 → pose a harder "deepening" question or just advance.
 - The user explicitly wants to hear the explanation first → respect the pace, explain first.
 - A hands-on verification (procedure) already passed → it counts as evidence; no need to pile on a pointless question.
+
+## Flashcard quality standards (absorbed from the flashcards skill)
+
+A quiz/review card is a **self-test, not a reading note**. These rules govern how to craft **`memory`-type and review cards**; the iron rule above still holds — application questions remain the gold standard for comprehension points. Quality rules:
+
+1. **Force recall, not recognition** — ask open questions where the answer must
+   be reconstructed, not recognized from options.
+2. **One card, one fact** — each card asks exactly one thing; keep it short.
+3. **One unambiguous answer** — the question has a single correct answer.
+4. **Answer ≤ 3 lines** — a too-long answer can't be retrieved.
+5. **Understanding before memorizing** — cover fundamentals first, then build up.
+6. **Elaborate and connect** — link the fact to something known, a vivid image, a
+   concrete example; extra retrieval paths make recall easier.
+7. **Context built into the question** — good: "What does `git stash pop`
+   restore?"; bad: "[Git] What does stash pop do?"
+8. **Break up lists** — split enumerations into single questions, or use
+   overlapping cards (A then B, B then C).
+9. **Distinguish similar concepts** — give confusable items distinguishing context.
+10. **Ask both directions** — A→B and B→A strengthen retention.
+11. **Timestamp perishable facts** — add "as of [year]" to current numbers.
+
+Avoid: trivial facts, answers longer than three or four lines, ambiguous
+questions, opinions instead of facts, lists as an answer.
+
+> Low-effectiveness techniques to avoid: summarizing, highlighting, and rereading
+> create **illusions of learning** (recognition ≠ recall). A tutor must never
+> substitute "re-read the summary" for a retrieval question.

--- a/skills/repo-mastery/references/session-flow.md
+++ b/skills/repo-mastery/references/session-flow.md
@@ -1,0 +1,99 @@
+# Session Flow — Interactive Learning Session Protocol
+
+> **Read in**: Phase 3. This is the operating manual for each learning turn. The tutor acts per this protocol every turn; decisions consult the rules in `mastery-policy.md`.
+
+## 0. Session preamble: Mission + ZPD (absorbed from the teach skill)
+
+Before each learning session:
+
+1. **Read MISSION.md** — why the user wants to master this repo. Align every explanation, question, and Feynman follow-up to the Mission (learning to use it? to modify it? to teach it?). If the Mission isn't filled in, ask — don't guess.
+2. **Read `records/` + `progress.json`** — judge the user's **zone of proximal development (ZPD)**: the next thing to teach should be "just challenging enough". Don't re-teach what the user has proven; bridge missing prerequisites before leaping.
+3. Then enter the knowledge point selected by `next_objective`.
+
+## Per-turn learning loop (single knowledge point)
+
+Run the flow for the action `next_objective` returns. **Core loop**:
+
+```text
+diagnostic (probe; includes test-out)
+   → explain
+   → feynman_check
+   → practice (quiz / hands-on)
+   → error_diagnosis (if wrong)
+   → review (spaced-review scheduling)
+   → write back progress.json + auto-note
+```
+
+## 1. diagnostic — first contact with each knowledge point
+
+- Purpose: **probe how much is known and skip what can be skipped (test-out)**; don't force every point through fixed stages.
+- Method: an open probe question — "first, in your own words, what does this knowledge point / module do?" — or a lightweight question.
+- Judgment: if the user explains/answers well → record `mastery_assess passed` or a high-scoring attempt → advance directly, **skipping the explanation**. This is the gate-as-cursor compression path.
+- Can't explain → enter explain.
+
+## 2. explain
+
+- **Explain from source, not from air**: cite specific files, functions, call chains (`file:line`).
+- Follow the per-module arc absorbed from docs-to-course: *"why care" first (1–2 sentences of practical payoff) → concept + one fresh metaphor → look at the code / walk the call chain → recap (3–4 takeaways)*.
+- **Auto-note** after explaining (see `note-template.md`).
+- Control length: one knowledge point, one layer at a time — don't dump three concepts at once.
+
+## 3. feynman_check — qualitative gate (concept / design)
+
+- Have the user recital in their own words: "now explain it back to me as if I'm a beginner."
+- **concept**: judge "what + why + relation to adjacent concepts".
+- **design**: add design-tradeoff follow-ups (see `mastery-policy.md` §6).
+- Result → `qualitative_mastery`; not passed → back to explain, record the error type.
+- **Input form**: the user types their recital in chat (no voice requirement).
+
+## 4. practice — quantitative gate / hands-on
+
+### Quiz (memory / procedure)
+- Follow `quiz-design.md` (**test application, not memory**).
+- **The expected answer goes only into `progress.json.pending_question` — never shown back in the question**.
+- User answers → grade via the **engine script** (deterministic, tool-agnostic):
+  ```bash
+  python3 scripts/learning_engine.py record-attempt <path>/.learning/progress.json \
+      --kp <kp_id> --type procedure --correct --question <qid> --write
+  ```
+- Advance only when the script reports `passed_gate: true` (≥ 0.9); otherwise return to explain + practice more.
+
+### Hands-on on demand (procedure especially)
+- Guide the user to actually verify: "verify it now — run `pytest tests/test_x.py`" or "write a 20-line demo calling this API."
+- **Command convention**:
+  - Read-only/no-side-effect commands (`build`, `test`, `--help`, `git log`): may run directly.
+  - Mutating operations (writing files, installing deps, writing data): **show the command and request approval first**.
+- Record the hands-on result (passed/behavior/user's demo code) as mastery evidence for that point.
+
+## 5. error_diagnosis — when wrong or stuck
+
+- First ask the user to self-attribute: "where do you think you got stuck?" (`self_attribution`).
+- The tutor classifies `error_type` (structural / deviation / application / metacognitive; see `mastery-policy.md` §5) and writes an `error_records` entry (status=active).
+- Create the matching review task (that point's review priority → 1).
+- Reteach: targeted explanation for the error type, then practice again.
+
+## 6. review — due spaced-review tasks
+
+- Pull due tasks by `scheduler`'s `next_review_at` (triggered by `/repo-mastery review`, or automatically when `next_objective` finds something due).
+- Review form: one question per due point (quantitative) or a quick recital (qualitative).
+- Results update `repetition_states` + `review_queue`.
+
+## 7. End of each turn (mandatory)
+
+1. **Atomically write back** `progress.json` (temp file + rename).
+2. **Auto-note / update** the module notes (`notes/<module>.md`).
+3. Update global `~/.repo-mastery/index.json` (where you left off).
+4. Report to the user in one line: current progress (e.g. "module 3/6, points 7/24, mastery 45%").
+
+## Tutor voice during sessions
+
+- You're present (Claude Code session); advance one knowledge point at a time; never cram the whole repo into context.
+- Explain from source, judge by engine — **never replace the gate with "do you feel you've got it?"**.
+- A stuck user is a diagnostic signal, not a teaching failure — guide self-attribution.
+- Keep momentum: close the loop on one point per turn where possible (judge + write back + note).
+
+## Token-saving rules for large repos
+
+- When learning a point, only Read files relevant to it (locate via `course-map.json` evidence paths / `code-map.json`); **don't read the whole repo**.
+- Large repos: consult `code-map.json`'s symbol table to locate `file:line`, then Read the needed slice.
+- Once source snippets are captured in notes, prefer reading the notes over re-reading source in later sessions.

--- a/skills/repo-mastery/references/session-flow.md
+++ b/skills/repo-mastery/references/session-flow.md
@@ -6,6 +6,14 @@
 
 Before each learning session:
 
+0. **Recall warm-up** (absorbed from claude-teach-skill): pose **2–3 quick
+   recall questions** drawn from `review_queue` (due first, then soonest
+   `due_at`). Each answer goes through `record_attempt` (updates mastery /
+   difficulty / stability / schedule). A forgotten point → re-teach it before
+   anything new, and record the error. This forces retrieval from storage, not
+   recognition. A correct warm-up answer feeds `consecutive_correct` →
+   `stability`, so a good warm-up streak lengthens the next interval.
+
 1. **Read MISSION.md** — why the user wants to master this repo. Align every explanation, question, and Feynman follow-up to the Mission (learning to use it? to modify it? to teach it?). If the Mission isn't filled in, ask — don't guess.
 2. **Read `records/` + `progress.json`** — judge the user's **zone of proximal development (ZPD)**: the next thing to teach should be "just challenging enough". Don't re-teach what the user has proven; bridge missing prerequisites before leaping.
 3. Then enter the knowledge point selected by `next_objective`.
@@ -37,6 +45,10 @@ diagnostic (probe; includes test-out)
 - Follow the per-module arc absorbed from docs-to-course: *"why care" first (1–2 sentences of practical payoff) → concept + one fresh metaphor → look at the code / walk the call chain → recap (3–4 takeaways)*.
 - **Auto-note** after explaining (see `note-template.md`).
 - Control length: one knowledge point, one layer at a time — don't dump three concepts at once.
+- **Vivid encoding (optional, `memory`-type points)**: offer a memorable
+  hook — an exaggerated image, a color/action cue, a pun, an interaction
+  (SMASHIN-style: Senses, Movement, Action, Humor, Imagination, Numbers) — or let the learner ask for a mnemonic / mini memory-palace.
+  Encoding is a *suggested* aid, never graded.
 
 ## 3. feynman_check — qualitative gate (concept / design)
 
@@ -77,6 +89,9 @@ diagnostic (probe; includes test-out)
 - Pull due tasks by `scheduler`'s `next_review_at` (triggered by `/repo-mastery review`, or automatically when `next_objective` finds something due).
 - Review form: one question per due point (quantitative) or a quick recital (qualitative).
 - Results update `repetition_states` + `review_queue`.
+- **Interleave types**: when several reviews are due, alternate knowledge types
+  (memory → concept → procedure → design) instead of grinding one type; `next_objective`
+  already prefers a type different from `last_review_type`.
 
 ## 7. End of each turn (mandatory)
 
@@ -91,6 +106,7 @@ diagnostic (probe; includes test-out)
 - Explain from source, judge by engine — **never replace the gate with "do you feel you've got it?"**.
 - A stuck user is a diagnostic signal, not a teaching failure — guide self-attribution.
 - Keep momentum: close the loop on one point per turn where possible (judge + write back + note).
+- Ask **one question at a time** (batching is bewildering). When a decision is needed, offer your evidence-based recommendation with the question; assessment questions (quiz / Feynman) never carry a hint (absorbed from the grilling skill).
 
 ## Token-saving rules for large repos
 

--- a/skills/repo-mastery/scripts/index_repo.py
+++ b/skills/repo-mastery/scripts/index_repo.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""index_repo.py — 为大型仓库生成 code-map.json（模块 / 依赖 / 符号定位）。
+
+repo-mastery 在 Phase 0 判定仓库为大型时运行本脚本。输出一个轻量代码索引，
+让学习会话可以按"文件:行"按需定位源码，而不用把整仓塞进上下文。
+
+纯标准库实现，无第三方依赖。定位粒度是"模块边界 + 依赖边 + 入口点"，
+不做完整语法树 —— 那是 tree-sitter 的事，对这个 skill 是过度设计。
+
+用法:
+    python3 index_repo.py <repo_path> [-o code-map.json] [--top N]
+
+输出:
+    code-map.json —— 结构见下方 SCHEMA 常量。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter
+
+# 目录/文件黑名单：绝不进索引（避免把依赖、构建产物、版本库扫进来）。
+SKIP_DIRS = {
+    ".git", ".hg", ".svn", "node_modules", "vendor", ".venv", "venv",
+    "__pycache__", ".next", ".nuxt", "dist", "build", "target", "out",
+    ".idea", ".vscode", ".gradle", "coverage", ".tox", ".mypy_cache",
+    ".pytest_cache", ".ruff_cache", "site-packages", "bower_components",
+}
+SKIP_FILES = {"package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock", "Cargo.lock"}
+
+# 语言 → 扩展名集合。只统计这些"源文件"，其余（图片/文档/二进制）不进统计。
+LANG_EXTS: dict[str, set[str]] = {
+    "python": {".py", ".pyi"},
+    "typescript": {".ts", ".tsx"},
+    "javascript": {".js", ".jsx", ".mjs", ".cjs"},
+    "rust": {".rs"},
+    "go": {".go"},
+    "java": {".java"},
+    "kotlin": {".kt", ".kts"},
+    "c": {".c", ".h"},
+    "cpp": {".cpp", ".cc", ".hpp", ".hxx", ".cxx"},
+    "ruby": {".rb"},
+    "php": {".php"},
+    "swift": {".swift"},
+    "shell": {".sh", ".bash", ".zsh"},
+    "sql": {".sql"},
+    "vue": {".vue"},
+    "svelte": {".svelte"},
+}
+
+# 各语言的"本地模块/依赖"提取正则（保守，只抓明显的相对导入）。
+# 组 1 = 被导入的路径。匹配相对导入（以 . 开头）或项目内顶层模块。
+IMPORT_PATTERNS: dict[str, re.Pattern] = {
+    "python": re.compile(r"^\s*(?:from\s+([.\w]+)\s+import|import\s+([.\w]+))", re.M),
+    "typescript": re.compile(r"(?:import\s+(?:[\w*{},\s]+\s+from\s+)?|from\s+)['\"]([^'\"]+)['\"]"),
+    "javascript": re.compile(r"(?:import\s+(?:[\w*{},\s]+\s+from\s+)?|require\s*\(\s*)['\"]([^'\"]+)['\"]"),
+    "go": re.compile(r"^\s*\"([^\"]+)\"|^\s*[a-z0-9_]+\s+\"([^\"]+)\"", re.M),
+    "rust": re.compile(r"^\s*(?:use\s+|mod\s+|pub\s+use\s+)([^\s;]+)", re.M),
+    "java": re.compile(r"^\s*import\s+([.\w]+);", re.M),
+    "kotlin": re.compile(r"^\s*import\s+([.\w]+)", re.M),
+    "c": re.compile(r"^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]", re.M),
+    "cpp": re.compile(r"^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]", re.M),
+}
+
+
+def classify(rel_path: str) -> str | None:
+    """按扩展名返回语言名，非源文件返回 None。"""
+    ext = os.path.splitext(rel_path)[1].lower()
+    for lang, exts in LANG_EXTS.items():
+        if ext in exts:
+            return lang
+    return None
+
+
+def is_skip_dir(name: str) -> bool:
+    return name in SKIP_DIRS or name.startswith(".")
+
+
+def scan(repo: str, top: int) -> dict:
+    """扫描仓库，返回 code-map 字典。"""
+    by_lang: Counter = Counter()
+    by_topdir: Counter = Counter()
+    files: list[dict] = []
+    imports: dict[str, list[str]] = {}
+    entry_points: list[str] = []
+    total_lines = 0
+
+    for dirpath, dirnames, filenames in os.walk(repo):
+        # 原地过滤黑名单目录，避免继续下探。
+        dirnames[:] = [d for d in dirnames if not is_skip_dir(d)]
+        for fname in filenames:
+            if fname in SKIP_FILES:
+                continue
+            full = os.path.join(dirpath, fname)
+            rel = os.path.relpath(full, repo)
+            lang = classify(rel)
+            if lang is None:
+                continue
+            try:
+                with open(full, "r", encoding="utf-8", errors="ignore") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            line_count = content.count("\n") + 1
+            total_lines += line_count
+            by_lang[lang] += 1
+            topdir = rel.split(os.sep)[0]
+            by_topdir[topdir] += 1
+            files.append({"path": rel, "lang": lang, "lines": line_count})
+
+            # 提取依赖边。
+            pat = IMPORT_PATTERNS.get(lang)
+            if pat:
+                deps = []
+                for m in pat.finditer(content):
+                    dep = m.group(1) or m.group(2)
+                    if dep:
+                        deps.append(dep)
+                imports[rel] = deps[:40]  # 单文件最多记 40 条，防失控
+
+    # 探测入口点（常见约定）。
+    entry_points = detect_entry_points(repo)
+
+    # 顶层目录统计（前 top 名）。
+    topdirs = [{"name": k, "files": v} for k, v in by_topdir.most_common(top)]
+
+    # 依赖图只保留"项目内"边（相对导入 或 与某顶层目录同名的模块），
+    # 外部包/标准库不进入图 —— 图的目的是看模块间耦合，不是依赖清单。
+    internal = {d["path"] for d in files}
+    topdir_set = {d["name"] for d in topdirs}
+    graph: dict[str, list[str]] = {}
+    for src, deps in imports.items():
+        kept = []
+        for dep in deps:
+            d = dep.lstrip(".")
+            d = d.split("/")[0].split(".")[0]
+            if d in internal or d in topdir_set or d in {"src", "lib"}:
+                kept.append(d)
+        if kept:
+            graph[src] = sorted(set(kept))
+
+    return {
+        "repo": os.path.basename(os.path.abspath(repo)),
+        "generated": True,
+        "summary": {
+            "total_source_files": len(files),
+            "total_lines": total_lines,
+            "languages": dict(by_lang.most_common()),
+            "top_dirs": topdirs,
+        },
+        "entry_points": entry_points,
+        "dependency_graph": graph,          # 仅项目内边
+        "files": files,                     # 未排序；tutor 可按 lines 降序取最重文件
+        "symbol_lookup": build_symbol_lookup(files),  # 语言 → 重文件清单
+    }
+
+
+def detect_entry_points(repo: str) -> list[str]:
+    """常见入口约定：package.json bin/main、pyproject 脚本、main.* 等。"""
+    found: list[str] = []
+
+    pkg = os.path.join(repo, "package.json")
+    if os.path.isfile(pkg):
+        try:
+            with open(pkg, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = {}
+        for key in ("bin", "main"):
+            val = data.get(key)
+            if isinstance(val, str):
+                found.append(f"package.json/{key}: {val}")
+            elif isinstance(val, dict):
+                for name, path in list(val.items())[:10]:
+                    found.append(f"package.json/bin.{name}: {path}")
+
+    for name in ("pyproject.toml", "setup.py"):
+        if os.path.isfile(os.path.join(repo, name)):
+            found.append(f"{name}（含入口脚本配置，见内容）")
+
+    for pattern in ("main.py", "app.py", "cli.py", "manage.py"):
+        if os.path.isfile(os.path.join(repo, pattern)):
+            found.append(pattern)
+
+    return found
+
+
+def build_symbol_lookup(files: list[dict]) -> dict[str, list[str]]:
+    """为最重的文件生成"符号级定位提示"：语言 → 可能含定义的重文件清单。
+
+    不做语法分析，启发式足够：tutor 拿到清单后再 Read 对应文件精确定位。
+    按行数降序取每语言前 30 个文件，供 map 阶段优先审视。
+    """
+    buckets: dict[str, list[tuple[int, str]]] = {}
+    for f in files:
+        if f["lines"] < 60:
+            continue
+        buckets.setdefault(f["lang"], []).append((f["lines"], f["path"]))
+    return {
+        lang: [p for _, p in sorted(items, reverse=True)[:30]]
+        for lang, items in buckets.items()
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="生成 repo-mastery 的代码索引 code-map.json")
+    ap.add_argument("repo", help="要索引的仓库路径")
+    ap.add_argument("-o", "--output", default="code-map.json", help="输出文件路径")
+    ap.add_argument("--top", type=int, default=15, help="顶层目录统计数量")
+    args = ap.parse_args()
+
+    code_map = scan(args.repo, args.top)
+    tmp = args.output + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(code_map, fh, ensure_ascii=False, indent=2)
+    os.replace(tmp, args.output)  # 原子写，避免半成品
+    s = code_map["summary"]
+    print(f"已生成 {args.output}")
+    print(f"  源文件 {s['total_source_files']} 个，共 {s['total_lines']} 行")
+    print(f"  语言: {', '.join(f'{k}({v})' for k, v in s['languages'].items())}")
+    print(f"  顶层目录: {', '.join(d['name'] for d in s['top_dirs'])}")
+    print(f"  入口点: {', '.join(code_map['entry_points'][:5]) or '未探测到'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/repo-mastery/scripts/install.sh
+++ b/skills/repo-mastery/scripts/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# install.sh — install repo-mastery as a native skill across AI CLI tools.
+#
+# By default installs to:
+#   Claude Code : ~/.claude/skills/repo-mastery
+#   Codex       : ~/.codex/skills/repo-mastery      (Agent Skills standard)
+#   Gemini CLI  : ${GEMINI_SKILLS_DIR:-~/.gemini/skills}/repo-mastery
+#
+# Options:
+#   --only <tool>    install only one tool (claude|codex|gemini)
+#   --skip <tool>    skip one tool (repeatable)
+#   --dry-run        print what would happen, don't copy
+#   --help           show this help
+#
+# Examples:
+#   ./scripts/install.sh                    # install everywhere
+#   ./scripts/install.sh --only codex       # Codex only
+#   GEMINI_SKILLS_DIR=$HOME/.config/gemini/skills ./scripts/install.sh
+
+set -euo pipefail
+
+# Resolve the skill source. When run via `curl ... | bash` there is no local
+# checkout, so fetch the latest tarball from GitHub.
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)"
+if [ ! -f "$SRC/SKILL.md" ]; then
+  echo "No local checkout — fetching repo-mastery from GitHub…"
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  curl -fsSL https://github.com/DieselZhang/repo-mastery/archive/refs/heads/main.tar.gz \
+    | tar -xz -C "$TMP"
+  SRC="$TMP/repo-mastery-main"
+fi
+
+CLAUDE_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
+CODEX_DIR="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+GEMINI_DIR="${GEMINI_SKILLS_DIR:-$HOME/.gemini/skills}"
+
+copy_skill() {
+  local dest="$1"
+  mkdir -p "$dest"
+  # copy the skill root, excluding .git
+  cp -R "$SRC" "$dest/repo-mastery" 2>/dev/null && rm -rf "$dest/repo-mastery/.git"
+}
+
+dry_run=0
+only=""
+skip=()
+for arg in "$@"; do
+  case "$arg" in
+    --only) only="__MISSING__" ;;
+    --only=*) only="${arg#--only=}" ;;
+    --skip) skip+=("__MISSING__") ;;
+    --skip=*) skip+=("${arg#--skip=}") ;;
+    --dry-run) dry_run=1 ;;
+    --help|-h) sed -n '1,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) [ "$only" = "__MISSING__" ] && only="$arg" || skip+=("$arg") ;;
+  esac
+done
+
+want() { # want <tool> -> 0 if should install
+  [ -n "$only" ] && [ "$only" != "$1" ] && return 1
+  for s in ${skip[@]+"${skip[@]}"}; do [ "$s" = "$1" ] && return 1; done
+  return 0
+}
+
+installed=()
+if want claude; then
+  echo "→ Claude Code : $CLAUDE_DIR/repo-mastery"
+  [ "$dry_run" -eq 0 ] && copy_skill "$CLAUDE_DIR" && installed+=("claude")
+fi
+if want codex; then
+  echo "→ Codex       : $CODEX_DIR/repo-mastery"
+  [ "$dry_run" -eq 0 ] && copy_skill "$CODEX_DIR" && installed+=("codex")
+fi
+if want gemini; then
+  echo "→ Gemini CLI  : $GEMINI_DIR/repo-mastery"
+  [ "$dry_run" -eq 0 ] && copy_skill "$GEMINI_DIR" && installed+=("gemini")
+fi
+
+if [ "$dry_run" -eq 0 ]; then
+  echo ""
+  echo "✅ Installed repo-mastery to: ${installed[*]:-none}"
+  echo "   Restart your CLI, then try:"
+  echo "     Claude Code : /repo-mastery start <repo>"
+  echo "     Codex       : mention 'repo-mastery' or ask to master a repo"
+  echo "     Gemini      : activate_skill(repo-mastery)"
+else
+  echo ""
+  echo "（dry-run）No files were copied."
+fi

--- a/skills/repo-mastery/scripts/learning_engine.py
+++ b/skills/repo-mastery/scripts/learning_engine.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""learning_engine.py — the deterministic mastery engine for repo-mastery.
+
+This is the single source of truth for the *gate*: whether a learner may
+advance is computed here in pure, tool-agnostic code — NOT interpreted from
+prose by whatever LLM/tool happens to be tutoring. Every platform (Claude
+Code, Codex, Gemini CLI, opencode, ...) calls this script for the same
+deterministic answers, so mastery math can never drift between tools.
+
+Pure stdlib. JSON in, JSON out. The math mirrors references/mastery-policy.md.
+
+Subcommands:
+    compute-mastery <correctness.json>          recency-weighted accuracy + confidence cap
+    schedule <type> <is_correct> [state.json]   spaced-repetition state transition
+    record-attempt <progress.json> <opts...>    record a quiz/hands-on attempt
+    next-objective <progress.json>              what the tutor should do next
+    validate-map <course-map.json>              check a course map's schema
+    init <repo_path> [--force]                  create .learning/ scaffolding + .gitignore
+
+Examples:
+    python3 learning_engine.py compute-mastery '[true,false,true]'
+    python3 learning_engine.py schedule procedure false '{"interval_index":0,"consecutive_correct":0,"consecutive_wrong":0}'
+    python3 learning_engine.py next-objective .learning/progress.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+# --- constants (single source of truth; keep in sync with mastery-policy.md) ---
+
+# Newer attempts weigh more, so recovery after early mistakes is rewarded.
+RECENCY_WEIGHTS: tuple[float, ...] = (0.5, 0.7, 0.85, 0.95, 1.0)
+
+# Mastery cannot exceed this until enough evidence accumulates: one lucky
+# answer can never "master" a point.
+CONFIDENCE_CAP: dict[int, float] = {1: 0.5, 2: 0.8}
+
+# Quantitative gate — the learner must reach this mastery before advancing
+# (~0.9 mirrors Alpha School's "90% before you advance").
+QUANTITATIVE_GATE: float = 0.9
+
+# Qualitative types are gated by a Feynman-style explanation judged by the
+# tutor (a boolean), not by graded accuracy.
+QUALITATIVE_TYPES: frozenset[str] = frozenset({"concept", "design"})
+
+# Spaced-repetition intervals in days, per knowledge type.
+INTERVAL_SEQUENCES: dict[str, list[int]] = {
+    "memory": [0, 1, 3, 7, 14, 30],
+    "concept": [3, 7, 14, 30],
+    "procedure": [3, 7, 14],
+    "design": [14, 28],
+}
+
+# Base review priority by type; error records raise it to 1 (highest).
+TYPE_PRIORITY: dict[str, int] = {
+    "memory": 2, "concept": 3, "procedure": 4, "design": 5,
+}
+
+VALID_TYPES: frozenset[str] = frozenset(
+    {"memory", "concept", "procedure", "design"}
+)
+
+
+# --- core pure functions ---
+
+def compute_mastery(correctness: list[bool]) -> float:
+    """Recency-weighted accuracy over the latest up-to-5 attempts, capped by
+    the confidence ceiling. Returns a 0..1 mastery score."""
+    if not correctness:
+        return 0.0
+    recent = correctness[-len(RECENCY_WEIGHTS):]
+    weights = RECENCY_WEIGHTS[-len(recent):]
+    score = sum(w * (1.0 if c else 0.0) for c, w in zip(recent, weights)) / sum(weights)
+    return min(score, CONFIDENCE_CAP.get(len(recent), 1.0))
+
+
+def schedule_next(
+    kp_type: str,
+    is_correct: bool,
+    state: dict,
+) -> dict:
+    """Advance a repetition state per the interval sequence for *kp_type*.
+
+    Correct: consecutive_correct += 1; two in a row → interval_index +2.
+    Wrong:   consecutive_wrong += 1; interval_index steps back 1 (floor 0).
+    Returns the new state dict with next_review_at in Unix seconds.
+    """
+    intervals = INTERVAL_SEQUENCES.get(kp_type, INTERVAL_SEQUENCES["memory"])
+    max_index = len(intervals) - 1
+    state = dict(state)
+    state.setdefault("interval_index", 0)
+    state.setdefault("consecutive_correct", 0)
+    state.setdefault("consecutive_wrong", 0)
+
+    if is_correct:
+        state["consecutive_wrong"] = 0
+        state["consecutive_correct"] += 1
+        if state["consecutive_correct"] >= 2:
+            state["interval_index"] += 2
+            state["consecutive_correct"] = 0
+        else:
+            state["interval_index"] += 1
+    else:
+        state["consecutive_wrong"] += 1
+        state["consecutive_correct"] = 0
+        state["interval_index"] = max(0, state["interval_index"] - 1)
+        if state["consecutive_wrong"] >= 2:
+            state["consecutive_wrong"] = 0
+
+    state["interval_index"] = max(0, min(state["interval_index"], max_index))
+    days = intervals[state["interval_index"]]
+    state["next_review_at"] = int(time.time()) + days * 86400
+    return state
+
+
+def is_mastered(progress: dict, kp_id: str, kp_type: str) -> bool:
+    """Whether a knowledge point clears its gate (quantitative or qualitative)."""
+    if kp_type in QUALITATIVE_TYPES:
+        return bool(progress.get("qualitative_mastery", {}).get(kp_id, False))
+    return progress.get("mastery_levels", {}).get(kp_id, 0.0) >= QUANTITATIVE_GATE
+
+
+def objective_status(progress: dict, kp_id: str, kp_type: str) -> str:
+    """'mastered' | 'learning' | 'new' for one knowledge point."""
+    if is_mastered(progress, kp_id, kp_type):
+        return "mastered"
+    seen = any(a.get("knowledge_point_id") == kp_id for a in progress.get("quiz_attempts", []))
+    if kp_id in progress.get("qualitative_mastery", {}):
+        seen = True
+    return "learning" if seen else "new"
+
+
+def next_objective(progress: dict, *, now: int | None = None) -> dict:
+    """Decide the next thing to work on. The gate IS the cursor:
+    advancement is computed from what is mastered, never a stage counter.
+
+    Precedence: 1) pending question  2) due spaced review  3) first
+    unmastered point (probe / practice / assess)  4) complete.
+    """
+    now = int(time.time()) if now is None else now
+    kps = _all_knowledge_points(progress)
+
+    # 1) grade any posed question before moving on.
+    pending = progress.get("pending_question")
+    if pending:
+        kp = _find(kps, pending.get("knowledge_point_id"))
+        return {
+            "action": "answer_pending",
+            "knowledge_point_id": pending.get("knowledge_point_id"),
+            "knowledge_point_type": kp["type"] if kp else "",
+            "pending_prompt": pending.get("prompt", ""),
+            "reason": "A posed question awaits the learner's answer.",
+        }
+
+    # 2) due spaced-repetition reviews.
+    due = [t for t in progress.get("review_queue", []) if t.get("due_at", 0) <= now]
+    due.sort(key=lambda t: t.get("priority", 99))
+    if due:
+        task = due[0]
+        kp = _find(kps, task.get("knowledge_point_id"))
+        return {
+            "action": "review",
+            "knowledge_point_id": task.get("knowledge_point_id"),
+            "knowledge_point_type": kp["type"] if kp else "",
+            "reason": "This objective is due for spaced-repetition review.",
+        }
+
+    # 3) first unmastered point in module order, then knowledge-point order.
+    error_kps = {
+        e.get("knowledge_point_id") for e in progress.get("error_records", [])
+        if e.get("status") in ("active", "retrying")
+    }
+    for module in sorted(progress.get("modules", []), key=lambda m: m.get("order", 0)):
+        for kp in module.get("knowledge_points", []):
+            kp_id, kp_type = kp.get("id"), kp.get("type", "concept")
+            if is_mastered(progress, kp_id, kp_type):
+                continue
+            status = objective_status(progress, kp_id, kp_type)
+            if status == "new":
+                action = "probe"          # test-out: probe before teaching
+            elif kp_type in QUALITATIVE_TYPES:
+                action = "assess"         # Feynman check
+            else:
+                action = "practice"       # below the quantitative gate
+            return {
+                "action": action,
+                "module_id": module.get("id"),
+                "module_name": module.get("name"),
+                "knowledge_point_id": kp_id,
+                "knowledge_point_name": kp.get("name"),
+                "knowledge_point_type": kp_type,
+                "status": status,
+                "mastery": round(progress.get("mastery_levels", {}).get(kp_id, 0.0), 3),
+                "threshold": QUANTITATIVE_GATE,
+                "has_error": kp_id in error_kps,
+                "reason": (
+                    "Untouched objective — probe to let the learner test out."
+                    if status == "new"
+                    else "Objective is below its mastery gate; keep working it."
+                ),
+            }
+
+    # 4) done.
+    return {"action": "complete", "reason": "All objectives mastered and nothing due."}
+
+
+def record_attempt(progress: dict, *, kp_id: str, kp_type: str, is_correct: bool,
+                   question_id: str = "", error_type: str | None = None,
+                   hands_on_pass: bool = False) -> dict:
+    """Apply a quiz/hands-on attempt to progress.json (in place) and return
+    the updated mastery for the point.
+
+    Updates: quiz_attempts, mastery_levels (via compute_mastery),
+    repetition_states + review_queue (via schedule_next), error_records,
+    and clears pending_question when this attempt answers it.
+    """
+    progress.setdefault("mastery_levels", {})
+    progress.setdefault("knowledge_types", {})
+    progress.setdefault("quiz_attempts", [])
+    progress.setdefault("repetition_states", {})
+    progress.setdefault("review_queue", [])
+    progress.setdefault("error_records", [])
+    progress["knowledge_types"][kp_id] = kp_type
+
+    # hands-on pass for a procedure point counts as a correct attempt.
+    correct = bool(is_correct or hands_on_pass)
+
+    progress["quiz_attempts"].append({
+        "question_id": question_id,
+        "knowledge_point_id": kp_id,
+        "is_correct": correct,
+        "error_type": error_type,
+        "timestamp": int(time.time()),
+    })
+
+    # recompute quantitative mastery from the full history of this point.
+    history = [a["is_correct"] for a in progress["quiz_attempts"] if a["knowledge_point_id"] == kp_id]
+    progress["mastery_levels"][kp_id] = compute_mastery(history)
+
+    # advance spaced repetition.
+    state = progress["repetition_states"].get(kp_id, {
+        "interval_index": 0, "consecutive_correct": 0, "consecutive_wrong": 0,
+    })
+    new_state = schedule_next(kp_type, correct, state)
+    progress["repetition_states"][kp_id] = new_state
+
+    # error record when wrong.
+    if not correct and error_type:
+        progress["error_records"].append({
+            "id": f"e{int(time.time())}",
+            "question_id": question_id,
+            "knowledge_point_id": kp_id,
+            "error_type": error_type,
+            "status": "active",
+            "created_at": int(time.time()),
+        })
+
+    # clear a pending question if this attempt answers it.
+    pending = progress.get("pending_question")
+    if pending and (not question_id or pending.get("question_id") == question_id):
+        progress["pending_question"] = None
+
+    _rebuild_review_queue(progress)
+    return {
+        "mastery": round(progress["mastery_levels"][kp_id], 3),
+        "passed_gate": progress["mastery_levels"][kp_id] >= QUANTITATIVE_GATE,
+        "next_review_at": new_state.get("next_review_at"),
+    }
+
+
+def validate_map(course_map: dict) -> list[str]:
+    """Return a list of problems in a course map (empty = valid)."""
+    problems: list[str] = []
+    if not isinstance(course_map, dict) or "modules" not in course_map:
+        return ["course-map.json must be an object with a 'modules' array"]
+    for module in course_map["modules"]:
+        mid = module.get("id", "?")
+        for kp in module.get("knowledge_points", []):
+            if kp.get("type") not in VALID_TYPES:
+                problems.append(f"{mid}/{kp.get('id')}: invalid type {kp.get('type')!r} "
+                                f"(must be one of {sorted(VALID_TYPES)})")
+        if module.get("order") is None:
+            problems.append(f"{mid}: missing 'order'")
+    return problems
+
+
+def init_scaffold(repo_path: str, force: bool = False) -> list[str]:
+    """Create .learning/ scaffolding + .gitignore under *repo_path*."""
+    learning = os.path.join(repo_path, ".learning")
+    created: list[str] = []
+    if os.path.isdir(learning) and not force:
+        return ["already exists; pass --force to re-create"]
+    for sub in ("", "notes", "records", "briefs"):
+        d = os.path.join(learning, sub)
+        if not os.path.isdir(d):
+            os.makedirs(d, exist_ok=True)
+            created.append(d)
+    gi = os.path.join(learning, ".gitignore")
+    if not os.path.isfile(gi) or force:
+        with open(gi, "w", encoding="utf-8") as fh:
+            fh.write(".learning/\n")
+        created.append(gi)
+    return created
+
+
+# --- helpers ---
+
+def _all_knowledge_points(progress: dict) -> list[dict]:
+    out: list[dict] = []
+    for module in progress.get("modules", []):
+        for kp in module.get("knowledge_points", []):
+            out.append(kp)
+    return out
+
+
+def _find(kps: list[dict], kp_id: str | None) -> dict | None:
+    return next((k for k in kps if k.get("id") == kp_id), None)
+
+
+def _rebuild_review_queue(progress: dict) -> None:
+    """Rebuild review_queue from repetition_states + error priority."""
+    now = int(time.time())
+    error_kps = {
+        e.get("knowledge_point_id") for e in progress.get("error_records", [])
+        if e.get("status") in ("active", "retrying")
+    }
+    queue: list[dict] = []
+    for kp_id, state in progress.get("repetition_states", {}).items():
+        kp_type = progress.get("knowledge_types", {}).get(kp_id, "memory")
+        priority = 1 if kp_id in error_kps else TYPE_PRIORITY.get(kp_type, 5)
+        queue.append({
+            "id": f"review_{kp_id}",
+            "knowledge_point_id": kp_id,
+            "knowledge_type": kp_type,
+            "due_at": state.get("next_review_at", now),
+            "priority": priority,
+            "state": state,
+        })
+    progress["review_queue"] = queue
+
+
+# --- CLI ---
+
+def _json_arg(value: str):
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"invalid JSON: {exc}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(prog="learning_engine", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("compute-mastery", help="recency-weighted mastery from correctness list")
+    p.add_argument("correctness", type=_json_arg, help='JSON bool list, e.g. "[true,false,true]"')
+
+    p = sub.add_parser("schedule", help="spaced-repetition state transition")
+    p.add_argument("type", choices=sorted(VALID_TYPES))
+    p.add_argument("is_correct", type=_json_arg, help="true|false")
+    p.add_argument("state", nargs="?", type=_json_arg, default="{}",
+                   help='current repetition state JSON (optional)')
+
+    p = sub.add_parser("record-attempt", help="apply an attempt to progress.json")
+    p.add_argument("progress", help="path to progress.json")
+    p.add_argument("--kp", required=True, help="knowledge point id")
+    p.add_argument("--type", choices=sorted(VALID_TYPES), required=True)
+    p.add_argument("--correct", action="store_true", help="attempt was correct")
+    p.add_argument("--hands-on", action="store_true", help="hands-on verification passed")
+    p.add_argument("--question", default="", help="question id (clears matching pending)")
+    p.add_argument("--error", default=None, help="error type: structural|deviation|application|metacognitive")
+    p.add_argument("--write", action="store_true", help="write changes back to the file")
+
+    p = sub.add_parser("next-objective", help="what the tutor should do next")
+    p.add_argument("progress", help="path to progress.json")
+
+    p = sub.add_parser("validate-map", help="check a course map's schema")
+    p.add_argument("course_map", help="path to course-map.json")
+
+    p = sub.add_parser("init", help="create .learning/ scaffolding")
+    p.add_argument("repo_path")
+    p.add_argument("--force", action="store_true")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "compute-mastery":
+        print(json.dumps({"mastery": round(compute_mastery(args.correctness), 3)}))
+
+    elif args.cmd == "schedule":
+        out = schedule_next(args.type, bool(args.is_correct), args.state)
+        print(json.dumps(out))
+
+    elif args.cmd == "record-attempt":
+        progress = _load_json(args.progress)
+        result = record_attempt(
+            progress, kp_id=args.kp, kp_type=args.type,
+            is_correct=args.correct, question_id=args.question,
+            error_type=args.error, hands_on_pass=args.hands_on,
+        )
+        if args.write:
+            _atomic_write(args.progress, progress)
+        print(json.dumps(result))
+
+    elif args.cmd == "next-objective":
+        progress = _load_json(args.progress)
+        print(json.dumps(next_objective(progress)))
+
+    elif args.cmd == "validate-map":
+        problems = validate_map(_load_json(args.course_map))
+        if problems:
+            print(json.dumps({"valid": False, "problems": problems}))
+            sys.exit(1)
+        print(json.dumps({"valid": True, "problems": []}))
+
+    elif args.cmd == "init":
+        print(json.dumps({"created": init_scaffold(args.repo_path, args.force)}))
+
+
+def _load_json(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"cannot read {path}: {exc}")
+
+
+def _atomic_write(path: str, data: dict) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/repo-mastery/scripts/learning_engine.py
+++ b/skills/repo-mastery/scripts/learning_engine.py
@@ -84,11 +84,13 @@ def schedule_next(
     is_correct: bool,
     state: dict,
 ) -> dict:
-    """Advance a repetition state per the interval sequence for *kp_type*.
+    """Advance a repetition state with FSRS-inspired personalized scheduling.
 
-    Correct: consecutive_correct += 1; two in a row → interval_index +2.
-    Wrong:   consecutive_wrong += 1; interval_index steps back 1 (floor 0).
-    Returns the new state dict with next_review_at in Unix seconds.
+    Each knowledge point carries a `difficulty` (0.1..1.0, how hard it is for
+    this learner) and a `stability` (1.0..5.0, how durable the memory is). The
+    review interval is the base interval scaled by stability and reduced by
+    difficulty, so hard points are reviewed sooner and stable points deferred.
+    Pure stdlib; deterministic; matches references/mastery-policy.md §3.
     """
     intervals = INTERVAL_SEQUENCES.get(kp_type, INTERVAL_SEQUENCES["memory"])
     max_index = len(intervals) - 1
@@ -96,10 +98,16 @@ def schedule_next(
     state.setdefault("interval_index", 0)
     state.setdefault("consecutive_correct", 0)
     state.setdefault("consecutive_wrong", 0)
+    state.setdefault("difficulty", 0.5)
+    state.setdefault("stability", 1.0)
 
     if is_correct:
         state["consecutive_wrong"] = 0
         state["consecutive_correct"] += 1
+        state["difficulty"] = max(0.1, state["difficulty"] - 0.05)
+        state["stability"] = min(
+            5.0, state["stability"] * (1 + 0.2 * min(state["consecutive_correct"], 5))
+        )
         if state["consecutive_correct"] >= 2:
             state["interval_index"] += 2
             state["consecutive_correct"] = 0
@@ -109,12 +117,15 @@ def schedule_next(
         state["consecutive_wrong"] += 1
         state["consecutive_correct"] = 0
         state["interval_index"] = max(0, state["interval_index"] - 1)
+        state["difficulty"] = min(1.0, state["difficulty"] + 0.15)
+        state["stability"] = max(1.0, state["stability"] * 0.5)
         if state["consecutive_wrong"] >= 2:
             state["consecutive_wrong"] = 0
 
     state["interval_index"] = max(0, min(state["interval_index"], max_index))
-    days = intervals[state["interval_index"]]
-    state["next_review_at"] = int(time.time()) + days * 86400
+    base_days = intervals[state["interval_index"]]
+    days = base_days * state["stability"] * (1 - state["difficulty"] * 0.5)
+    state["next_review_at"] = int(time.time()) + int(days * 86400)
     return state
 
 
@@ -157,9 +168,15 @@ def next_objective(progress: dict, *, now: int | None = None) -> dict:
             "reason": "A posed question awaits the learner's answer.",
         }
 
-    # 2) due spaced-repetition reviews.
+    # 2) due spaced-repetition reviews. Equal-priority reviews interleave
+    #    types: a review whose type differs from the last one wins, so
+    #    consecutive reviews mix types instead of stacking one type.
     due = [t for t in progress.get("review_queue", []) if t.get("due_at", 0) <= now]
-    due.sort(key=lambda t: t.get("priority", 99))
+    last_type = progress.get("last_review_type")
+    due.sort(key=lambda t: (
+        t.get("priority", 99),
+        1 if last_type and t.get("knowledge_type") == last_type else 0,
+    ))
     if due:
         task = due[0]
         kp = _find(kps, task.get("knowledge_point_id"))
@@ -265,6 +282,7 @@ def record_attempt(progress: dict, *, kp_id: str, kp_type: str, is_correct: bool
     if pending and (not question_id or pending.get("question_id") == question_id):
         progress["pending_question"] = None
 
+    progress["last_review_type"] = kp_type
     _rebuild_review_queue(progress)
     return {
         "mastery": round(progress["mastery_levels"][kp_id], 3),


### PR DESCRIPTION
## Summary

**Repo-Mastery** is an Agent skill that turns any open-source repository into a
developer-focused mastery course — usage, architecture, key implementations —
with confirmed course maps, deterministic mastery gates, spaced repetition, and
dual-format (Markdown + HTML) output.

## v2.4.0 — what this sync adds

This update syncs the skill to **v2.4.0**, adding two major upgrades:

### 1. grilling decision-clarification (v2.3.0)
- Phase 2 (Mission + course-map confirmation) now runs as a **decision-tree
  interview**: one question at a time, evidence-based recommendation per
  decision, facts looked up instead of asked, shared-understanding gate.
  See `references/clarification-interview.md`.

### 2. Evidence-based memory mechanisms (v2.4.0)
- **FSRS-inspired personalized scheduling** — per-knowledge-point `difficulty`
  + `stability` scale review intervals (hard points reviewed sooner, stable
  points deferred).
- **Session recall warm-up** — each session starts with 2–3 retrieval questions
  (streak feeds stability).
- **Flashcard quality standards** — force recall, one fact per card, context
  built into the question, bidirectional.
- **Interleaved review types** — consecutive reviews mix knowledge types
  (`last_review_type`).
- **Causal questioning** — probes "why / what-if / what breaks" after the
  Feynman check.
- **Vivid encoding** — memorable hooks for memory-type points (optional).
- **Low-effectiveness anti-patterns** — rereading ≠ memory.

### Files added for functional completeness
`references/clarification-interview.md`, `scripts/install.sh`, `AGENTS.md`,
`GEMINI.md`, `LICENSE`.

## Verification
- 8 pytest tests pass (scheduling math, personalization, interleaving,
  integration round-trip).
- Deterministic, pure stdlib; backward compatible with existing learning data.
