### PR TITLE
chore(deps): integrate safe Dependabot runtime updates

### DIFF
--- a/ecc2/Cargo.lock
+++ b/ecc2/Cargo.lock
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,16 @@
       },
       "bin": {
         "ecc": "scripts/ecc.js",
-        "ecc-universal": "scripts/ecc.js",
         "ecc-control-pane": "scripts/control-pane.js",
         "ecc-install": "scripts/install-apply.js",
         "ecc-memory-mcp": "scripts/memory-mcp.mjs",
-        "ecc-plan-canvas": "scripts/plan-canvas.js"
+        "ecc-plan-canvas": "scripts/plan-canvas.js",
+        "ecc-universal": "scripts/ecc.js"
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
         "@opencode-ai/plugin": "1.17.3",
-        "@types/node": "25.9.2",
+        "@types/node": "26.1.2",
         "c8": "11.0.0",
         "eslint": "10.6.0",
         "globals": "17.4.0",
@@ -443,13 +443,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/unist": {
@@ -2795,9 +2795,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -474,7 +474,7 @@
   "devDependencies": {
     "@eslint/js": "9.39.2",
     "@opencode-ai/plugin": "1.17.3",
-    "@types/node": "25.9.2",
+    "@types/node": "26.1.2",
     "c8": "11.0.0",
     "eslint": "10.6.0",
     "globals": "17.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "anthropic>=0.111.0",
+    "anthropic>=0.120.2",
     "openai>=1.30.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
     "ruff>=0.4",
-    "mypy>=2.1.0",
+    "mypy>=2.3.0",
     "pyyaml>=6.0.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
-    "ruff>=0.4",
+    "ruff>=0.16.1",
     "mypy>=2.3.0",
     "pyyaml>=6.0.3",
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,12 +292,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:25.9.2":
-  version: 25.9.2
-  resolution: "@types/node@npm:25.9.2"
+"@types/node@npm:26.1.2":
+  version: 26.1.2
+  resolution: "@types/node@npm:26.1.2"
   dependencies:
-    undici-types: "npm:>=7.24.0 <7.24.7"
-  checksum: 10c0/f14c0d56361febb985eccc45cf0834ee6e2f07c4389a636f3e1a55ebde320077a80bface18c9afd3092f5fa295925502c1a9d55f805efa813f634aa9c941cbac
+    undici-types: "npm:~8.3.0"
+  checksum: 10c0/a45503222c7db8f374afd5c9381db63dd95b6b1f703abea0890dd3d4a09eeb41da489e08a1a45baf18fe89fb77fbf310ff2789f680c490b04dafc41a60800a86
   languageName: node
   linkType: hard
 
@@ -581,7 +581,7 @@ __metadata:
     "@eslint/js": "npm:9.39.2"
     "@iarna/toml": "npm:2.2.5"
     "@opencode-ai/plugin": "npm:1.17.3"
-    "@types/node": "npm:25.9.2"
+    "@types/node": "npm:26.1.2"
     ajv: "npm:8.20.0"
     c8: "npm:11.0.0"
     eslint: "npm:10.6.0"
@@ -2027,10 +2027,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:>=7.24.0 <7.24.7":
-  version: 7.24.6
-  resolution: "undici-types@npm:7.24.6"
-  checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10c0/c8aa7e2fbebfce519654dafadc0ece59be888d2ccaf180fb4495da875e7b536d2456345c384069c7e6f3e9c9ab7435f074957da306f142343eee86ff8048855a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Carries forward the reviewed, compatible updates from Dependabot PRs #2658, #2659, #2660, #2743, and #2745 in one exact-head integration batch:

- raise the tested mypy, Ruff, and Anthropic SDK floors;
- refresh the Cargo lockfile for the clap patch release;
- update Node type definitions to 26.1.2;
- add the package-lock update omitted by Dependabot so npm CI remains reproducible.

This intentionally excludes #2742 because raising the OpenAI minimum across its breaking 1.x → 2.x boundary does not support a v2-only ECC feature. It also excludes #2744 for a separate security/runtime pass around markdownlint-cli and its Node engine boundary.

## Verification

- npm ci --ignore-scripts
- npm run lint
- npm test — 3,725/3,725 passed
- git diff --check

Local Python and Rust toolchains were unavailable. Hosted Python CI must pass on this exact head, and the lock-only Rust update will receive a separate cargo check before merge.