### PR TITLE
fix(install): record install health in state store

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -134,7 +134,8 @@ function printHumanPlan(plan, dryRun) {
   console.log('\nCompute: ' + getComputeSponsorCopy());
 }
 
-function main() {
+async function main() {
+  let stateStore;
   try {
     const options = parseInstallArgs(process.argv);
 
@@ -177,13 +178,25 @@ function main() {
       return;
     }
 
-    const result = applyInstallPlan(rawPlan);
+    // Keep the status database projection synchronized with the install-state
+    // file written by the plan. The store is opened only for real installs so
+    // dry-runs remain side-effect free.
+    const { createStateStore } = require('./lib/state-store');
+    stateStore = await createStateStore({
+      homeDir: process.env.HOME || os.homedir(),
+    });
+    const result = applyInstallPlan(rawPlan, {
+      upsertInstallState: installState => stateStore.upsertInstallState(installState),
+    });
+    stateStore.close();
+    stateStore = undefined;
     if (options.json) {
       console.log(JSON.stringify({ dryRun: false, result }, null, 2));
     } else {
       printHumanPlan(result, false);
     }
   } catch (error) {
+    stateStore?.close();
     process.stderr.write(`Error: ${error.message}${getHelpText()}`);
     process.exit(1);
   }

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -73,6 +73,22 @@ function stateWithContentDigests(state) {
   };
 }
 
+// Keep the SQLite install-state projection in sync with the install-state
+// file. The file remains the source of truth; this projection is consumed by
+// `ecc status` and is intentionally limited to the fields represented by the
+// install_state table.
+function buildInstallStateStoreRecord(state) {
+  return {
+    targetId: state.target.id,
+    targetRoot: state.target.root,
+    profile: state.request.profile,
+    modules: state.resolution.selectedModules,
+    operations: state.operations,
+    installedAt: state.installedAt,
+    sourceVersion: state.source.repoVersion,
+  };
+}
+
 function cloneJsonValue(value) {
   if (value === undefined) {
     return undefined;
@@ -225,6 +241,7 @@ function previewInstallPlan(plan) {
 
 function applyInstallPlan(plan, dependencies = {}) {
   const persistInstallState = dependencies.writeInstallState || writeInstallState;
+  const persistInstallStateStore = dependencies.upsertInstallState;
   const beforeOperationWrite = dependencies.beforeOperationWrite;
   const beforeInstallStateWrite = dependencies.beforeInstallStateWrite;
   const migration = prepareClaudeSkillMigration(plan);
@@ -330,6 +347,9 @@ function applyInstallPlan(plan, dependencies = {}) {
     beforeInstallStateWrite({ plan: appliedPlan, state: finalState });
   }
   persistInstallState(plan.installStatePath, finalState);
+  if (typeof persistInstallStateStore === 'function') {
+    persistInstallStateStore(buildInstallStateStoreRecord(finalState));
+  }
 
   return {
     ...plan,
@@ -348,5 +368,6 @@ function applyInstallPlan(plan, dependencies = {}) {
 module.exports = {
   applyInstallPlan,
   assertSafeInstallOperation,
+  buildInstallStateStoreRecord,
   previewInstallPlan,
 };

--- a/tests/lib/install-claude-skill-migration.test.js
+++ b/tests/lib/install-claude-skill-migration.test.js
@@ -5,7 +5,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { applyInstallPlan } = require('../../scripts/lib/install/apply');
+const {
+  applyInstallPlan,
+  buildInstallStateStoreRecord,
+} = require('../../scripts/lib/install/apply');
 const { readInstallState, writeInstallState } = require('../../scripts/lib/install-state');
 const { uninstallInstalledStates } = require('../../scripts/lib/install-lifecycle');
 
@@ -164,6 +167,26 @@ function runTests() {
   console.log('\n=== Testing Claude flat-skill migration ===\n');
   let passed = 0;
   let failed = 0;
+
+  if (test('projects the final install state for the status store', () => {
+    const fixture = createFixture();
+    try {
+      const records = [];
+      applyInstallPlan(fixture.plan, {
+        upsertInstallState: record => records.push(record),
+      });
+      assert.strictEqual(records.length, 1);
+      assert.deepStrictEqual(records[0], buildInstallStateStoreRecord(
+        readInstallState(fixture.installStatePath)
+      ));
+      assert.strictEqual(records[0].targetId, 'claude-home');
+      assert.strictEqual(records[0].targetRoot, fixture.targetRoot);
+      assert.deepStrictEqual(records[0].modules, ['workflow-quality']);
+      assert.strictEqual(records[0].operations.length, fixture.operations.length);
+    } finally {
+      cleanup(fixture.tempDir);
+    }
+  })) passed++; else failed++;
 
   for (const target of ['claude', 'claude-project']) {
     if (test(`migrates state-managed nested skills for ${target} without deleting untracked files`, () => {


### PR DESCRIPTION
## What Changed
- Project the final JSON install state into the SQLite `install_state` table after a successful install.
- Wire the production installer to open the state store and upsert the projection.
- Add a regression test covering the projection mapping.

## Why This Change
Fixes #2750. `ecc status` previously reported `Install health: missing` and `Targets recorded: 0` after every successful install because no production path called `upsertInstallState()`.

## Testing Done
- [x] Manual install verified: `ecc status` reports `healthy` with one recorded target.
- [x] `node tests/lib/install-claude-skill-migration.test.js` (17 passed)
- [x] `node tests/lib/state-store.test.js` (16 passed)
- [x] ESLint passed for all changed files.
- [x] `git diff --check` passed.
- [ ] Full `tests/scripts/install-apply.test.js` suite (exceeded the local 180-second timeout while running repeated installer subprocesses).
- [x] Edge cases covered: project/home target fields and selected modules/operations mapping.

## Type of Change
- [x] `fix:` Bug fix
- [x] `test:` Tests

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant code comments
- [x] README updated (not needed)
