### PR TITLE
fix(learning): isolate observer project scope

### DIFF
--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -335,14 +335,6 @@ except Exception:
     pass
 
 parsed = json.load(sys.stdin)
-observation = {
-    "timestamp": os.environ["TIMESTAMP"],
-    "event": parsed["event"],
-    "tool": parsed["tool"],
-    "session": parsed["session"],
-    "project_id": os.environ.get("PROJECT_ID_ENV", "global"),
-    "project_name": os.environ.get("PROJECT_NAME_ENV", "global")
-}
 
 # Scrub secrets: match common key=value, key: value, and key"value patterns
 # Includes optional auth scheme (e.g., "Bearer", "Basic") before token
@@ -361,11 +353,17 @@ def scrub(val):
         return None
     return _SECRET_RE.sub(lambda m: m.group(1) + m.group(2) + (m.group(3) or "") + "[REDACTED]", str(val))
 
-observation["cwd"] = scrub(parsed.get("cwd", ""))
-if parsed["input"]:
-    observation["input"] = scrub(parsed["input"])
-if parsed["output"] is not None:
-    observation["output"] = scrub(parsed["output"])
+observation = {
+    "timestamp": os.environ["TIMESTAMP"],
+    "event": parsed["event"],
+    "tool": parsed["tool"],
+    "session": parsed["session"],
+    "project_id": os.environ.get("PROJECT_ID_ENV", "global"),
+    "project_name": os.environ.get("PROJECT_NAME_ENV", "global"),
+    "cwd": scrub(parsed.get("cwd", "")),
+    **({"input": scrub(parsed["input"])} if parsed["input"] else {}),
+    **({"output": scrub(parsed["output"])} if parsed["output"] is not None else {})
+}
 
 print(json.dumps(observation))
 ' >> "$OBSERVATIONS_FILE"
@@ -656,27 +654,21 @@ fi
 
 # Signal only the observer that owns this observation's project scope.
 if [ "$should_signal" -eq 1 ]; then
-  signaled_pids=" "
-  for pid_file in "${PROJECT_DIR}/.observer.pid"; do
-    if [ -f "$pid_file" ]; then
-      observer_pid=$(cat "$pid_file" 2>/dev/null || true)
-      # Validate PID is a positive integer (>1)
-      case "$observer_pid" in
-        ''|*[!0-9]*|0|1)
-          _REMOVE_FILE_IF_PRESENT "$pid_file"
-          continue
-          ;;
-      esac
-      # Deduplicate: skip if already signaled this pass
-      case "$signaled_pids" in
-        *" $observer_pid "*) continue ;;
-      esac
-      if kill -0 "$observer_pid" 2>/dev/null; then
-        kill -USR1 "$observer_pid" 2>/dev/null || true
-        signaled_pids="${signaled_pids}${observer_pid} "
-      fi
-    fi
-  done
+  pid_file="${PROJECT_DIR}/.observer.pid"
+  if [ -f "$pid_file" ]; then
+    observer_pid=$(cat "$pid_file" 2>/dev/null || true)
+    # Validate PID is a positive integer (>1)
+    case "$observer_pid" in
+      ''|*[!0-9]*|0|1)
+        _REMOVE_FILE_IF_PRESENT "$pid_file"
+        ;;
+      *)
+        if kill -0 "$observer_pid" 2>/dev/null; then
+          kill -USR1 "$observer_pid" 2>/dev/null || true
+        fi
+        ;;
+    esac
+  fi
 fi
 
 exit 0

--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -113,7 +113,10 @@ except(KeyError, TypeError, ValueError):
     print("")
 ' 2>/dev/null || echo "")
 
-# If cwd was provided in stdin, use it for project detection
+# Prefer the hook payload because it belongs to this exact event. If the
+# payload has no usable cwd, only trust an explicit, valid project directory;
+# never let detect-project.sh infer scope from the hook process's inherited
+# working directory.
 if [ -n "$STDIN_CWD" ] && [ -d "$STDIN_CWD" ]; then
   _GIT_ROOT=$(git -C "$STDIN_CWD" rev-parse --show-toplevel 2>/dev/null || true)
   if [ -n "$_GIT_ROOT" ]; then
@@ -123,6 +126,11 @@ if [ -n "$STDIN_CWD" ] && [ -d "$STDIN_CWD" ]; then
     unset CLAUDE_PROJECT_DIR
     export CLV2_NO_PROJECT=1
   fi
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR" ]; then
+  unset CLV2_NO_PROJECT
+else
+  unset CLAUDE_PROJECT_DIR
+  export CLV2_NO_PROJECT=1
 fi
 
 # ─────────────────────────────────────────────
