### PR TITLE
docs(repo-scan): repair pinned installation flow

### DIFF
--- a/docs/ja-JP/skills/repo-scan/SKILL.md
+++ b/docs/ja-JP/skills/repo-scan/SKILL.md
@@ -18,14 +18,19 @@ origin: community
 ## インストール
 
 ```bash
-# Fetch only the pinned commit for reproducibility
-mkdir -p ~/.claude/skills/repo-scan
-git init repo-scan
-cd repo-scan
-git remote add origin https://github.com/haibindev/repo-scan.git
-git fetch --depth 1 origin 2742664
-git checkout --detach FETCH_HEAD
-cp -r . ~/.claude/skills/repo-scan
+# Clone first so the pinned commit can be reviewed before installation
+REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
+REPO_SCAN_TMP="$(mktemp -d)"
+REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
+
+git clone --filter=blob:none --no-checkout \
+  https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
+git -C "$REPO_SCAN_TMP/source" checkout --detach "$REPO_SCAN_COMMIT"
+
+# Review "$REPO_SCAN_TMP/source", then install tracked files without .git metadata
+mkdir -p "$REPO_SCAN_INSTALL_DIR"
+git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf - -C "$REPO_SCAN_INSTALL_DIR"
 ```
 
 > エージェントスキルをインストールする前に、ソースコードをレビューしてください。

--- a/docs/ja-JP/skills/repo-scan/SKILL.md
+++ b/docs/ja-JP/skills/repo-scan/SKILL.md
@@ -22,11 +22,19 @@ origin: community
 set -euo pipefail
 
 REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
-REPO_SCAN_TMP="$(mktemp -d)"
 REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+REPO_SCAN_INSTALL_PARENT="$(dirname "$REPO_SCAN_INSTALL_DIR")"
+mkdir -p "$REPO_SCAN_INSTALL_PARENT"
+REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
 REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
-REPO_SCAN_BACKUP=""
-trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
+REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_KEEP_TMP=0
+cleanup_repo_scan_install() {
+  if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
+    rm -rf -- "$REPO_SCAN_TMP"
+  fi
+}
+trap cleanup_repo_scan_install EXIT
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
@@ -44,15 +52,16 @@ if [ "$REPO_SCAN_CONFIRM" != install ]; then
   exit 1
 fi
 
-mkdir -p "$(dirname "$REPO_SCAN_INSTALL_DIR")"
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
-  REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
   mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
 if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
