### PR TITLE
docs(rules): add naming conventions to TypeScript/JavaScript coding style

### DIFF
--- a/rules/typescript/coding-style.md
+++ b/rules/typescript/coding-style.md
@@ -113,6 +113,39 @@ export function formatUser(user) {
 }
 ```
 
+## Naming Conventions
+
+Follow standard TypeScript/JavaScript naming conventions:
+
+- Variables, functions, methods, and object properties: `camelCase` with descriptive names
+- Interfaces, type aliases, classes, enums, and React components: `PascalCase`
+- Constants and top-level immutable configurations: `UPPER_SNAKE_CASE`
+- Booleans: prefer `is`, `has`, `should`, or `can` prefixes (`isActive`, `hasPermission`, `shouldRetry`)
+- React custom hooks: `camelCase` with a `use` prefix (`useAuth`, `useLocalStorage`)
+- Generics: single uppercase letter (`T`, `K`, `V`) or descriptive PascalCase with `T` prefix (`TData`, `TError`)
+
+```typescript
+// Variables and functions
+const userProfile = await fetchUserProfile(userId)
+
+// Interfaces and types
+interface UserProfile {
+  userId: string
+  isActive: boolean
+}
+
+type QueryStatus = 'idle' | 'loading' | 'success' | 'error'
+
+// Constants
+const MAX_RETRY_COUNT = 3
+const DEFAULT_TIMEOUT_MS = 5000
+
+// React custom hooks
+function useDebounce<TValue>(value: TValue, delayMs: number): TValue {
+  // ...
+}
+```
+
 ## Immutability
 
 Use spread operator for immutable updates:


### PR DESCRIPTION
## Summary

Adds a dedicated `## Naming Conventions` section to `rules/typescript/coding-style.md` (scoped to `**/*.ts`, `**/*.tsx`, `**/*.js`, `**/*.jsx`).

### Background
While language rules like `rules/rust/coding-style.md`, `rules/cpp/coding-style.md`, and `rules/python/coding-style.md` specify their respective casing conventions (e.g. `snake_case`, PEP 8), `rules/typescript/coding-style.md` did not declare explicit naming conventions for TypeScript and JavaScript.

### Changes
- Variables, functions, methods, and object properties: `camelCase` with descriptive names
- Interfaces, type aliases, classes, enums, and React components: `PascalCase`
- Constants and top-level immutable configurations: `UPPER_SNAKE_CASE`
- Booleans: descriptive prefixes (`is`, `has`, `should`, `can`)
- React custom hooks: `camelCase` with a `use` prefix
- Generics: single uppercase letter (`T`, `K`, `V`) or `T`-prefixed PascalCase (`TData`, `TError`)
- Included clean, idiomatic TypeScript code examples

## Verification
- `node scripts/ci/check-unicode-safety.js` — passed
- `node scripts/ci/validate-rules.js` — validated 122 rule files
- `node scripts/ci/validate-no-personal-paths.js` — passed
- `npm run catalog:check` — passed
