### PR TITLE
test: fix Nasiko Windows status expectation

### DIFF
--- a/tests/ci/nasiko-control-plane.test.js
+++ b/tests/ci/nasiko-control-plane.test.js
@@ -218,13 +218,14 @@ async function main() {
     }],
     ['read-only status has a stable absent result shape', () => {
       const { readStatus } = require('../../scripts/nasiko');
+      const { normalizePlatform } = require('../../scripts/lib/nasiko-release');
       const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-nasiko-absent-'));
       try {
         assert.deepStrictEqual(readStatus({ installDir: fixtureRoot }), {
           installed: false,
           qualified: false,
           version: null,
-          executable: path.join(fs.realpathSync(fixtureRoot), 'nasiko'),
+          executable: path.join(fs.realpathSync(fixtureRoot), normalizePlatform().binaryName),
         });
       } finally { fs.rmSync(fixtureRoot, { recursive: true, force: true }); }
     }],


### PR DESCRIPTION
## Summary
- derive the expected Nasiko executable name from the platform contract
- expect `nasiko.exe` on Windows while retaining `nasiko` on macOS/Linux
- close the single portability assertion that failed all Windows jobs after #2800

## Test plan
- `node tests/ci/nasiko-control-plane.test.js` (11/11)
- `npm run lint`
- `git diff --check`
- full local suite: Nasiko and 3,937/3,938 tests passed; one unrelated existing stateful failure in `hooks/ecc-context-monitor.test.js` (`cost warnings dedupe by tier`)
- require GitHub Windows matrix before merge