### PR TITLE
feat: add orchestration efficiency evidence scenario

### DIFF
--- a/docs/architecture/evaluator-rag-prototype.md
+++ b/docs/architecture/evaluator-rag-prototype.md
@@ -23,6 +23,10 @@ working examples, reference-set gaps, and validation commands before a skill
 amendment can be promoted. A deep-analyzer evidence scenario requires analyzer
 corpus cases, expected-output comparisons, and risk-taxonomy proof before
 repository or commit-analysis behavior can change.
+An orchestration-efficiency evidence scenario requires matched single-agent
+controls, aggregate controller and worker cost, accepted quality, coordination
+costs, and sequential paired replications before parallelism is called faster
+or cheaper.
 
 ## Reference Pressure
 
@@ -122,6 +126,10 @@ Current corpus:
 - `deep-analyzer-evidence`: requires maintained analyzer corpus cases,
   expected-output comparisons, representative repository/commit histories, and
   regression commands before deep-analysis behavior can be promoted.
+- `orchestration-efficiency-evidence`: requires dependency and ownership plans,
+  matched single-agent controls, common acceptance gates, aggregate worker
+  costs, retained failures and coordination overhead, and repeated sequential
+  pairs before an orchestration-efficiency recommendation can be promoted.
 
 ## ECC Tools Mapping
 

--- a/docs/architecture/evaluator-rag-prototype.md
+++ b/docs/architecture/evaluator-rag-prototype.md
@@ -23,10 +23,10 @@ working examples, reference-set gaps, and validation commands before a skill
 amendment can be promoted. A deep-analyzer evidence scenario requires analyzer
 corpus cases, expected-output comparisons, and risk-taxonomy proof before
 repository or commit-analysis behavior can change.