-  if [ -n "$REPO_SCAN_BACKUP" ] && \
-    { [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; }; then
-    mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"
+  if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
+    if ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
+        "$REPO_SCAN_BACKUP" >&2
+    fi
   fi
   exit 1
 fi

--- a/docs/ja-JP/skills/repo-scan/SKILL.md
+++ b/docs/ja-JP/skills/repo-scan/SKILL.md
@@ -19,18 +19,43 @@ origin: community
 
 ```bash
 # Clone first so the pinned commit can be reviewed before installation
+set -euo pipefail
+
 REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
 REPO_SCAN_TMP="$(mktemp -d)"
 REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
+REPO_SCAN_BACKUP=""
 trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
 git -C "$REPO_SCAN_TMP/source" checkout --detach "$REPO_SCAN_COMMIT"
+mkdir -p "$REPO_SCAN_STAGE"
+git -C "$REPO_SCAN_TMP/source" archive "$REPO_SCAN_COMMIT" | \
+  tar -xf - -C "$REPO_SCAN_STAGE"
 
-# Review "$REPO_SCAN_TMP/source", then install tracked files without .git metadata
-mkdir -p "$REPO_SCAN_INSTALL_DIR"
-git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf - -C "$REPO_SCAN_INSTALL_DIR"
+# Review "$REPO_SCAN_TMP/source" before approving installation.
+printf 'Type install to replace %s after reviewing the pinned source: ' \
+  "$REPO_SCAN_INSTALL_DIR" >&2
+read -r REPO_SCAN_CONFIRM
+if [ "$REPO_SCAN_CONFIRM" != install ]; then
+  printf 'Installation cancelled.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$REPO_SCAN_INSTALL_DIR")"
+if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
+  REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+  mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
+fi
+if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
+  if [ -n "$REPO_SCAN_BACKUP" ] && \
+    { [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; }; then
+    mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"
+  fi
+  exit 1
+fi
 ```
 
 > エージェントスキルをインストールする前に、ソースコードをレビューしてください。

--- a/docs/ja-JP/skills/repo-scan/SKILL.md
+++ b/docs/ja-JP/skills/repo-scan/SKILL.md
@@ -28,10 +28,15 @@ mkdir -p "$REPO_SCAN_INSTALL_PARENT"
 REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
 REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
 REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_LOCK="$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.lock"
 REPO_SCAN_KEEP_TMP=0
+REPO_SCAN_LOCK_HELD=0
 cleanup_repo_scan_install() {
   if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
     rm -rf -- "$REPO_SCAN_TMP"
+  fi
+  if [ "$REPO_SCAN_LOCK_HELD" -eq 1 ] && ! rmdir -- "$REPO_SCAN_LOCK"; then
+    printf 'Could not release installation lock at %s\n' "$REPO_SCAN_LOCK" >&2
   fi
 }
 trap cleanup_repo_scan_install EXIT
@@ -51,13 +56,23 @@ if [ "$REPO_SCAN_CONFIRM" != install ]; then
   printf 'Installation cancelled.\n' >&2
   exit 1
 fi
+if ! mkdir -- "$REPO_SCAN_LOCK" 2>/dev/null; then
+  printf 'Another repo-scan installation holds the lock at %s\n' \
+    "$REPO_SCAN_LOCK" >&2
+  exit 1
+fi
+REPO_SCAN_LOCK_HELD=1
 
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
   mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
 if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
   if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
-    if ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+    if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Replacement failed and target was recreated; previous installation preserved at %s\n' \
+        "$REPO_SCAN_BACKUP" >&2
+    elif ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2

--- a/docs/ja-JP/skills/repo-scan/SKILL.md
+++ b/docs/ja-JP/skills/repo-scan/SKILL.md
@@ -26,11 +26,13 @@ REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
 REPO_SCAN_INSTALL_PARENT="$(dirname "$REPO_SCAN_INSTALL_DIR")"
 mkdir -p "$REPO_SCAN_INSTALL_PARENT"
 REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
-REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
-REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_TOKEN="${REPO_SCAN_TMP##*.}"
+REPO_SCAN_STAGE="$REPO_SCAN_TMP/stage-$REPO_SCAN_TOKEN"
+REPO_SCAN_BACKUP="$REPO_SCAN_TMP/backup-$REPO_SCAN_TOKEN"
 REPO_SCAN_LOCK="$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.lock"
 REPO_SCAN_KEEP_TMP=0
 REPO_SCAN_LOCK_HELD=0
+REPO_SCAN_MV_HAS_NO_TARGET=0
 cleanup_repo_scan_install() {
   if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
     rm -rf -- "$REPO_SCAN_TMP"
@@ -40,6 +42,39 @@ cleanup_repo_scan_install() {
   fi
 }
 trap cleanup_repo_scan_install EXIT
+mkdir "$REPO_SCAN_TMP/mv-probe-source"
+if mv -T -- "$REPO_SCAN_TMP/mv-probe-source" \
+  "$REPO_SCAN_TMP/mv-probe-destination" 2>/dev/null; then
+  REPO_SCAN_MV_HAS_NO_TARGET=1
+  rmdir "$REPO_SCAN_TMP/mv-probe-destination"
+else
+  rmdir "$REPO_SCAN_TMP/mv-probe-source"
+fi
+move_repo_scan_dir() {
+  REPO_SCAN_MOVE_SOURCE=$1
+  REPO_SCAN_MOVE_DESTINATION=$2
+  REPO_SCAN_MOVE_NAME=${REPO_SCAN_MOVE_SOURCE##*/}
+  if [ -e "$REPO_SCAN_MOVE_DESTINATION" ] || [ -L "$REPO_SCAN_MOVE_DESTINATION" ]; then
+    return 1
+  fi
+  if [ "$REPO_SCAN_MV_HAS_NO_TARGET" -eq 1 ]; then
+    mv -T -- "$REPO_SCAN_MOVE_SOURCE" "$REPO_SCAN_MOVE_DESTINATION"
+    return
+  fi
+  if ! mv -- "$REPO_SCAN_MOVE_SOURCE" "$REPO_SCAN_MOVE_DESTINATION"; then
+    return 1
+  fi
+  if [ -e "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" ] || \
+    [ -L "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" ]; then
+    if ! mv -- "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" \
+      "$REPO_SCAN_MOVE_SOURCE"; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Move conflict recovery failed; staged data remains at %s\n' \
+        "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" >&2
+    fi
+    return 1
+  fi
+}
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
@@ -64,15 +99,15 @@ fi
 REPO_SCAN_LOCK_HELD=1
 
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
-  mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
+  move_repo_scan_dir "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
-if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
+if ! move_repo_scan_dir "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
   if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
     if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement failed and target was recreated; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2
-    elif ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+    elif ! move_repo_scan_dir "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2

--- a/docs/zh-CN/skills/repo-scan/SKILL.md
+++ b/docs/zh-CN/skills/repo-scan/SKILL.md
@@ -18,14 +18,19 @@ origin: community
 ## 安装
 
 ```bash
-# Fetch only the pinned commit for reproducibility
-mkdir -p ~/.claude/skills/repo-scan
-git init repo-scan
-cd repo-scan
-git remote add origin https://github.com/haibindev/repo-scan.git
-git fetch --depth 1 origin 2742664
-git checkout --detach FETCH_HEAD
-cp -r . ~/.claude/skills/repo-scan
+# Clone first so the pinned commit can be reviewed before installation
+REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
+REPO_SCAN_TMP="$(mktemp -d)"
+REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
+
+git clone --filter=blob:none --no-checkout \
+  https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
+git -C "$REPO_SCAN_TMP/source" checkout --detach "$REPO_SCAN_COMMIT"
+
+# Review "$REPO_SCAN_TMP/source", then install tracked files without .git metadata
+mkdir -p "$REPO_SCAN_INSTALL_DIR"
+git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf - -C "$REPO_SCAN_INSTALL_DIR"
 ```
 
 > 安装任何代理技能前，请先审查源码。

--- a/docs/zh-CN/skills/repo-scan/SKILL.md
+++ b/docs/zh-CN/skills/repo-scan/SKILL.md
@@ -19,18 +19,43 @@ origin: community
 
 ```bash
 # Clone first so the pinned commit can be reviewed before installation
+set -euo pipefail
+
 REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
 REPO_SCAN_TMP="$(mktemp -d)"
 REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
+REPO_SCAN_BACKUP=""
 trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
 git -C "$REPO_SCAN_TMP/source" checkout --detach "$REPO_SCAN_COMMIT"
+mkdir -p "$REPO_SCAN_STAGE"
+git -C "$REPO_SCAN_TMP/source" archive "$REPO_SCAN_COMMIT" | \
+  tar -xf - -C "$REPO_SCAN_STAGE"
 
-# Review "$REPO_SCAN_TMP/source", then install tracked files without .git metadata
-mkdir -p "$REPO_SCAN_INSTALL_DIR"
-git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf - -C "$REPO_SCAN_INSTALL_DIR"
+# Review "$REPO_SCAN_TMP/source" before approving installation.
+printf 'Type install to replace %s after reviewing the pinned source: ' \
+  "$REPO_SCAN_INSTALL_DIR" >&2
+read -r REPO_SCAN_CONFIRM
+if [ "$REPO_SCAN_CONFIRM" != install ]; then
+  printf 'Installation cancelled.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$REPO_SCAN_INSTALL_DIR")"
+if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
+  REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+  mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
+fi
+if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
+  if [ -n "$REPO_SCAN_BACKUP" ] && \
+    { [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; }; then
+    mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"
+  fi
+  exit 1
+fi
 ```
 
 > 安装任何代理技能前，请先审查源码。

--- a/docs/zh-CN/skills/repo-scan/SKILL.md
+++ b/docs/zh-CN/skills/repo-scan/SKILL.md
@@ -22,11 +22,19 @@ origin: community
 set -euo pipefail
 
 REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
-REPO_SCAN_TMP="$(mktemp -d)"
 REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+REPO_SCAN_INSTALL_PARENT="$(dirname "$REPO_SCAN_INSTALL_DIR")"
+mkdir -p "$REPO_SCAN_INSTALL_PARENT"
+REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
 REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
-REPO_SCAN_BACKUP=""
-trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
+REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_KEEP_TMP=0
+cleanup_repo_scan_install() {
+  if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
+    rm -rf -- "$REPO_SCAN_TMP"
+  fi
+}
+trap cleanup_repo_scan_install EXIT
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
@@ -44,15 +52,16 @@ if [ "$REPO_SCAN_CONFIRM" != install ]; then
   exit 1
 fi
 
-mkdir -p "$(dirname "$REPO_SCAN_INSTALL_DIR")"
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
-  REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
   mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
 if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
-  if [ -n "$REPO_SCAN_BACKUP" ] && \
-    { [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; }; then
-    mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"
+  if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
+    if ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
+        "$REPO_SCAN_BACKUP" >&2
+    fi
   fi
   exit 1
 fi

--- a/docs/zh-CN/skills/repo-scan/SKILL.md
+++ b/docs/zh-CN/skills/repo-scan/SKILL.md
@@ -28,10 +28,15 @@ mkdir -p "$REPO_SCAN_INSTALL_PARENT"
 REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
 REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
 REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_LOCK="$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.lock"
 REPO_SCAN_KEEP_TMP=0
+REPO_SCAN_LOCK_HELD=0
 cleanup_repo_scan_install() {
   if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
     rm -rf -- "$REPO_SCAN_TMP"
+  fi
+  if [ "$REPO_SCAN_LOCK_HELD" -eq 1 ] && ! rmdir -- "$REPO_SCAN_LOCK"; then
+    printf 'Could not release installation lock at %s\n' "$REPO_SCAN_LOCK" >&2
   fi
 }
 trap cleanup_repo_scan_install EXIT
@@ -51,13 +56,23 @@ if [ "$REPO_SCAN_CONFIRM" != install ]; then
   printf 'Installation cancelled.\n' >&2
   exit 1
 fi
+if ! mkdir -- "$REPO_SCAN_LOCK" 2>/dev/null; then
+  printf 'Another repo-scan installation holds the lock at %s\n' \
+    "$REPO_SCAN_LOCK" >&2
+  exit 1
+fi
+REPO_SCAN_LOCK_HELD=1
 
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
   mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
 if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
   if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
-    if ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+    if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Replacement failed and target was recreated; previous installation preserved at %s\n' \
+        "$REPO_SCAN_BACKUP" >&2
+    elif ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2

--- a/docs/zh-CN/skills/repo-scan/SKILL.md
+++ b/docs/zh-CN/skills/repo-scan/SKILL.md
@@ -26,11 +26,13 @@ REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
 REPO_SCAN_INSTALL_PARENT="$(dirname "$REPO_SCAN_INSTALL_DIR")"
 mkdir -p "$REPO_SCAN_INSTALL_PARENT"
 REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
-REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
-REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_TOKEN="${REPO_SCAN_TMP##*.}"
+REPO_SCAN_STAGE="$REPO_SCAN_TMP/stage-$REPO_SCAN_TOKEN"
+REPO_SCAN_BACKUP="$REPO_SCAN_TMP/backup-$REPO_SCAN_TOKEN"
 REPO_SCAN_LOCK="$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.lock"
 REPO_SCAN_KEEP_TMP=0
 REPO_SCAN_LOCK_HELD=0
+REPO_SCAN_MV_HAS_NO_TARGET=0
 cleanup_repo_scan_install() {
   if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
     rm -rf -- "$REPO_SCAN_TMP"
@@ -40,6 +42,39 @@ cleanup_repo_scan_install() {
   fi
 }
 trap cleanup_repo_scan_install EXIT
+mkdir "$REPO_SCAN_TMP/mv-probe-source"
+if mv -T -- "$REPO_SCAN_TMP/mv-probe-source" \
+  "$REPO_SCAN_TMP/mv-probe-destination" 2>/dev/null; then
+  REPO_SCAN_MV_HAS_NO_TARGET=1
+  rmdir "$REPO_SCAN_TMP/mv-probe-destination"
+else
+  rmdir "$REPO_SCAN_TMP/mv-probe-source"
+fi
+move_repo_scan_dir() {
+  REPO_SCAN_MOVE_SOURCE=$1
+  REPO_SCAN_MOVE_DESTINATION=$2
+  REPO_SCAN_MOVE_NAME=${REPO_SCAN_MOVE_SOURCE##*/}
+  if [ -e "$REPO_SCAN_MOVE_DESTINATION" ] || [ -L "$REPO_SCAN_MOVE_DESTINATION" ]; then
+    return 1
+  fi
+  if [ "$REPO_SCAN_MV_HAS_NO_TARGET" -eq 1 ]; then
+    mv -T -- "$REPO_SCAN_MOVE_SOURCE" "$REPO_SCAN_MOVE_DESTINATION"
+    return
+  fi
+  if ! mv -- "$REPO_SCAN_MOVE_SOURCE" "$REPO_SCAN_MOVE_DESTINATION"; then
+    return 1
+  fi
+  if [ -e "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" ] || \
+    [ -L "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" ]; then
+    if ! mv -- "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" \
+      "$REPO_SCAN_MOVE_SOURCE"; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Move conflict recovery failed; staged data remains at %s\n' \
+        "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" >&2
+    fi
+    return 1
+  fi
+}
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
@@ -64,15 +99,15 @@ fi
 REPO_SCAN_LOCK_HELD=1
 
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
-  mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
+  move_repo_scan_dir "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
-if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
+if ! move_repo_scan_dir "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
   if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
     if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement failed and target was recreated; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2
-    elif ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+    elif ! move_repo_scan_dir "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -19,14 +19,19 @@ metadata:
 ## Installation
 
 ```bash
-# Fetch only the pinned commit for reproducibility
-mkdir -p ~/.claude/skills/repo-scan
-git init repo-scan
-cd repo-scan
-git remote add origin https://github.com/haibindev/repo-scan.git
-git fetch --depth 1 origin 2742664
-git checkout --detach FETCH_HEAD
-cp -r . ~/.claude/skills/repo-scan
+# Clone first so the pinned commit can be reviewed before installation
+REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
+REPO_SCAN_TMP="$(mktemp -d)"
+REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
+
+git clone --filter=blob:none --no-checkout \
+  https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
+git -C "$REPO_SCAN_TMP/source" checkout --detach "$REPO_SCAN_COMMIT"
+
+# Review "$REPO_SCAN_TMP/source", then install tracked files without .git metadata
+mkdir -p "$REPO_SCAN_INSTALL_DIR"
+git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf - -C "$REPO_SCAN_INSTALL_DIR"
 ```
 
 > Review the source before installing any agent skill.

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -23,11 +23,19 @@ metadata:
 set -euo pipefail
 
 REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
-REPO_SCAN_TMP="$(mktemp -d)"
 REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+REPO_SCAN_INSTALL_PARENT="$(dirname "$REPO_SCAN_INSTALL_DIR")"
+mkdir -p "$REPO_SCAN_INSTALL_PARENT"
+REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
 REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
-REPO_SCAN_BACKUP=""
-trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
+REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_KEEP_TMP=0
+cleanup_repo_scan_install() {
+  if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
+    rm -rf -- "$REPO_SCAN_TMP"
+  fi
+}
+trap cleanup_repo_scan_install EXIT
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
@@ -45,15 +53,16 @@ if [ "$REPO_SCAN_CONFIRM" != install ]; then
   exit 1
 fi
 
-mkdir -p "$(dirname "$REPO_SCAN_INSTALL_DIR")"
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
-  REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
   mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
 if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
-  if [ -n "$REPO_SCAN_BACKUP" ] && \
-    { [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; }; then
-    mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"
+  if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
+    if ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
+        "$REPO_SCAN_BACKUP" >&2
+    fi
   fi
   exit 1
 fi

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -20,18 +20,43 @@ metadata:
 
 ```bash
 # Clone first so the pinned commit can be reviewed before installation
+set -euo pipefail
+
 REPO_SCAN_COMMIT=2742664ebcad1450c208eda0ae45d3c17fad5dd8
 REPO_SCAN_TMP="$(mktemp -d)"
 REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
+REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
+REPO_SCAN_BACKUP=""
 trap 'rm -rf "$REPO_SCAN_TMP"' EXIT
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
 git -C "$REPO_SCAN_TMP/source" checkout --detach "$REPO_SCAN_COMMIT"
+mkdir -p "$REPO_SCAN_STAGE"
+git -C "$REPO_SCAN_TMP/source" archive "$REPO_SCAN_COMMIT" | \
+  tar -xf - -C "$REPO_SCAN_STAGE"
 
-# Review "$REPO_SCAN_TMP/source", then install tracked files without .git metadata
-mkdir -p "$REPO_SCAN_INSTALL_DIR"
-git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf - -C "$REPO_SCAN_INSTALL_DIR"
+# Review "$REPO_SCAN_TMP/source" before approving installation.
+printf 'Type install to replace %s after reviewing the pinned source: ' \
+  "$REPO_SCAN_INSTALL_DIR" >&2
+read -r REPO_SCAN_CONFIRM
+if [ "$REPO_SCAN_CONFIRM" != install ]; then
+  printf 'Installation cancelled.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$REPO_SCAN_INSTALL_DIR")"
+if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
+  REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+  mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
+fi
+if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
+  if [ -n "$REPO_SCAN_BACKUP" ] && \
+    { [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; }; then
+    mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"
+  fi
+  exit 1
+fi
 ```
 
 > Review the source before installing any agent skill.

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -29,10 +29,15 @@ mkdir -p "$REPO_SCAN_INSTALL_PARENT"
 REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
 REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
 REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_LOCK="$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.lock"
 REPO_SCAN_KEEP_TMP=0
+REPO_SCAN_LOCK_HELD=0
 cleanup_repo_scan_install() {
   if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
     rm -rf -- "$REPO_SCAN_TMP"
+  fi
+  if [ "$REPO_SCAN_LOCK_HELD" -eq 1 ] && ! rmdir -- "$REPO_SCAN_LOCK"; then
+    printf 'Could not release installation lock at %s\n' "$REPO_SCAN_LOCK" >&2
   fi
 }
 trap cleanup_repo_scan_install EXIT
@@ -52,13 +57,23 @@ if [ "$REPO_SCAN_CONFIRM" != install ]; then
   printf 'Installation cancelled.\n' >&2
   exit 1
 fi
+if ! mkdir -- "$REPO_SCAN_LOCK" 2>/dev/null; then
+  printf 'Another repo-scan installation holds the lock at %s\n' \
+    "$REPO_SCAN_LOCK" >&2
+  exit 1
+fi
+REPO_SCAN_LOCK_HELD=1
 
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
   mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
 if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
   if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
-    if ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+    if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Replacement failed and target was recreated; previous installation preserved at %s\n' \
+        "$REPO_SCAN_BACKUP" >&2
+    elif ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -27,11 +27,13 @@ REPO_SCAN_INSTALL_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/repo-scan"
 REPO_SCAN_INSTALL_PARENT="$(dirname "$REPO_SCAN_INSTALL_DIR")"
 mkdir -p "$REPO_SCAN_INSTALL_PARENT"
 REPO_SCAN_TMP="$(mktemp -d "$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.XXXXXX")"
-REPO_SCAN_STAGE="$REPO_SCAN_TMP/install"
-REPO_SCAN_BACKUP="$REPO_SCAN_TMP/previous-install"
+REPO_SCAN_TOKEN="${REPO_SCAN_TMP##*.}"
+REPO_SCAN_STAGE="$REPO_SCAN_TMP/stage-$REPO_SCAN_TOKEN"
+REPO_SCAN_BACKUP="$REPO_SCAN_TMP/backup-$REPO_SCAN_TOKEN"
 REPO_SCAN_LOCK="$REPO_SCAN_INSTALL_PARENT/.repo-scan-install.lock"
 REPO_SCAN_KEEP_TMP=0
 REPO_SCAN_LOCK_HELD=0
+REPO_SCAN_MV_HAS_NO_TARGET=0
 cleanup_repo_scan_install() {
   if [ "$REPO_SCAN_KEEP_TMP" -eq 0 ]; then
     rm -rf -- "$REPO_SCAN_TMP"
@@ -41,6 +43,39 @@ cleanup_repo_scan_install() {
   fi
 }
 trap cleanup_repo_scan_install EXIT
+mkdir "$REPO_SCAN_TMP/mv-probe-source"
+if mv -T -- "$REPO_SCAN_TMP/mv-probe-source" \
+  "$REPO_SCAN_TMP/mv-probe-destination" 2>/dev/null; then
+  REPO_SCAN_MV_HAS_NO_TARGET=1
+  rmdir "$REPO_SCAN_TMP/mv-probe-destination"
+else
+  rmdir "$REPO_SCAN_TMP/mv-probe-source"
+fi
+move_repo_scan_dir() {
+  REPO_SCAN_MOVE_SOURCE=$1
+  REPO_SCAN_MOVE_DESTINATION=$2
+  REPO_SCAN_MOVE_NAME=${REPO_SCAN_MOVE_SOURCE##*/}
+  if [ -e "$REPO_SCAN_MOVE_DESTINATION" ] || [ -L "$REPO_SCAN_MOVE_DESTINATION" ]; then
+    return 1
+  fi
+  if [ "$REPO_SCAN_MV_HAS_NO_TARGET" -eq 1 ]; then
+    mv -T -- "$REPO_SCAN_MOVE_SOURCE" "$REPO_SCAN_MOVE_DESTINATION"
+    return
+  fi
+  if ! mv -- "$REPO_SCAN_MOVE_SOURCE" "$REPO_SCAN_MOVE_DESTINATION"; then
+    return 1
+  fi
+  if [ -e "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" ] || \
+    [ -L "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" ]; then
+    if ! mv -- "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" \
+      "$REPO_SCAN_MOVE_SOURCE"; then
+      REPO_SCAN_KEEP_TMP=1
+      printf 'Move conflict recovery failed; staged data remains at %s\n' \
+        "$REPO_SCAN_MOVE_DESTINATION/$REPO_SCAN_MOVE_NAME" >&2
+    fi
+    return 1
+  fi
+}
 
 git clone --filter=blob:none --no-checkout \
   https://github.com/haibindev/repo-scan.git "$REPO_SCAN_TMP/source"
@@ -65,15 +100,15 @@ fi
 REPO_SCAN_LOCK_HELD=1
 
 if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
-  mv -- "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
+  move_repo_scan_dir "$REPO_SCAN_INSTALL_DIR" "$REPO_SCAN_BACKUP"
 fi
-if ! mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
+if ! move_repo_scan_dir "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"; then
   if [ -e "$REPO_SCAN_BACKUP" ] || [ -L "$REPO_SCAN_BACKUP" ]; then
     if [ -e "$REPO_SCAN_INSTALL_DIR" ] || [ -L "$REPO_SCAN_INSTALL_DIR" ]; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement failed and target was recreated; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2
-    elif ! mv -- "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
+    elif ! move_repo_scan_dir "$REPO_SCAN_BACKUP" "$REPO_SCAN_INSTALL_DIR"; then
       REPO_SCAN_KEEP_TMP=1
       printf 'Replacement and rollback failed; previous installation preserved at %s\n' \
         "$REPO_SCAN_BACKUP" >&2

--- a/tests/skills/repo-scan-install.test.js
+++ b/tests/skills/repo-scan-install.test.js
@@ -1,0 +1,44 @@
+/**
+ * Regression tests for #2774: repo-scan installation must be reproducible.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const skillFiles = [
+  path.join('skills', 'repo-scan', 'SKILL.md'),
+  path.join('docs', 'zh-CN', 'skills', 'repo-scan', 'SKILL.md'),
+  path.join('docs', 'ja-JP', 'skills', 'repo-scan', 'SKILL.md')
+];
+const pinnedCommit = '2742664ebcad1450c208eda0ae45d3c17fad5dd8';
+
+function installationBlock(relativePath) {
+  const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+  const match = source.match(/```bash\n([\s\S]*?)```/);
+  assert.ok(match, `${relativePath} must contain a bash installation block`);
+  return match[1];
+}
+
+console.log('\nrepo-scan installation docs (#2774):');
+
+const blocks = skillFiles.map(installationBlock);
+for (const [index, block] of blocks.entries()) {
+  const relativePath = skillFiles[index];
+  assert.ok(block.includes(`REPO_SCAN_COMMIT=${pinnedCommit}`), `${relativePath} must pin the full commit SHA`);
+  assert.ok(block.includes('git clone --filter=blob:none --no-checkout'), `${relativePath} must clone before checkout`);
+  assert.ok(block.includes('checkout --detach "$REPO_SCAN_COMMIT"'), `${relativePath} must detach at the pin`);
+  assert.ok(block.includes('git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf -'), `${relativePath} must install tracked files from the archive stream`);
+  assert.ok(block.includes('${CLAUDE_CONFIG_DIR:-$HOME/.claude}'), `${relativePath} must honor CLAUDE_CONFIG_DIR`);
+  assert.ok(!block.includes('cp -r .'), `${relativePath} must not copy .git metadata`);
+  assert.ok(!block.includes('git fetch --depth 1 origin 2742664\n'), `${relativePath} must not fetch the short SHA`);
+}
+
+for (const block of blocks.slice(1)) {
+  assert.strictEqual(block, blocks[0], 'translated installation commands must stay synchronized');
+}
+
+console.log(`  PASS ${skillFiles.length} installation blocks use the verified pinned flow`);

--- a/tests/skills/repo-scan-install.test.js
+++ b/tests/skills/repo-scan-install.test.js
@@ -41,4 +41,5 @@ for (const block of blocks.slice(1)) {
   assert.strictEqual(block, blocks[0], 'translated installation commands must stay synchronized');
 }
 
-console.log(`  PASS ${skillFiles.length} installation blocks use the verified pinned flow`);
+console.log(`  Passed: ${skillFiles.length}`);
+console.log('  Failed: 0');

--- a/tests/skills/repo-scan-install.test.js
+++ b/tests/skills/repo-scan-install.test.js
@@ -83,24 +83,54 @@ exec "$REAL_GIT" "$@"
 `);
   writeExecutable(path.join(binDir, 'mv'), `#!/usr/bin/env bash
 set -euo pipefail
-if [ "\${1:-}" = -- ]; then shift; fi
-source_path="\${1:-}"
+original_args=("$@")
+no_target=0
+positional=()
+for arg in "$@"; do
+  case "$arg" in
+    -T) no_target=1 ;;
+    --) ;;
+    *) positional+=("$arg") ;;
+  esac
+done
+source_path="\${positional[0]:-}"
+destination="\${positional[1]:-}"
 case "$source_path" in
-  */install)
+  */mv-probe-source)
+    case "\${REPO_SCAN_TEST_MV_FAILURE:-}" in
+      *-portable) if [ "$no_target" -eq 1 ]; then exit 64; fi ;;
+    esac
+    exec "$REAL_MV" "\${original_args[@]}"
+    ;;
+esac
+case "$source_path" in
+  */stage-*)
     case "\${REPO_SCAN_TEST_MV_FAILURE:-}" in
       replace|rollback) exit 73 ;;
-      target-conflict)
-        mkdir -p -- "\${2:-}"
-        printf 'concurrent installation\n' > "\${2:-}/concurrent-marker.txt"
-        exit 75
+      rollback-target-conflict|rollback-target-conflict-portable) exit 73 ;;
+      target-conflict|target-conflict-portable)
+        if [ ! -e "$SHIM_DIR/conflict-created" ]; then
+          mkdir -p -- "$destination"
+          printf 'concurrent installation\n' > "$destination/concurrent-marker.txt"
+          : > "$SHIM_DIR/conflict-created"
+        fi
         ;;
     esac
     ;;
-  */previous-install)
-    if [ "\${REPO_SCAN_TEST_MV_FAILURE:-}" = rollback ]; then exit 74; fi
+  */backup-*)
+    case "\${REPO_SCAN_TEST_MV_FAILURE:-}" in
+      rollback) exit 74 ;;
+      rollback-target-conflict|rollback-target-conflict-portable)
+        if [ ! -e "$SHIM_DIR/conflict-created" ]; then
+          mkdir -p -- "$destination"
+          printf 'concurrent installation\n' > "$destination/concurrent-marker.txt"
+          : > "$SHIM_DIR/conflict-created"
+        fi
+        ;;
+    esac
     ;;
 esac