@@ -353,6 +361,7 @@ def scrub(val):
         return None
     return _SECRET_RE.sub(lambda m: m.group(1) + m.group(2) + (m.group(3) or "") + "[REDACTED]", str(val))
 
+observation["cwd"] = scrub(parsed.get("cwd", ""))
 if parsed["input"]:
     observation["input"] = scrub(parsed["input"])
 if parsed["output"] is not None:
@@ -503,15 +512,16 @@ print(str(cfg.get('observer', {}).get('enabled', False)).lower())
   fi
 fi
 
-# Check both project-scoped AND global PID files (with stale PID recovery)
+# Check only this observation's project-scoped PID file. PROJECT_DIR already
+# equals CONFIG_DIR for global scope, so a separate global check only lets a
+# global observer suppress or wake an unrelated project observer (#2746).
 if [ "$OBSERVER_ENABLED" = "true" ]; then
   # Clean up stale PID files first.
   # `if` context (not `|| true`) so `set -e` stays satisfied while we still
-  # capture whether either PID file pointed at a live observer.
+  # capture whether the project PID file pointed at a live observer.
   OBSERVER_ALIVE=false
   OBSERVER_DIED=false
   if _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid"; then OBSERVER_ALIVE=true; fi
-  if _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid"; then OBSERVER_ALIVE=true; fi
 
   # A live observer clears the streak so a later one-off crash does not inherit
   # an old count. This is an idempotent unlink, not a read-modify-write, so it
@@ -522,15 +532,14 @@ if [ "$OBSERVER_ENABLED" = "true" ]; then
   fi
 
   # Check if observer is now running after cleanup
-  if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+  if [ ! -f "${PROJECT_DIR}/.observer.pid" ]; then
     # Use flock if available (Linux), fallback for macOS
     if command -v flock >/dev/null 2>&1; then
       (
         flock -n 9 || exit 0
-        # Double-check PID files after acquiring lock
+        # Double-check the project PID file after acquiring the lock
         _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-        _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
-        if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+        if [ ! -f "${PROJECT_DIR}/.observer.pid" ]; then
           _START_OBSERVER_LOGGED
         fi
       ) 9>"$LAZY_START_LOCK"
@@ -542,8 +551,7 @@ if [ "$OBSERVER_ENABLED" = "true" ]; then
           trap '_REMOVE_FILE_IF_PRESENT "$LAZY_START_LOCK"' EXIT
           lockfile -r 1 -l 30 "$LAZY_START_LOCK" 2>/dev/null || exit 0
           _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-          _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
-          if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+          if [ ! -f "${PROJECT_DIR}/.observer.pid" ]; then
             _START_OBSERVER_LOGGED
           fi
           _REMOVE_FILE_IF_PRESENT "$LAZY_START_LOCK"
@@ -554,8 +562,7 @@ if [ "$OBSERVER_ENABLED" = "true" ]; then
           trap 'rmdir "${LAZY_START_LOCK}.d" 2>/dev/null || true' EXIT
           mkdir "${LAZY_START_LOCK}.d" 2>/dev/null || exit 0
           _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-          _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
-          if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+          if [ ! -f "${PROJECT_DIR}/.observer.pid" ]; then
             _START_OBSERVER_LOGGED
           fi
         )
@@ -647,10 +654,10 @@ else
   # corrupts the counter or signals spuriously.
 fi
 
-# Signal observer if running and throttle allows (check both project-scoped and global observer, deduplicate)
+# Signal only the observer that owns this observation's project scope.
 if [ "$should_signal" -eq 1 ]; then
   signaled_pids=" "
-  for pid_file in "${PROJECT_DIR}/.observer.pid" "${CONFIG_DIR}/.observer.pid"; do
+  for pid_file in "${PROJECT_DIR}/.observer.pid"; do
     if [ -f "$pid_file" ]; then
       observer_pid=$(cat "$pid_file" 2>/dev/null || true)
       # Validate PID is a positive integer (>1)

--- a/skills/continuous-learning-v2/hooks/observe.sh
+++ b/skills/continuous-learning-v2/hooks/observe.sh
@@ -108,7 +108,7 @@ import json, sys
 try:
     data = json.load(sys.stdin)
     cwd = data.get("cwd", "")
