### PR TITLE
fix lint for trade planner metadata assertion

### DIFF
--- a/tests/ci/ito-trade-planner-skill.test.js
+++ b/tests/ci/ito-trade-planner-skill.test.js
@@ -34,7 +34,7 @@ function main() {
   const skill = read('skills/ito-trade-planner/SKILL.md');
   const tests = [
     ['has portable discovery metadata and representative triggers', () => {
-      assert.match(skill, /^---\nname: ito-trade-planner\ndescription: [^\n]+\nmetadata:\n  origin: ECC\n---/);
+      assert.match(skill, /^---\nname: ito-trade-planner\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n---/);
       for (const trigger of ['trade plan', 'planning worksheet', 'venue comparison', 'basket adjustment']) {
         assert.match(skill, new RegExp(trigger, 'i'), `missing trigger phrase: ${trigger}`);
       }


### PR DESCRIPTION
## What changed

- replaces the counted literal spaces in the trade-planner metadata regex with an explicit `{2}` quantifier
- retains the behavior assertion that validates the exact portable YAML metadata shape

## Why

ECC `main` at `d451f5100af57e33a73400b14b03e126ff49a3f9` fails ESLint `no-regex-spaces` at `tests/ci/ito-trade-planner-skill.test.js:37`. The same unchanged base defect causes the Lint failure on #2714 head `a1bef6fcfc01dd420f66b31bcf97b8d8628318f9`; this PR keeps that unrelated fix out of #2714.

## Validation

- `node tests/ci/ito-trade-planner-skill.test.js` — 6 passed, 0 failed
- ESLint on the changed file — passed
- `git diff --check` — passed

This is a draft pending CI and integrator confirmation that the Runtime freeze does not extend to this isolated ECC base repair. After merge, #2714 must rebase onto updated ECC main and rerun full CI.
