### PR TITLE
fix: stop doctor flagging rewritten markdown as drift

### DIFF
--- a/scripts/lib/install-lifecycle.js
+++ b/scripts/lib/install-lifecycle.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const fs = require('fs');
 const { execFileSync } = require('child_process');
 const os = require('os');
@@ -133,6 +134,20 @@ function resolveOperationSourcePath(repoRoot, operation) {
 function areFilesEqual(leftPath, rightPath) {
   try {
     return readFileNoFollow(leftPath).equals(readFileNoFollow(rightPath));
+  } catch (_error) {
+    return false;
+  }
+}
+
+function hasContentDigest(filePath, expectedDigest) {
+  if (!/^[a-f0-9]{64}$/i.test(String(expectedDigest || ''))) {
+    return false;
+  }
+
+  try {
+    return crypto.createHash('sha256')
+      .update(readFileNoFollow(filePath))
+      .digest('hex') === expectedDigest.toLowerCase();
   } catch (_error) {
     return false;
   }
@@ -871,7 +886,9 @@ function inspectManagedOperation(repoRoot, trustedRoot, operation) {
       };
     }
 
-    if (!areFilesEqual(copySourcePath, inspectedPath)) {
+    const matchesRecordedContent = hasContentDigest(inspectedPath, operation.contentSha256);
+    const matchesSourceContent = !operation.contentSha256 && areFilesEqual(copySourcePath, inspectedPath);
+    if (!matchesRecordedContent && !matchesSourceContent) {
       return {
         status: 'drifted',
         operation,

--- a/tests/lib/install-lifecycle.test.js
+++ b/tests/lib/install-lifecycle.test.js
@@ -3,6 +3,7 @@
  */
 
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -1454,6 +1455,40 @@ function runTests() {
       assert.strictEqual(report.results.length, 1);
       assert.strictEqual(report.results[0].status, 'warning');
       assert.ok(report.results[0].issues.some(issue => issue.code === 'drifted-managed-files'));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('doctor accepts rewritten copy-file content recorded in install-state', () => {
+    const homeDir = createTempDir('install-lifecycle-home-');
+    const projectRoot = createTempDir('install-lifecycle-project-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      const destinationPath = path.join(targetRoot, 'rules', 'rewritten.md');
+      const installedContent = '[rules](../ecc/rules.md)\n';
+      const contentSha256 = crypto.createHash('sha256').update(installedContent).digest('hex');
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.writeFileSync(destinationPath, installedContent);
+
+      writeCursorState(projectRoot, {
+        operations: [managedOperation('copy-file', destinationPath, {
+          sourceRelativePath: 'rules/common/coding-style.md',
+          contentSha256,
+        })],
+      });
+
+      const report = buildDoctorReport({
+        repoRoot: REPO_ROOT,
+        homeDir,
+        projectRoot,
+        targets: ['cursor'],
+      });
+
+      assert.strictEqual(report.results[0].status, 'ok');
+      assert.ok(!report.results[0].issues.some(issue => issue.code === 'drifted-managed-files'));
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## What Changed

- Verify managed `copy-file` destinations against the SHA-256 digest recorded after install when one is available.
- Keep the source-byte comparison fallback for legacy install-state records without a digest.
- Add regression coverage for rewritten markdown whose installed bytes differ from the repository source.

## Why This Change

The installer rewrites relative links in namespaced markdown before writing it, then records the resulting bytes in `install-state.json`. `ecc doctor` compared that rewritten destination with the unrewritten repository source and permanently reported drift. The doctor now validates the installed bytes against the recorded digest, so a clean install remains healthy while user edits still report drift.

## Testing Done

- [x] Manual testing completed
- [x] Automated targeted tests pass locally (`node tests/lib/install-lifecycle.test.js`, 49 passed)
- [x] Edge case covered: rewritten destination content differs from source but matches its recorded digest
- [x] `node --check` on changed JavaScript files
- [x] ESLint on changed files
- [x] `git diff --check`
- [ ] Full `node tests/run-all.js` not run (targeted lifecycle suite covers the changed path)

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] No dependency or generated-file changes
- [x] Follows conventional commits format

Closes #2696