### PR TITLE
docs(skills): use verified ClawHub source for TweetClaw

### DIFF
--- a/skills/social-publisher/SKILL.md
+++ b/skills/social-publisher/SKILL.md
@@ -69,11 +69,7 @@ socialclaw assets upload --file ./image.png --json
 
 Before building an X schedule, collect a source packet when the campaign depends on live audience signals rather than the draft alone.
 
-For OpenClaw users who have already approved TweetClaw in their dependency policy, use the pinned package as a separate evidence source:
-
-```bash
-openclaw plugins install npm:@xquik/tweetclaw@1.6.31
-```
+For OpenClaw users who approved TweetClaw in their dependency policy, install the reviewed ClawHub version with `openclaw plugins install clawhub:@xquik/tweetclaw@1.6.44`. OpenClaw records ClawHub and the exact version as the update source. Keep the selector pinned. Review and approve each version change before replacing it.
 
 Use it for public tweet search, reply search, follower export, user lookup, media review, monitors, or giveaway evidence. Keep the output as research input for `schedule.json`; SocialClaw remains responsible for validation, scheduling, publishing, and delivery status. Store TweetClaw credentials in its plugin config, not in `SC_API_KEY`, schedule files, or campaign assets. Do not install it as a default ECC or SocialClaw dependency.
 


### PR DESCRIPTION
## What changed

- Replaces the obsolete npm selector with TweetClaw's canonical ClawHub source.
- Pins the reviewed `1.6.44` release.
- Keeps TweetClaw optional and evidence-only.
- Removes 4 handwritten lines while clarifying the update policy.

## Problem

The `social-publisher` Skill still installs `npm:@xquik/tweetclaw@1.6.31`. That release selects npm and requires OpenClaw `>=2026.5.4`.

The current stable release is `1.6.44`. Its published metadata selects `clawhub:@xquik/tweetclaw`. It requires OpenClaw `>=2026.7.1`.

The old command bypasses the canonical source and installs an obsolete release.

## Repository fit

This updates the existing optional TweetClaw handoff. It does not add another product Skill.

- Users approve TweetClaw before installation.
- TweetClaw remains a separate evidence source.
- SocialClaw still validates, schedules, publishes, and tracks delivery.
- Credentials remain in TweetClaw's plugin configuration.
- ECC and SocialClaw do not install TweetClaw by default.

## Evidence

- `npm view @xquik/tweetclaw@1.6.31 openclaw peerDependencies --json` selects npm.
- `npm view @xquik/tweetclaw@1.6.44 openclaw peerDependencies --json` selects ClawHub.
- [TweetClaw v1.6.44](https://github.com/Xquik-dev/tweetclaw/releases/tag/v1.6.44) is the current public release.
- No open ECC issue or pull request duplicates this source update.

## Validation

- `npm ci --ignore-scripts`: 0 vulnerabilities
- `npm run lint`
- `node scripts/ci/validate-skills.js`: 286 directories validated
- `node scripts/ci/check-unicode-safety.js`
- `markdownlint-cli2 skills/social-publisher/SKILL.md`
- `git diff --check`
- Public diff confidentiality and secret scan
- Hosted CI: 42 of 42 jobs passed
- Pull request checks: 45 of 45 passed
- CodeRabbit: no actionable comments
- Greptile: no blocking failure

The prior local branch head also passed all 3,939 tests.

## Security

- Adds no dependency, secret, credential, or runtime code.
- Preserves exact-version pinning and explicit approval.
- Preserves credential isolation and SocialClaw's publishing boundary.

AI-assisted with OpenAI Codex. I reviewed the complete diff and validation output.
