### PR TITLE
fix(install): exclude __pycache__ and Python bytecode from install plans

### DIFF
--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -80,7 +80,8 @@ function validateLegacyTarget(target) {
   throw new Error(`Unknown install target: ${target}. Expected one of ${SUPPORTED_INSTALL_TARGETS.join(', ')}`);
 }
 
-const IGNORED_DIRECTORY_NAMES = new Set(['node_modules', '.git']);
+const IGNORED_DIRECTORY_NAMES = new Set(['node_modules', '.git', '__pycache__']);
+const IGNORED_FILE_EXTENSIONS = new Set(['.pyc', '.pyo', '.pyd']);
 
 function listFilesRecursive(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -101,6 +102,9 @@ function listFilesRecursive(dirPath) {
         files.push(path.join(entry.name, childFile));
       }
     } else if (entry.isFile()) {
+      if (IGNORED_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+        continue;
+      }
       files.push(entry.name);
     }
   }

--- a/tests/lib/install-executor.test.js
+++ b/tests/lib/install-executor.test.js
@@ -54,6 +54,8 @@ function writeLegacySourceFixture(root) {
   writeFile(root, path.join('rules', 'common', 'nested', 'shared.md'), '# Shared\n');
   writeFile(root, path.join('rules', 'common', 'node_modules', 'ignored.md'), '# Ignored\n');
   writeFile(root, path.join('rules', 'common', '.git', 'ignored.md'), '# Ignored\n');
+  writeFile(root, path.join('rules', 'common', '__pycache__', 'ignored.cpython-314.pyc'), 'ignored\n');
+  writeFile(root, path.join('rules', 'common', 'stray.pyc'), 'ignored\n');
   writeFile(root, path.join('rules', 'typescript', 'testing.md'), '# TS\n');
   writeFile(root, path.join('rules', 'python', 'testing.md'), '# Python\n');
 
@@ -111,6 +113,8 @@ function writeManifestSourceFixture(root) {
   writeFile(root, path.join('src', 'nested', 'feature.js'), 'console.log("feature");\n');
   writeFile(root, path.join('src', 'node_modules', 'ignored.js'), 'console.log("ignored");\n');
   writeFile(root, path.join('src', '.git', 'ignored.js'), 'console.log("ignored");\n');
+  writeFile(root, path.join('src', '__pycache__', 'ignored.cpython-314.pyc'), 'ignored\n');
+  writeFile(root, path.join('src', 'stray.pyc'), 'ignored\n');
   writeFile(root, path.join('src', 'nested', 'ecc-install-state.json'), '{}\n');
   writeFile(root, path.join('rules', 'common', 'coding-style.md'), '# Common\n');
   writeFile(root, path.join('skills', 'demo', 'SKILL.md'), '# Demo\n');
@@ -192,6 +196,8 @@ function runTests() {
       assert.ok(operationFor(plan, path.join('custom-rules', 'typescript', 'testing.md')));
       assert.ok(!plan.operations.some(operation => operation.sourceRelativePath.includes('node_modules')));
       assert.ok(!plan.operations.some(operation => operation.sourceRelativePath.includes('.git')));
+      assert.ok(!plan.operations.some(operation => operation.sourceRelativePath.includes('__pycache__')));
+      assert.ok(!plan.operations.some(operation => operation.sourceRelativePath.endsWith('.pyc')));
       assert.deepStrictEqual(plan.statePreview.request.legacyLanguages, ['typescript', 'missing-lang', '../bad']);
       assert.strictEqual(plan.statePreview.request.legacyMode, true);
       assert.strictEqual(plan.statePreview.source.repoVersion, '9.8.7');
@@ -354,6 +360,8 @@ function runTests() {
       assert.ok(!normalizedSources.includes('src/nested/ecc-install-state.json'));
       assert.ok(!normalizedSources.some(source => source.includes('node_modules')));
       assert.ok(!normalizedSources.some(source => source.includes('.git')));
+      assert.ok(!normalizedSources.some(source => source.includes('__pycache__')));
+      assert.ok(!normalizedSources.some(source => source.endsWith('.pyc')));
       assert.ok(plan.operations.some(operation => (
         operation.sourceRelativePath === path.join('.claude-plugin', 'plugin.json')
         && operation.destinationPath === path.join(homeDir, '.claude', 'plugin.json')


### PR DESCRIPTION
Fixes #2727.

## Problem

`listFilesRecursive` in `scripts/lib/install-executor.js` skipped `node_modules` and `.git`, but descended into `__pycache__`. Any Python bytecode left in the repo was planned as an installable source file and copied into the install root:

```
hooks-runtime | scripts/lib/__pycache__/repro.cpython-314.pyc -> ~/.claude/scripts/lib/__pycache__/repro.cpython-314.pyc
```

This is reachable from normal use: `npm run dashboard` runs `ecc_dashboard.py`, which imports `scripts/lib/ecc_dashboard_runtime.py` and creates `scripts/lib/__pycache__/`. Every install after that ships the bytecode — potentially compiled for a different Python version than the user runs.

`package.json` `files` already carries `"!**/__pycache__/**"`, `"!**/*.pyc"`, `"!**/*.pyo"` and `"!**/*.pyd"`, so `npm pack` dropped these while the installer picked them up. This change aligns the planner with that existing intent.

## Change

- `IGNORED_DIRECTORY_NAMES` gains `__pycache__`.
- New `IGNORED_FILE_EXTENSIONS` (`.pyc`, `.pyo`, `.pyd`) covers bytecode that lands outside a `__pycache__` directory.

## Tests

`tests/lib/install-executor.test.js` already asserted that `node_modules` and `.git` are excluded, using fixtures that write a decoy file into each. This follows the same shape: both fixtures now write `__pycache__/ignored.cpython-314.pyc` and a loose `stray.pyc`, with matching negative assertions in the legacy-compat and manifest plan tests.

Verified the tests fail without the source change:

```
# with scripts/lib/install-executor.js reverted
node tests/lib/install-executor.test.js
Results: Passed: 14, Failed: 2

# with the fix
Results: Passed: 16, Failed: 0
```

Full suite: `yarn test` → 3713 passed, 0 failed. `eslint` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)