### PR TITLE
test: satisfy trade planner regex lint

### DIFF
--- a/tests/ci/ito-basket-compare-skill.test.js
+++ b/tests/ci/ito-basket-compare-skill.test.js
@@ -46,7 +46,7 @@ function main() {
   const skill = fs.readFileSync(SKILL_PATH, "utf8");
   const tests = [
     ["has valid discoverable frontmatter and representative trigger phrases", () => {
-      assert.match(skill, /^---\nname: ito-basket-compare\ndescription: [^\n]+\nmetadata:\n  origin: ECC\n---\n/);
+      assert.match(skill, /^---\nname: ito-basket-compare\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n---\n/);
       for (const phrase of ["compare this basket", "basket vs", "gap analysis", "stale assumptions", "watchlist"]) {
         assert.match(skill.toLowerCase(), new RegExp(phrase));
       }

--- a/tests/ci/ito-trade-planner-skill.test.js
+++ b/tests/ci/ito-trade-planner-skill.test.js
@@ -34,7 +34,7 @@ function main() {
   const skill = read('skills/ito-trade-planner/SKILL.md');
   const tests = [
     ['has portable discovery metadata and representative triggers', () => {
-      assert.match(skill, /^---\nname: ito-trade-planner\ndescription: [^\n]+\nmetadata:\n  origin: ECC\n---/);
+      assert.match(skill, /^---\nname: ito-trade-planner\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n---/);
       for (const trigger of ['trade plan', 'planning worksheet', 'venue comparison', 'basket adjustment']) {
         assert.match(skill, new RegExp(trigger, 'i'), `missing trigger phrase: ${trigger}`);
       }


### PR DESCRIPTION
## Summary
- replace the counted literal-space regex with an explicit `{2}` quantifier
- retain the exact discovery/frontmatter behavior assertion

## Evidence
- `node tests/ci/ito-trade-planner-skill.test.js` — 6/6 pass
- `npx eslint tests/ci/ito-trade-planner-skill.test.js` — pass
- `git diff --check` — pass

This is the isolated base fix for the pre-existing lint failure seen by #2714. Hold merge during the release freeze until the release owner confirms a non-runtime ECC base fix may land.