### PR TITLE
docs(antigravity): clarify npm 2.2 release boundary

### DIFF
--- a/docs/ANTIGRAVITY-GUIDE.md
+++ b/docs/ANTIGRAVITY-GUIDE.md
@@ -8,6 +8,14 @@ Native Antigravity 2.0 installation requires ECC 2.2.0 or newer. ECC 2.1.0 uses
 the legacy `.agent/` adapter and does not provide the native layout described
 below.
 
+> [!IMPORTANT]
+> **Temporary release status:** npm latest is currently `ecc-universal@2.1.0`.
+> ECC 2.2.0 has not been published to npm yet. Until it is published, use a
+> current source checkout of `main` for native `.agents` support or wait for the
+> release.
+
+<!-- Temporary: remove this release-status paragraph only after `ecc-universal@2.2.0` is published and registry readback succeeds. -->
+
 ## Quick start
 
 ```bash

--- a/tests/docs/antigravity-guide.test.js
+++ b/tests/docs/antigravity-guide.test.js
@@ -33,6 +33,21 @@ test('guide requires an installer with native Antigravity 2.0 support', () => {
   );
 });
 
+test('guide states the temporary npm release boundary', () => {
+  assert.ok(
+    guide.includes('npm latest is currently `ecc-universal@2.1.0`'),
+    'Guide should identify the package version users receive from npm today'
+  );
+  assert.ok(
+    guide.includes('ECC 2.2.0 has not been published to npm yet'),
+    'Guide should not imply that native Antigravity support is already published'
+  );
+  assert.ok(
+    guide.includes('remove this release-status paragraph only after `ecc-universal@2.2.0` is published and registry readback succeeds'),
+    'Guide should retain a removal condition for the temporary release warning'
+  );
+});
+
 test('guide keeps the target project as the working directory', () => {
   assert.ok(
     guide.includes('Run every command below from the project you want to configure'),

--- a/tests/docs/antigravity-guide.test.js
+++ b/tests/docs/antigravity-guide.test.js
@@ -43,6 +43,10 @@ test('guide states the temporary npm release boundary', () => {
     'Guide should not imply that native Antigravity support is already published'
   );
   assert.ok(
+    guide.includes('current source checkout of `main` for native `.agents` support'),
+    'Guide should direct users to the main source checkout until ECC 2.2.0 is published'
+  );
+  assert.ok(
     guide.includes('remove this release-status paragraph only after `ecc-universal@2.2.0` is published and registry readback succeeds'),
     'Guide should retain a removal condition for the temporary release warning'
   );


### PR DESCRIPTION
## Summary
- state that npm latest is currently `ecc-universal@2.1.0`
- state that ECC 2.2.0 has not been published to npm yet
- direct users to current source `main` or the upcoming release for native `.agents` support
- retain a removal condition tied to successful 2.2.0 registry readback

## Verification
- `node tests/docs/antigravity-guide.test.js` (6/6)
- ESLint
- markdownlint
- `git diff --check`
- live registry check: `npm view ecc-universal version` returns `2.1.0`
- independent review: no CRITICAL, HIGH, or MEDIUM findings