-exec "$REAL_MV" -- "$source_path" "\${2:-}"
+exec "$REAL_MV" "\${original_args[@]}"
 `);
   return binDir;
 }
@@ -124,14 +154,17 @@ function prepareInstallScenario(installParent, installDir, scenario) {
 function failureMode(scenario) {
   if (scenario === 'replacement-failure') return 'replace';
   if (scenario === 'rollback-failure') return 'rollback';
-  if (scenario === 'target-conflict') return 'target-conflict';
+  if (scenario.includes('target-conflict')) return scenario;
   return '';
 }
 
 function assertPreservedBackup(result, installParent) {
   const workspaces = transactionDirs(installParent);
   assert.strictEqual(workspaces.length, 1, result.stderr);
-  const preservedBackup = path.join(installParent, workspaces[0], 'previous-install');
+  const workspace = path.join(installParent, workspaces[0]);
+  const backupName = fs.readdirSync(workspace).find(name => name.startsWith('backup-'));
+  assert.ok(backupName, result.stderr);
+  const preservedBackup = path.join(workspace, backupName);
   assert.strictEqual(
     fs.readFileSync(path.join(preservedBackup, 'old-marker.txt'), 'utf8'),
     'previous installation\n'
@@ -164,9 +197,13 @@ function assertInstallationResult({ result, scenario, installDir, installParent 
 
   assertPreservedBackup(result, installParent);
   assert.ok(!fs.existsSync(lockDir));
-  if (scenario === 'target-conflict') {
+  if (scenario.includes('target-conflict')) {
     assert.ok(fs.existsSync(path.join(installDir, 'concurrent-marker.txt')));
-    assert.match(result.stderr, /target was recreated/);
+    assert.ok(
+      !fs.readdirSync(installDir).some(name => /^(stage|backup)-/.test(name)),
+      'native mv must not leave staged or backup directories nested in the target'
+    );
+    assert.match(result.stderr, /target was recreated|rollback failed/);
   } else {
     assert.match(result.stderr, /previous installation preserved at/);
   }
@@ -223,7 +260,10 @@ for (const [index, block] of blocks.entries()) {
   assert.ok(block.includes('mktemp -d "$REPO_SCAN_INSTALL_PARENT/'), `${relativePath} must stage on the target filesystem`);
   assert.ok(block.includes('REPO_SCAN_KEEP_TMP=0'), `${relativePath} must track cleanup safety`);
   assert.ok(block.includes('REPO_SCAN_LOCK_HELD=0'), `${relativePath} must track lock ownership`);
+  assert.ok(block.includes('REPO_SCAN_MV_HAS_NO_TARGET=0'), `${relativePath} must probe no-target moves`);
   assert.ok(block.includes('trap cleanup_repo_scan_install EXIT'), `${relativePath} must use conditional cleanup`);
+  assert.ok(block.includes('mv -T -- "$REPO_SCAN_MOVE_SOURCE"'), `${relativePath} must reject an existing GNU mv destination`);
+  assert.ok(block.includes('move_repo_scan_dir()'), `${relativePath} must guard portable directory moves`);
   assert.ok(block.includes('git clone --filter=blob:none --no-checkout'), `${relativePath} must clone before checkout`);
   assert.ok(block.includes('checkout --detach "$REPO_SCAN_COMMIT"'), `${relativePath} must detach at the pin`);
   assert.ok(block.includes('archive "$REPO_SCAN_COMMIT"'), `${relativePath} must archive the exact pinned commit`);
@@ -232,8 +272,9 @@ for (const [index, block] of blocks.entries()) {
   assert.ok(block.includes('read -r REPO_SCAN_CONFIRM'), `${relativePath} must require explicit confirmation`);
   assert.ok(block.includes('mkdir -- "$REPO_SCAN_LOCK"'), `${relativePath} must serialize replacement`);
   assert.ok(block.includes('[ "$REPO_SCAN_CONFIRM" != install ]'), `${relativePath} must default-deny installation`);
-  assert.ok(block.indexOf('read -r REPO_SCAN_CONFIRM') < block.indexOf('mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must confirm before replacing the target`);
-  assert.ok(block.indexOf('mkdir -- "$REPO_SCAN_LOCK"') < block.indexOf('mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must lock before replacing the target`);
+  assert.ok(block.includes('move_repo_scan_dir "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must use guarded replacement`);
+  assert.ok(block.indexOf('read -r REPO_SCAN_CONFIRM') < block.indexOf('move_repo_scan_dir "$REPO_SCAN_STAGE"'), `${relativePath} must confirm before replacing the target`);
+  assert.ok(block.indexOf('mkdir -- "$REPO_SCAN_LOCK"') < block.indexOf('move_repo_scan_dir "$REPO_SCAN_STAGE"'), `${relativePath} must lock before replacing the target`);
   assert.ok(!block.includes('rm -rf "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must preserve the old target until replacement succeeds`);
   assert.ok(block.includes('${CLAUDE_CONFIG_DIR:-$HOME/.claude}'), `${relativePath} must honor CLAUDE_CONFIG_DIR`);
   assert.ok(!block.includes('cp -r .'), `${relativePath} must not copy .git metadata`);
@@ -258,6 +299,9 @@ if (bashBinary) {
       'replacement-failure',
       'rollback-failure',
       'target-conflict',
+      'target-conflict-portable',
+      'rollback-target-conflict',
+      'rollback-target-conflict-portable',
       'lock-held',
     ]) {
       executeInstallation(block, scenario);

--- a/tests/skills/repo-scan-install.test.js
+++ b/tests/skills/repo-scan-install.test.js
@@ -5,7 +5,9 @@
 'use strict';
 
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -15,6 +17,155 @@ const skillFiles = [
   { relativePath: path.join('docs', 'ja-JP', 'skills', 'repo-scan', 'SKILL.md'), heading: '## インストール' }
 ];
 const pinnedCommit = '2742664ebcad1450c208eda0ae45d3c17fad5dd8';
+const bashBinary = process.env.ECC_TEST_BASH || (process.platform === 'win32' ? null : 'bash');
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+    env: { ...process.env, ...(options.env || {}) },
+  });
+}
+
+function toShellPath(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  return normalized.replace(/^([A-Za-z]):\//, (_, drive) => `/${drive.toLowerCase()}/`);
+}
+
+function writeExecutable(filePath, content) {
+  fs.writeFileSync(filePath, content, { encoding: 'utf8', mode: 0o755 });
+  fs.chmodSync(filePath, 0o755);
+}
+
+function requireShellCommand(command) {
+  const result = run(bashBinary, ['-lc', `command -v ${command}`]);
+  assert.strictEqual(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function createLocalSource(root) {
+  const sourceRepo = path.join(root, 'source-repo');
+  fs.mkdirSync(sourceRepo, { recursive: true });
+  assert.strictEqual(run('git', ['init', '--quiet'], { cwd: sourceRepo }).status, 0);
+  fs.writeFileSync(path.join(sourceRepo, 'SKILL.md'), 'pinned fixture\n');
+  fs.mkdirSync(path.join(sourceRepo, 'scripts'));
+  fs.writeFileSync(path.join(sourceRepo, 'scripts', 'scan.sh'), '#!/bin/sh\n');
+  assert.strictEqual(run('git', ['add', '.'], { cwd: sourceRepo }).status, 0);
+  const commit = run('git', ['commit', '--quiet', '-m', 'fixture'], {
+    cwd: sourceRepo,
+    env: {
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+  assert.strictEqual(commit.status, 0, commit.stderr);
+  return sourceRepo;
+}
+
+function createCommandShims(root) {
+  const binDir = path.join(root, 'bin');
+  fs.mkdirSync(binDir);
+  writeExecutable(path.join(binDir, 'git'), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = clone ]; then
+  target="\${!#}"
+  exec "$REAL_GIT" clone --quiet "$LOCAL_REPO" "$target"
+fi
+if [ "\${1:-}" = -C ] && [ "\${3:-}" = checkout ]; then
+  exec "$REAL_GIT" -C "$2" checkout --quiet --detach HEAD
+fi
+if [ "\${1:-}" = -C ] && [ "\${3:-}" = archive ]; then
+  exec "$REAL_GIT" -C "$2" archive HEAD
+fi
+exec "$REAL_GIT" "$@"
+`);
+  writeExecutable(path.join(binDir, 'mv'), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = -- ]; then shift; fi
+source_path="\${1:-}"
+case "$source_path" in
+  */install)
+    if [ -n "\${REPO_SCAN_TEST_MV_FAILURE:-}" ]; then exit 73; fi
+    ;;
+  */previous-install)
+    if [ "\${REPO_SCAN_TEST_MV_FAILURE:-}" = rollback ]; then exit 74; fi
+    ;;
+esac
+exec "$REAL_MV" -- "$source_path" "\${2:-}"
+`);
+  return binDir;
+}
+
+function transactionDirs(installParent) {
+  if (!fs.existsSync(installParent)) return [];
+  return fs.readdirSync(installParent).filter(name => name.startsWith('.repo-scan-install.'));
+}
+
+function executeInstallation(block, scenario) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-repo-scan-install-'));
+  try {
+    const sourceRepo = createLocalSource(root);
+    const binDir = createCommandShims(root);
+    const configDir = path.join(root, 'config');
+    const installParent = path.join(configDir, 'skills');
+    const installDir = path.join(installParent, 'repo-scan');
+    if (scenario !== 'fresh') {
+      fs.mkdirSync(installDir, { recursive: true });
+      fs.writeFileSync(path.join(installDir, 'old-marker.txt'), 'previous installation\n');
+    }
+
+    const result = run(bashBinary, ['-c', `export PATH="$SHIM_DIR:$PATH"\n${block}`], {
+      input: 'install\n',
+      cwd: repoRoot,
+      env: {
+        CLAUDE_CONFIG_DIR: toShellPath(configDir),
+        LOCAL_REPO: toShellPath(sourceRepo),
+        REAL_GIT: requireShellCommand('git'),
+        REAL_MV: requireShellCommand('mv'),
+        REPO_SCAN_TEST_MV_FAILURE:
+          scenario === 'replacement-failure'
+            ? 'replace'
+            : scenario === 'rollback-failure'
+              ? 'rollback'
+              : '',
+        SHIM_DIR: toShellPath(binDir),
+      },
+      timeout: 30000,
+    });
+
+    if (scenario === 'fresh' || scenario === 'existing') {
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.strictEqual(fs.readFileSync(path.join(installDir, 'SKILL.md'), 'utf8').trim(), 'pinned fixture');
+      assert.ok(!fs.existsSync(path.join(installDir, '.git')));
+      assert.ok(!fs.existsSync(path.join(installDir, 'old-marker.txt')));
+      assert.deepStrictEqual(transactionDirs(installParent), []);
+      return;
+    }
+
+    assert.notStrictEqual(result.status, 0, 'forced replacement failure must propagate');
+    if (scenario === 'replacement-failure') {
+      assert.strictEqual(
+        fs.readFileSync(path.join(installDir, 'old-marker.txt'), 'utf8'),
+        'previous installation\n'
+      );
+      assert.deepStrictEqual(transactionDirs(installParent), []);
+      return;
+    }
+
+    const workspaces = transactionDirs(installParent);
+    assert.strictEqual(workspaces.length, 1, result.stderr);
+    const preservedBackup = path.join(installParent, workspaces[0], 'previous-install');
+    assert.strictEqual(
+      fs.readFileSync(path.join(preservedBackup, 'old-marker.txt'), 'utf8'),
+      'previous installation\n'
+    );
+    assert.match(result.stderr, /previous installation preserved at/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
 
 function installationBlock({ relativePath, heading }) {
   const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
@@ -31,11 +182,14 @@ function installationBlock({ relativePath, heading }) {
 console.log('\nrepo-scan installation docs (#2774):');
 
 const blocks = skillFiles.map(installationBlock);
+let passed = 0;
 for (const [index, block] of blocks.entries()) {
   const { relativePath } = skillFiles[index];
   assert.ok(block.includes(`REPO_SCAN_COMMIT=${pinnedCommit}`), `${relativePath} must pin the full commit SHA`);
   assert.ok(block.includes('set -euo pipefail'), `${relativePath} must fail closed`);
-  assert.ok(block.includes(`trap 'rm -rf "$REPO_SCAN_TMP"' EXIT`), `${relativePath} must clean up its temporary directory`);
+  assert.ok(block.includes('mktemp -d "$REPO_SCAN_INSTALL_PARENT/'), `${relativePath} must stage on the target filesystem`);
+  assert.ok(block.includes('REPO_SCAN_KEEP_TMP=0'), `${relativePath} must track cleanup safety`);
+  assert.ok(block.includes('trap cleanup_repo_scan_install EXIT'), `${relativePath} must use conditional cleanup`);
   assert.ok(block.includes('git clone --filter=blob:none --no-checkout'), `${relativePath} must clone before checkout`);
   assert.ok(block.includes('checkout --detach "$REPO_SCAN_COMMIT"'), `${relativePath} must detach at the pin`);
   assert.ok(block.includes('archive "$REPO_SCAN_COMMIT"'), `${relativePath} must archive the exact pinned commit`);
@@ -48,11 +202,28 @@ for (const [index, block] of blocks.entries()) {
   assert.ok(block.includes('${CLAUDE_CONFIG_DIR:-$HOME/.claude}'), `${relativePath} must honor CLAUDE_CONFIG_DIR`);
   assert.ok(!block.includes('cp -r .'), `${relativePath} must not copy .git metadata`);
   assert.ok(!block.includes('git fetch --depth 1 origin 2742664\n'), `${relativePath} must not fetch the short SHA`);
+  assert.ok(block.includes('REPO_SCAN_KEEP_TMP=1'), `${relativePath} must preserve a failed rollback backup`);
+  passed++;
 }
 
 for (const block of blocks.slice(1)) {
   assert.strictEqual(block, blocks[0], 'translated installation commands must stay synchronized');
+  passed++;
 }
 
-console.log(`  Passed: ${skillFiles.length}`);
+if (bashBinary) {
+  for (const block of blocks) {
+    const syntax = run(bashBinary, ['-n'], { input: block });
+    assert.strictEqual(syntax.status, 0, syntax.stderr);
+    passed++;
+    for (const scenario of ['fresh', 'existing', 'replacement-failure', 'rollback-failure']) {
+      executeInstallation(block, scenario);
+      passed++;
+    }
+  }
+} else {
+  console.log('  Integration coverage skipped on Windows without ECC_TEST_BASH');
+}
+
+console.log(`  Passed: ${passed}`);
 console.log('  Failed: 0');

--- a/tests/skills/repo-scan-install.test.js
+++ b/tests/skills/repo-scan-install.test.js
@@ -10,15 +10,20 @@ const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const skillFiles = [
-  path.join('skills', 'repo-scan', 'SKILL.md'),
-  path.join('docs', 'zh-CN', 'skills', 'repo-scan', 'SKILL.md'),
-  path.join('docs', 'ja-JP', 'skills', 'repo-scan', 'SKILL.md')
+  { relativePath: path.join('skills', 'repo-scan', 'SKILL.md'), heading: '## Installation' },
+  { relativePath: path.join('docs', 'zh-CN', 'skills', 'repo-scan', 'SKILL.md'), heading: '## 安装' },
+  { relativePath: path.join('docs', 'ja-JP', 'skills', 'repo-scan', 'SKILL.md'), heading: '## インストール' }
 ];
 const pinnedCommit = '2742664ebcad1450c208eda0ae45d3c17fad5dd8';
 
-function installationBlock(relativePath) {
+function installationBlock({ relativePath, heading }) {
   const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
-  const match = source.match(/```bash\n([\s\S]*?)```/);
+  const headingStart = source.indexOf(`${heading}\n`);
+  assert.notStrictEqual(headingStart, -1, `${relativePath} must contain ${heading}`);
+  const afterHeading = source.slice(headingStart + heading.length + 1);
+  const nextHeading = afterHeading.search(/^## /m);
+  const installationSection = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
+  const match = installationSection.match(/```bash\n([\s\S]*?)```/);
   assert.ok(match, `${relativePath} must contain a bash installation block`);
   return match[1];
 }
@@ -27,11 +32,19 @@ console.log('\nrepo-scan installation docs (#2774):');
 
 const blocks = skillFiles.map(installationBlock);
 for (const [index, block] of blocks.entries()) {
-  const relativePath = skillFiles[index];
+  const { relativePath } = skillFiles[index];
   assert.ok(block.includes(`REPO_SCAN_COMMIT=${pinnedCommit}`), `${relativePath} must pin the full commit SHA`);
+  assert.ok(block.includes('set -euo pipefail'), `${relativePath} must fail closed`);
+  assert.ok(block.includes(`trap 'rm -rf "$REPO_SCAN_TMP"' EXIT`), `${relativePath} must clean up its temporary directory`);
   assert.ok(block.includes('git clone --filter=blob:none --no-checkout'), `${relativePath} must clone before checkout`);
   assert.ok(block.includes('checkout --detach "$REPO_SCAN_COMMIT"'), `${relativePath} must detach at the pin`);
-  assert.ok(block.includes('git -C "$REPO_SCAN_TMP/source" archive HEAD | tar -xf -'), `${relativePath} must install tracked files from the archive stream`);
+  assert.ok(block.includes('archive "$REPO_SCAN_COMMIT"'), `${relativePath} must archive the exact pinned commit`);
+  assert.ok(block.includes('tar -xf - -C "$REPO_SCAN_STAGE"'), `${relativePath} must extract into a fresh staging directory`);
+  assert.ok(block.includes('# Review "$REPO_SCAN_TMP/source"'), `${relativePath} must instruct source review`);
+  assert.ok(block.includes('read -r REPO_SCAN_CONFIRM'), `${relativePath} must require explicit confirmation`);
+  assert.ok(block.includes('[ "$REPO_SCAN_CONFIRM" != install ]'), `${relativePath} must default-deny installation`);
+  assert.ok(block.indexOf('read -r REPO_SCAN_CONFIRM') < block.indexOf('mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must confirm before replacing the target`);
+  assert.ok(!block.includes('rm -rf "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must preserve the old target until replacement succeeds`);
   assert.ok(block.includes('${CLAUDE_CONFIG_DIR:-$HOME/.claude}'), `${relativePath} must honor CLAUDE_CONFIG_DIR`);
   assert.ok(!block.includes('cp -r .'), `${relativePath} must not copy .git metadata`);
   assert.ok(!block.includes('git fetch --depth 1 origin 2742664\n'), `${relativePath} must not fetch the short SHA`);

--- a/tests/skills/repo-scan-install.test.js
+++ b/tests/skills/repo-scan-install.test.js
@@ -87,7 +87,14 @@ if [ "\${1:-}" = -- ]; then shift; fi
 source_path="\${1:-}"
 case "$source_path" in
   */install)
-    if [ -n "\${REPO_SCAN_TEST_MV_FAILURE:-}" ]; then exit 73; fi
+    case "\${REPO_SCAN_TEST_MV_FAILURE:-}" in
+      replace|rollback) exit 73 ;;
+      target-conflict)
+        mkdir -p -- "\${2:-}"
+        printf 'concurrent installation\n' > "\${2:-}/concurrent-marker.txt"
+        exit 75
+        ;;
+    esac
     ;;
   */previous-install)
     if [ "\${REPO_SCAN_TEST_MV_FAILURE:-}" = rollback ]; then exit 74; fi
@@ -100,7 +107,69 @@ exec "$REAL_MV" -- "$source_path" "\${2:-}"
 
 function transactionDirs(installParent) {
   if (!fs.existsSync(installParent)) return [];
-  return fs.readdirSync(installParent).filter(name => name.startsWith('.repo-scan-install.'));
+  return fs.readdirSync(installParent).filter(
+    name => name.startsWith('.repo-scan-install.') && name !== '.repo-scan-install.lock'
+  );
+}
+
+function prepareInstallScenario(installParent, installDir, scenario) {
+  if (scenario === 'fresh') return;
+  fs.mkdirSync(installDir, { recursive: true });
+  fs.writeFileSync(path.join(installDir, 'old-marker.txt'), 'previous installation\n');
+  if (scenario === 'lock-held') {
+    fs.mkdirSync(path.join(installParent, '.repo-scan-install.lock'));
+  }
+}
+
+function failureMode(scenario) {
+  if (scenario === 'replacement-failure') return 'replace';
+  if (scenario === 'rollback-failure') return 'rollback';
+  if (scenario === 'target-conflict') return 'target-conflict';
+  return '';
+}
+
+function assertPreservedBackup(result, installParent) {
+  const workspaces = transactionDirs(installParent);
+  assert.strictEqual(workspaces.length, 1, result.stderr);
+  const preservedBackup = path.join(installParent, workspaces[0], 'previous-install');
+  assert.strictEqual(
+    fs.readFileSync(path.join(preservedBackup, 'old-marker.txt'), 'utf8'),
+    'previous installation\n'
+  );
+}
+
+function assertInstallationResult({ result, scenario, installDir, installParent }) {
+  const lockDir = path.join(installParent, '.repo-scan-install.lock');
+  if (scenario === 'fresh' || scenario === 'existing') {
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(fs.readFileSync(path.join(installDir, 'SKILL.md'), 'utf8').trim(), 'pinned fixture');
+    assert.ok(!fs.existsSync(path.join(installDir, '.git')));
+    assert.ok(!fs.existsSync(path.join(installDir, 'old-marker.txt')));
+    assert.deepStrictEqual(transactionDirs(installParent), []);
+    assert.ok(!fs.existsSync(lockDir));
+    return;
+  }
+
+  assert.notStrictEqual(result.status, 0, 'forced installation failure must propagate');
+  if (scenario === 'replacement-failure' || scenario === 'lock-held') {
+    assert.strictEqual(
+      fs.readFileSync(path.join(installDir, 'old-marker.txt'), 'utf8'),
+      'previous installation\n'
+    );
+    assert.deepStrictEqual(transactionDirs(installParent), []);
+    assert.strictEqual(fs.existsSync(lockDir), scenario === 'lock-held');
+    if (scenario === 'lock-held') assert.match(result.stderr, /holds the lock/);
+    return;
+  }
+
+  assertPreservedBackup(result, installParent);
+  assert.ok(!fs.existsSync(lockDir));
+  if (scenario === 'target-conflict') {
+    assert.ok(fs.existsSync(path.join(installDir, 'concurrent-marker.txt')));
+    assert.match(result.stderr, /target was recreated/);
+  } else {
+    assert.match(result.stderr, /previous installation preserved at/);
+  }
 }
 
 function executeInstallation(block, scenario) {
@@ -111,11 +180,7 @@ function executeInstallation(block, scenario) {
     const configDir = path.join(root, 'config');
     const installParent = path.join(configDir, 'skills');
     const installDir = path.join(installParent, 'repo-scan');
-    if (scenario !== 'fresh') {
-      fs.mkdirSync(installDir, { recursive: true });
-      fs.writeFileSync(path.join(installDir, 'old-marker.txt'), 'previous installation\n');
-    }
-
+    prepareInstallScenario(installParent, installDir, scenario);
     const result = run(bashBinary, ['-c', `export PATH="$SHIM_DIR:$PATH"\n${block}`], {
       input: 'install\n',
       cwd: repoRoot,
@@ -124,44 +189,12 @@ function executeInstallation(block, scenario) {
         LOCAL_REPO: toShellPath(sourceRepo),
         REAL_GIT: requireShellCommand('git'),
         REAL_MV: requireShellCommand('mv'),
-        REPO_SCAN_TEST_MV_FAILURE:
-          scenario === 'replacement-failure'
-            ? 'replace'
-            : scenario === 'rollback-failure'
-              ? 'rollback'
-              : '',
+        REPO_SCAN_TEST_MV_FAILURE: failureMode(scenario),
         SHIM_DIR: toShellPath(binDir),
       },
       timeout: 30000,
     });
-
-    if (scenario === 'fresh' || scenario === 'existing') {
-      assert.strictEqual(result.status, 0, result.stderr);
-      assert.strictEqual(fs.readFileSync(path.join(installDir, 'SKILL.md'), 'utf8').trim(), 'pinned fixture');
-      assert.ok(!fs.existsSync(path.join(installDir, '.git')));
-      assert.ok(!fs.existsSync(path.join(installDir, 'old-marker.txt')));
-      assert.deepStrictEqual(transactionDirs(installParent), []);
-      return;
-    }
-
-    assert.notStrictEqual(result.status, 0, 'forced replacement failure must propagate');
-    if (scenario === 'replacement-failure') {
-      assert.strictEqual(
-        fs.readFileSync(path.join(installDir, 'old-marker.txt'), 'utf8'),
-        'previous installation\n'
-      );
-      assert.deepStrictEqual(transactionDirs(installParent), []);
-      return;
-    }
-
-    const workspaces = transactionDirs(installParent);
-    assert.strictEqual(workspaces.length, 1, result.stderr);
-    const preservedBackup = path.join(installParent, workspaces[0], 'previous-install');
-    assert.strictEqual(
-      fs.readFileSync(path.join(preservedBackup, 'old-marker.txt'), 'utf8'),
-      'previous installation\n'
-    );
-    assert.match(result.stderr, /previous installation preserved at/);
+    assertInstallationResult({ result, scenario, installDir, installParent });
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -189,6 +222,7 @@ for (const [index, block] of blocks.entries()) {
   assert.ok(block.includes('set -euo pipefail'), `${relativePath} must fail closed`);
   assert.ok(block.includes('mktemp -d "$REPO_SCAN_INSTALL_PARENT/'), `${relativePath} must stage on the target filesystem`);
   assert.ok(block.includes('REPO_SCAN_KEEP_TMP=0'), `${relativePath} must track cleanup safety`);
+  assert.ok(block.includes('REPO_SCAN_LOCK_HELD=0'), `${relativePath} must track lock ownership`);
   assert.ok(block.includes('trap cleanup_repo_scan_install EXIT'), `${relativePath} must use conditional cleanup`);
   assert.ok(block.includes('git clone --filter=blob:none --no-checkout'), `${relativePath} must clone before checkout`);
   assert.ok(block.includes('checkout --detach "$REPO_SCAN_COMMIT"'), `${relativePath} must detach at the pin`);
@@ -196,8 +230,10 @@ for (const [index, block] of blocks.entries()) {
   assert.ok(block.includes('tar -xf - -C "$REPO_SCAN_STAGE"'), `${relativePath} must extract into a fresh staging directory`);
   assert.ok(block.includes('# Review "$REPO_SCAN_TMP/source"'), `${relativePath} must instruct source review`);
   assert.ok(block.includes('read -r REPO_SCAN_CONFIRM'), `${relativePath} must require explicit confirmation`);
+  assert.ok(block.includes('mkdir -- "$REPO_SCAN_LOCK"'), `${relativePath} must serialize replacement`);
   assert.ok(block.includes('[ "$REPO_SCAN_CONFIRM" != install ]'), `${relativePath} must default-deny installation`);
   assert.ok(block.indexOf('read -r REPO_SCAN_CONFIRM') < block.indexOf('mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must confirm before replacing the target`);
+  assert.ok(block.indexOf('mkdir -- "$REPO_SCAN_LOCK"') < block.indexOf('mv -- "$REPO_SCAN_STAGE" "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must lock before replacing the target`);
   assert.ok(!block.includes('rm -rf "$REPO_SCAN_INSTALL_DIR"'), `${relativePath} must preserve the old target until replacement succeeds`);
   assert.ok(block.includes('${CLAUDE_CONFIG_DIR:-$HOME/.claude}'), `${relativePath} must honor CLAUDE_CONFIG_DIR`);
   assert.ok(!block.includes('cp -r .'), `${relativePath} must not copy .git metadata`);
@@ -216,7 +252,14 @@ if (bashBinary) {
     const syntax = run(bashBinary, ['-n'], { input: block });
     assert.strictEqual(syntax.status, 0, syntax.stderr);
     passed++;
-    for (const scenario of ['fresh', 'existing', 'replacement-failure', 'rollback-failure']) {
+    for (const scenario of [
+      'fresh',
+      'existing',
+      'replacement-failure',
+      'rollback-failure',
+      'target-conflict',
+      'lock-held',
+    ]) {
       executeInstallation(block, scenario);
       passed++;
     }


### PR DESCRIPTION
## What Changed

- replace the unfetchable short-SHA installation flow with a full 40-character pinned commit
- clone into a temporary review directory before installation
- install only tracked files through `git archive`, avoiding copied `.git` metadata
- honor `CLAUDE_CONFIG_DIR`
- keep English, Simplified Chinese, and Japanese installation commands synchronized
- add a regression test for all three documentation surfaces

## Why This Change

The documented `git fetch --depth 1 origin 2742664` command treats a short object ID as a remote ref and fails when followed verbatim. The subsequent `cp -r .` would also copy repository metadata into the installed skill.

Closes #2774

## Testing Done

- [x] Manual testing completed
- [x] Automated focused tests pass locally
- [x] Edge cases considered and tested

Validation performed:

- exact Git Bash install flow checked out `2742664ebcad1450c208eda0ae45d3c17fad5dd8`
- archive extraction produced 29 tracked files and no `.git` directory
- `node tests/skills/repo-scan-install.test.js`
- `node scripts/ci/validate-skills.js`
- `npm run catalog:check`
- `node scripts/ci/validate-no-personal-paths.js`
- `npx markdownlint` on all three changed skill documents

## Type of Change

- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)