-An orchestration-efficiency evidence scenario requires matched single-agent
-controls, aggregate controller and worker cost, accepted quality, coordination
-costs, and sequential paired replications before parallelism is called faster
-or cheaper.
+In an orchestration-efficiency evidence scenario, single-agent controls must be
+matched, and aggregate controller and worker cost, accepted quality,
+coordination costs, and sequential paired replications are required before
+parallelism is called faster or cheaper.
 
 ## Reference Pressure
 

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/candidate-playbook.md
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/candidate-playbook.md
@@ -1,0 +1,58 @@
+# Orchestration Efficiency Evidence Playbook
+
+Candidate id: `controlled-paired-orchestration-evaluation`
+
+Use this playbook before recommending multiple agents for a task class or
+claiming an orchestrated workflow is faster, cheaper, or more reliable than one
+agent.
+
+## Accepted Path
+
+1. Define the task, acceptance evaluator, and observable evidence requirements.
+2. Draw the dependency graph and name exclusive write ownership. If workers
+   need the same file or an unsettled interface, keep that work sequential.
+3. Freeze the controlled fields for both variants:
+   - starting revision and task text;
+   - model and reasoning effort;
+   - permissions and tools;
+   - time limit and machine-load policy;
+   - acceptance evaluator and evidence format.
+4. Run one `single_agent` candidate and one `orchestrated` candidate
+   sequentially. Alternate run order across later pairs.
+5. Apply the same evaluator to every attempt. Keep failures in the dataset.
+6. Record per candidate:
+   - acceptance and evidence completeness;
+   - elapsed time;
+   - total tokens or cost across controller, every worker, and retries;
+   - worker count and ownership;
+   - conflicts, integration rework, retries, and human corrections.
+7. Write `unavailable` for telemetry the harness does not expose. Never estimate
+   missing totals.
+8. Repeat at least three fresh pairs before recommending a task-class boundary.
+   Report raw receipts before interpretation.
+
+## Rejected Path
+
+Do not infer efficiency because workers ran in parallel, the controller context
+looked smaller, or one orchestrated candidate finished successfully.
+
+Do not compare candidates with different prompts, revisions, models, tools,
+permissions, time limits, evaluators, or machine load.
+
+Do not report controller-only tokens, exclude failed attempts, or hide merge
+conflicts and integration work outside the result.
+
+Do not publish a general claim from one pair, overlapping variants, fixed run
+order, or unavailable aggregate telemetry.
+
+## Minimum Validation
+
+- `node tests/lib/orchestration-session.test.js`
+- Task-specific acceptance evaluator for every candidate
+- Raw run receipts containing all controlled fields and coordination costs
+- `git diff --check`
+- At least three sequential pairs with alternated order before a general claim
+
+Record the evidence source and attribution when an external experiment informs
+the scenario. Keep publication, agent launch, candidate edits, and repository
+mutation outside this read-only evaluator pass.

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/report.json
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/report.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "ecc.evaluator-rag.report.v1",
+  "scenario_id": "orchestration-efficiency-evidence",
+  "run_id": "2026-08-11-orchestration-efficiency-prototype",
+  "result": "prototype_passed",
+  "read_only": true,
+  "scores": {
+    "control_matching": 0.96,
+    "acceptance_first": 1,
+    "aggregate_cost_coverage": 0.94,
+    "coordination_cost_coverage": 0.93,
+    "claim_safety": 1
+  },
+  "findings": [
+    {
+      "id": "quality-before-efficiency",
+      "severity": "warning",
+      "summary": "Elapsed time or token totals are not decision-useful when candidates fail different acceptance gates or evidence requirements."
+    },
+    {
+      "id": "aggregate-worker-cost-required",
+      "severity": "warning",
+      "summary": "Controller-only telemetry understates orchestration cost; totals must include every worker and retry or remain explicitly unavailable."
+    },
+    {
+      "id": "coordination-cost-visible",
+      "severity": "info",
+      "summary": "Conflicts, integration rework, retries, and human corrections are part of the result rather than incidental notes."
+    },
+    {
+      "id": "replication-before-recommendation",
+      "severity": "warning",
+      "summary": "One pair, overlapping variants, or fixed run order can qualify a harness but cannot establish a general orchestration efficiency boundary."
+    }
+  ],
+  "recommended_next_action": {
+    "candidate_id": "controlled-paired-orchestration-evaluation",
+    "action": "Use the promoted playbook to design sequential paired runs, preserve every attempt, and recommend orchestration only for task classes where accepted quality and measured coordination cost justify it."
+  }
+}

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/scenario.json
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/scenario.json
@@ -54,6 +54,7 @@
     "aggregate controller and worker cost is recorded or explicitly unavailable",
     "elapsed time, retries, conflicts, integration rework, and human corrections are retained",
     "failed candidates remain in the comparison",
