### PR TITLE
feat: add OrcaRouter as an OpenAI-compatible LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,13 @@ ATLAS_API_KEY=
 # ATLAS_BASE_URL=https://api.atlascloud.ai/v1
 # ATLAS_MODEL=anthropic/claude-sonnet-4.6
 
+# --- Optional: OrcaRouter (OpenAI-compatible, 150+ LLM models) ---------------
+# Single gateway endpoint + one sk-orca-* key for OpenAI, Anthropic, Google,
+# DeepSeek, Qwen and more. Docs: https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
+# ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+# ORCAROUTER_MODEL=orcarouter/auto
+
 # ─── ECC agent data (multi-harness isolation) ───────────────────────────────
 # Memory hooks (sessions, learned skills, aliases, metrics). Default: ~/.claude
 # Use a separate root when running ECC in Cursor alongside Claude Code:

--- a/README.md
+++ b/README.md
@@ -470,6 +470,14 @@ export ANTHROPIC_AUTH_TOKEN=your-token
 claude
 ```
 
+For OpenAI-compatible gateways, ECC's bundled LLM abstraction (`src/llm`) selects a provider through `LLM_PROVIDER`. OrcaRouter is available as a built-in provider — one `sk-orca-*` key reaches 150+ OpenAI, Anthropic, Google, DeepSeek, and Qwen models:
+
+```bash
+export LLM_PROVIDER=orcarouter
+export ORCAROUTER_API_KEY=sk-orca-xxxx
+# optional: export ORCAROUTER_MODEL=orcarouter/auto
+```
+
 If your gateway remaps model names, configure that in Claude Code rather than in ECC. ECC's hooks, skills, commands, and rules are model-provider agnostic once the `claude` CLI is already working. See Anthropic's [LLM gateway documentation](https://docs.anthropic.com/en/docs/claude-code/llm-gateway) and [model configuration documentation](https://docs.anthropic.com/en/docs/claude-code/model-config).
 
 Run or self-host any open-source model behind that gateway using separate compute and serving setup. If you need GPU capacity, [Itô](https://compute.itomarkets.com) is ECC's preferred compute sponsor; any GPU provider works. The sponsorship link is passive: it does not invoke an RFQ, reserve capacity, provision compute, or configure serving. Separately, `ecc ito find` invokes the explicitly configured canonical Itô CLI and submits a live authenticated RFQ; it does not reserve capacity. Managed inference through Itô is not live yet.

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -21,6 +21,7 @@ class ProviderType(str, Enum):
     ASTRAFLOW = "astraflow"
     ASTRAFLOW_CN = "astraflow_cn"
     ATLAS = "atlas"
+    ORCAROUTER = "orcarouter"
 
 
 @dataclass(frozen=True)

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -5,6 +5,7 @@ from llm.providers.atlas import AtlasProvider
 from llm.providers.claude import ClaudeProvider
 from llm.providers.ollama import OllamaProvider
 from llm.providers.openai import OpenAIProvider
+from llm.providers.orcarouter import OrcaRouterProvider
 from llm.providers.resolver import get_provider, register_provider
 
 __all__ = (
@@ -14,6 +15,7 @@ __all__ = (
     "ClaudeProvider",
     "OpenAIProvider",
     "OllamaProvider",
+    "OrcaRouterProvider",
     "get_provider",
     "register_provider",
 )

--- a/src/llm/providers/orcarouter.py
+++ b/src/llm/providers/orcarouter.py
@@ -1,0 +1,137 @@
+"""OrcaRouter OpenAI-compatible provider adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from openai import OpenAI
+
+from llm.core.interface import (
+    AuthenticationError,
+    ContextLengthError,
+    LLMProvider,
+    RateLimitError,
+)
+from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
+from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
+
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+# ``orcarouter/auto`` is the per-request virtual router: OrcaRouter picks the
+# best model for each call. Concrete namespaced models such as
+# ``openai/gpt-4o-mini`` also work through the same endpoint.
+DEFAULT_ORCAROUTER_MODEL = "orcarouter/auto"
+
+
+def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
+    if not raw_arguments:
+        return {}
+
+    try:
+        arguments = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {"raw": raw_arguments}
+
+    if isinstance(arguments, dict):
+        return arguments
+    return {"value": arguments}
+
+
+class OrcaRouterProvider(LLMProvider):
+    """OrcaRouter endpoint using OpenAI-compatible chat completions.
+
+    OrcaRouter (https://www.orcarouter.ai) exposes 150+ models from OpenAI,
+    Anthropic, Google, DeepSeek, Qwen and others behind a single OpenAI-
+    compatible API and one ``sk-orca-*`` key, so it reuses the same
+    chat-completions flow as the other OpenAI-compatible adapters here.
+    """
+
+    provider_type = ProviderType.ORCAROUTER
+    api_key_env = "ORCAROUTER_API_KEY"
+    base_url_env = "ORCAROUTER_BASE_URL"
+    model_env = "ORCAROUTER_MODEL"
+    default_base_url = ORCAROUTER_BASE_URL
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_model: str | None = None,
+    ) -> None:
+        self.api_key = api_key or os.environ.get(self.api_key_env) or ""
+        self.base_url = base_url or os.environ.get(self.base_url_env, self.default_base_url)
+        env_model = os.environ.get(self.model_env)
+        self.default_model = default_model or env_model or DEFAULT_ORCAROUTER_MODEL
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url, _enforce_credentials=False)
+        self._models = [
+            ModelInfo(
+                name=self.default_model,
+                provider=self.provider_type,
+                supports_tools=True,
+                supports_vision=False,
+            )
+        ]
+
+    def generate(self, llm_input: LLMInput) -> LLMOutput:
+        try:
+            params: dict[str, Any] = {
+                "model": llm_input.model or self.default_model,
+                "messages": [msg.to_dict() for msg in llm_input.messages],
+            }
+            if llm_input.temperature != 1.0:
+                params["temperature"] = llm_input.temperature
+            if llm_input.max_tokens is not None:
+                params["max_tokens"] = llm_input.max_tokens
+            if llm_input.tools:
+                params["tools"] = [tool.to_openai_tool() for tool in llm_input.tools]
+
+            response = self.client.chat.completions.create(**params)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError(EMPTY_FILTERED_RESPONSE_ERROR)
+            choice = response.choices[0]
+
+            tool_calls = None
+            if choice.message.tool_calls:
+                tool_calls = [
+                    ToolCall(
+                        id=tc.id or "",
+                        name=tc.function.name,
+                        arguments=_parse_tool_arguments(tc.function.arguments),
+                    )
+                    for tc in choice.message.tool_calls
+                ]
+
+            usage = None
+            if response.usage:
+                usage = {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+
+            return LLMOutput(
+                content=choice.message.content or "",
+                tool_calls=tool_calls,
+                model=response.model,
+                usage=usage,
+                stop_reason=choice.finish_reason,
+            )
+        except Exception as e:
+            msg = str(e)
+            if "401" in msg or "authentication" in msg.lower():
+                raise AuthenticationError(msg, provider=self.provider_type) from e
+            if "429" in msg or "rate_limit" in msg.lower():
+                raise RateLimitError(msg, provider=self.provider_type) from e
+            if "context" in msg.lower() and "length" in msg.lower():
+                raise ContextLengthError(msg, provider=self.provider_type) from e
+            raise
+
+    def list_models(self) -> list[ModelInfo]:
+        return self._models.copy()
+
+    def validate_config(self) -> bool:
+        return bool(self.api_key)
+
+    def get_default_model(self) -> str:
+        return self.default_model

--- a/src/llm/providers/resolver.py
+++ b/src/llm/providers/resolver.py
@@ -12,6 +12,7 @@ from llm.providers.atlas import AtlasProvider
 from llm.providers.claude import ClaudeProvider
 from llm.providers.ollama import OllamaProvider
 from llm.providers.openai import OpenAIProvider
+from llm.providers.orcarouter import OrcaRouterProvider
 
 _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.ASTRAFLOW: AstraflowProvider,
@@ -20,6 +21,7 @@ _PROVIDER_MAP: dict[ProviderType, type[LLMProvider]] = {
     ProviderType.CLAUDE: ClaudeProvider,
     ProviderType.OPENAI: OpenAIProvider,
     ProviderType.OLLAMA: OllamaProvider,
+    ProviderType.ORCAROUTER: OrcaRouterProvider,
 }
 
 LLM_ENV_FILE = ".llm.env"

--- a/tests/test_orcarouter_provider.py
+++ b/tests/test_orcarouter_provider.py
@@ -1,0 +1,150 @@
+from types import SimpleNamespace
+
+from llm.core.types import (
+    LLMInput,
+    Message,
+    ProviderType,
+    Role,
+    ToolCall,
+    ToolDefinition,
+)
+from llm.providers.orcarouter import (
+    DEFAULT_ORCAROUTER_MODEL,
+    ORCAROUTER_BASE_URL,
+    OrcaRouterProvider,
+)
+
+
+def _tool() -> ToolDefinition:
+    return ToolDefinition(
+        name="search",
+        description="Search",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+
+
+class _Completions:
+    def __init__(self, response: SimpleNamespace) -> None:
+        self.params = None
+        self.response = response
+
+    def create(self, **params):
+        self.params = params
+        return self.response
+
+
+class _Client:
+    def __init__(self, response: SimpleNamespace) -> None:
+        self.completions = _Completions(response)
+        self.chat = SimpleNamespace(completions=self.completions)
+
+
+def _response(**overrides) -> SimpleNamespace:
+    message = SimpleNamespace(content="ok", tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    defaults = {
+        "choices": [choice],
+        "model": "orcarouter/auto",
+        "usage": SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_orcarouter_provider_defaults_to_orcarouter_endpoint(monkeypatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ORCAROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("ORCAROUTER_MODEL", raising=False)
+
+    provider = OrcaRouterProvider()
+
+    assert provider.provider_type == ProviderType.ORCAROUTER
+    assert provider.base_url == ORCAROUTER_BASE_URL
+    assert provider.get_default_model() == DEFAULT_ORCAROUTER_MODEL
+    assert provider.validate_config() is False
+
+
+def test_orcarouter_provider_reads_env_config(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.setenv("ORCAROUTER_MODEL", "openai/gpt-4o-mini")
+    monkeypatch.delenv("ORCAROUTER_BASE_URL", raising=False)
+
+    provider = OrcaRouterProvider()
+
+    assert provider.provider_type == ProviderType.ORCAROUTER
+    assert provider.base_url == ORCAROUTER_BASE_URL
+    assert provider.get_default_model() == "openai/gpt-4o-mini"
+    assert provider.validate_config() is True
+
+
+def test_orcarouter_provider_generates_openai_compatible_chat_completion():
+    provider = OrcaRouterProvider(api_key="test", default_model="openai/gpt-4o-mini")
+    client = _Client(_response(model="openai/gpt-4o-mini"))
+    provider.client = client
+
+    output = provider.generate(
+        LLMInput(
+            messages=[Message(role=Role.USER, content="hi")],
+            max_tokens=128,
+            tools=[_tool()],
+        )
+    )
+
+    assert output.content == "ok"
+    assert output.model == "openai/gpt-4o-mini"
+    assert output.usage == {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+    assert client.completions.params["model"] == "openai/gpt-4o-mini"
+    assert client.completions.params["max_tokens"] == 128
+    assert "temperature" not in client.completions.params
+    assert client.completions.params["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                "strict": True,
+            },
+        }
+    ]
+
+
+def test_orcarouter_provider_forwards_non_default_temperature():
+    provider = OrcaRouterProvider(api_key="test")
+    client = _Client(_response())
+    provider.client = client
+
+    provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")], temperature=0.2))
+
+    assert client.completions.params["temperature"] == 0.2
+
+
+def test_orcarouter_provider_parses_tool_calls():
+    provider = OrcaRouterProvider(api_key="test")
+    tool_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="search", arguments='{"query":"orcarouter"}'),
+    )
+    message = SimpleNamespace(content="", tool_calls=[tool_call])
+    client = _Client(_response(choices=[SimpleNamespace(message=message, finish_reason="tool_calls")], usage=None))
+    provider.client = client
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    assert output.tool_calls == [ToolCall(id="call_1", name="search", arguments={"query": "orcarouter"})]
+    assert output.usage is None
+
+
+def test_orcarouter_provider_preserves_malformed_tool_arguments():
+    provider = OrcaRouterProvider(api_key="test")
+    tool_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="search", arguments="{not-json"),
+    )
+    message = SimpleNamespace(content="", tool_calls=[tool_call])
+    client = _Client(_response(choices=[SimpleNamespace(message=message, finish_reason="tool_calls")]))
+    provider.client = client
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    assert output.tool_calls == [ToolCall(id="call_1", name="search", arguments={"raw": "{not-json"})]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -8,6 +8,7 @@ from llm.providers import (
     ClaudeProvider,
     OllamaProvider,
     OpenAIProvider,
+    OrcaRouterProvider,
     get_provider,
 )
 
@@ -42,6 +43,11 @@ class TestGetProvider:
         provider = get_provider("atlas")
         assert isinstance(provider, AtlasProvider)
         assert provider.provider_type == ProviderType.ATLAS
+
+    def test_get_orcarouter_provider(self):
+        provider = get_provider("orcarouter")
+        assert isinstance(provider, OrcaRouterProvider)
+        assert provider.provider_type == ProviderType.ORCAROUTER
 
     def test_get_provider_by_enum(self):
         provider = get_provider(ProviderType.CLAUDE)


### PR DESCRIPTION
## What Changed

Adds **OrcaRouter** as a built-in OpenAI-compatible provider in the `src/llm` abstraction layer, mirroring the existing `astraflow`/`atlas` adapters.

- `ProviderType.ORCAROUTER = "orcarouter"` in `src/llm/core/types.py`
- New `OrcaRouterProvider` in `src/llm/providers/orcarouter.py` — OpenAI-compatible chat-completions flow against `https://api.orcarouter.ai/v1`, default model `orcarouter/auto` (per-request virtual router; concrete namespaced models like `openai/gpt-4o-mini` also work)
- Registered in the resolver `_PROVIDER_MAP` and exported from `llm.providers`
- Config via `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` / `ORCAROUTER_MODEL` (documented in `.env.example` and the README gateway section)
- 6 provider unit tests + a resolver registration test

Select it with `LLM_PROVIDER=orcarouter` (or `.llm.env`), or `get_provider("orcarouter")`.

## Why This Change

[OrcaRouter](https://www.orcarouter.ai) exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single OpenAI-compatible endpoint and one `sk-orca-*` key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Adding it as a first-class provider follows the same pattern as the existing OpenAI-compatible adapters, so users get the same tool-calling, temperature, and model-config behavior they already rely on.

## Testing Done

- [x] `python -m ruff check src tests` — clean
- [x] `python -m pytest tests/test_*.py -m "not integration"` — 91 passed (incl. 7 new OrcaRouter tests)
- [x] L3 live test through `OrcaRouterProvider.generate()` against the real endpoint: `LIVE-OK model=gpt-4o-mini-2024-07-18 reply='ORCA-OK'` and routed `orcarouter/auto` → upstream model
- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed (live key used only in a throwaway local test, removed afterwards)
- [x] Follows conventional commits format
- [x] No sensitive data exposed in logs or output

I'm an engineer on the OrcaRouter team.
