### PR TITLE
fix(manifests): reference skills/skill-comply so --profile full installs it

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -326,6 +326,7 @@
         "skills/plan-canvas",
         "skills/plankton-code-quality",
         "skills/production-audit",
+        "skills/skill-comply",
         "skills/skill-scout",
         "skills/skill-stocktake",
         "skills/strategic-compact",


### PR DESCRIPTION
Refs #2789.

## What happens

`skills/skill-comply/` is not referenced by any module in `manifests/install-modules.json`, so `install-apply.js --profile full` never copies it. Every other curated skill is referenced.

Running the reporter's check on current `main`:

```
skill dirs: 284 | referenced: 283
unreferenced: [ 'skill-comply' ]
```

After this change:

```
skill dirs: 284 | referenced: 284
unreferenced: []
```

(The counts have moved from the 281 in the issue as skills were added; the gap is the same one.)

This is the last remaining instance of #2431 ("install-modules.json is missing 79 curated skills"), which closed as completed after covering 78 of the 79.

The gap is invisible from the install output, and `npm run catalog:check` does not catch it — it compares documentation counts against the repository catalog (68/94/284), not against manifest coverage, so it passes either way.

## Placement

`workflow-quality`, alphabetically between `production-audit` and `skill-scout`.

`skill-comply` measures whether agents actually follow the skills, rules and definitions they were given — an agent-quality concern, so it sits with `agent-introspection-debugging`, `ai-regression-testing` and `skill-stocktake` rather than in `security`, whose compliance skills (`hipaa-compliance`, `healthcare-phi-compliance`) are about regulatory domains.

## Checks

- reporter's repro script: 284 dirs / 284 referenced, empty unreferenced list
- `node scripts/ci/validate-install-manifests.js` — validated 34 install modules, 81 install components, 7 profiles
- `node scripts/ci/validate-skills.js` — validated 284 skill directories
- `npm run catalog:check` — documentation counts match the repository catalog

One line, no behaviour change beyond the skill now being installed by the profiles that carry `workflow-quality`.

Note this does not address the companion issue #2790 (`install-apply` replacing rather than merging `install-state`); it only removes the reason the `--skills skill-comply` workaround was needed.