+    "at least three fresh sequential pairs with alternated order are completed before promotion",
     "at least one one-run parallelism claim is rejected"
   ]
 }

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/scenario.json
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/scenario.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "ecc.evaluator-rag.scenario.v1",
+  "scenario_id": "orchestration-efficiency-evidence",
+  "title": "Require controlled evidence before claiming orchestration efficiency",
+  "mode": "read_only_prototype",
+  "objective": "Given a proposed multi-agent workflow or completed run, retrieve the dependency graph, ownership boundaries, acceptance evidence, matched single-agent baseline, and aggregate cost telemetry before promoting an orchestration recommendation.",
+  "sources": [
+    {
+      "kind": "repo_skill",
+      "path": "skills/parallel-execution-optimizer/SKILL.md",
+      "purpose": "Defines dependency mapping, isolated write surfaces, and evidence-based integration for parallel work"
+    },
+    {
+      "kind": "repo_skill",
+      "path": "skills/context-budget/SKILL.md",
+      "purpose": "Defines context and token overhead inventory instead of assuming more agents reduce total cost"
+    },
+    {
+      "kind": "repo_source",
+      "path": "scripts/lib/orchestration-session.js",
+      "purpose": "Provides ECC orchestration session state and worker lifecycle evidence"
+    },
+    {
+      "kind": "repo_test",
+      "command": "node tests/lib/orchestration-session.test.js",
+      "purpose": "Regression gate for orchestration session behavior"
+    },
+    {
+      "kind": "external_experiment",
+      "url": "https://github.com/Phelan164/codex-howto/blob/527296fa7d9ba1828d639ec000e0543c42ee2739/examples/measurements/incident-orchestration-smoke-2026-08-11.md",
+      "purpose": "Contributed smoke evidence showing why overlapping runs and unavailable aggregate tokens cannot support an efficiency claim"
+    }
+  ],
+  "retrieval_questions": [
+    "Which task dependencies and exclusive write surfaces justify multiple workers?",
+    "Were the single-agent and orchestrated candidates run from the same task, revision, model, reasoning effort, permissions, tools, time limit, and evaluator?",
+    "Did every attempted candidate meet the same acceptance and evidence-quality gates?",
+    "What were total tokens or cost across the controller and all workers, elapsed time, retries, conflicts, integration rework, and human corrections?",
+    "Were failures and unavailable telemetry retained rather than estimated or excluded?",
+    "How many sequential paired runs and alternated run orders support the recommendation?"
+  ],
+  "forbidden_actions": [
+    "claiming that parallel agents are faster or cheaper without a matched accepted single-agent baseline",
+    "comparing candidates with different tasks, revisions, models, reasoning effort, permissions, tools, time limits, or evaluators",
+    "reporting controller-only tokens or cost while omitting worker totals",
+    "excluding failed candidates, edit conflicts, integration rework, retries, or human corrections",
+    "estimating unavailable telemetry or turning one overlapping smoke run into a general efficiency claim",
+    "launching workers, editing candidate repositories, publishing benchmarks, or posting announcements from this read-only evaluator run"
+  ],
+  "acceptance_gates": [
+    "dependency graph and exclusive ownership boundaries are recorded",
+    "single-agent and orchestrated controls are matched",
+    "all attempted candidates use the same acceptance evaluator",
+    "aggregate controller and worker cost is recorded or explicitly unavailable",
+    "elapsed time, retries, conflicts, integration rework, and human corrections are retained",
+    "failed candidates remain in the comparison",
+    "at least one one-run parallelism claim is rejected"
+  ]
+}

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/trace.json
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/trace.json
@@ -18,7 +18,7 @@
       "evidence": [
         "skills/context-budget/SKILL.md",
         "node tests/lib/orchestration-session.test.js",
-        "contributed orchestration smoke evidence pinned to commit 527296f"
+        "https://github.com/Phelan164/codex-howto/blob/527296fa7d9ba1828d639ec000e0543c42ee2739/examples/measurements/incident-orchestration-smoke-2026-08-11.md"
       ]
     },
     {

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/trace.json
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/trace.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "ecc.evaluator-rag.trace.v1",
+  "scenario_id": "orchestration-efficiency-evidence",
+  "run_id": "2026-08-11-orchestration-efficiency-prototype",
+  "read_only": true,
+  "events": [
+    {
+      "phase": "observation",
+      "summary": "A workflow proposes multiple agents or reports an orchestrated result. The evaluator records the task boundary and claims without launching workers or changing candidate repositories.",
+      "evidence": [
+        "skills/parallel-execution-optimizer/SKILL.md",
+        "scripts/lib/orchestration-session.js"
+      ]
+    },
+    {
+      "phase": "retrieval",
+      "summary": "Retrieved dependency and ownership plans, matched run controls, acceptance results, aggregate token or cost telemetry, elapsed time, failures, conflicts, integration rework, retries, and human corrections.",
+      "evidence": [
+        "skills/context-budget/SKILL.md",
+        "node tests/lib/orchestration-session.test.js",
+        "contributed orchestration smoke evidence pinned to commit 527296f"
+      ]
+    },
+    {
+      "phase": "proposal",
+      "summary": "Generated two candidates: a controlled paired evaluation that preserves all attempts and an intuition-only claim that parallelism implies efficiency.",
+      "candidate_ids": [
+        "controlled-paired-orchestration-evaluation",
+        "parallelism-implies-efficiency"
+      ]
+    },
+    {
+      "phase": "verification",
+      "summary": "Accepted the controlled paired evaluation because it matches controls, evaluates quality first, aggregates worker cost, and keeps negative results. Rejected the intuition-only claim because it relies on one overlapping run with unavailable token totals.",
+      "evidence": [
+        "examples/evaluator-rag-prototype/orchestration-efficiency-evidence/verifier-result.json"
+      ]
+    },
+    {
+      "phase": "promotion",
+      "summary": "Promoted only the read-only orchestration evidence playbook. It does not launch agents, edit candidates, publish results, or claim that orchestration is efficient.",
+      "promoted_candidate_id": "controlled-paired-orchestration-evaluation"
+    }
+  ]
+}

