### PR TITLE
fix: complete Discord delivery receipts reliably

### DIFF
--- a/scripts/discord/announcement-core.mjs
+++ b/scripts/discord/announcement-core.mjs
@@ -72,11 +72,12 @@ export function discussionReceiptMarker(key) {
 }
 
 export function findDiscussionReceipt(comments, marker) {
-  return comments.find(comment => (
-    comment?.author?.login === 'github-actions[bot]'
+  const trusted = comments.filter(comment => (
+    ['github-actions', 'github-actions[bot]'].includes(comment?.author?.login)
     && typeof comment.body === 'string'
     && comment.body.includes(marker)
-  )) || null;
+  ));
+  return trusted.find(comment => discussionReceiptStatus(comment) === 'complete') || trusted[0] || null;
 }
 
 export function discussionReceiptStatus(comment) {

--- a/scripts/discord/release-announce.mjs
+++ b/scripts/discord/release-announce.mjs
@@ -127,13 +127,6 @@ async function addReceiptComment(discussionId, body) {
   return data.addDiscussionComment.comment.id;
 }
 
-async function updateReceiptComment(commentId, body) {
-  await githubGraphql(
-    `mutation($id:ID!,$body:String!){updateDiscussionComment(input:{commentId:$id,body:$body}){comment{id}}}`,
-    { id: commentId, body },
-  );
-}
-
 async function deleteReceiptComment(commentId) {
   await githubGraphql(
     `mutation($id:ID!){deleteDiscussionComment(input:{id:$id}){clientMutationId}}`,
@@ -179,7 +172,10 @@ async function deliver(discussion) {
       throw new Error(`Discord webhook request failed (${response.status})`);
     }
     const message = await response.json();
-    await updateReceiptComment(claimId, `${marker}\n\nDiscord delivery: complete (message ${message.id}).`);
+    await addReceiptComment(discussion.id, `${marker}\n\nDiscord delivery: complete (message ${message.id}).`);
+    await deleteReceiptComment(claimId).catch(() => {
+      console.warn('announcement delivered; pending receipt cleanup requires attention');
+    });
     console.log('announcement delivered by channel webhook');
     return;
   }

--- a/tests/scripts/release-announce.test.js
+++ b/tests/scripts/release-announce.test.js
@@ -52,7 +52,8 @@ const receiptMarker = discussionReceiptMarker('affaan-m/ECC:discussion:D_kw123')
 assert.match(receiptMarker, /^<!-- ecc-discord-receipt:[a-f0-9]{32} -->$/);
 assert.equal(findDiscussionReceipt([
   { id: 'forged', body: `Discord delivery: complete\n${receiptMarker}`, author: { login: 'attacker' } },
-  { id: 'comment-1', body: `Discord delivery: complete\n${receiptMarker}`, author: { login: 'github-actions[bot]' } },
+  { id: 'pending', body: `Discord delivery: pending.\n${receiptMarker}`, author: { login: 'github-actions' } },
+  { id: 'comment-1', body: `Discord delivery: complete\n${receiptMarker}`, author: { login: 'github-actions' } },
 ], receiptMarker).id, 'comment-1');
 assert.equal(findDiscussionReceipt([{ id: 'comment-2', body: 'unrelated' }], receiptMarker), null);
 assert.equal(discussionReceiptStatus({ body: `Discord delivery: pending.\n${receiptMarker}` }), 'pending');


### PR DESCRIPTION
## Summary
- trust the live GitHub Actions GraphQL identity
- prefer complete receipts over stale pending claims
- record completion before best-effort pending cleanup

## Live evidence
- Announcement #2736 was delivered visibly to ECC #announcements
- the failed post-delivery receipt was manually reconciled

## Verification
- focused core/workflow tests pass
- lint and diff checks pass
- independent code and security reviews approved c7b31914