-    print(cwd)
+    print(cwd if isinstance(cwd, str) else "")
 except(KeyError, TypeError, ValueError):
     print("")
 ' 2>/dev/null || echo "")
@@ -353,6 +353,7 @@ def scrub(val):
         return None
     return _SECRET_RE.sub(lambda m: m.group(1) + m.group(2) + (m.group(3) or "") + "[REDACTED]", str(val))
 
+raw_cwd = parsed.get("cwd")
 observation = {
     "timestamp": os.environ["TIMESTAMP"],
     "event": parsed["event"],
@@ -360,7 +361,7 @@ observation = {
     "session": parsed["session"],
     "project_id": os.environ.get("PROJECT_ID_ENV", "global"),
     "project_name": os.environ.get("PROJECT_NAME_ENV", "global"),
-    "cwd": scrub(parsed.get("cwd", "")),
+    "cwd": scrub(raw_cwd if isinstance(raw_cwd, str) else ""),
     **({"input": scrub(parsed["input"])} if parsed["input"] else {}),
     **({"output": scrub(parsed["output"])} if parsed["output"] is not None else {})
 }

--- a/tests/hooks/continuous-learning-scope-contract.test.js
+++ b/tests/hooks/continuous-learning-scope-contract.test.js
@@ -26,7 +26,7 @@ assert.ok(
   'project observations must not inspect or signal an unrelated global observer PID'
 );
 assert.ok(
-  observe.includes('observation["cwd"] = scrub(parsed.get("cwd", ""))'),
+  observe.includes('"cwd": scrub(parsed.get("cwd", ""))'),
   'every stored observation must retain a scrubbed cwd diagnostic'
 );
 assert.ok(

--- a/tests/hooks/continuous-learning-scope-contract.test.js
+++ b/tests/hooks/continuous-learning-scope-contract.test.js
@@ -1,0 +1,38 @@
+/**
+ * Cross-platform source contract for continuous-learning-v2 scope routing (#2746).
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const observePath = path.join(repoRoot, 'skills', 'continuous-learning-v2', 'hooks', 'observe.sh');
+const startObserverPath = path.join(repoRoot, 'skills', 'continuous-learning-v2', 'agents', 'start-observer.sh');
+const observe = fs.readFileSync(observePath, 'utf8');
+const startObserver = fs.readFileSync(startObserverPath, 'utf8');
+
+console.log('\ncontinuous-learning-v2 scope contract (#2746):');
+
+assert.match(
+  observe,
+  /elif \[ -n "\$\{CLAUDE_PROJECT_DIR:-\}" \] && \[ -d "\$CLAUDE_PROJECT_DIR" \]; then[\s\S]*?else[\s\S]*?export CLV2_NO_PROJECT=1/,
+  'missing payload cwd must use only a valid explicit project directory or global scope'
+);
+assert.ok(
+  !observe.includes('${CONFIG_DIR}/.observer.pid'),
+  'project observations must not inspect or signal an unrelated global observer PID'
+);
+assert.ok(
+  observe.includes('observation["cwd"] = scrub(parsed.get("cwd", ""))'),
+  'every stored observation must retain a scrubbed cwd diagnostic'
+);
+assert.ok(
+  startObserver.includes('PID_FILE="${PROJECT_DIR}/.observer.pid"') &&
+    startObserver.includes('OBSERVATIONS_FILE="${PROJECT_DIR}/observations.jsonl"'),
+  'observer processes must remain keyed to their project storage directory'
+);
+
+console.log('  PASS deterministic detection, project PID isolation, and cwd diagnostics are enforced');

--- a/tests/hooks/continuous-learning-scope-contract.test.js
+++ b/tests/hooks/continuous-learning-scope-contract.test.js
@@ -26,7 +26,7 @@ assert.ok(
   'project observations must not inspect or signal an unrelated global observer PID'
 );
 assert.ok(
-  observe.includes('"cwd": scrub(parsed.get("cwd", ""))'),
+  observe.includes('"cwd": scrub(raw_cwd if isinstance(raw_cwd, str) else "")'),
   'every stored observation must retain a scrubbed cwd diagnostic'
 );
 assert.ok(

--- a/tests/hooks/observe-subdirectory-detection.test.js
+++ b/tests/hooks/observe-subdirectory-detection.test.js
@@ -95,10 +95,8 @@ function runObserve({ homeDir, cwd, args = ['post'], extraEnv = {} }) {
     tool_input: { file_path: 'README.md' },
     tool_response: 'ok',
     session_id: 'session-subdir-test',
+    ...(cwd === undefined ? {} : { cwd }),
   };
-  if (cwd !== undefined) {
-    hookPayload.cwd = cwd;
-  }
   const payload = JSON.stringify(hookPayload);
 
   return spawnSync(bashBinary, [observeShPath, ...args], {
@@ -247,6 +245,7 @@ test('missing cwd does not inherit the hook process git repository', () => {
     assert.strictEqual(observation.project_id, 'global');
     assert.strictEqual(observation.cwd, '');
     assert.ok(!fs.existsSync(path.join(homunculusDir, 'projects.json')));
+    assert.ok(!fs.existsSync(path.join(homunculusDir, 'projects')));
   } finally {
     cleanupDir(testRoot);
   }
@@ -276,6 +275,11 @@ test('missing cwd uses a valid explicit CLAUDE_PROJECT_DIR', () => {
     );
     assert.strictEqual(observation.cwd, '');
     assert.notStrictEqual(observation.project_id, 'global');
+    assert.ok(
+      !fs.existsSync(
+        path.join(homeDir, '.local', 'share', 'ecc-homunculus', 'observations.jsonl')
+      )
+    );
   } finally {
     cleanupDir(testRoot);
   }

--- a/tests/hooks/observe-subdirectory-detection.test.js
+++ b/tests/hooks/observe-subdirectory-detection.test.js
@@ -5,7 +5,9 @@
  * root when cwd is a subdirectory inside a repository.
  */
 
-if (process.platform === 'win32') {
+const bashBinary = process.env.ECC_TEST_BASH || 'bash';
+
+if (process.platform === 'win32' && !process.env.ECC_TEST_BASH) {
   console.log('Skipping bash-dependent observe tests on Windows');
   process.exit(0);
 }
@@ -57,7 +59,8 @@ function normalizeComparablePath(filePath) {
     return filePath;
   }
 
-  const normalized = fs.realpathSync(filePath);
+  const resolver = fs.realpathSync.native || fs.realpathSync;
+  const normalized = resolver(filePath);
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
@@ -87,15 +90,18 @@ function gitInit(dir) {
 }
 
 function runObserve({ homeDir, cwd, args = ['post'], extraEnv = {} }) {
-  const payload = JSON.stringify({
+  const hookPayload = {
     tool_name: 'Read',
     tool_input: { file_path: 'README.md' },
     tool_response: 'ok',
     session_id: 'session-subdir-test',
-    cwd,
-  });
+  };
+  if (cwd !== undefined) {
+    hookPayload.cwd = cwd;
+  }
+  const payload = JSON.stringify(hookPayload);
 
-  return spawnSync('bash', [observeShPath, ...args], {
+  return spawnSync(bashBinary, [observeShPath, ...args], {
     cwd: repoRoot,
     encoding: 'utf8',
     input: payload,
@@ -169,7 +175,7 @@ test('git rev-parse fails cleanly outside a repo when discovery is bounded', () 
 
   try {
     const result = spawnSync(
-      'bash',
+      bashBinary,
       ['-lc', 'git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null || echo ""'],
       {
         encoding: 'utf8',
@@ -211,6 +217,65 @@ test('observe.sh writes project metadata for the git root when cwd is a subdirec
 
     const observationsPath = path.join(projectDir, 'observations.jsonl');
     assert.ok(fs.existsSync(observationsPath), 'observe.sh should append an observation');
+    const observation = JSON.parse(fs.readFileSync(observationsPath, 'utf8').trim());
+    assert.strictEqual(
+      normalizeComparablePath(observation.cwd),
+      normalizeComparablePath(subDir),
+      'stored observation should retain the payload cwd for diagnosis'
+    );
+  } finally {
+    cleanupDir(testRoot);
+  }
+});
+
+test('missing cwd does not inherit the hook process git repository', () => {
+  const testRoot = createTempDir();
+
+  try {
+    const homeDir = path.join(testRoot, 'home');
+    fs.mkdirSync(homeDir, { recursive: true });
+
+    // runObserve executes from repoRoot, which is itself a git repository.
+    // A missing payload cwd must not let detect-project.sh inherit that scope.
+    const result = runObserve({ homeDir, cwd: undefined });
+    assert.strictEqual(result.status, 0, result.stderr);
+
+    const homunculusDir = path.join(homeDir, '.local', 'share', 'ecc-homunculus');
+    const observation = JSON.parse(
+      fs.readFileSync(path.join(homunculusDir, 'observations.jsonl'), 'utf8').trim()
+    );
+    assert.strictEqual(observation.project_id, 'global');
+    assert.strictEqual(observation.cwd, '');
+    assert.ok(!fs.existsSync(path.join(homunculusDir, 'projects.json')));
+  } finally {
+    cleanupDir(testRoot);
+  }
+});
+
+test('missing cwd uses a valid explicit CLAUDE_PROJECT_DIR', () => {
+  const testRoot = createTempDir();
+
+  try {
+    const homeDir = path.join(testRoot, 'home');
+    const repoDir = path.join(testRoot, 'repo');
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(repoDir, { recursive: true });
+    gitInit(repoDir);
+
+    const result = runObserve({
+      homeDir,
+      cwd: undefined,
+      extraEnv: { CLAUDE_PROJECT_DIR: repoDir },
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+
+    const { metadata, projectDir } = readSingleProjectMetadata(homeDir);
+    assert.strictEqual(normalizeComparablePath(metadata.root), normalizeComparablePath(repoDir));
+    const observation = JSON.parse(
+      fs.readFileSync(path.join(projectDir, 'observations.jsonl'), 'utf8').trim()
+    );
+    assert.strictEqual(observation.cwd, '');
+    assert.notStrictEqual(observation.project_id, 'global');
   } finally {
     cleanupDir(testRoot);
   }

--- a/tests/hooks/observe-subdirectory-detection.test.js
+++ b/tests/hooks/observe-subdirectory-detection.test.js
@@ -251,6 +251,29 @@ test('missing cwd does not inherit the hook process git repository', () => {
   }
 });
 
+test('null cwd is normalized and does not inherit the hook process git repository', () => {
+  const testRoot = createTempDir();
+
+  try {
+    const homeDir = path.join(testRoot, 'home');
+    fs.mkdirSync(homeDir, { recursive: true });
+
+    const result = runObserve({ homeDir, cwd: null });
+    assert.strictEqual(result.status, 0, result.stderr);
+
+    const homunculusDir = path.join(homeDir, '.local', 'share', 'ecc-homunculus');
+    const observation = JSON.parse(
+      fs.readFileSync(path.join(homunculusDir, 'observations.jsonl'), 'utf8').trim()
+    );
+    assert.strictEqual(observation.project_id, 'global');
+    assert.strictEqual(observation.cwd, '');
+    assert.ok(!fs.existsSync(path.join(homunculusDir, 'projects.json')));
+    assert.ok(!fs.existsSync(path.join(homunculusDir, 'projects')));
+  } finally {
+    cleanupDir(testRoot);
+  }
+});
+
 test('missing cwd uses a valid explicit CLAUDE_PROJECT_DIR', () => {
   const testRoot = createTempDir();
 


### PR DESCRIPTION
## What Changed

- make missing or invalid payload `cwd` deterministic: use a valid explicit `CLAUDE_PROJECT_DIR`, otherwise force global scope instead of inheriting the hook process cwd
- persist a scrubbed `cwd` field in every parsed observation for diagnosis
- isolate observer liveness, lazy-start, and SIGUSR1 signaling to the current `PROJECT_DIR`
- add behavioral coverage for subdirectories, missing cwd, explicit project fallback, and stored cwd
- add a cross-platform source contract for project-scoped observer PIDs

## Why This Change

When hook payloads lack a usable cwd, project detection can currently inherit an unrelated process working directory. A live global observer PID also suppresses project-specific observer startup and can be signaled by unrelated project observations. Together these paths allow slow cross-project scope contamination.

The observer process remains intentionally keyed to one project; the fix prevents a global observer from standing in for a project observer rather than mutating daemon scope in place.

Closes #2746

## Testing Done

- [x] Manual testing completed
- [x] Automated focused tests pass locally
- [x] Edge cases considered and tested

Validation performed:

- Git Bash `bash -n` on `observe.sh` and `start-observer.sh`
- `node tests/hooks/observe-subdirectory-detection.test.js` with Git Bash override (8/8)
- `node tests/hooks/continuous-learning-scope-contract.test.js`
- `node tests/hooks/observer-memory.test.js` (31/31)
- `node tests/hooks/observe-nosurvive-warning.test.js` (3/3)
- `node tests/hooks/observe-signal-counter-race.test.js` (2/2)
- `node scripts/ci/validate-skills.js`
- `node scripts/ci/validate-hooks.js`

`shellcheck` is not installed in the local Windows environment; syntax and behavioral checks used Git Bash. CI provides the Linux validation boundary.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (not installed locally; `bash -n` passed)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)