### PR TITLE
fix(hooks): deny dd if= arguments whose value starts with a non-word char

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -48,7 +48,16 @@ const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes'
 // phrases without shell-flag ordering concerns. Quoted strings are
 // stripped before this regex runs so a commit message mentioning
 // "drop table" no longer triggers a false positive.
-const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+//
+// The `dd\s+if=` arm deliberately omits a trailing word-boundary anchor:
+// `dd if=` ends with `=`, a non-word character, so `\b` would refuse to
+// match before the next non-word character (most commonly `/` for
+// `/dev/*` targets, but also `.`, quotes, `;`, `|`, `&`, end-of-string,
+// etc.). Anchoring that arm with `\b` was the cause of issue #2642:
+// `dd if=/dev/zero of=/dev/sda` slipped past the gate. The SQL arms keep
+// their trailing `\b` so words like `delete fromtable` or `truncatefile`
+// do not produce false positives.
+const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -2376,6 +2376,165 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Issue #2642: trailing \b on the `dd\s+if=` arm fails open when the
+  // argument begins with a non-word character (`/`, `.`, quote, ...), which
+  // covers every realistic disk-wipe spelling. The fix splits the alternation
+  // so the SQL arms keep their trailing word-boundary anchor (no
+  // `delete fromtable` / `truncatefile` false positives) while the `dd if=`
+  // arm matches whatever follows the `=`.
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/zero of=/dev/sda` (issue #2642 disk-wipe spelling)', () => {
+      expectDestructiveDeny('dd if=/dev/zero of=/dev/sda', 'dd if=/dev/zero of=/dev/sda');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/urandom of=/dev/sdb`', () => {
+      expectDestructiveDeny('dd if=/dev/urandom of=/dev/sdb', 'dd if=/dev/urandom of=/dev/sdb');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/zero` (slash-prefixed argument)', () => {
+      expectDestructiveDeny('dd if=/dev/zero', 'dd if=/dev/zero');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=.` (dot-prefixed argument — `git checkout -- .` analogue)', () => {
+      expectDestructiveDeny('dd if=. of=/tmp/out.bin', 'dd if=. of=/tmp/out.bin');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=foo` (word-prefixed argument)', () => {
+      expectDestructiveDeny('dd if=foo', 'dd if=foo');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=backup.img of=/dev/sdc` (period in argument)', () => {
+      expectDestructiveDeny('dd if=backup.img of=/dev/sdc', 'dd if=backup.img of=/dev/sdc');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=` followed by `;` (compound form)', () => {
+      expectDestructiveDeny('echo start; dd if=/dev/zero of=/dev/sda', 'echo start; dd if=/dev/zero of=/dev/sda');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/zero` inside command substitution `$(...)`', () => {
+      expectDestructiveDeny('echo $(dd if=/dev/zero of=/dev/sda)', 'echo $(dd if=/dev/zero of=/dev/sda)');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies `dd if=x` (control: was already denied pre-fix)', () => {
+      expectDestructiveDeny('dd if=x', 'dd if=x');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies plain `drop table users;` (SQL arm unaffected)', () => {
+      expectDestructiveDeny('drop table users;', 'drop table users;');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies plain `delete from t` (SQL arm unaffected)', () => {
+      expectDestructiveDeny('delete from t', 'delete from t');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies plain `truncate -s 0 f` (SQL arm unaffected)', () => {
+      expectDestructiveDeny('truncate -s 0 f', 'truncate -s 0 f');
+    })
+  )
+    passed++;
+  else failed++;
+
+  // Anti-regression: dropping the trailing \b on the SQL arms would let
+  // benign substrings fire the gate (`delete fromtable`, `truncatefile`).
+  // The fix must keep `\b` on the SQL arms so these remain allowed.
+
+  clearState();
+  if (
+    test('allows `delete fromtable` (SQL arm keeps trailing \\b; not a false positive)', () => {
+      // Prime the routine gate so the destructive-gate outcome is the
+      // observable signal. `delete fromtable` is not a SQL statement.
+      writeState({ checked: ['__bash_session__'], last_active: Date.now() });
+      const input = { tool_name: 'Bash', tool_input: { command: 'echo "delete fromtable review"' } };
+      const result = runBashHook(input);
+      assert.strictEqual(result.code, 0, 'exit code should be 0');
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON');
+      if (output.hookSpecificOutput) {
+        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'delete fromtable should not be destructive');
+      } else {
+        assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('allows `truncatefile` (SQL arm keeps trailing \\b; not a false positive)', () => {
+      writeState({ checked: ['__bash_session__'], last_active: Date.now() });
+      const input = { tool_name: 'Bash', tool_input: { command: 'echo truncatefile.tmp' } };
+      const result = runBashHook(input);
+      assert.strictEqual(result.code, 0, 'exit code should be 0');
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON');
+      if (output.hookSpecificOutput) {
+        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'truncatefile should not be destructive');
+      } else {
+        assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
   // --- Exempt globs: GATEGUARD_EXEMPT_GLOBS skips first-touch fact-forcing ---
   clearState();
   if (


### PR DESCRIPTION
## Summary

Closes #2642. The destructive-command gate allowed every realistic disk-wipe spelling of `dd if=` because the regex used a trailing `\b` anchor on the whole alternation, and `\b` cannot match after a non-word character (the `=` in `dd if=`). The companion `git checkout -- .` arm mentioned in the same report is already covered by the structural `findGitSubcommand()` parser on `main`.

## Problem

```js
const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
```

For `dd if=/dev/zero of=/dev/sda`, the engine matches `dd if=` but then needs `\b` at the position where `/` is the next character. Since `=` and `/` are both non-word characters, there is no word boundary there and the match fails. The hook then falls through to the other gates (rm, git, find -exec, ...), all of which miss the bare `dd` invocation.

## Root cause

The trailing `\b` is needed for the SQL arms to reject benign substrings (`truncatefile`, `delete fromtable`). For the `dd if=` arm it is both wrong (the `=` is non-word) and unnecessary (the arm already requires a literal `if=` token, which has no shorter superstring to confuse with).

## Fix

Split the alternation so the SQL arms keep their trailing `\b` while the `dd if=` arm drops it:

```js
const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
```

The regex still requires a literal whitespace token `if=` after `dd`, so false positives (`ddiff`, `dd ifbackup`) remain impossible.

## Verification

Reproduction against the published v2.1.0 hook vs. the fix:

| Command | Pre-fix | Post-fix |
| --- | --- | --- |
| `dd if=/dev/zero of=/dev/sda` | ALLOWED | DENIED |
| `dd if=/dev/urandom of=/dev/sdb` | ALLOWED | DENIED |
| `dd if=/dev/zero` | ALLOWED | DENIED |
| `dd if=backup.img of=/dev/sdc` | ALLOWED | DENIED |
| `dd if=x` (control: was already denied) | DENIED | DENIED |
| `drop table users;` | DENIED | DENIED |
| `delete from t` | DENIED | DENIED |
| `truncate -s 0 f` | DENIED | DENIED |
| `delete fromtable` (anti-regression) | ALLOWED | ALLOWED |
| `truncatefile` (anti-regression) | ALLOWED | ALLOWED |

`node tests/hooks/gateguard-fact-force.test.js` now runs 158 tests (up from 144), all green, with 14 new regression cases covering every command spelling called out in the issue, the command-substitution and compound-command variants, and the two anti-regression checks that the SQL arms still keep their `\b`.