--- a/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/verifier-result.json
+++ b/examples/evaluator-rag-prototype/orchestration-efficiency-evidence/verifier-result.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "ecc.evaluator-rag.verifier.v1",
+  "scenario_id": "orchestration-efficiency-evidence",
+  "run_id": "2026-08-11-orchestration-efficiency-prototype",
+  "read_only": true,
+  "candidates": [
+    {
+      "candidate_id": "controlled-paired-orchestration-evaluation",
+      "decision": "accepted",
+      "score": 0.95,
+      "reasons": [
+        "records a dependency graph and exclusive write ownership before delegation",
+        "matches task, revision, model, reasoning effort, permissions, tools, time limit, and evaluator",
+        "requires acceptance and evidence quality before comparing elapsed time or cost",
+        "aggregates controller, worker, and retry tokens or cost and marks unavailable telemetry honestly",
+        "retains failed candidates, conflicts, integration rework, retries, and human corrections",
+        "requires repeated sequential pairs and alternated run order before a general recommendation"
+      ],
+      "rollback": "Withdraw the recommendation and retain the raw run receipts if later replications reverse the result; this read-only playbook launches no workers and changes no candidate repository."
+    },
+    {
+      "candidate_id": "parallelism-implies-efficiency",
+      "decision": "rejected",
+      "score": 0.12,
+      "reasons": [
+        "treats more agents as inherently faster and cheaper",
+        "has no matched accepted single-agent baseline",
+        "reports no aggregate worker token or cost total",
+        "ignores overlap, machine contention, conflicts, integration rework, and failed attempts",
+        "turns one smoke run with unavailable telemetry into a general efficiency claim"
+      ],
+      "rollback": "Do not publish the claim; restart from matched controls, acceptance evidence, complete run receipts, and sequential paired replications."
+    }
+  ],
+  "promoted_candidate_id": "controlled-paired-orchestration-evaluation"
+}

--- a/tests/docs/evaluator-rag-prototype.test.js
+++ b/tests/docs/evaluator-rag-prototype.test.js
@@ -453,7 +453,12 @@ test('orchestration efficiency scenario rejects intuition-only parallelism claim
   assert.strictEqual(rejected.decision, 'rejected');
   assert.strictEqual(verifier.promoted_candidate_id, accepted.candidate_id);
   assert.ok(rejected.reasons.join('\n').includes('no matched accepted single-agent baseline'));
-  assert.ok(JSON.stringify(trace).includes(scenario.sources.find(source => source.kind === 'external_experiment').url));
+  const externalExperiment = scenario.sources.find(source => source.kind === 'external_experiment');
+  const retrieval = trace.events.find(event => event.phase === 'retrieval');
+
+  assert.ok(externalExperiment, 'Missing external orchestration experiment source');
+  assert.ok(retrieval, 'Missing orchestration retrieval trace event');
+  assert.ok(retrieval.evidence.includes(externalExperiment.url));
   assert.ok(playbook.includes('total tokens or cost across controller, every worker, and retries'));
   assert.ok(playbook.includes('At least three sequential pairs with alternated order'));
 });

--- a/tests/docs/evaluator-rag-prototype.test.js
+++ b/tests/docs/evaluator-rag-prototype.test.js
@@ -453,6 +453,7 @@ test('orchestration efficiency scenario rejects intuition-only parallelism claim
   assert.strictEqual(rejected.decision, 'rejected');
   assert.strictEqual(verifier.promoted_candidate_id, accepted.candidate_id);
   assert.ok(rejected.reasons.join('\n').includes('no matched accepted single-agent baseline'));
+  assert.ok(JSON.stringify(trace).includes(scenario.sources.find(source => source.kind === 'external_experiment').url));
   assert.ok(playbook.includes('total tokens or cost across controller, every worker, and retries'));
   assert.ok(playbook.includes('At least three sequential pairs with alternated order'));
 });

--- a/tests/docs/evaluator-rag-prototype.test.js
+++ b/tests/docs/evaluator-rag-prototype.test.js
@@ -438,7 +438,8 @@ test('orchestration efficiency scenario rejects intuition-only parallelism claim
     'single-agent and orchestrated controls are matched',
     'all attempted candidates use the same acceptance evaluator',
     'aggregate controller and worker cost is recorded or explicitly unavailable',
-    'failed candidates remain in the comparison'
+    'failed candidates remain in the comparison',
+    'at least three fresh sequential pairs with alternated order are completed before promotion'
   ]) {
     assert.ok(scenario.acceptance_gates.includes(required), `Missing orchestration acceptance gate: ${required}`);
   }

--- a/tests/docs/evaluator-rag-prototype.test.js
+++ b/tests/docs/evaluator-rag-prototype.test.js
@@ -409,6 +409,53 @@ test('deep analyzer evidence scenario rejects no-corpus analyzer changes', () =>
   assert.ok(playbook.includes('Deep Analyzer Evidence'));
 });
 
+test('orchestration efficiency scenario rejects intuition-only parallelism claims', () => {
+  const scenario = readFixtureJson('orchestration-efficiency-evidence/scenario.json');
+  const trace = readFixtureJson('orchestration-efficiency-evidence/trace.json');
+  const report = readFixtureJson('orchestration-efficiency-evidence/report.json');
+  const verifier = readFixtureJson('orchestration-efficiency-evidence/verifier-result.json');
+  const playbook = read('examples/evaluator-rag-prototype/orchestration-efficiency-evidence/candidate-playbook.md');
+
+  assert.strictEqual(scenario.scenario_id, 'orchestration-efficiency-evidence');
+  assert.strictEqual(trace.scenario_id, scenario.scenario_id);
+  assert.strictEqual(report.scenario_id, scenario.scenario_id);
+  assert.strictEqual(verifier.scenario_id, scenario.scenario_id);
+  assert.strictEqual(trace.read_only, true);
+  assert.strictEqual(report.read_only, true);
+  assert.strictEqual(verifier.read_only, true);
+
+  for (const blocked of [
+    'claiming that parallel agents are faster or cheaper without a matched accepted single-agent baseline',
+    'reporting controller-only tokens or cost while omitting worker totals',
+    'excluding failed candidates, edit conflicts, integration rework, retries, or human corrections',
+    'estimating unavailable telemetry or turning one overlapping smoke run into a general efficiency claim'
+  ]) {
+    assert.ok(scenario.forbidden_actions.includes(blocked), `Missing orchestration forbidden action: ${blocked}`);
+  }
+
+  for (const required of [
+    'dependency graph and exclusive ownership boundaries are recorded',
+    'single-agent and orchestrated controls are matched',
+    'all attempted candidates use the same acceptance evaluator',
+    'aggregate controller and worker cost is recorded or explicitly unavailable',
+    'failed candidates remain in the comparison'
+  ]) {
+    assert.ok(scenario.acceptance_gates.includes(required), `Missing orchestration acceptance gate: ${required}`);
+  }
+
+  const accepted = verifier.candidates.find(candidate => candidate.candidate_id === 'controlled-paired-orchestration-evaluation');
+  const rejected = verifier.candidates.find(candidate => candidate.candidate_id === 'parallelism-implies-efficiency');
+
+  assert.ok(accepted, 'Missing accepted controlled orchestration candidate');
+  assert.ok(rejected, 'Missing rejected intuition-only orchestration candidate');
+  assert.strictEqual(accepted.decision, 'accepted');
+  assert.strictEqual(rejected.decision, 'rejected');
+  assert.strictEqual(verifier.promoted_candidate_id, accepted.candidate_id);
+  assert.ok(rejected.reasons.join('\n').includes('no matched accepted single-agent baseline'));
+  assert.ok(playbook.includes('total tokens or cost across controller, every worker, and retries'));
+  assert.ok(playbook.includes('At least three sequential pairs with alternated order'));
+});
+
 if (failed > 0) {
   console.log(`\nFailed: ${failed}`);
   process.exit(1);


### PR DESCRIPTION
## What Changed

Adds an `orchestration-efficiency-evidence` scenario to the evaluator-RAG prototype corpus.

The scenario:

- requires a dependency graph and exclusive write ownership before delegation;
- compares matched single-agent and orchestrated controls with the same acceptance evaluator;
- counts aggregate controller, worker, and retry cost instead of controller-only telemetry;
- preserves failures, conflicts, integration rework, retries, and human corrections;
- rejects general efficiency claims from one overlapping smoke run;
- requires repeated sequential pairs with alternated order before a task-class recommendation.

It includes the scenario, trace, report, verifier result, candidate playbook, documentation entry, and a regression test.

## Why This Change

ECC already has strong orchestration and context-budget guidance. The evaluator corpus did not yet encode the decision boundary for when parallel execution actually earns its coordination cost.

This contribution deliberately does not add another orchestration skill. It turns the existing guidance into a read-only evidence gate that rejects intuition-only claims such as “more agents are automatically faster or cheaper.”

The external smoke evidence is attributed and pinned to an immutable `codex-howto` commit. That experiment did **not** establish an efficiency result; its missing aggregate token telemetry and overlapping variants are the reason this scenario requires stronger controls.

## Testing Done

- [x] Manual fixture and diff review completed
- [x] `npm run lint`
- [x] `node tests/docs/evaluator-rag-prototype.test.js` — 14 passed
- [x] `node tests/lib/orchestration-session.test.js` — 8 passed
- [x] All new JSON fixtures validated with `jq -e`
- [x] `git diff --check`
- [x] Edge cases considered: unmatched controls, controller-only cost, failed attempts omitted, overlapping runs, fixed order, and unavailable telemetry
- [ ] Full `npm test` gauntlet passes locally

The full gauntlet was attempted in Codex's restricted workspace. Existing environment-dependent tests failed when they tried to write under `~/.claude` or bind loopback servers (`EPERM`), including hook, MCP health, and plan-canvas integration cases. The focused tests and repository lint above pass.

## Type of Change

- [x] `feat:` New feature
- [ ] `fix:` Bug fix
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No shell scripts changed
- [x] Pre-commit-equivalent focused checks pass locally
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Dependencies / Export Surface

- No dependencies, `package.json`, skills, commands, agents, hooks, CLI tools, or export surfaces changed.

## Documentation

- [x] Updated the evaluator-RAG architecture corpus list
- [x] Added a candidate playbook for the scenario
- [ ] README updated — not needed for this corpus-only addition

## Attribution

The contributed smoke record that motivated the stricter evidence gate is pinned in `scenario.json`:

https://github.com/Phelan164/codex-howto/blob/527296fa7d9ba1828d639ec000e0543c42ee2739/examples/measurements/incident-orchestration-smoke-2026-08-11.md
